### PR TITLE
fix(readme): fixed rendering of readme files in storybook

### DIFF
--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -15,7 +15,10 @@ export default class Container extends Component {
     const { story } = this.props;
 
     let bgColor = '#ffffff';
-    if (story().props.context.kind === '[Experimental] UI Shell') {
+    if (
+      story().props.context &&
+      story().props.context.kind === '[Experimental] UI Shell'
+    ) {
       bgColor = '#f3f3f3';
     }
 

--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -4,6 +4,7 @@ import { configure, addDecorator } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { withOptions } from '@storybook/addon-options';
 import { configureActions } from '@storybook/addon-actions';
+import { addReadme } from 'storybook-readme';
 // import { checkA11y } from 'storybook-addon-a11y';
 import Container from './Container';
 
@@ -19,6 +20,8 @@ addDecorator(
     url: 'https://github.com/carbon-design-system/ibm-dotcom-library',
   })
 );
+
+addDecorator(addReadme);
 
 configureActions({
   depth: 100,

--- a/packages/react/src/components/Footer/__stories__/Footer.stories.js
+++ b/packages/react/src/components/Footer/__stories__/Footer.stories.js
@@ -1,9 +1,15 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Footer } from '../';
+import readme from '../README.md';
 
 import '../../../../../styles/scss/components/footer/index.scss';
 
 storiesOf('Footer', module)
+  .addParameters({
+    readme: {
+      sidebar: readme,
+    },
+  })
   .add('Default / Tall', () => <Footer />)
   .add('Short', () => <Footer type="short" />);

--- a/packages/react/src/components/HorizontalRule/__stories__/HorizontalRule.stories.js
+++ b/packages/react/src/components/HorizontalRule/__stories__/HorizontalRule.stories.js
@@ -2,11 +2,17 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, select, text } from '@storybook/addon-knobs';
 import '@ibmdotcom/styles/scss/components/horizontalrule/_horizontalrule.scss';
+import readme from '../README.md';
 
 import HorizontalRule from '../HorizontalRule';
 
 storiesOf('HorizontalRule', module)
   .addDecorator(withKnobs)
+  .addParameters({
+    readme: {
+      sidebar: readme,
+    },
+  })
   .add('Default', () => {
     const styles = {
       solid: '',


### PR DESCRIPTION
### Related Ticket(s)

https://github.ibm.com/webstandards/digital-design/issues/1524

### Description

The storybook output previously did not connect the readme addon, so the readme panel was showing up blank. This fixes this issue so that now the README files are rendering for the corresponding component.

<img width="1350" alt="Screen Shot 2019-08-27 at 12 43 58 PM" src="https://user-images.githubusercontent.com/1641214/63790951-61b86680-c8c8-11e9-86da-4653ca47a232.png">

### Changelog

**New**

- README addon connected
- Added readme's to HR and Footer
