### PR TITLE
docs(vanilla): update docs deprecation note

### DIFF
--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -1,3 +1,10 @@
+# This package is no longer supported or maintained.
+
+We are deprecating this package in favor of
+[@carbon/ibmdotcom-web-components](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components).
+
+---
+
 # @carbon/ibmdotcom-vanilla
 
 > A collection of IBM.com components implemented using


### PR DESCRIPTION
### Description

Add deprecation notice to `@carbon/ibmdotcom-vanilla` README.

### Changelog

**Changed**

- update README

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
