### PR TITLE
chore(services-store): added null check of services-store vendor folder

### DIFF
--- a/packages/web-components/gulp-tasks/config.js
+++ b/packages/web-components/gulp-tasks/config.js
@@ -28,13 +28,6 @@ const { browser: browsers, spec: specs, ...rest } = commander
   .parse(process.argv);
 const cloptions = { browsers: Array.from(browsers), specs: Array.from(specs), ...rest };
 
-let servicesStoreLink;
-try {
-  servicesStoreLink = path.resolve(path.dirname(require.resolve('@carbon/ibmdotcom-services-store/package.json')), 'es');
-} catch (err) {
-  servicesStoreLink = null;
-}
-
 module.exports = {
   ENV_PRODUCTION: 'production',
   cloptions,
@@ -45,7 +38,7 @@ module.exports = {
   sassDestDir: 'scss',
   tasksDir: 'gulp-tasks',
   testsDir: 'tests',
-  servicesStoreESSrcDir: servicesStoreLink,
+  servicesStoreESSrcDir: path.resolve(__dirname, '../../services-store/es'),
   servicesStoreVendorSrcDir: path.resolve(__dirname, '../src/internal/vendor/@carbon/ibmdotcom-services-store'),
   servicesStoreVendorESDstDir: path.resolve(__dirname, '../es/internal/vendor/@carbon/ibmdotcom-services-store'),
 };

--- a/packages/web-components/gulp-tasks/config.js
+++ b/packages/web-components/gulp-tasks/config.js
@@ -28,6 +28,13 @@ const { browser: browsers, spec: specs, ...rest } = commander
   .parse(process.argv);
 const cloptions = { browsers: Array.from(browsers), specs: Array.from(specs), ...rest };
 
+let servicesStoreLink;
+try {
+  servicesStoreLink = path.resolve(path.dirname(require.resolve('@carbon/ibmdotcom-services-store/package.json')), 'es');
+} catch (err) {
+  servicesStoreLink = null;
+}
+
 module.exports = {
   ENV_PRODUCTION: 'production',
   cloptions,
@@ -38,7 +45,7 @@ module.exports = {
   sassDestDir: 'scss',
   tasksDir: 'gulp-tasks',
   testsDir: 'tests',
-  servicesStoreESSrcDir: path.resolve(path.dirname(require.resolve('@carbon/ibmdotcom-services-store/package.json')), 'es'),
+  servicesStoreESSrcDir: servicesStoreLink,
   servicesStoreVendorSrcDir: path.resolve(__dirname, '../src/internal/vendor/@carbon/ibmdotcom-services-store'),
   servicesStoreVendorESDstDir: path.resolve(__dirname, '../es/internal/vendor/@carbon/ibmdotcom-services-store'),
 };


### PR DESCRIPTION
### Related Ticket(s)

#3258 

### Description

The motivation of this PR is that a `yarn reset` would fail if the
vendor folder for the service store doesn't exist, primarily during a
`gulp clean`. In order to allow the `gulp clean` to continue, it cannot
have an exit code 1 if the folder doesn't exist, and just continue with
the clean.

The full `yarn install`/`yarn build` works afterwards, as the link works
after that.

### Changelog

**Changed**

- added null check for `servicesStoreESSrcDir` in gulp `config.js`