### PR TITLE
fix(lightbox-m-viewer): adding again `autoPlay` to video

### DIFF
--- a/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
+++ b/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
@@ -105,7 +105,7 @@ const LightboxMediaViewer = ({ media, onClose, ...modalProps }) => {
               <div
                 className={`${prefix}--lightbox-media-viewer__media ${prefix}--no-gutter`}>
                 {media.type === 'video' ? (
-                  <VideoPlayer videoId={media.src} />
+                  <VideoPlayer videoId={media.src} autoPlay />
                 ) : (
                   <Image defaultSrc={media.src} alt={videoData.alt} />
                 )}


### PR DESCRIPTION
### Description

For some reason, removing the `autoPlay` prop from `VideoPlayer` at the `LightboxMediaViewer` is causing:
 - the video thumb to not fully occupy the available space for the video;
 - the lightbox media viewer to close on video click.
