### PR TITLE
docs(example): introduce RTL example

### DIFF
--- a/packages/web-components/docs/enable-rtl.md
+++ b/packages/web-components/docs/enable-rtl.md
@@ -1,0 +1,28 @@
+## Using RTL version of CSS
+
+`@carbon/ibmdotcom-web-components` ships both LTR/RTL versions of CSS modules in `lit-element`'s [`css` tagged template](https://lit-element.polymer-project.org/guide/styles#add-styles). They have `.css.js` and `.rtl.css.js` extensions, respectively. The Web Components modules loads the LTR versions by default, but you can let those modules load the RTL versions with a technique called "dependency injection".
+
+[Webpack `NormalModuleReplacementPlugin`](https://webpack.js.org/plugins/normal-module-replacement-plugin/) is one of those let you do dependency injection. Below example lets the Web Components modules load `.rtl.css.js` whenever our Web Components module tries to load `.css.js`:
+
+```javascript
+const reCssBundle = /\.css\.js$/i;
+
+...
+
+module.exports = {
+  ...
+  plugins: [
+    ...
+    new webpack.NormalModuleReplacementPlugin(reCssBundle, resource => {
+      resource.request = resource.request.replace(reCssBundle, '.rtl.css.js');
+    }),
+  ],
+  ...
+};
+```
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/usage/rtl)
+> example implementation.
+
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/usage/rtl)

--- a/packages/web-components/docs/enable-rtl.stories.mdx
+++ b/packages/web-components/docs/enable-rtl.stories.mdx
@@ -1,5 +1,5 @@
 import { Description, Meta } from '@storybook/addon-docs/blocks';
-import readme from '../../../docs/enable-rtl.md';
+import readme from './enable-rtl.md';
 
 <Meta title="Overview/Enable Right-to-Left (RTL)" />
 

