### PR TITLE
chore(rename): renaming to the new repo url

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,6 +28,6 @@ fit within the scope of any of the existing doc fix projects.
 
 ## Submission Guidelines
 
-Read more about our [submission guidelines](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/docs/submission-guidelines.md).
+Read more about our [submission guidelines](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/submission-guidelines.md).
 
 **Thank you for your contribution!**

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ If you are building pages for IBM.com,
 
 ## Documentation
 
-- See our documentation site [here](https://carbon-for-ibm-dotcom.mybluemix.net)
-  for full how-to docs and guidelines
+- See our documentation site
+  [here](http://www.ibm.com/standards/web/carbon-for-ibm-dotcom) for full how-to
+  docs and guidelines
 - [Contributing](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/.github/CONTRIBUTING.md):
   Guidelines for making contributions to this repo.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://github.com/carbon-design-system/carbon/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Carbon is released under the Apache-2.0 license" />
   </a>
-  <a href="https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md">
+  <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/.github/CONTRIBUTING.md">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" />
   </a>
   <a href="https://percy.io/538fc19a/IBM.com-Library-React">
@@ -26,29 +26,29 @@
 ## Getting started
 
 If you're just getting started, check out
-[`react`](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/react).
+[`react`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/react).
 Web Components coming soon!
 
 If you're trying to find something specific, here's a full list of packages that
 we support!
 
-| Package name                                                                                                                         | Description                                                         |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
-| [`@carbon/ibmdotcom-react`](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/react)                   | IBM.com React components and patterns                               |
-| [`@carbon/ibmdotcom-web-components`](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/web-components) | IBM.com Vanilla components with a new web standard (Web Components) |
-| [`@carbon/ibmdotcom-vanilla`](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/vanilla)               | IBM.com Vanilla components                                          |
-| [`@carbon/ibmdotcom-services`](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/services)             | IBM.com ES6 Service classes                                         |
-| [`@carbon/ibmdotcom-styles`](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles)                 | Framework agnostic styles package for IBM.com components            |
-| [`@carbon/ibmdotcom-utilities`](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/utilities)           | IBM.com ES6 Utility classes                                         |
+| Package name                                                                                                                            | Description                                                         |
+| --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [`@carbon/ibmdotcom-react`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/react)                   | IBM.com React components and patterns                               |
+| [`@carbon/ibmdotcom-web-components`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/web-components) | IBM.com Vanilla components with a new web standard (Web Components) |
+| [`@carbon/ibmdotcom-vanilla`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/vanilla)               | IBM.com Vanilla components                                          |
+| [`@carbon/ibmdotcom-services`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/services)             | IBM.com ES6 Service classes                                         |
+| [`@carbon/ibmdotcom-styles`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles)                 | Framework agnostic styles package for IBM.com components            |
+| [`@carbon/ibmdotcom-utilities`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/utilities)           | IBM.com ES6 Utility classes                                         |
 
 If you are building pages for IBM.com,
-[see what is needed on the page](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/docs/building-for-ibm-dotcom.md).
+[see what is needed on the page](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/building-for-ibm-dotcom.md).
 
 ## Documentation
 
-- See our documentation site [here](https://ibm-dotcom-library.mybluemix.net)
+- See our documentation site [here](https://carbon-for-ibm-dotcom.mybluemix.net)
   for full how-to docs and guidelines
-- [Contributing](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md):
+- [Contributing](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/.github/CONTRIBUTING.md):
   Guidelines for making contributions to this repo.
 
 ## 🙌 Contributing
@@ -56,12 +56,12 @@ If you are building pages for IBM.com,
 We're always looking for contributors to help us fix bugs, build new features,
 or help us improve the project documentation. If you're interested, definitely
 check out our
-[Contributing Guide](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md)
+[Contributing Guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/.github/CONTRIBUTING.md)
 and our
-[Developer Guide](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/docs/developing.md)!
+[Developer Guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/developing.md)!
 👀
 
 ## 📝 License
 
 Licensed under the
-[Apache 2.0 License](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/LICENSE).
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/LICENSE).

--- a/docs/contributing-license.md
+++ b/docs/contributing-license.md
@@ -4,12 +4,12 @@ We're always looking for contributors to help us fix bugs, build new features,
 or help us improve the project documentation. If you're interested, definitely
 check out our guides:
 
-- [Contributing Guide](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md)
-- [Developer Guide](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/docs/developing.md)
-- [Contributing to the React package](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/react/docs/contributing-to-react.md)
+- [Contributing Guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/.github/CONTRIBUTING.md)
+- [Developer Guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/developing.md)
+- [Contributing to the React package](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/react/docs/contributing-to-react.md)
 - Contributing to the `Web Components` package (coming soon!)
 
 ## 📝 License
 
 Licensed under the
-[Apache 2.0 License](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/LICENSE).
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/LICENSE).

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -23,15 +23,15 @@ contributing back to the repository. This includes regular team
 members/maintainers.
 
 1. Fork the project by navigating to the main
-   [repository](https://github.com/carbon-design-system/ibm-dotcom-library/) and
+   [repository](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/) and
    clicking the **Fork** button on the top-right corner.
 
 2. Navigate to your forked repository and copy the **SSH url**. Clone your fork
    by running the following in your terminal:
 
    ```
-   $ git clone git@github.com:{ YOUR_USERNAME }/ibm-dotcom-library.git
-   $ cd ibm-dotcom-library
+   $ git clone git@github.com:{ YOUR_USERNAME }/carbon-for-ibm-dotcom.git
+   $ cd carbon-for-ibm-dotcom
    ```
 
    See [GitHub docs](https://help.github.com/articles/fork-a-repo/) for more
@@ -39,10 +39,10 @@ members/maintainers.
 
 3. Once cloned, you will see `origin` as your default remote, pointing to your
    personal forked repository. Add a remote named `upstream` pointing to the
-   main `ibm-dotcom-library`:
+   main `carbon-for-ibm-dotcom`:
 
    ```
-   $ git remote add upstream git@github.com:carbon-design-system/ibm-dotcom-library.git
+   $ git remote add upstream git@github.com:carbon-design-system/carbon-for-ibm-dotcom.git
    $ git remote -v
    ```
 
@@ -91,7 +91,7 @@ yarn build
 
 Afterwards, you should be good to go! For more information about how we handle
 dependencies, definitely take a look at our write-up
-[here](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/docs/dependencies.md).
+[here](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/dependencies.md).
 
 ## Common tasks
 
@@ -171,7 +171,7 @@ https://yarnpkg.com/lang/en/docs/cli/link/
    ```
 
 7. In Github, navigate to
-   [carbon-design-system/ibm-dotcom-library](https://github.com/carbon-design-system/ibm-dotcom-library/)
+   [carbon-design-system/carbon-for-ibm-dotcom](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/)
    and click the button that reads "Compare & pull request".
 
 8. Write a title and description, then click "Create pull request".

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "ibm-dotcom-library",
+  "name": "carbon-for-ibm-dotcom",
   "private": true,
   "version": "0.0.0",
-  "repository": "git@github.com:carbon-design-system/ibm-dotcom-library.git",
+  "repository": "git@github.com:carbon-design-system/carbon-for-ibm-dotcom.git",
   "license": "Apache-2.0",
   "engines": {
     "node": "12.x"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.11.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@1.11.0-rc.1...@carbon/ibmdotcom-react@1.11.0) (2020-09-22)
+# [1.11.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-react@1.11.0-rc.1...@carbon/ibmdotcom-react@1.11.0) (2020-09-22)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-react
 
@@ -12,108 +12,108 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.11.0-rc.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@1.11.0-rc.0...@carbon/ibmdotcom-react@1.11.0-rc.1) (2020-09-16)
+# [1.11.0-rc.1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-react@1.11.0-rc.0...@carbon/ibmdotcom-react@1.11.0-rc.1) (2020-09-16)
 
 ### Bug Fixes
 
 - **masthead:** remove hide L0 logic
-  ([#3960](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3960))
-  ([fe2ae3f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/fe2ae3f)),
+  ([#3960](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3960))
+  ([fe2ae3f](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/fe2ae3f)),
   closes
-  [#3958](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3958)
+  [#3958](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3958)
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.11.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@1.10.2...@carbon/ibmdotcom-react@1.11.0-rc.0) (2020-09-11)
+# [1.11.0-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-react@1.10.2...@carbon/ibmdotcom-react@1.11.0-rc.0) (2020-09-11)
 
 # 1.11.0-beta.4917 (2020-09-11)
 
 ### Bug Fixes
 
 - **HorizontalRule:** change style prop name to type
-  ([#3892](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3892))
-  ([3317f57](https://github.com/carbon-design-system/ibm-dotcom-library/commit/3317f57))
+  ([#3892](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3892))
+  ([3317f57](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/3317f57))
 - **Masthead:** indicate the active navigation item in Masthead navigation links
-  ([#3890](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3890))
-  ([42b1599](https://github.com/carbon-design-system/ibm-dotcom-library/commit/42b1599)),
+  ([#3890](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3890))
+  ([42b1599](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/42b1599)),
   closes
-  [#3826](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3826)
+  [#3826](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3826)
 - **MastheadLeftNav:** when user goes through menu levels, set scrollTop to 0
-  ([#3921](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3921))
-  ([0ecc2a5](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0ecc2a5)),
+  ([#3921](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3921))
+  ([0ecc2a5](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/0ecc2a5)),
   closes
-  [#3730](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3730)
+  [#3730](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3730)
 
 ### Features
 
 - **search:** add redirect and typeahead hooks
-  ([#3918](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3918))
-  ([84c0481](https://github.com/carbon-design-system/ibm-dotcom-library/commit/84c0481)),
+  ([#3918](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3918))
+  ([84c0481](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/84c0481)),
   closes
-  [#3766](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3766)
+  [#3766](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3766)
 
 ## 1.10.2 (2020-09-08)
 
 ### Bug Fixes
 
 - **styles:** dedupe Carbon grid in the bundle
-  ([#3811](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3811))
-  ([4119a43](https://github.com/carbon-design-system/ibm-dotcom-library/commit/4119a43)),
+  ([#3811](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3811))
+  ([4119a43](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/4119a43)),
   closes
-  [#3809](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3809)
+  [#3809](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3809)
 
 ### Features
 
 - **Card:** supports onClick
-  ([#3812](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3812))
-  ([9245135](https://github.com/carbon-design-system/ibm-dotcom-library/commit/9245135)),
+  ([#3812](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3812))
+  ([9245135](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/9245135)),
   closes
-  [#3756](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3756)
+  [#3756](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3756)
 
 # 1.11.0-beta.4847 (2020-08-28)
 
 ### Bug Fixes
 
 - **CardGroup:** passing pictogram prop to card from CardGroup
-  ([#3689](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3689))
-  ([fa2b2ef](https://github.com/carbon-design-system/ibm-dotcom-library/commit/fa2b2ef)),
+  ([#3689](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3689))
+  ([fa2b2ef](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/fa2b2ef)),
   closes
-  [#3654](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3654)
+  [#3654](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3654)
 - **leadspace:** fixes codesandbox leadspace example
-  ([#3581](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3581))
-  ([59414e1](https://github.com/carbon-design-system/ibm-dotcom-library/commit/59414e1))
+  ([#3581](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3581))
+  ([59414e1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/59414e1))
 - **Masthead:** keep focus in sub menus
-  ([#3723](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3723))
-  ([af1ce57](https://github.com/carbon-design-system/ibm-dotcom-library/commit/af1ce57)),
+  ([#3723](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3723))
+  ([af1ce57](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/af1ce57)),
   closes
-  [#3663](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3663)
+  [#3663](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3663)
 - **MegaMenu:** explicity set focus to HeaderMenu L0 item when clicked
-  ([#3751](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3751))
-  ([626d40f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/626d40f)),
+  ([#3751](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3751))
+  ([626d40f](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/626d40f)),
   closes
-  [#3617](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3617)
-  [#3731](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3731)
+  [#3617](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3617)
+  [#3731](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3731)
 
 ### Features
 
 - **card-with-pictogram:** adding new card variation
-  ([#3654](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3654))
-  ([3bdc14e](https://github.com/carbon-design-system/ibm-dotcom-library/commit/3bdc14e))
+  ([#3654](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3654))
+  ([3bdc14e](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/3bdc14e))
 - **Footer:** add micro variation
-  ([#3645](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3645))
-  ([14acb43](https://github.com/carbon-design-system/ibm-dotcom-library/commit/14acb43)),
+  ([#3645](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3645))
+  ([14acb43](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/14acb43)),
   closes
-  [#3431](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3431)
+  [#3431](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3431)
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.10.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@1.10.2-rc.2...@carbon/ibmdotcom-react@1.10.2) (2020-09-08)
+## [1.10.2](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-react@1.10.2-rc.2...@carbon/ibmdotcom-react@1.10.2) (2020-09-08)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-react
 
@@ -122,7 +122,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.10.2-rc.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@1.10.2-rc.1...@carbon/ibmdotcom-react@1.10.2-rc.2) (2020-09-03)
+## [1.10.2-rc.2](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-react@1.10.2-rc.1...@carbon/ibmdotcom-react@1.10.2-rc.2) (2020-09-03)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-react
 

--- a/packages/react/docs/contributing-to-react.md
+++ b/packages/react/docs/contributing-to-react.md
@@ -30,19 +30,19 @@ We try to have any contributions to the library to live in their corresponding
 package(s). The main packages to look out for when contributing a React 
 component:
 
-- **Styles**: ([@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles)) 
+- **Styles**: ([@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/styles)) 
 All styles should live in the styles package in the monorepo. This way, the
 styles can be shared with any other framework package (e.g. web components). 
 In addition, the way that web components utilize styles requires that there 
 isn't a heavy amount of nesting happening in the `SCSS` code. 
-- **Services**: ([@carbon/ibmdotcom-services](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services))
+- **Services**: ([@carbon/ibmdotcom-services](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/services))
 If your component makes any API requests to a service that does not currently
 exist yet in our Services package, you can add in a new ES6 service class in
 this package. If you need to test across multiple packages, you can make use of
-[yarn link](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/docs/developing.md#developing-locally).
+[yarn link](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/developing.md#developing-locally).
 Be sure to properly export the class from the main `index.js`.
-- **Utilities**: ([@carbon/ibmdotcom-utilities](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities))
-Similar to ([Services](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services)),
+- **Utilities**: ([@carbon/ibmdotcom-utilities](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/utilities))
+Similar to ([Services](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/services)),
 any abstract utilities can be added to the Utilities package as an ES6 class or
 function. Be sure to properly export the class or function from the main 
 `index.js`.
@@ -56,7 +56,7 @@ are looking for one of many values values (e.g. `PropTypes.oneOf`)
 
 ## Stable Selectors
 
-Every component must include [stable selectors](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/docs/stable-selectors.md) 
+Every component must include [stable selectors](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/stable-selectors.md) 
 as part of the overall markup, identifying any key elements that would be useful
 to have the ability to identify in a DOM search. At minimum, there should be at
 least a container level stable selector defined, and all should use the `dds--`
@@ -81,7 +81,7 @@ const MyComponent = () => {
 If this is a new component or enhancement, we would require that it is 
 introduced into Carbon for IBM.com behind a feature flag. 
 
-[You can read full details on how to create and implement a feature flag here](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/react/docs/feature-flags.md).
+[You can read full details on how to create and implement a feature flag here](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/react/docs/feature-flags.md).
 
 An example of creating a Storybook story that will be ignored if the feature
 flag is disabled:
@@ -170,4 +170,4 @@ yarn test:unit:updateSnapshot
 <li>Export any new components from the main `index.js`</li>
 </ul>
 
-Read more about our [submission guidelines](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/docs/submission-guidelines.md).
+Read more about our [submission guidelines](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/submission-guidelines.md).

--- a/packages/react/src/components/Card/README.stories.mdx
+++ b/packages/react/src/components/Card/README.stories.mdx
@@ -9,10 +9,10 @@ import { Card } from './Card';
 > while presenting content in a concise and readable style.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/Card)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react/examples/codesandbox/components/Card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/Card)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react/examples/codesandbox/components/Card)
 
 ## Getting started
 
@@ -31,7 +31,7 @@ Here's a quick example to get you started.
 
 > 💡 Only import fonts once per usage. Don't forget to import the Card styles
 > from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 ##### JS
 
@@ -49,14 +49,14 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 ```
 
 Add the following line in your `.env` file at the root of your project.
-[See more details](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles#usage).
+[See more details](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/styles#usage).
 
 ```
   SASS_PATH=node_modules:src
 ```
 
 > 💡 Don't forget to import the card link styles from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 ## Props
 

--- a/packages/react/src/components/CardGroup/README.stories.mdx
+++ b/packages/react/src/components/CardGroup/README.stories.mdx
@@ -25,13 +25,13 @@ Here's a quick example to get you started.
 
 > 💡 Only import fonts once per usage. Don't forget to import the card-group
 > styles from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CardGroup)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react/examples/codesandbox/components/CardGroup)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CardGroup)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react/examples/codesandbox/components/CardGroup)
 
 ##### JS
 
@@ -49,7 +49,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 ```
 
 Add the following line in your `.env` file at the root of your project.
-[See more details](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles#usage)..
+[See more details](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/styles#usage)..
 
 ```
   SASS_PATH=node_modules:src

--- a/packages/react/src/components/CardLink/README.stories.mdx
+++ b/packages/react/src/components/CardLink/README.stories.mdx
@@ -9,10 +9,10 @@ import { CardLink } from '../CardLink';
 > while presenting content in a concise and readable style.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CardLink)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react/examples/codesandbox/components/CardLink)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CardLink)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react/examples/codesandbox/components/CardLink)
 
 ## Getting started
 
