### PR TITLE
fix(lightbox-m-viewer): removing autoplay from VideoPlayer

### DIFF
--- a/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
+++ b/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
@@ -105,7 +105,7 @@ const LightboxMediaViewer = ({ media, onClose, ...modalProps }) => {
               <div
                 className={`${prefix}--lightbox-media-viewer__media ${prefix}--no-gutter`}>
                 {media.type === 'video' ? (
-                  <VideoPlayer videoId={media.src} autoPlay={true} />
+                  <VideoPlayer videoId={media.src} />
                 ) : (
                   <Image defaultSrc={media.src} alt={videoData.alt} />
                 )}


### PR DESCRIPTION
### Description

This property was causing the `LightboxMediaPlayer` to trigger the video even for the component closed/collapsed. 

### Changelog

**Removed**

- `autoPlay` prop from `VideoPlayer` at `LightboxMediaViewer`;