--- a/packages/web-components/examples/codesandbox/usage/rtl/index.hbs
+++ b/packages/web-components/examples/codesandbox/usage/rtl/index.hbs
@@ -1,0 +1,272 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html dir="{{dir}}" lang="{{lang}}">
+  <head>
+    <script type="text/javascript">
+      // The minimum prerequisite to use our service for translation data, etc.
+      window.digitalData = {
+        page: {
+          pageInfo: {
+            language: '{{lang}}',
+            ibm: {
+              siteID: 'IBMTESTWWW',
+            },
+          },
+          isDataLayerReady: true,
+        },
+      };
+    </script>
+    <title>@carbon/ibmdotcom-web-components example</title>
+    <meta charset="UTF-8" />
+    <style type="text/css">
+      html, body {
+        margin: 0;
+      }
+
+      /* Minimum setting to use IBM Plex font */
+      @font-face {
+        font-weight: 400;
+        font-family: 'IBM Plex Sans';
+        font-style: normal;
+        src:
+          local('IBM Plex Sans'), local('IBMPlexSans'), url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+        font-display: auto;
+      }
+
+      @font-face {
+        font-weight: 600;
+        font-family: 'IBM Plex Sans';
+        font-style: normal;
+        src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'), url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+        font-display: auto;
+      }
+
+      /* From: https://github.com/carbon-design-system/carbon/blob/v10.22.0/packages/type/scss/_reset.scss#L31-L32 */
+      body {
+        font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+        text-rendering: optimizeLegibility;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* From: https://github.com/carbon-design-system/carbon/blob/v10.22.0/packages/type/scss/_reset.scss#L48-L84 */
+      h2, p {
+        font-weight: 400;
+        letter-spacing: 0;
+      }
+
+      h2 {
+        font-size: 2rem;
+        line-height: 1.25;
+      }
+
+      p {
+        font-size: 1rem;
+        line-height: 1.5;
+      }
+
+      /* Margin settings for demo content */
+      h2:first-of-type {
+        margin-top: 0;
+      }
+
+      main {
+        margin: calc(3rem + 1px) auto 0 auto;
+        padding: 3rem;
+        max-width: 99rem;
+      }
+    </style>
+    <script src="bundle-{{dir}}.js"></script>
+    <!-- The minimum prerequisite to use our locale selector -->
+    <link rel="alternate" hreflang="en-us" href="https://www.ibm.com/us-en/">
+    <link rel="alternate" hreflang="x-default" href="https://www.ibm.com">
+    <link rel="alternate" hreflang="en-af" href="https://www.ibm.com/af-en">
+    <link rel="alternate" hreflang="fr-dz" href="https://www.ibm.com/dz-fr">
+    <link rel="alternate" hreflang="pt-ao" href="https://www.ibm.com/ao-pt">
+    <link rel="alternate" hreflang="en-ai" href="https://www.ibm.com/ai-en">
+    <link rel="alternate" hreflang="en-ag" href="https://www.ibm.com/ag-en">
+    <link rel="alternate" hreflang="es-ar" href="https://www.ibm.com/ar-es">
+    <link rel="alternate" hreflang="en-aw" href="https://www.ibm.com/aw-en">
+    <link rel="alternate" hreflang="en-au" href="https://www.ibm.com/au-en">
+    <link rel="alternate" hreflang="de-at" href="https://www.ibm.com/at-de">
+    <link rel="alternate" hreflang="en-bs" href="https://www.ibm.com/bs-en">
+    <link rel="alternate" hreflang="en-bh" href="https://www.ibm.com/bh-en">
+    <link rel="alternate" hreflang="en-bd" href="https://www.ibm.com/bd-en">
+    <link rel="alternate" hreflang="en-bb" href="https://www.ibm.com/bb-en">
+    <link rel="alternate" hreflang="en-be" href="https://www.ibm.com/be-en">
+    <link rel="alternate" hreflang="en-bm" href="https://www.ibm.com/bm-en">
+    <link rel="alternate" hreflang="es-bo" href="https://www.ibm.com/bo-es">
+    <link rel="alternate" hreflang="en-bw" href="https://www.ibm.com/bw-en">
+    <link rel="alternate" hreflang="pt-br" href="https://www.ibm.com/br-pt">
+    <link rel="alternate" hreflang="en-vg" href="https://www.ibm.com/vg-en">
+    <link rel="alternate" hreflang="en-bn" href="https://www.ibm.com/bn-en">
+    <link rel="alternate" hreflang="en-bg" href="https://www.ibm.com/bg-en">
+    <link rel="alternate" hreflang="fr-bf" href="https://www.ibm.com/bf-fr">
+    <link rel="alternate" hreflang="en-kh" href="https://www.ibm.com/kh-en">
+    <link rel="alternate" hreflang="fr-cm" href="https://www.ibm.com/cm-fr">
+    <link rel="alternate" hreflang="en-ca" href="https://www.ibm.com/ca-en">
+    <link rel="alternate" hreflang="fr-ca" href="https://www.ibm.com/ca-fr">
+    <link rel="alternate" hreflang="en-ky" href="https://www.ibm.com/ky-en">
+    <link rel="alternate" hreflang="fr-td" href="https://www.ibm.com/td-fr">
+    <link rel="alternate" hreflang="es-cl" href="https://www.ibm.com/cl-es">
+    <link rel="alternate" hreflang="zh-cn" href="https://www.ibm.com/cn-zh">
+    <link rel="alternate" hreflang="es-co" href="https://www.ibm.com/co-es">
+    <link rel="alternate" hreflang="fr-cd" href="https://www.ibm.com/cd-fr">
+    <link rel="alternate" hreflang="fr-cg" href="https://www.ibm.com/cg-fr">
+    <link rel="alternate" hreflang="es-cr" href="https://www.ibm.com/cr-es">
+    <link rel="alternate" hreflang="en-hr" href="https://www.ibm.com/hr-en">
+    <link rel="alternate" hreflang="en-cw" href="https://www.ibm.com/cw-en">
+    <link rel="alternate" hreflang="en-cy" href="https://www.ibm.com/cy-en">
+    <link rel="alternate" hreflang="en-cz" href="https://www.ibm.com/cz-en">
+    <link rel="alternate" hreflang="en-dm" href="https://www.ibm.com/dm-en">
+    <link rel="alternate" hreflang="en-dk" href="https://www.ibm.com/dk-en">
+    <link rel="alternate" hreflang="es-ec" href="https://www.ibm.com/ec-es">
+    <link rel="alternate" hreflang="en-eg" href="https://www.ibm.com/eg-en">
+    <link rel="alternate" hreflang="en-ee" href="https://www.ibm.com/ee-en">
+    <link rel="alternate" hreflang="en-et" href="https://www.ibm.com/et-en">
+    <link rel="alternate" hreflang="en-fi" href="https://www.ibm.com/fi-en">
+    <link rel="alternate" hreflang="fr-fr" href="https://www.ibm.com/fr-fr">
+    <link rel="alternate" hreflang="fr-ga" href="https://www.ibm.com/ga-fr">
+    <link rel="alternate" hreflang="de-de" href="https://www.ibm.com/de-de">
+    <link rel="alternate" hreflang="en-gh" href="https://www.ibm.com/gh-en">
+    <link rel="alternate" hreflang="en-gr" href="https://www.ibm.com/gr-en">
+    <link rel="alternate" hreflang="en-gd" href="https://www.ibm.com/gd-en">
+    <link rel="alternate" hreflang="en-gy" href="https://www.ibm.com/gy-en">
+    <link rel="alternate" hreflang="en-hk" href="https://www.ibm.com/hk-en">
+    <link rel="alternate" hreflang="en-hu" href="https://www.ibm.com/hu-en">
+    <link rel="alternate" hreflang="en-in" href="https://www.ibm.com/in-en">
+    <link rel="alternate" hreflang="en-id" href="https://www.ibm.com/id-en">
+    <link rel="alternate" hreflang="en-iq" href="https://www.ibm.com/iq-en">
+    <link rel="alternate" hreflang="en-ie" href="https://www.ibm.com/ie-en">
+    <link rel="alternate" hreflang="en-il" href="https://www.ibm.com/il-en">
+    <link rel="alternate" hreflang="it-it" href="https://www.ibm.com/it-it">
+    <link rel="alternate" hreflang="fr-ci" href="https://www.ibm.com/ci-fr">
+    <link rel="alternate" hreflang="en-jm" href="https://www.ibm.com/jm-en">
+    <link rel="alternate" hreflang="ja-jp" href="https://www.ibm.com/jp-ja">
+    <link rel="alternate" hreflang="en-jo" href="https://www.ibm.com/jo-en">
+    <link rel="alternate" hreflang="en-kz" href="https://www.ibm.com/kz-en">
+    <link rel="alternate" hreflang="en-ke" href="https://www.ibm.com/ke-en">
+    <link rel="alternate" hreflang="ko-kr" href="https://www.ibm.com/kr-ko">
+    <link rel="alternate" hreflang="en-kw" href="https://www.ibm.com/kw-en">
+    <link rel="alternate" hreflang="en-lv" href="https://www.ibm.com/lv-en">
+    <link rel="alternate" hreflang="en-lb" href="https://www.ibm.com/lb-en">
+    <link rel="alternate" hreflang="en-ly" href="https://www.ibm.com/ly-en">
+    <link rel="alternate" hreflang="en-lt" href="https://www.ibm.com/lt-en">
+    <link rel="alternate" hreflang="en-mw" href="https://www.ibm.com/mw-en">
+    <link rel="alternate" hreflang="en-my" href="https://www.ibm.com/my-en">
+    <link rel="alternate" hreflang="fr-mu" href="https://www.ibm.com/mu-fr">
+    <link rel="alternate" hreflang="es-mx" href="https://www.ibm.com/mx-es">
+    <link rel="alternate" hreflang="en-ms" href="https://www.ibm.com/ms-en">
+    <link rel="alternate" hreflang="fr-ma" href="https://www.ibm.com/ma-fr">
+    <link rel="alternate" hreflang="pt-mz" href="https://www.ibm.com/mz-pt">
+    <link rel="alternate" hreflang="en-na" href="https://www.ibm.com/na-en">
+    <link rel="alternate" hreflang="en-np" href="https://www.ibm.com/np-en">
+    <link rel="alternate" hreflang="en-nl" href="https://www.ibm.com/nl-en">
+    <link rel="alternate" hreflang="en-nz" href="https://www.ibm.com/nz-en">
+    <link rel="alternate" hreflang="fr-ne" href="https://www.ibm.com/ne-fr">
+    <link rel="alternate" hreflang="en-ng" href="https://www.ibm.com/ng-en">
+    <link rel="alternate" hreflang="en-no" href="https://www.ibm.com/no-en">
+    <link rel="alternate" hreflang="en-om" href="https://www.ibm.com/om-en">
+    <link rel="alternate" hreflang="en-pk" href="https://www.ibm.com/pk-en">
+    <link rel="alternate" hreflang="es-py" href="https://www.ibm.com/py-es">
+    <link rel="alternate" hreflang="es-pe" href="https://www.ibm.com/pe-es">
+    <link rel="alternate" hreflang="en-ph" href="https://www.ibm.com/ph-en">
+    <link rel="alternate" hreflang="pl-pl" href="https://www.ibm.com/pl-pl">
+    <link rel="alternate" hreflang="en-pt" href="https://www.ibm.com/pt-en">
+    <link rel="alternate" hreflang="en-qa" href="https://www.ibm.com/qa-en">
+    <link rel="alternate" hreflang="en-ro" href="https://www.ibm.com/ro-en">
+    <link rel="alternate" hreflang="ru-ru" href="https://www.ibm.com/ru-ru">
+    <link rel="alternate" hreflang="en-kn" href="https://www.ibm.com/kn-en">
+    <link rel="alternate" hreflang="en-lc" href="https://www.ibm.com/lc-en">
+    <link rel="alternate" hreflang="en-vc" href="https://www.ibm.com/vc-en">
+    <link rel="alternate" hreflang="en-sa" href="https://www.ibm.com/sa-en">
+    <link rel="alternate" hreflang="fr-sn" href="https://www.ibm.com/sn-fr">
+    <link rel="alternate" hreflang="en-rs" href="https://www.ibm.com/rs-en">
+    <link rel="alternate" hreflang="fr-sc" href="https://www.ibm.com/sc-fr">
+    <link rel="alternate" hreflang="en-sl" href="https://www.ibm.com/sl-en">
+    <link rel="alternate" hreflang="en-sg" href="https://www.ibm.com/sg-en">
+    <link rel="alternate" hreflang="en-sk" href="https://www.ibm.com/sk-en">
+    <link rel="alternate" hreflang="en-si" href="https://www.ibm.com/si-en">
+    <link rel="alternate" hreflang="en-za" href="https://www.ibm.com/za-en">
+    <link rel="alternate" hreflang="es-es" href="https://www.ibm.com/es-es">
+    <link rel="alternate" hreflang="en-lk" href="https://www.ibm.com/lk-en">
+    <link rel="alternate" hreflang="en-sr" href="https://www.ibm.com/sr-en">
+    <link rel="alternate" hreflang="en-se" href="https://www.ibm.com/se-en">
+    <link rel="alternate" hreflang="fr-ch" href="https://www.ibm.com/ch-fr">
+    <link rel="alternate" hreflang="de-ch" href="https://www.ibm.com/ch-de">
+    <link rel="alternate" hreflang="zh-tw" href="https://www.ibm.com/tw-zh">
+    <link rel="alternate" hreflang="en-tz" href="https://www.ibm.com/tz-en">
+    <link rel="alternate" hreflang="en-th" href="https://www.ibm.com/th-en">
+    <link rel="alternate" hreflang="en-tt" href="https://www.ibm.com/tt-en">
+    <link rel="alternate" hreflang="fr-tn" href="https://www.ibm.com/tn-fr">
+    <link rel="alternate" hreflang="tr-tr" href="https://www.ibm.com/tr-tr">
+    <link rel="alternate" hreflang="en-ye" href="https://www.ibm.com/ye-en">
+    <link rel="alternate" hreflang="en-tc" href="https://www.ibm.com/tc-en">
+    <link rel="alternate" hreflang="en-ua" href="https://www.ibm.com/ua-en">
+    <link rel="alternate" hreflang="en-ug" href="https://www.ibm.com/ug-en">
+    <link rel="alternate" hreflang="en-ae" href="https://www.ibm.com/ae-en">
+    <link rel="alternate" hreflang="en-gb" href="https://www.ibm.com/uk-en">
+    <link rel="alternate" hreflang="es-uy" href="https://www.ibm.com/uy-es">
+    <link rel="alternate" hreflang="en-uz" href="https://www.ibm.com/uz-en">
+    <link rel="alternate" hreflang="es-ve" href="https://www.ibm.com/ve-es">
+    <link rel="alternate" hreflang="en-vn" href="https://www.ibm.com/vn-en">
+    <link rel="alternate" hreflang="en-zm" href="https://www.ibm.com/zm-en">
+    <link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en">
+  </head>
+  <body>
+    <dds-masthead-container></dds-masthead-container>
+    <main class="bx--content dds-ce-demo--ui-shell-content">
+      <div class="bx--grid">
+        <div class="bx--row">
+          <div class="bx--col-lg-13">
+            <p>Change browser's <code>Accept-Language</code> setting to switch the UI direction.</p>
+            <h2>
+              Purpose and function
+            </h2>
+            <p>
+              The shell is perhaps the most crucial piece of any UI built with Carbon. It contains the shared navigation framework
+              for the entire design system and ties the products in IBM’s portfolio together in a cohesive and elegant way. The
+              shell is the home of the topmost navigation, where users can quickly and dependably gain their bearings and move
+              between pages.
+              <br />
+              <br />
+              The shell was designed with maximum flexibility built in, to serve the needs of a broad range of products and users.
+              Adopting the shell ensures compliance with IBM design standards, simplifies development efforts, and provides great
+              user experiences. All IBM products built with Carbon are required to use the shell’s header.
+              <br />
+              <br />
+              To better understand the purpose and function of the UI shell, consider the “shell” of MacOS, which contains the Apple
+              menu, top-level navigation, and universal, OS-level controls at the top of the screen, as well as a universal dock
+              along the bottom or side of the screen. The Carbon UI shell is roughly analogous in function to these parts of the Mac
+              UI. For example, the app switcher portion of the shell can be compared to the dock in MacOS.
+            </p>
+            <h2>
+              Header responsive behavior
+            </h2>
+            <p>
+              As a header scales down to fit smaller screen sizes, headers with persistent side nav menus should have the side nav
+              collapse into “hamburger” menu. See the example to better understand responsive behavior of the header.
+            </p>
+            <h2>
+              Secondary navigation
+            </h2>
+            <p>
+              The side-nav contains secondary navigation and fits below the header. It can be configured to be either fixed-width or
+              flexible, with only one level of nested items allowed. Both links and category lists can be used in the side-nav and
+              may be mixed together. There are several configurations of the side-nav, but only one configuration should be used per
+              product section. If tabs are needed on a page when using a side-nav, then the tabs are secondary in hierarchy to the
+              side-nav.
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+    <dds-footer-container></dds-footer-container>
+  </body>
+</html>

--- a/packages/web-components/examples/codesandbox/usage/rtl/package.json
+++ b/packages/web-components/examples/codesandbox/usage/rtl/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ibmdotcom-web-components-rtl-example",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "webpack serve"
+  },
+  "devDependencies": {
+    "handlebars": "^4.7.0",
+    "html-webpack-plugin": "^4.5.0",
+    "webpack": "^4.0.0",
+    "webpack-cli": "^4.0.0",
+    "webpack-dev-server": "^3.11.0"
+  },
+  "dependencies": {
+    "@carbon/ibmdotcom-web-components": "canary",
+    "accept-language-parser": "^1.5.0",
+    "carbon-web-components": "^1.7.1",
+    "lit-element": "^2.4.0",
+    "lit-html": "^1.3.0",
+    "rtl-detect": "^1.0.0"
+  }
+}

