### PR TITLE
feat(locale): introducing cache busting logic

### DIFF
--- a/packages/services/src/services/Locale/__tests__/data/timestamp_response.json
+++ b/packages/services/src/services/Locale/__tests__/data/timestamp_response.json
@@ -1,0 +1,1467 @@
+{
+  "translations": {
+    "mapView": "Map View",
+    "listView": "List View",
+    "sortBy": "Sort By",
+    "select": "Select a country/region"
+  },
+  "regionList": [
+    {
+      "name": "Americas",
+      "key": "am",
+      "countryList": [
+        {
+          "name": "Anguilla",
+          "locale": [
+            [
+              "en-ai",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Antigua and Barbuda",
+          "locale": [
+            [
+              "en-ag",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Argentina",
+          "locale": [
+            [
+              "es-ar",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Aruba",
+          "locale": [
+            [
+              "en-aw",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Bahamas",
+          "locale": [
+            [
+              "en-bs",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Barbados",
+          "locale": [
+            [
+              "en-bb",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Bermuda",
+          "locale": [
+            [
+              "en-bm",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Bolivia",
+          "locale": [
+            [
+              "es-bo",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Brazil",
+          "locale": [
+            [
+              "pt-br",
+              "Portuguese"
+            ]
+          ]
+        },
+        {
+          "name": "Canada",
+          "locale": [
+            [
+              "en-ca",
+              "English"
+            ],
+            [
+              "fr-ca",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Cayman Islands",
+          "locale": [
+            [
+              "en-ky",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Chile",
+          "locale": [
+            [
+              "es-cl",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Colombia",
+          "locale": [
+            [
+              "es-co",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Costa Rica",
+          "locale": [
+            [
+              "es-cr",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Curacao",
+          "locale": [
+            [
+              "en-cw",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Dominica",
+          "locale": [
+            [
+              "en-dm",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Ecuador",
+          "locale": [
+            [
+              "es-ec",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Grenada",
+          "locale": [
+            [
+              "en-gd",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Guyana",
+          "locale": [
+            [
+              "en-gy",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Jamaica",
+          "locale": [
+            [
+              "en-jm",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Mexico",
+          "locale": [
+            [
+              "es-mx",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Montserrat",
+          "locale": [
+            [
+              "en-ms",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Paraguay",
+          "locale": [
+            [
+              "es-py",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Peru",
+          "locale": [
+            [
+              "es-pe",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Saint Kitts and Nevis",
+          "locale": [
+            [
+              "en-kn",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Saint Lucia",
+          "locale": [
+            [
+              "en-lc",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Saint Vincent and the Grenadines",
+          "locale": [
+            [
+              "en-vc",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Suriname",
+          "locale": [
+            [
+              "en-sr",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Trinidad and Tobago",
+          "locale": [
+            [
+              "en-tt",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Turks and Caicos Islands",
+          "locale": [
+            [
+              "en-tc",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "United States",
+          "locale": [
+            [
+              "en-us",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Uruguay",
+          "locale": [
+            [
+              "es-uy",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Venezuela",
+          "locale": [
+            [
+              "es-ve",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Virgin Islands, British",
+          "locale": [
+            [
+              "en-vg",
+              "English"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Asia Pacific",
+      "key": "ap",
+      "countryList": [
+        {
+          "name": "Australia",
+          "locale": [
+            [
+              "en-au",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Bangladesh",
+          "locale": [
+            [
+              "en-bd",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Brunei Darussalam",
+          "locale": [
+            [
+              "en-bn",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Cambodia",
+          "locale": [
+            [
+              "en-kh",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "China",
+          "locale": [
+            [
+              "zh-cn",
+              "Chinese (Simplified)"
+            ]
+          ]
+        },
+        {
+          "name": "Hong Kong S.A.R. of China",
+          "locale": [
+            [
+              "en-hk",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "India",
+          "locale": [
+            [
+              "en-in",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Indonesia",
+          "locale": [
+            [
+              "en-id",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Japan",
+          "locale": [
+            [
+              "ja-jp",
+              "Japanese"
+            ]
+          ]
+        },
+        {
+          "name": "Korea, Republic of",
+          "locale": [
+            [
+              "ko-kr",
+              "Korean"
+            ]
+          ]
+        },
+        {
+          "name": "Malaysia",
+          "locale": [
+            [
+              "en-my",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "New Zealand",
+          "locale": [
+            [
+              "en-nz",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Philippines",
+          "locale": [
+            [
+              "en-ph",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Singapore",
+          "locale": [
+            [
+              "en-sg",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Sri Lanka",
+          "locale": [
+            [
+              "en-lk",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Taiwan",
+          "locale": [
+            [
+              "zh-tw",
+              "Chinese (Traditional)"
+            ]
+          ]
+        },
+        {
+          "name": "Thailand",
+          "locale": [
+            [
+              "en-th",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Vietnam",
+          "locale": [
+            [
+              "en-vn",
+              "English"
+            ],
+            [
+              "vi-vn",
+              "Vietnamese"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Europe",
+      "key": "eu",
+      "countryList": [
+        {
+          "name": "Austria",
+          "locale": [
+            [
+              "de-at",
+              "German"
+            ]
+          ]
+        },
+        {
+          "name": "Belgium/Luxembourg",
+          "locale": [
+            [
+              "nl-be",
+              "Dutch"
+            ],
+            [
+              "en-be",
+              "English"
+            ],
+            [
+              "fr-be",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Bulgaria",
+          "locale": [
+            [
+              "bg-bg",
+              "Bulgarian"
+            ]
+          ]
+        },
+        {
+          "name": "Bulgaria",
+          "locale": [
+            [
+              "en-bg",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Croatia",
+          "locale": [
+            [
+              "hr-hr",
+              "Croatian"
+            ]
+          ]
+        },
+        {
+          "name": "Croatia",
+          "locale": [
+            [
+              "en-hr",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Cyprus",
+          "locale": [
+            [
+              "en-cy",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Czech Republic",
+          "locale": [
+            [
+              "en-cz",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Czech Republic",
+          "locale": [
+            [
+              "cs-cz",
+              "Czech"
+            ]
+          ]
+        },
+        {
+          "name": "Denmark",
+          "locale": [
+            [
+              "en-dk",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Denmark",
+          "locale": [
+            [
+              "da-dk",
+              "Danish"
+            ]
+          ]
+        },
+        {
+          "name": "Estonia",
+          "locale": [
+            [
+              "et-ee",
+              "Estonian"
+            ]
+          ]
+        },
+        {
+          "name": "Estonia",
+          "locale": [
+            [
+              "en-ee",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Finland",
+          "locale": [
+            [
+              "fi-fi",
+              "Finnish"
+            ]
+          ]
+        },
+        {
+          "name": "Finland",
+          "locale": [
+            [
+              "en-fi",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "France",
+          "locale": [
+            [
+              "fr-fr",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Germany",
+          "locale": [
+            [
+              "de-de",
+              "German"
+            ]
+          ]
+        },
+        {
+          "name": "Greece",
+          "locale": [
+            [
+              "el-gr",
+              "Greek"
+            ]
+          ]
+        },
+        {
+          "name": "Greece",
+          "locale": [
+            [
+              "en-gr",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Hungary",
+          "locale": [
+            [
+              "en-hu",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Hungary",
+          "locale": [
+            [
+              "hu-hu",
+              "Hungarian"
+            ]
+          ]
+        },
+        {
+          "name": "Ireland",
+          "locale": [
+            [
+              "en-ie",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Italy",
+          "locale": [
+            [
+              "it-it",
+              "Italian"
+            ]
+          ]
+        },
+        {
+          "name": "Kazakhstan",
+          "locale": [
+            [
+              "kk-kz",
+              "Kazakh"
+            ]
+          ]
+        },
+        {
+          "name": "Kazakhstan",
+          "locale": [
+            [
+              "en-kz",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Latvia",
+          "locale": [
+            [
+              "lv-lv",
+              "Latvian"
+            ]
+          ]
+        },
+        {
+          "name": "Latvia",
+          "locale": [
+            [
+              "en-lv",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Lithuania",
+          "locale": [
+            [
+              "en-lt",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Lithuania",
+          "locale": [
+            [
+              "lt-lt",
+              "Lithuanian"
+            ]
+          ]
+        },
+        {
+          "name": "Netherlands",
+          "locale": [
+            [
+              "nl-nl",
+              "Dutch"
+            ]
+          ]
+        },
+        {
+          "name": "Netherlands",
+          "locale": [
+            [
+              "en-nl",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Norway",
+          "locale": [
+            [
+              "no-no",
+              "Norwegian"
+            ]
+          ]
+        },
+        {
+          "name": "Norway",
+          "locale": [
+            [
+              "en-no",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Poland",
+          "locale": [
+            [
+              "pl-pl",
+              "Polish"
+            ]
+          ]
+        },
+        {
+          "name": "Portugal",
+          "locale": [
+            [
+              "pt-pt",
+              "Portuguese"
+            ]
+          ]
+        },
+        {
+          "name": "Portugal",
+          "locale": [
+            [
+              "en-pt",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Romania",
+          "locale": [
+            [
+              "ro-ro",
+              "Romanian"
+            ]
+          ]
+        },
+        {
+          "name": "Romania",
+          "locale": [
+            [
+              "en-ro",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Russian Federation",
+          "locale": [
+            [
+              "ru-ru",
+              "Russian"
+            ]
+          ]
+        },
+        {
+          "name": "Serbia",
+          "locale": [
+            [
+              "sr-rs",
+              "Serbian"
+            ]
+          ]
+        },
+        {
+          "name": "Serbia",
+          "locale": [
+            [
+              "en-rs",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Slovakia",
+          "locale": [
+            [
+              "sk-sk",
+              "Slovak"
+            ]
+          ]
+        },
+        {
+          "name": "Slovakia",
+          "locale": [
+            [
+              "en-sk",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Slovenia",
+          "locale": [
+            [
+              "en-si",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Slovenia",
+          "locale": [
+            [
+              "sl-si",
+              "Slovenian"
+            ]
+          ]
+        },
+        {
+          "name": "Spain",
+          "locale": [
+            [
+              "es-es",
+              "Spanish"
+            ]
+          ]
+        },
+        {
+          "name": "Sweden",
+          "locale": [
+            [
+              "en-se",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Sweden",
+          "locale": [
+            [
+              "sv-se",
+              "Swedish"
+            ]
+          ]
+        },
+        {
+          "name": "Switzerland",
+          "locale": [
+            [
+              "fr-ch",
+              "French"
+            ],
+            [
+              "de-ch",
+              "German"
+            ]
+          ]
+        },
+        {
+          "name": "Turkey",
+          "locale": [
+            [
+              "tr-tr",
+              "Turkish"
+            ]
+          ]
+        },
+        {
+          "name": "Ukraine",
+          "locale": [
+            [
+              "uk-ua",
+              "Ukrainian"
+            ]
+          ]
+        },
+        {
+          "name": "Ukraine",
+          "locale": [
+            [
+              "en-ua",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "United Kingdom",
+          "locale": [
+            [
+              "en-gb",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Uzbekistan",
+          "locale": [
+            [
+              "en-uz",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Uzbekistan",
+          "locale": [
+            [
+              "uz-uz",
+              "Uzbek"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Middle East and Africa",
+      "key": "mea",
+      "countryList": [
+        {
+          "name": "Afghanistan",
+          "locale": [
+            [
+              "en-af",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Algeria",
+          "locale": [
+            [
+              "fr-dz",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Angola",
+          "locale": [
+            [
+              "pt-ao",
+              "Portuguese"
+            ]
+          ]
+        },
+        {
+          "name": "Bahrain",
+          "locale": [
+            [
+              "en-bh",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Botswana",
+          "locale": [
+            [
+              "en-bw",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Burkina Faso",
+          "locale": [
+            [
+              "fr-bf",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Cameroon",
+          "locale": [
+            [
+              "en-cm",
+              "English"
+            ],
+            [
+              "fr-cm",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Chad",
+          "locale": [
+            [
+              "fr-td",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Congo",
+          "locale": [
+            [
+              "fr-cg",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Congo, The Democratic Republic of the",
+          "locale": [
+            [
+              "fr-cd",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Egypt",
+          "locale": [
+            [
+              "en-eg",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Ethiopia",
+          "locale": [
+            [
+              "en-et",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Gabon",
+          "locale": [
+            [
+              "fr-ga",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Ghana",
+          "locale": [
+            [
+              "en-gh",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Iraq",
+          "locale": [
+            [
+              "en-iq",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Israel",
+          "locale": [
+            [
+              "he-il",
+              "Hebrew"
+            ]
+          ]
+        },
+        {
+          "name": "Israel",
+          "locale": [
+            [
+              "en-il",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Ivory Coast",
+          "locale": [
+            [
+              "fr-ci",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Jordan",
+          "locale": [
+            [
+              "en-jo",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Kenya",
+          "locale": [
+            [
+              "en-ke",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Kuwait",
+          "locale": [
+            [
+              "en-kw",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Lebanon",
+          "locale": [
+            [
+              "en-lb",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Libya",
+          "locale": [
+            [
+              "en-ly",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Madagascar",
+          "locale": [
+            [
+              "fr-mg",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Malawi",
+          "locale": [
+            [
+              "en-mw",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Mauritius",
+          "locale": [
+            [
+              "en-mu",
+              "English"
+            ],
+            [
+              "fr-mu",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Morocco",
+          "locale": [
+            [
+              "fr-ma",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Mozambique",
+          "locale": [
+            [
+              "pt-mz",
+              "Portuguese"
+            ]
+          ]
+        },
+        {
+          "name": "Namibia",
+          "locale": [
+            [
+              "en-na",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Nepal",
+          "locale": [
+            [
+              "en-np",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Niger",
+          "locale": [
+            [
+              "fr-ne",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Nigeria",
+          "locale": [
+            [
+              "en-ng",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Oman",
+          "locale": [
+            [
+              "en-om",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Pakistan",
+          "locale": [
+            [
+              "en-pk",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Qatar",
+          "locale": [
+            [
+              "en-qa",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Saudi Arabia",
+          "locale": [
+            [
+              "en-sa",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Saudi Arabia",
+          "locale": [
+            [
+              "ar-sa",
+              "Arabic"
+            ]
+          ]
+        },
+        {
+          "name": "Senegal",
+          "locale": [
+            [
+              "fr-sn",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Seychelles",
+          "locale": [
+            [
+              "fr-sc",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Sierra Leone",
+          "locale": [
+            [
+              "en-sl",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "South Africa",
+          "locale": [
+            [
+              "en-za",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Tanzania, United Republic of",
+          "locale": [
+            [
+              "en-tz",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Tunisia",
+          "locale": [
+            [
+              "fr-tn",
+              "French"
+            ]
+          ]
+        },
+        {
+          "name": "Uganda",
+          "locale": [
+            [
+              "en-ug",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "United Arab Emirates",
+          "locale": [
+            [
+              "en-ae",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "United Arab Emirates",
+          "locale": [
+            [
+              "ar-ae",
+              "Arabic"
+            ]
+          ]
+        },
+        {
+          "name": "Yemen",
+          "locale": [
+            [
+              "en-ye",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Zambia",
+          "locale": [
+            [
+              "en-zm",
+              "English"
+            ]
+          ]
+        },
+        {
+          "name": "Zimbabwe",
+          "locale": [
+            [
+              "en-zw",
+              "English"
+            ]
+          ]
+        }
+      ]
+    }
+  ],
+  "timestamp": 1337
+}


### PR DESCRIPTION
### Related Ticket(s)

#3959 

### Description

As done in [TranslationAPI](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/4240), this PR adds a new timestamp property within the response json to compare with the current time. If the timestamp is older than two hours, a new response will be fetched with a new, current timestamp.

Also implemented tests for the new methods.

### Changelog

**New**

- `timestamp` property added to the response json for cache busting purposes

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