@@ -31,7 +31,7 @@ Here's a quick example to get you started.
 
 > 💡 Only import fonts once per usage. Don't forget to import the Card styles
 > from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 ##### JS
 
@@ -63,14 +63,14 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 ```
 
 Add the following line in your `.env` file at the root of your project.
-[See more details](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles#usage).
+[See more details](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/styles#usage).
 
 ```
   SASS_PATH=node_modules:src
 ```
 
 > 💡 Don't forget to import the card styles from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 ## Props
 

--- a/packages/react/src/components/HorizontalRule/README.stories.mdx
+++ b/packages/react/src/components/HorizontalRule/README.stories.mdx
@@ -7,10 +7,10 @@ import HorizontalRule from './HorizontalRule';
 > Horizontal rules provide thematic breaks between content.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/HorizontalRule)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react/examples/codesandbox/components/HorizontalRule)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/HorizontalRule)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react/examples/codesandbox/components/HorizontalRule)
 
 ## Getting started
 
@@ -29,7 +29,7 @@ Here's a quick example to get you started.
 
 > 💡 Only import fonts once per usage. Don't forget to import the HorizontalRule
 > styles from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 ##### JS
 

--- a/packages/react/src/components/Image/README.stories.mdx
+++ b/packages/react/src/components/Image/README.stories.mdx
@@ -8,10 +8,10 @@ import Image from './Image';
 > specific image depending on viewport size.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/Image)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react/examples/codesandbox/components/Image)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/Image)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react/examples/codesandbox/components/Image)
 
 ## Getting started
 
@@ -30,7 +30,7 @@ Here's a quick example to get you started.
 
 > 💡 Only import fonts once per usage. Don't forget to import the Image styles
 > from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 ##### JS
 
@@ -73,14 +73,14 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 ```
 
 Add the following line in your `.env` file at the root of your project.
