### PR TITLE
chore(dotcomshell): adjust TOC offset in storybook

### DIFF
--- a/packages/react/src/components/DotcomShell/__stories__/data/content.js
+++ b/packages/react/src/components/DotcomShell/__stories__/data/content.js
@@ -30,7 +30,7 @@ import React from 'react';
  */
 const Content = () => (
   <>
-    <TableOfContents menuLabel="Jump to" theme="white">
+    <TableOfContents menuLabel="Jump to" theme="white" stickyOffset="64">
       <a name="section-1" data-title="Lorem ipsum dolor sit amet" />
       <Layout type="2-1">
         <div>


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Fix `TableOfContents` offset in `DotcomShell` story to remove overlap.

Need to add responsive support for all breakpoints.

current:
![image](https://user-images.githubusercontent.com/909118/97440088-611cc500-18fd-11eb-816e-d8ea594a968d.png)

fixed:
![image](https://user-images.githubusercontent.com/909118/97440122-6ed24a80-18fd-11eb-8c51-59bae62e9338.png)


### Changelog

**Changed**

- add `stickyOffset` to `DotcomShell` story (`64px` per design specs)


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
