### PR TITLE
fix(linklist): fix linklist focus styles

### DIFF
--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -88,7 +88,8 @@
     }
 
     .#{$prefix}--card:focus {
-      outline-color: $focus;
+      outline: 2px solid $focus;
+      outline-offset: -2px;
     }
 
     .#{$prefix}--card.#{$prefix}--tile {
@@ -101,6 +102,10 @@
         @include use-carbon-productive-tokens();
         @include carbon--type-style('body-short-01');
       }
+    }
+
+    &:focus {
+      outline: none;
     }
   }
 

--- a/packages/web-components/src/components/link-list/link-list.scss
+++ b/packages/web-components/src/components/link-list/link-list.scss
@@ -22,6 +22,11 @@
       flex: 1;
     }
   }
+
+  &:focus {
+    outline: 2px solid $focus;
+    outline-offset: -2px;
+  }
 }
 
 :host(#{$dds-prefix}-link-list):last-of-type {


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Fix focus styles for web components `LinkList`

![image](https://user-images.githubusercontent.com/909118/96631066-daa42a00-12e3-11eb-9e78-dfdaf4400a58.png)


### Changelog

**Changed**

- `LinkList` focus styles

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