--- a/packages/web-components/examples/codesandbox/usage/rtl/sandbox.config.json
+++ b/packages/web-components/examples/codesandbox/usage/rtl/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}

--- a/packages/web-components/examples/codesandbox/usage/rtl/src/index.js
+++ b/packages/web-components/examples/codesandbox/usage/rtl/src/index.js
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '@carbon/ibmdotcom-web-components/es/components/masthead/masthead-container.js';
+import '@carbon/ibmdotcom-web-components/es/components/footer/footer-container.js';

--- a/packages/web-components/examples/codesandbox/usage/rtl/webpack.config.js
+++ b/packages/web-components/examples/codesandbox/usage/rtl/webpack.config.js
@@ -1,0 +1,73 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const path = require('path');
+const acceptLanguageParser = require('accept-language-parser');
+const Handlebars = require('handlebars');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const rtlDetect = require('rtl-detect');
+
+const templateCache = {};
+const reCssBundle = /\.css\.js$/i;
+
+const devServer = {
+  contentBase: path.resolve(__dirname, 'src'),
+  setup(app, server) {
+    app.get('/', (req, res) => {
+      const { fileSystem, waitUntilValid } = server.middleware;
+      waitUntilValid(async () => {
+        // Determins user's preferred language
+        const { code, region } = acceptLanguageParser.parse(req.headers['accept-language'])[0];
+        const dir = !rtlDetect.isRtlLang(code) ? 'ltr' : 'rtl';
+        // Renders the Handlebars template from the data
+        const filename = path.resolve(__dirname, 'dist/index.hbs');
+        if (!templateCache[filename]) {
+          templateCache[filename] = Handlebars.compile(fileSystem.readFileSync(filename).toString());
+        }
+        res.setHeader('Content-Type', 'text/html');
+        res.setHeader('Cache-Control', 'public, max-age=0');
+        res.send(
+          templateCache[filename]({
+            dir,
+            lang: !region ? code : `${code}-${region}`,
+          })
+        );
+        res.end();
+      });
+    });
+  },
+};
+
+function getConfig(dir) {
+  return {
+    output: {
+      filename: `bundle-${dir}.js`,
+    },
+    plugins: [
+      // Puts `.hbs` file into WebPack Dev Server's virtual file system.
+      // If you have other means to load `.hbs` file, this is not needed.
+      new HtmlWebpackPlugin({
+        template: 'index.hbs',
+        filename: 'index.hbs',
+        inject: false,
+      }),
+      // Uses `.rtl.css.js` instead of `.css.js` for RTL bundle
+      new webpack.NormalModuleReplacementPlugin(reCssBundle, resource => {
+        if (dir === 'rtl') {
+          resource.request = resource.request.replace(reCssBundle, '.rtl.css.js');
+        }
+      }),
+    ],
+  };
+}
+
+module.exports = [Object.assign(getConfig('ltr'), { devServer }), getConfig('rtl')];

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -289,13 +289,22 @@
     left: 0;
     z-index: calc(#{z('header')} - 1);
     clip-path: polygon(
-      mini-units(6) 0,
-      100% 0,
+        mini-units(6) 0,
+        100% 0,
+        100% 100%,
+        0 100%,
+        0 calc(#{mini-units(6)} + 1px),
+        mini-units(6) calc(#{mini-units(6)} + 1px)
+      )
+      #{'/*rtl:polygon(
+      0 0,
+      calc(100% - ' + mini-units(6) + ') 0,
+      calc(100% - ' + mini-units(6) + ') calc(' +
+      mini-units(6) + ' + 1px),
+      100% calc(' + mini-units(6) + ' + 1px),
       100% 100%,
-      0 100%,
-      0 calc(#{mini-units(6)} + 1px),
-      mini-units(6) calc(#{mini-units(6)} + 1px)
-    );
+      0 100%
+    )*/'};
 
     @include carbon--breakpoint-down(md) {
       background-color: $ui-background;


### PR DESCRIPTION
### Related Ticket(s)

Refs #3772.

### Description

Introduces a CodeSandbox example that demonstrates how our adaptors can create a RTL page with `@carbon/ibmdotcom-web-components`, as well as its corresponding documentation.

Also fixes an issue that the left nav overlay is not flipped for RTL.

### Changelog

**New**

- RTL CodeSandbox example.
- Documentation on how to use RTL.