-[See more details](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles#usage).
+[See more details](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/styles#usage).
 
 ```
   SASS_PATH=node_modules:src
 ```
 
 > 💡 Don't forget to import the image styles from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 ## Props
 

--- a/packages/react/src/components/PictogramItem/README.stories.mdx
+++ b/packages/react/src/components/PictogramItem/README.stories.mdx
@@ -21,7 +21,7 @@ Here's a quick example to get you started.
 
 > 💡 Only import fonts once per usage. Don't forget to import the PictogramItem
 > styles from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 ##### JS
 
@@ -61,14 +61,14 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 ```
 
 Add the following line in your `.env` file at the root of your project.
-[See more details](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles#usage).
+[See more details](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/styles#usage).
 
 ```
   SASS_PATH=node_modules:src
 ```
 
 > 💡 Don't forget to import the pictogram item styles from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 ## Props
 

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.11.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.11.0-rc.0...@carbon/ibmdotcom-services@1.11.0) (2020-09-22)
+# [1.11.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.11.0-rc.0...@carbon/ibmdotcom-services@1.11.0) (2020-09-22)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -12,15 +12,15 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.11.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.10.2...@carbon/ibmdotcom-services@1.11.0-rc.0) (2020-09-11)
+# [1.11.0-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.10.2...@carbon/ibmdotcom-services@1.11.0-rc.0) (2020-09-11)
 
 ### Features
 
 - **search:** add redirect and typeahead hooks
-  ([#3918](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3918))
-  ([84c0481](https://github.com/carbon-design-system/ibm-dotcom-library/commit/84c0481)),
+  ([#3918](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3918))
+  ([84c0481](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/84c0481)),
   closes
-  [#3766](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3766)
+  [#3766](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3766)
 
 ## 1.10.2 (2020-09-08)
 
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.10.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.10.2-rc.2...@carbon/ibmdotcom-services@1.10.2) (2020-09-08)
+## [1.10.2](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.10.2-rc.2...@carbon/ibmdotcom-services@1.10.2) (2020-09-08)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -40,22 +40,22 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.10.2-rc.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.10.2-rc.1...@carbon/ibmdotcom-services@1.10.2-rc.2) (2020-09-03)
+## [1.10.2-rc.2](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.10.2-rc.1...@carbon/ibmdotcom-services@1.10.2-rc.2) (2020-09-03)
 
 ### Bug Fixes
 
 - **translation:** adding string/replace of login url state param
-  ([#3852](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3852))
-  ([435500c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/435500c)),
+  ([#3852](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3852))
+  ([435500c](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/435500c)),
   closes
-  [#3851](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3851)
+  [#3851](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3851)
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.10.2-rc.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.10.2-rc.0...@carbon/ibmdotcom-services@1.10.2-rc.1) (2020-09-02)
+## [1.10.2-rc.1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.10.2-rc.0...@carbon/ibmdotcom-services@1.10.2-rc.1) (2020-09-02)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -64,22 +64,22 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.10.2-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.10.1...@carbon/ibmdotcom-services@1.10.2-rc.0) (2020-09-01)
+## [1.10.2-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.10.1...@carbon/ibmdotcom-services@1.10.2-rc.0) (2020-09-01)
 
 ### Bug Fixes
 
 - **lang:** get immediate lang value rather than waiting for DDO
-  ([#3822](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3822))
-  ([49e1308](https://github.com/carbon-design-system/ibm-dotcom-library/commit/49e1308)),
+  ([#3822](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3822))
+  ([49e1308](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/49e1308)),
   closes
-  [#3824](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3824)
+  [#3824](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3824)
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.10.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.10.1-rc.0...@carbon/ibmdotcom-services@1.10.1) (2020-08-28)
+## [1.10.1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.10.1-rc.0...@carbon/ibmdotcom-services@1.10.1) (2020-08-28)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -88,7 +88,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.10.1-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.10.0...@carbon/ibmdotcom-services@1.10.1-rc.0) (2020-08-27)
+## [1.10.1-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.10.0...@carbon/ibmdotcom-services@1.10.1-rc.0) (2020-08-27)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -97,7 +97,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.10.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.10.0-rc.0...@carbon/ibmdotcom-services@1.10.0) (2020-08-26)
+# [1.10.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.10.0-rc.0...@carbon/ibmdotcom-services@1.10.0) (2020-08-26)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -106,35 +106,35 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.10.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.9.0...@carbon/ibmdotcom-services@1.10.0-rc.0) (2020-08-19)
+# [1.10.0-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.9.0...@carbon/ibmdotcom-services@1.10.0-rc.0) (2020-08-19)
 
 ### Bug Fixes
 
 - **devenv:** use ibm-common.js
-  ([#3578](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3578))
-  ([36b148c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/36b148c)),
+  ([#3578](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3578))
+  ([36b148c](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/36b148c)),
   closes
-  [#3575](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3575)
+  [#3575](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3575)
 - **VideoPlayerAPI:** stop video when modal closes
-  ([#3427](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3427))
-  ([b61b5ee](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b61b5ee)),
+  ([#3427](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3427))
+  ([b61b5ee](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/b61b5ee)),
   closes
-  [#3295](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3295)
+  [#3295](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3295)
 
 ### Features
 
 - **masthead:** support profile API
-  ([#3463](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3463))
-  ([1f41b05](https://github.com/carbon-design-system/ibm-dotcom-library/commit/1f41b05)),
+  ([#3463](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3463))
+  ([1f41b05](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/1f41b05)),
   closes
-  [#3432](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3432)
+  [#3432](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3432)
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.9.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.9.0-rc.1...@carbon/ibmdotcom-services@1.9.0) (2020-07-29)
+# [1.9.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.9.0-rc.1...@carbon/ibmdotcom-services@1.9.0) (2020-07-29)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -143,7 +143,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.9.0-rc.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.9.0-rc.0...@carbon/ibmdotcom-services@1.9.0-rc.1) (2020-07-22)
+# [1.9.0-rc.1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.9.0-rc.0...@carbon/ibmdotcom-services@1.9.0-rc.1) (2020-07-22)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -152,20 +152,20 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.9.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.8.0...@carbon/ibmdotcom-services@1.9.0-rc.0) (2020-07-17)
+# [1.9.0-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.8.0...@carbon/ibmdotcom-services@1.9.0-rc.0) (2020-07-17)
 
 ### Bug Fixes
 
 - **ddo:** setting the proper attribute for version in ddo
-  ([#3190](https://github.com/carbon-design-system/ibm-dotcom-library/issues/3190))
-  ([22bf463](https://github.com/carbon-design-system/ibm-dotcom-library/commit/22bf463))
+  ([#3190](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/3190))
+  ([22bf463](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/22bf463))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.8.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.8.0-rc.2...@carbon/ibmdotcom-services@1.8.0) (2020-06-23)
+# [1.8.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.8.0-rc.2...@carbon/ibmdotcom-services@1.8.0) (2020-06-23)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -174,7 +174,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.8.0-rc.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.8.0-rc.1...@carbon/ibmdotcom-services@1.8.0-rc.2) (2020-06-17)
+# [1.8.0-rc.2](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.8.0-rc.1...@carbon/ibmdotcom-services@1.8.0-rc.2) (2020-06-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -183,53 +183,53 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.8.0-rc.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.8.0-rc.0...@carbon/ibmdotcom-services@1.8.0-rc.1) (2020-06-16)
+# [1.8.0-rc.1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.8.0-rc.0...@carbon/ibmdotcom-services@1.8.0-rc.1) (2020-06-16)
 
 ### Features
 
 - **services:** support REACT_APP_TRANSLATION_HOST
-  ([#2766](https://github.com/carbon-design-system/ibm-dotcom-library/issues/2766))
-  ([1a9800d](https://github.com/carbon-design-system/ibm-dotcom-library/commit/1a9800d)),
+  ([#2766](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/2766))
+  ([1a9800d](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/1a9800d)),
   closes
-  [#2761](https://github.com/carbon-design-system/ibm-dotcom-library/issues/2761)
+  [#2761](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/2761)
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.8.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.7.0...@carbon/ibmdotcom-services@1.8.0-rc.0) (2020-06-12)
+# [1.8.0-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.7.0...@carbon/ibmdotcom-services@1.8.0-rc.0) (2020-06-12)
 
 ### Bug Fixes
 
 - **VideoPlayer:** have overlay poster image on video player to align with
   visual specs
-  ([#2716](https://github.com/carbon-design-system/ibm-dotcom-library/issues/2716))
-  ([0ceed38](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0ceed38))
+  ([#2716](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/2716))
+  ([0ceed38](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/0ceed38))
 
 # 1.8.0-beta.4335 (2020-06-05)
 
 ### Bug Fixes
 
 - **corsproxy:** removing cors proxy on production environments
-  ([#2633](https://github.com/carbon-design-system/ibm-dotcom-library/issues/2633))
-  ([81a4587](https://github.com/carbon-design-system/ibm-dotcom-library/commit/81a4587))
+  ([#2633](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/2633))
+  ([81a4587](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/81a4587))
 - **services:** fix uncaught rejections
-  ([#2655](https://github.com/carbon-design-system/ibm-dotcom-library/issues/2655))
-  ([77b5298](https://github.com/carbon-design-system/ibm-dotcom-library/commit/77b5298))
+  ([#2655](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/2655))
+  ([77b5298](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/77b5298))
 
 ### Features
 
 - **component:** enhance card to support video
-  ([#2652](https://github.com/carbon-design-system/ibm-dotcom-library/issues/2652))
-  ([d363d4f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/d363d4f))
+  ([#2652](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/2652))
+  ([d363d4f](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/d363d4f))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.7.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.7.0-rc.1...@carbon/ibmdotcom-services@1.7.0) (2020-05-27)
+# [1.7.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.7.0-rc.1...@carbon/ibmdotcom-services@1.7.0) (2020-05-27)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -238,7 +238,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.7.0-rc.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.7.0-rc.0...@carbon/ibmdotcom-services@1.7.0-rc.1) (2020-05-20)
+# [1.7.0-rc.1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.7.0-rc.0...@carbon/ibmdotcom-services@1.7.0-rc.1) (2020-05-20)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -247,23 +247,23 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.7.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.6.0...@carbon/ibmdotcom-services@1.7.0-rc.0) (2020-05-18)
+# [1.7.0-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.6.0...@carbon/ibmdotcom-services@1.7.0-rc.0) (2020-05-18)
 
 ### Bug Fixes
 
 - **jest:** accounting for CORS_PROXY in service unit tests
-  ([2d5d154](https://github.com/carbon-design-system/ibm-dotcom-library/commit/2d5d154))
+  ([2d5d154](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/2d5d154))
 - **video-player:** set different partner and uiconf ids for vp
-  ([523d45c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/523d45c))
+  ([523d45c](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/523d45c))
 - **videoplayer:** format partnerid and handle html in desc
-  ([6708a1c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/6708a1c))
+  ([6708a1c](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/6708a1c))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.6.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.6.0-rc.1...@carbon/ibmdotcom-services@1.6.0) (2020-04-28)
+# [1.6.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.6.0-rc.1...@carbon/ibmdotcom-services@1.6.0) (2020-04-28)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -272,62 +272,62 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.6.0-rc.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.6.0-rc.0...@carbon/ibmdotcom-services@1.6.0-rc.1) (2020-04-22)
+# [1.6.0-rc.1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.6.0-rc.0...@carbon/ibmdotcom-services@1.6.0-rc.1) (2020-04-22)
 
 ### Bug Fixes
 
 - **service:** cache video data in an object within service
-  ([606969c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/606969c))
+  ([606969c](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/606969c))
 - **services:** set associative array for cache object
-  ([f61adc2](https://github.com/carbon-design-system/ibm-dotcom-library/commit/f61adc2))
+  ([f61adc2](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/f61adc2))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.6.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.5.1...@carbon/ibmdotcom-services@1.6.0-rc.0) (2020-04-17)
+# [1.6.0-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.5.1...@carbon/ibmdotcom-services@1.6.0-rc.0) (2020-04-17)
 
 ### Bug Fixes
 
 - **analytics:** add documentation to vp analytics method
-  ([b6a6d36](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b6a6d36))
+  ([b6a6d36](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/b6a6d36))
 - **analytics:** unit tests
-  ([154bd9c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/154bd9c))
+  ([154bd9c](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/154bd9c))
 - **issue-1695:** edit locale.js/update tests
-  ([a475210](https://github.com/carbon-design-system/ibm-dotcom-library/commit/a475210))
+  ([a475210](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/a475210))
 - **issue-1695:** refactoring
-  ([3129d2f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/3129d2f))
+  ([3129d2f](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/3129d2f))
 - **issue-1695:** using DDO to get language
-  ([32ef879](https://github.com/carbon-design-system/ibm-dotcom-library/commit/32ef879))
+  ([32ef879](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/32ef879))
 - **issue-2103:** getfromddo returns false
-  ([4d75802](https://github.com/carbon-design-system/ibm-dotcom-library/commit/4d75802))
+  ([4d75802](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/4d75802))
 - **issue-2103:** isReady() catch, new test
-  ([a9a0777](https://github.com/carbon-design-system/ibm-dotcom-library/commit/a9a0777))
+  ([a9a0777](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/a9a0777))
 - **locale:** setting default host to www.ibm.com
-  ([5e8f4f5](https://github.com/carbon-design-system/ibm-dotcom-library/commit/5e8f4f5))
+  ([5e8f4f5](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/5e8f4f5))
 - **locale-service:** changed dash to em-dash in location string
-  ([5003965](https://github.com/carbon-design-system/ibm-dotcom-library/commit/5003965))
+  ([5003965](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/5003965))
 - **translation:** fixes multiple translation api fetches
-  ([959c8de](https://github.com/carbon-design-system/ibm-dotcom-library/commit/959c8de))
+  ([959c8de](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/959c8de))
 - **unittesting:** aligning jest versions across packages
-  ([c4e8ac0](https://github.com/carbon-design-system/ibm-dotcom-library/commit/c4e8ac0))
+  ([c4e8ac0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/c4e8ac0))
 - **video-player:** import analytics api using relative path
-  ([f4aa71c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/f4aa71c))
+  ([f4aa71c](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/f4aa71c))
 
 ### Features
 
 - **analytics:** metrics for kaltura video player
-  ([0b5e2a5](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0b5e2a5))
+  ([0b5e2a5](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/0b5e2a5))
 - **videoplayerAPI:** adding VideoPlayerAPI test coverage
-  ([b1253db](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b1253db))
+  ([b1253db](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/b1253db))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.5.1-rc.0...@carbon/ibmdotcom-services@1.5.1) (2020-03-30)
+## [1.5.1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.5.1-rc.0...@carbon/ibmdotcom-services@1.5.1) (2020-03-30)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -336,7 +336,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.5.1-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.5.0...@carbon/ibmdotcom-services@1.5.1-rc.0) (2020-03-23)
+## [1.5.1-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.5.0...@carbon/ibmdotcom-services@1.5.1-rc.0) (2020-03-23)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -345,7 +345,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.5.0-rc.0...@carbon/ibmdotcom-services@1.5.0) (2020-03-18)
+# [1.5.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.5.0-rc.0...@carbon/ibmdotcom-services@1.5.0) (2020-03-18)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -354,19 +354,19 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.4.1...@carbon/ibmdotcom-services@1.5.0-rc.0) (2020-03-06)
+# [1.5.0-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.4.1...@carbon/ibmdotcom-services@1.5.0-rc.0) (2020-03-06)
 
 ### Bug Fixes
 
 - **storybook:** update FPO image host for stories
-  ([896ef4f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/896ef4f))
+  ([896ef4f](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/896ef4f))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.4.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.4.1-rc.0...@carbon/ibmdotcom-services@1.4.1) (2020-02-28)
+## [1.4.1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.4.1-rc.0...@carbon/ibmdotcom-services@1.4.1) (2020-02-28)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -375,7 +375,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.4.1-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.4.0...@carbon/ibmdotcom-services@1.4.1-rc.0) (2020-02-26)
+## [1.4.1-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.4.0...@carbon/ibmdotcom-services@1.4.1-rc.0) (2020-02-26)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -384,7 +384,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.4.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.4.0-rc.2...@carbon/ibmdotcom-services@1.4.0) (2020-02-25)
+# [1.4.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.4.0-rc.2...@carbon/ibmdotcom-services@1.4.0) (2020-02-25)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -393,7 +393,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.4.0-rc.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.4.0-rc.1...@carbon/ibmdotcom-services@1.4.0-rc.2) (2020-02-25)
+# [1.4.0-rc.2](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.4.0-rc.1...@carbon/ibmdotcom-services@1.4.0-rc.2) (2020-02-25)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -402,7 +402,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.4.0-rc.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.4.0-rc.0...@carbon/ibmdotcom-services@1.4.0-rc.1) (2020-02-24)
+# [1.4.0-rc.1](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.4.0-rc.0...@carbon/ibmdotcom-services@1.4.0-rc.1) (2020-02-24)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -411,26 +411,26 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.4.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@1.3.1...@carbon/ibmdotcom-services@1.4.0-rc.0) (2020-02-14)
+# [1.4.0-rc.0](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/compare/@carbon/ibmdotcom-services@1.3.1...@carbon/ibmdotcom-services@1.4.0-rc.0) (2020-02-14)
 
 ### Bug Fixes
 
 - **eslint:** adjust config for sort-imports in eslint
-  ([3a4a3dc](https://github.com/carbon-design-system/ibm-dotcom-library/commit/3a4a3dc))
+  ([3a4a3dc](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/3a4a3dc))
 - **storybook:** fixes IE11 loading issues in Storybook; fixes
-  [#840](https://github.com/carbon-design-system/ibm-dotcom-library/issues/840)
-  ([53d2fa3](https://github.com/carbon-design-system/ibm-dotcom-library/commit/53d2fa3))
+  [#840](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/840)
+  ([53d2fa3](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/53d2fa3))
 
 ### Features
 
 - **services:** added api method and updated the jsdoc
-  ([4c15c42](https://github.com/carbon-design-system/ibm-dotcom-library/commit/4c15c42))
+  ([4c15c42](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/4c15c42))
 - **services:** created a videoplayer service to load script and embed
-  ([6b7cdf2](https://github.com/carbon-design-system/ibm-dotcom-library/commit/6b7cdf2))
+  ([6b7cdf2](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/6b7cdf2))
 - **services:** kwidget.api warpped inside the checkScript
-  ([849364d](https://github.com/carbon-design-system/ibm-dotcom-library/commit/849364d))
+  ([849364d](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/849364d))
 - **services:** removed tests for now
-  ([12d98ce](https://github.com/carbon-design-system/ibm-dotcom-library/commit/12d98ce))
+  ([12d98ce](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/12d98ce))
 - **services:** updated the changes
   ([a5407d9](https://github.com/carbon-design-system/ibm-dotcom-library/commit/a5407d9))
 

--- a/packages/services/src/services/Analytics/README.md
+++ b/packages/services/src/services/Analytics/README.md
@@ -35,10 +35,10 @@ function initVideoPlayerTrigger() {
 We're always looking for contributors to help us fix bugs, build new features,
 or help us improve the project documentation. If you're interested, definitely
 check out our
-[Contributing Guide](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md)!
+[Contributing Guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/.github/CONTRIBUTING.md)!
 👀
 
 ## 📝 License
 
 Licensed under the
-[Apache 2.0 License](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/LICENSE).
+[Apache 2.0 License](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/LICENSE).

--- a/packages/vanilla/.storybook/config.js
+++ b/packages/vanilla/.storybook/config.js
@@ -15,7 +15,7 @@ const SORT_ORDER_GROUP = ['Overview', 'Components'];
 addParameters({
   options: {
     name: `Carbon for IBM.com Vanilla Components`,
-    url: 'https://github.com/carbon-design-system/ibm-dotcom-library',
+    url: 'https://github.com/carbon-design-system/carbon-for-ibm-dotcom',
     storySort(lhs, rhs) {
       const { kind: lhsKind } = lhs[1];
       const { kind: rhsKind } = rhs[1];

--- a/tasks/beta-releases.js
+++ b/tasks/beta-releases.js
@@ -30,7 +30,7 @@ program
  *
  * @type {string}
  */
-const repoSlug = 'carbon-design-system/ibm-dotcom-library';
+const repoSlug = 'carbon-design-system/carbon-for-ibm-dotcom';
 
 /**
  * Github release API

--- a/tasks/deploy_preview_comment.js
+++ b/tasks/deploy_preview_comment.js
@@ -28,7 +28,7 @@ const botUser = 'ibmdotcom-bot';
  * Github Repo Slug
  * @type {string}
  */
-const repoSlug = 'carbon-design-system/ibm-dotcom-library';
+const repoSlug = 'carbon-design-system/carbon-for-ibm-dotcom';
 
 /**
  * Stores the arguments

--- a/tasks/tag-release.js
+++ b/tasks/tag-release.js
@@ -19,7 +19,7 @@ const chalk = require('chalk');
  *
  * @type {string}
  */
-const repoSlug = 'carbon-design-system/ibm-dotcom-library';
+const repoSlug = 'carbon-design-system/carbon-for-ibm-dotcom';
 
 /**
  * Github release API


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This rename is mostly documentation. However, this does fix a CI build
issue with the comment creation script where it will need to point to
the new repo name.

### Changelog

**Changed**

- Changed repo link to `carbon-for-ibm-dotcom`
