### PR TITLE
fix(masthead): fixed search bar for dir='rtl'

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -122,7 +122,7 @@ const MastheadSearch = ({
 
   const [state, dispatch] = useReducer(_reducer, _initialState);
 
-  const dir = document.querySelector('html').getAttribute('dir') == 'rtl';
+  const rtl = document.querySelector('html').getAttribute('dir') == 'rtl';
 
   useEffect(() => {
     const abortController =
@@ -193,7 +193,7 @@ const MastheadSearch = ({
   }
 
   const className = cx({
-    [`${prefix}--masthead__search--rtl`]: dir,
+    [`${prefix}--masthead__search--rtl`]: rtl,
     [`${prefix}--masthead__search`]: true,
     [`${prefix}--masthead__search--active`]: state.isSearchOpen,
   });
@@ -371,9 +371,6 @@ const MastheadSearch = ({
     return value.trim().length >= renderValue;
   }
 
-  document.querySelector('html').dir = 'rtl';
-  console.log(dir);
-
   return (
     <div
       data-autoid={`${stablePrefix}--masthead__search`}
@@ -403,7 +400,7 @@ const MastheadSearch = ({
       )}
       <div
         className={
-          dir
+          rtl
             ? `${prefix}--header__search--actions--rtl`
             : `${prefix}--header__search--actions`
         }>

--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -122,6 +122,8 @@ const MastheadSearch = ({
 
   const [state, dispatch] = useReducer(_reducer, _initialState);
 
+  const dir = document.querySelector('html').getAttribute('dir') == 'rtl';
+
   useEffect(() => {
     const abortController =
       typeof AbortController !== 'undefined'
@@ -191,6 +193,7 @@ const MastheadSearch = ({
   }
 
   const className = cx({
+    [`${prefix}--masthead__search--rtl`]: dir,
     [`${prefix}--masthead__search`]: true,
     [`${prefix}--masthead__search--active`]: state.isSearchOpen,
   });
@@ -368,6 +371,9 @@ const MastheadSearch = ({
     return value.trim().length >= renderValue;
   }
 
+  document.querySelector('html').dir = 'rtl';
+  console.log(dir);
+
   return (
     <div
       data-autoid={`${stablePrefix}--masthead__search`}
@@ -395,7 +401,12 @@ const MastheadSearch = ({
           />
         </form>
       )}
-      <div className={`${prefix}--header__search--actions`}>
+      <div
+        className={
+          dir
+            ? `${prefix}--header__search--actions--rtl`
+            : `${prefix}--header__search--actions`
+        }>
         <HeaderGlobalAction
           onClick={searchIconClick}
           aria-label={

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -94,6 +94,12 @@
     right: 0;
   }
 
+  .#{$prefix}--header__search--actions--rtl {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
   // search container
   .#{$prefix}--masthead__search,
   :host(#{$dds-prefix}-masthead-search) {
@@ -109,6 +115,14 @@
 
       .#{$prefix}--header__search--actions {
         z-index: 10001;
+      }
+
+      .#{$prefix}--header__search--actions--rtl {
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 10001;
+        right: auto;
       }
 
       .react-autosuggest__container {
@@ -179,6 +193,11 @@
         right: 0;
       }
     }
+  }
+
+  .#{$prefix}--masthead__search--rtl,
+  :host(#{$dds-prefix}-masthead-search) {
+    margin-left: 0;
   }
 
   .react-autosuggest__container {


### PR DESCRIPTION
### Related Ticket(s)
#3984 

### Description

The search button remained in its original position on the right even when `dir='rtl'` was active. This issue remained even when the search bar was opened, glitching through the header menus.

Before:
![Screen Shot 2020-10-08 at 6 56 55 PM](https://user-images.githubusercontent.com/24970122/95533466-13650a80-0998-11eb-90f6-75dd071296cb.png)




![Screen Shot 2020-10-08 at 6 57 39 PM](https://user-images.githubusercontent.com/24970122/95533497-27107100-0998-11eb-87f9-c185dc5498d1.png)


After:

![Screen Shot 2020-10-08 at 7 07 49 PM](https://user-images.githubusercontent.com/24970122/95534048-abafbf00-0999-11eb-80f9-c3f0e9175f13.png)

![Screen Shot 2020-10-08 at 7 08 26 PM](https://user-images.githubusercontent.com/24970122/95534051-ae121900-0999-11eb-83c1-458c05b2e6f1.png)


### Changelog

**New**

- Added new .scss classes to account for rtl style changes.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
