### PR TITLE
chore(dotcomshell): add WithL1 story

### DIFF
--- a/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
+++ b/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
@@ -10,6 +10,7 @@ import Content from './data/content';
 import DotcomShell from '../DotcomShell';
 import { Micro as footerMicroStory } from '../../Footer/__stories__/Footer.stories.js';
 import { Default as footerStory } from '../../Footer/__stories__/Footer.stories.js';
+import { WithL1 as l1Story } from '../../Masthead/__stories__/Masthead.stories.js';
 import languageItems from '../../Footer/__data__/language-items.json';
 import { Default as mastheadStory } from '../../Masthead/__stories__/Masthead.stories.js';
 import React from 'react';
@@ -275,6 +276,25 @@ MicroFooterLanguageOnly.story = {
                   groupId
                 ),
             languageInitialItem: { id: 'en', text: 'English' },
+          },
+        };
+      },
+    },
+  },
+};
+
+export const WithL1 = ({ parameters }) => <Default parameters={parameters} />;
+
+WithL1.story = {
+  name: 'With L1',
+  parameters: {
+    knobs: {
+      escapeHTML: false,
+      DotcomShell: () => {
+        const { Masthead: mastheadKnobs } = l1Story.story.parameters.knobs;
+        return {
+          mastheadProps: {
+            ...mastheadKnobs({ groupId: 'Masthead' }),
           },
         };
       },

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -161,18 +161,34 @@ WithL1.story = {
   parameters: {
     knobs: {
       escapeHTML: false,
-      Masthead: ({ groupId }) => ({
-        ...Default.story.parameters.knobs.Masthead({ groupId }),
-        mastheadL1Data: {
-          title: text('L1 title (title)', 'Stock Charts', groupId),
-          titleLink: text(
-            'L1 title link (titleLink)',
-            'https://example.com/',
+      Masthead: ({ groupId }) => {
+        return {
+          hasProfile: boolean(
+            'show the profile functionality (hasProfile)',
+            true,
             groupId
           ),
-          navigationL1: mastheadKnobs.navigation.custom,
-        },
-      }),
+          hasSearch: boolean(
+            'show the search functionality (hasSearch)',
+            true,
+            groupId
+          ),
+          placeHolderText: text(
+            'search placeholder (placeHolderText)',
+            'Search all of IBM',
+            groupId
+          ),
+          mastheadL1Data: {
+            title: text('L1 title (title)', 'Stock Charts', groupId),
+            titleLink: text(
+              'L1 title link (titleLink)',
+              'https://example.com/',
+              groupId
+            ),
+            navigationL1: mastheadKnobs.navigation.custom,
+          },
+        };
+      },
     },
   },
 };


### PR DESCRIPTION
### Description

Adds `WithL1` story to `DotcomShell` in React Storybook

### Changelog

**New**

- `WithL1` story to `DotcomShell`

**Changed**

- clean up knobs in `Masthead: WithL1` story


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
