### PR TITLE
fix(megamenu): added protection to fix layout problem

### DIFF
--- a/packages/react/src/components/Masthead/MastheadMegaMenu/CategoryGroup.js
+++ b/packages/react/src/components/Masthead/MastheadMegaMenu/CategoryGroup.js
@@ -18,22 +18,26 @@ const { prefix } = settings;
  */
 const CategoryGroup = ({ href, title, children, ...rest }) => (
   <div className={`${prefix}--masthead__megamenu__category-group`}>
-    {href ? (
-      <LinkWithIcon
-        href={href}
-        className={`${prefix}--masthead__megamenu__category-headline`}
-        data-autoid={`${rest.autoid}-list${rest.index}`}>
-        <span>{title}</span>
-        <ArrowRight16 />
-      </LinkWithIcon>
-    ) : (
-      <div
-        className={`${prefix}--masthead__megamenu__category-headline`}
-        data-autoid={`${rest.autoid}-list${rest.index}`}>
-        <p>{title}</p>
+    <div className={`${prefix}--masthead__megamenu__category-group-shield`}>
+      <div className={`${prefix}--masthead__megamenu__category-group-content`}>
+        {href ? (
+          <LinkWithIcon
+            href={href}
+            className={`${prefix}--masthead__megamenu__category-headline`}
+            data-autoid={`${rest.autoid}-list${rest.index}`}>
+            <span>{title}</span>
+            <ArrowRight16 />
+          </LinkWithIcon>
+        ) : (
+          <div
+            className={`${prefix}--masthead__megamenu__category-headline`}
+            data-autoid={`${rest.autoid}-list${rest.index}`}>
+            <p>{title}</p>
+          </div>
+        )}
+        {children}
       </div>
-    )}
-    {children}
+    </div>
   </div>
 );
 

--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -111,8 +111,8 @@
   }
 
   .#{$prefix}--masthead__megamenu__categories {
-    column-count: 4;
     padding: 0 0 $layout-03 $layout-01;
+    column-count: 4;
 
     .#{$prefix}--masthead__megamenu__container--hasHighlights & {
       column-count: 3;
@@ -127,14 +127,16 @@
   }
 
   .#{$prefix}--masthead__megamenu__category-group {
-    display: flex;
-    flex-direction: column;
-    padding-bottom: $spacing-07;
-    overflow: hidden;
-    break-inside: avoid-column;
+    display: inline;
 
-    .#{$prefix}--masthead__megamenu__categories-section & {
+    .#{$prefix}--masthead__megamenu__categories-section &-shield {
       margin-left: -1rem;
+    }
+
+    &-content {
+      width: 100%;
+      display: inline-block;
+      padding-bottom: $spacing-07;
     }
   }
 
@@ -174,6 +176,7 @@
     color: $text-02;
     text-decoration: none;
     padding: 7px $spacing-05;
+    display: block;
 
     &:hover,
     &:active {


### PR DESCRIPTION
### Related Ticket(s)

fixes #4078 

### Description

What a fickle little layout problem we have here. I saw we were having trouble with this and had an idea of how to fix it. Basically, I threw in one or two wrapping divs to help protect the content, and render consistently across the board. It looks like it's working from my perspective and understanding, but let me know if I missed some consideration here.

### Changelog

**Changed**

- Added two new divs to help protect content and help fix 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
