### PR TITLE
docs(template): introduce Handlebars example

### DIFF
--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -142,11 +142,13 @@ class LocaleAPI {
    * Clears the cache.
    */
   static clearCache() {
-    Object.keys(_requestsList).forEach(key => delete _requestsList[key]);
-    for (let i = 0; i < sessionStorage.length; ++i) {
-      const key = sessionStorage.key(i);
-      if (key.indexOf(_sessionListKey) === 0) {
-        sessionStorage.removeItem(key);
+    if (typeof sessionStorage !== 'undefined') {
+      Object.keys(_requestsList).forEach(key => delete _requestsList[key]);
+      for (let i = 0; i < sessionStorage.length; ++i) {
+        const key = sessionStorage.key(i);
+        if (key.indexOf(_sessionListKey) === 0) {
+          sessionStorage.removeItem(key);
+        }
       }
     }
   }
@@ -298,9 +300,10 @@ class LocaleAPI {
    * @param {Function} reject rejects the promise
    */
   static fetchList(cc, lc, resolve, reject) {
-    const sessionList = JSON.parse(
-      sessionStorage.getItem(`${_sessionListKey}-${cc}-${lc}`)
-    );
+    const sessionList =
+      typeof sessionStorage === 'undefined'
+        ? undefined
+        : JSON.parse(sessionStorage.getItem(`${_sessionListKey}-${cc}-${lc}`));
 
     if (sessionList) {
       resolve(sessionList);

--- a/packages/services/src/services/Translation/Translation.js
+++ b/packages/services/src/services/Translation/Translation.js
@@ -49,13 +49,15 @@ class TranslationAPI {
    * Clears the cache.
    */
   static clearCache() {
-    Object.keys(_requestsTranslation).forEach(
-      key => delete _requestsTranslation[key]
-    );
-    for (let i = 0; i < sessionStorage.length; ++i) {
-      const key = sessionStorage.key(i);
-      if (key.indexOf(_sessionTranslationKey) === 0) {
-        sessionStorage.removeItem(key);
+    if (typeof sessionStorage !== 'undefined') {
+      Object.keys(_requestsTranslation).forEach(
+        key => delete _requestsTranslation[key]
+      );
+      for (let i = 0; i < sessionStorage.length; ++i) {
+        const key = sessionStorage.key(i);
+        if (key.indexOf(_sessionTranslationKey) === 0) {
+          sessionStorage.removeItem(key);
+        }
       }
     }
   }
@@ -104,9 +106,14 @@ class TranslationAPI {
    * @param {Function} reject rejects the promise
    */
   static fetchTranslation(lang, country, resolve, reject) {
-    const sessionTranslation = JSON.parse(
-      sessionStorage.getItem(`${_sessionTranslationKey}-${country}-${lang}`)
-    );
+    const sessionTranslation =
+      typeof sessionStorage === 'undefined'
+        ? undefined
+        : JSON.parse(
+            sessionStorage.getItem(
+              `${_sessionTranslationKey}-${country}-${lang}`
+            )
+          );
 
     if (sessionTranslation) {
       resolve(sessionTranslation);

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -166,6 +166,73 @@ module: {
 
 [![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/usage/webpack-sass)
 
+### Using server-side template
+
+`@carbon/ibmdotcom-web-components` uses client-side templates by default for masthead, footer, etc.
+Optionally, you can use server-side template engines, e.g. [Handlebars](https://handlebarsjs.com), to render them.
+
+The first step is loading the data for the template.
+You can use [`@carbon/ibmdotcom-services`](https://www.npmjs.com/package/@carbon/ibmdotcom-services) to load the data:
+
+```javascript
+const { default: LocaleAPI } = require('@carbon/ibmdotcom-services/lib/services/Locale/Locale');
+const { default: TranslateAPI } = require('@carbon/ibmdotcom-services/lib/services/Translation/Translation');
+
+// This allows to use `@carbon/ibmdotcom-services` in node.js environment
+global.sessionStorage = {
+  getItem() {
+    return '""';
+  },
+  setItem() {},
+};
+
+// Uses IBM.com services to load the data to render the template with
+const [langDisplay, translation] = await Promise.all([
+  LocaleAPI.getLangDisplay({
+    cc: region,
+    lc: code,
+  }),
+  TranslateAPI.getTranslation({
+    cc: region,
+    lc: code,
+  }),
+]);
+
+const { footerMenu: footerLinks, footerThin: legalLinks } = translation;
+
+...
+```
+
+Once the data is available, leaf components for masthead, footer, etc. can be used, for example:
+
+```handlebars
+<dds-footer>
+  <dds-footer-logo slot="brand"></dds-footer-logo>
+  <dds-footer-nav>
+    {{#each footerLinks}}
+      <dds-footer-nav-group title-text="{{title}}">
+        {{#each links}}
+          <dds-footer-nav-item href="{{url}}">{{title}}</dds-footer-nav-item>
+        {{/each}}
+      </dds-footer-nav-group>
+    {{/each}}
+  </dds-footer-nav>
+  <dds-locale-button slot="locale-button">{{langDisplay}}</dds-locale-button>
+  <dds-legal-nav slot="legal-nav">
+    {{#each legalLinks}}
+      <dds-legal-nav-item href="{{url}}">{{title}}</dds-legal-nav-item>
+    {{/each}}
+    <dds-legal-nav-cookie-preferences-placeholder></dds-legal-nav-cookie-preferences-placeholder>
+  </dds-legal-nav>
+</dds-footer>
+```
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/usage/handlebars)
+> example implementation.
+
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/usage/handlebars)
+
 ## Browser support
 
 Based on [ibm.com browser support](https://www.ibm.com/standards/web/browser-support/):

--- a/packages/web-components/examples/codesandbox/usage/handlebars/index.hbs
+++ b/packages/web-components/examples/codesandbox/usage/handlebars/index.hbs
@@ -1,0 +1,156 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+  <head>
+    <title>@carbon/ibmdotcom-web-components example</title>
+    <meta charset="UTF-8" />
+    <link rel="alternate" hreflang="x-default" href="https://www.ibm.com">
+    {{#each allCountryList}}
+      <link rel="alternate" hreflang="{{locale}}" href="{{href}}">
+    {{/each}}
+    <style type="text/css">
+      body {
+        visibility: hidden; /* Avoids FOUC */
+      }
+    </style>
+  </head>
+  <body>
+    <dds-masthead>
+      <dds-masthead-menu-button></dds-masthead-menu-button>
+      <dds-masthead-logo></dds-masthead-logo>
+      <dds-top-nav menu-bar-label="IBM [Platform]">
+        {{#each navLinks}}
+          {{#if menuItems}}
+            <dds-top-nav-menu menu-label="{{title}}" trigger-content="{{title}}">
+              {{#each menuItems}}
+                <dds-top-nav-menu-item href="{{url}}" title="{{title}}"></dds-top-nav-menu-item>
+              {{/each}}
+            </dds-top-nav-menu>
+          {{else}}
+            <dds-top-nav-item href="{{url}}" title="{{title}}"></dds-top-nav-item>
+          {{/if}}
+        {{/each}}
+      </dds-top-nav>
+      <dds-masthead-search-container></dds-masthead-search-container>
+      <dds-masthead-global-bar>
+        <dds-masthead-profile authenticated>
+          {{#each profileItems}}
+            <dds-masthead-profile-item href="{{href}}">{{title}}</dds-masthead-profile-item>
+          {{/each}}
+        </dds-masthead-profile>
+      </dds-masthead-global-bar>
+      <dds-left-nav-overlay></dds-left-nav-overlay>
+      <dds-left-nav menu-bar-label="IBM [Platform]">
+        {{#each navLinks}}
+          {{#if menuItems}}
+            <dds-left-nav-menu title="{{title}}">
+              {{#each menuItems}}
+                <dds-left-nav-menu-item href="{{url}}" title="{{title}}"></dds-left-nav-menu-item>
+              {{/each}}
+            </dds-left-nav-menu>
+          {{else}}
+            <dds-left-nav-item href="{{url}}" title="{{title}}"></dds-left-nav-item>
+          {{/if}}
+        {{/each}}
+      </dds-left-nav>
+    </dds-masthead>
+    <main class="bx--content dds-ce-demo--ui-shell-content">
+      <div class="bx--grid">
+        <div class="bx--row">
+          <div class="bx--col-lg-13">
+            <h2>
+              Purpose and function
+            </h2>
+            <p>
+              The shell is perhaps the most crucial piece of any UI built with Carbon. It contains the shared navigation framework
+              for the entire design system and ties the products in IBM’s portfolio together in a cohesive and elegant way. The
+              shell is the home of the topmost navigation, where users can quickly and dependably gain their bearings and move
+              between pages.
+              <br />
+              <br />
+              The shell was designed with maximum flexibility built in, to serve the needs of a broad range of products and users.
+              Adopting the shell ensures compliance with IBM design standards, simplifies development efforts, and provides great
+              user experiences. All IBM products built with Carbon are required to use the shell’s header.
+              <br />
+              <br />
+              To better understand the purpose and function of the UI shell, consider the “shell” of MacOS, which contains the Apple
+              menu, top-level navigation, and universal, OS-level controls at the top of the screen, as well as a universal dock
+              along the bottom or side of the screen. The Carbon UI shell is roughly analogous in function to these parts of the Mac
+              UI. For example, the app switcher portion of the shell can be compared to the dock in MacOS.
+            </p>
+            <h2>
+              Header responsive behavior
+            </h2>
+            <p>
+              As a header scales down to fit smaller screen sizes, headers with persistent side nav menus should have the side nav
+              collapse into “hamburger” menu. See the example to better understand responsive behavior of the header.
+            </p>
+            <h2>
+              Secondary navigation
+            </h2>
+            <p>
+              The side-nav contains secondary navigation and fits below the header. It can be configured to be either fixed-width or
+              flexible, with only one level of nested items allowed. Both links and category lists can be used in the side-nav and
+              may be mixed together. There are several configurations of the side-nav, but only one configuration should be used per
+              product section. If tabs are needed on a page when using a side-nav, then the tabs are secondary in hierarchy to the
+              side-nav.
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+    <dds-footer>
+      <dds-footer-logo slot="brand"></dds-footer-logo>
+      <dds-footer-nav>
+        {{#each footerLinks}}
+          <dds-footer-nav-group title-text="{{title}}">
+            {{#each links}}
+              <dds-footer-nav-item href="{{url}}">{{title}}</dds-footer-nav-item>
+            {{/each}}
+          </dds-footer-nav-group>
+        {{/each}}
+      </dds-footer-nav>
+      <dds-locale-button slot="locale-button">{{langDisplay}}</dds-locale-button>
+      <dds-legal-nav slot="legal-nav">
+        {{#each legalLinks}}
+          <dds-legal-nav-item href="{{url}}">{{title}}</dds-legal-nav-item>
+        {{/each}}
+        <dds-legal-nav-cookie-preferences-placeholder></dds-legal-nav-cookie-preferences-placeholder>
+      </dds-legal-nav>
+    </dds-footer>
+    <dds-locale-modal
+      close-button-assistive-text="{{localeModal.modalClose}}"
+      header-title="{{localeModal.headerTitle}}"
+      lang-display="{{langDisplay}}"
+    >
+      <dds-regions>
+        {{#each regionList}}
+          {{#if countryList}}
+            <dds-region-item name="{{name}}"></dds-region-item>
+          {{else}}
+            <dds-region-item invalid name="{{name}}"></dds-region-item>
+          {{/if}}
+        {{/each}}
+      </dds-regions>
+      <dds-locale-search
+        close-button-assistive-text="{{localeModal.searchClearText}}"
+        label-text="{{localeModal.searchLabel}}"
+        placeholder="{{localeModal.searchPlaceholder}}"
+        availability-label-text="{{localeModal.availabilityText}}"
+        unavailability-label-text="{{localeModal.unavailabilityText}}"
+      >
+        {{#each allCountryList}}
+          <dds-locale-item country="{{country}}" href="{{href}}" language="{{language}}" locale="{{locale}}" region="{{region}}">
+          </dds-locale-item>
+        {{/each}}
+      </dds-locale-search>
+    </dds-locale-modal>
+  </body>
+</html>

--- a/packages/web-components/examples/codesandbox/usage/handlebars/package.json
+++ b/packages/web-components/examples/codesandbox/usage/handlebars/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "ibmdotcom-web-components-handlebars-example",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "webpack serve"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.0.0",
+    "css-loader": "^4.3.0",
+    "handlebars": "^4.7.0",
+    "html-webpack-plugin": "^4.5.0",
+    "node-sass": "^4.14.0",
+    "postcss": "^8.1.0",
+    "postcss-loader": "^4.0.0",
+    "sass-loader": "^10.0.0",
+    "style-loader": "^2.0.0",
+    "webpack": "^4.0.0",
+    "webpack-cli": "^4.0.0",
+    "webpack-dev-server": "^3.11.0"
+  },
+  "dependencies": {
+    "@carbon/ibmdotcom-services": "canary",
+    "@carbon/ibmdotcom-web-components": "canary",
+    "accept-language-parser": "^1.5.0",
+    "carbon-components": "^10.21.0",
+    "carbon-web-components": "^1.7.1",
+    "lit-element": "^2.4.0",
+    "lit-html": "^1.3.0"
+  }
+}

--- a/packages/web-components/examples/codesandbox/usage/handlebars/sandbox.config.json
+++ b/packages/web-components/examples/codesandbox/usage/handlebars/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}

--- a/packages/web-components/examples/codesandbox/usage/handlebars/src/index.js
+++ b/packages/web-components/examples/codesandbox/usage/handlebars/src/index.js
@@ -1,0 +1,18 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '@carbon/ibmdotcom-web-components/es/components/masthead/masthead-container.js';
+import '@carbon/ibmdotcom-web-components/es/components/footer/footer-container.js';
+import './index.scss';
+
+document.addEventListener('click', event => {
+  if (event.target.matches('dds-locale-button')) {
+    document.querySelector('dds-locale-modal').open = true;
+  }
+});

--- a/packages/web-components/examples/codesandbox/usage/handlebars/src/index.scss
+++ b/packages/web-components/examples/codesandbox/usage/handlebars/src/index.scss
@@ -1,0 +1,31 @@
+//
+// @license
+//
+// Copyright IBM Corp. 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import 'carbon-components/scss/globals/grid/grid';
+@import 'carbon-components/scss/components/ui-shell/content';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/font-face/mono';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/font-face/sans';
+
+@include carbon--font-face-mono();
+@include carbon--font-face-sans();
+
+body {
+  visibility: inherit; // Initially hidden to avoid FOUC
+  padding: calc(#{mini-units(6)} + 1px) 0 0 0;
+}
+
+.bx--content.dds-ce-demo--ui-shell-content {
+  h2 {
+    margin: 30px 0;
+
+    &:first-of-type {
+      margin-top: 0;
+    }
+  }
+}

--- a/packages/web-components/examples/codesandbox/usage/handlebars/webpack.config.js
+++ b/packages/web-components/examples/codesandbox/usage/handlebars/webpack.config.js
@@ -1,0 +1,149 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const path = require('path');
+const acceptLanguageParser = require('accept-language-parser');
+const autoprefixer = require('autoprefixer');
+const Handlebars = require('handlebars');
+const sass = require('node-sass');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { default: LocaleAPI } = require('@carbon/ibmdotcom-services/lib/services/Locale/Locale');
+const { default: TranslateAPI } = require('@carbon/ibmdotcom-services/lib/services/Translation/Translation');
+
+const templateCache = {};
+
+global.sessionStorage = {
+  getItem() {
+    return '""';
+  },
+  setItem() {},
+};
+
+const devServer = {
+  contentBase: path.resolve(__dirname, 'src'),
+  setup(app, server) {
+    app.get('/', (req, res) => {
+      const { fileSystem, waitUntilValid } = server.middleware;
+      waitUntilValid(async () => {
+        // Determins user's preferred language
+        const { code, region } = acceptLanguageParser.parse(req.headers['accept-language'])[0];
+        // Loads translation, etc. data from IBM.com services
+        const [langDisplay, localeList, translation] = await Promise.all([
+          LocaleAPI.getLangDisplay({
+            cc: region,
+            lc: code,
+          }),
+          LocaleAPI.getList({
+            cc: region,
+            lc: code,
+          }),
+          TranslateAPI.getTranslation({
+            cc: region,
+            lc: code,
+          }),
+        ]);
+        // Creates the sorted list of available locales
+        const collator = new Intl.Collator(`${code}-${region}`);
+        const sortCountries = countries => countries.sort((lhs, rhs) => collator.compare(lhs.name, rhs.name));
+        const locales = new Map();
+        localeList.regionList.forEach(({ countryList, name: regionItem }) => {
+          sortCountries(countryList).forEach(({ name: countryItem, locale: localeItems }) => {
+            localeItems.forEach(([localeItem, languageItem]) => {
+              const localeTokens = /^(\w+)-(\w+)$/.exec(localeItem) || [];
+              locales.set(localeItem, {
+                locale: localeItem,
+                region: regionItem,
+                country: countryItem,
+                href: `https://www.ibm.com/${localeTokens[2]}-${localeTokens[1]}`,
+                language: languageItem,
+              });
+            });
+          });
+        });
+        // Renders the Handlebars template from the data
+        const filename = path.resolve(__dirname, 'dist/index.hbs');
+        if (!templateCache[filename]) {
+          templateCache[filename] = Handlebars.compile(fileSystem.readFileSync(filename).toString());
+        }
+        const { mastheadNav, profileMenu, footerMenu, footerThin } = translation;
+        const { localeModal, regionList } = localeList;
+        res.setHeader('Content-Type', 'text/html');
+        res.setHeader('Cache-Control', 'public, max-age=0');
+        res.send(
+          templateCache[filename]({
+            allCountryList: Array.from(locales.values()),
+            langDisplay,
+            navLinks: mastheadNav.links.map(link => ({
+              ...link,
+              menuItems: !link.menuSections
+                ? undefined
+                : link.menuSections.reduce((acc, { menuItems }) => acc.concat(menuItems), []),
+            })),
+            profileItems: profileMenu.signedin,
+            footerLinks: footerMenu,
+            legalLinks: footerThin,
+            regionList,
+            localeModal,
+          })
+        );
+        res.end();
+      });
+    });
+  },
+};
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.scss$/,
+        sideEffects: true,
+        use: [
+          'style-loader',
+          'css-loader',
+          {
+            loader: 'postcss-loader',
+            options: {
+              postcssOptions: {
+                // `autoprefixer` is a requirement for Carbon core Sass code
+                plugins: [autoprefixer],
+              },
+            },
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              implementation: sass,
+              sassOptions: {
+                includePaths: ['node_modules'],
+                // `enable-css-custom-properties` feature flag is a requirement for Carbon for IBM.com styles
+                data: `
+                  $feature-flags: (
+                    enable-css-custom-properties: true,
+                  );
+                `,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    // Puts `.hbs` file into WebPack Dev Server's virtual file system.
+    // If you have other means to load `.hbs` file, this is not needed.
+    new HtmlWebpackPlugin({
+      template: 'index.hbs',
+      filename: 'index.hbs',
+    }),
+  ],
+  devServer,
+};


### PR DESCRIPTION
### Description

Introduces the guide to use our Web Components library with a server-side template like Handlebars, along with a CodeSandbox example.

### Changelog

**New**

- The guide to use our Web Components library with a server-side template like Handlebars
- CodeSandbox example for above usage.