### PR TITLE
fix(language-selector): update language selector to use select

### DIFF
--- a/packages/react/src/components/Footer/Footer.js
+++ b/packages/react/src/components/Footer/Footer.js
@@ -231,7 +231,8 @@ Footer.propTypes = {
 
   /**
    * Array of items for the language selector,
-   * utilizes the [Carbon Select](https://react.carbondesignsystem.com/?path=/story/select--default) component.
+   * uses [Carbon ComboBox](https://react.carbondesignsystem.com/?path=/story/combobox--combobox) for desktop,
+   * and [Carbon Select](https://react.carbondesignsystem.com/?path=/story/select--default) for tablet/mobile.
    */
   languageItems: PropTypes.arrayOf(PropTypes.object),
 

--- a/packages/react/src/components/Footer/Footer.js
+++ b/packages/react/src/components/Footer/Footer.js
@@ -225,18 +225,18 @@ Footer.propTypes = {
   disableLocaleButton: PropTypes.bool,
 
   /**
-   * `true` to switch the locale button with a language dropdown.
+   * `true` to switch the locale button with a language selector.
    */
   languageOnly: PropTypes.bool,
 
   /**
-   * Array of items for the language dropdown,
-   * utilizes the [Carbon ComboBox](https://react.carbondesignsystem.com/?path=/story/combobox--default).
+   * Array of items for the language selector,
+   * utilizes the [Carbon Select](https://react.carbondesignsystem.com/?path=/story/select--default) component.
    */
   languageItems: PropTypes.arrayOf(PropTypes.object),
 
   /**
-   * Sets the initial language dropdown value when the component is loaded.
+   * Sets the initial language selector value when the component is loaded.
    * The default is the first item.
    */
   languageInitialItem: PropTypes.shape({
@@ -245,7 +245,7 @@ Footer.propTypes = {
   }),
 
   /**
-   * Callback function onChange of the language dropdown.
+   * Callback function onChange of the language selector.
    */
   languageCallback: PropTypes.func,
 };

--- a/packages/react/src/components/Footer/Footer.js
+++ b/packages/react/src/components/Footer/Footer.js
@@ -30,6 +30,7 @@ const Footer = ({
   langCode,
   disableLocaleButton,
   languageOnly,
+  labelText,
   languageItems,
   languageInitialItem,
   languageCallback,
@@ -112,6 +113,7 @@ const Footer = ({
               localeButtonAria,
               displayLang,
               languageOnly,
+              labelText,
               languageItems,
               languageInitialItem,
               languageCallback
@@ -128,6 +130,7 @@ const Footer = ({
                 localeButtonAria,
                 displayLang,
                 languageOnly,
+                labelText,
                 languageItems,
                 languageInitialItem,
                 languageCallback
@@ -146,6 +149,7 @@ const Footer = ({
  * @param {string} localeButtonAria String for the aria label
  * @param {string} displayLang display language for locale button
  * @param {boolean} languageOnly Switches to the language selector
+ * @param {string} labelText Label text for locale/language selector
  * @param {Array} languageItems Array of language data for the dropdown
  * @param {object} languageInitialItem Initial language selected
  * @param {Function} languageCallback Callback function when language is selected
@@ -157,6 +161,7 @@ function _loadLocaleLanguage(
   localeButtonAria,
   displayLang,
   languageOnly,
+  labelText,
   languageItems,
   languageInitialItem,
   languageCallback
@@ -167,6 +172,7 @@ function _loadLocaleLanguage(
         items={languageItems}
         initialSelectedItem={languageInitialItem}
         callback={languageCallback}
+        labelText={labelText}
       />
     );
   } else if (!disableLocaleButton) {
@@ -228,6 +234,11 @@ Footer.propTypes = {
    * `true` to switch the locale button with a language selector.
    */
   languageOnly: PropTypes.bool,
+
+  /**
+   * Label text for combobox/select
+   */
+  labelText: PropTypes.string,
 
   /**
    * Array of items for the language selector,

--- a/packages/react/src/components/Footer/LanguageSelector.js
+++ b/packages/react/src/components/Footer/LanguageSelector.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
-import ComboBox from '../../internal/vendor/carbon-components-react/components/ComboBox/ComboBox';
+import React, { useState } from 'react';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import PropTypes from 'prop-types';
-import root from 'window-or-global';
+import Select from '../../internal/vendor/carbon-components-react/components/Select/Select';
+import SelectItem from '../../internal/vendor/carbon-components-react/components/SelectItem/SelectItem';
 import settings from 'carbon-components/es/globals/js/settings';
 
 const { stablePrefix } = ddsSettings;
@@ -19,13 +19,7 @@ const { prefix } = settings;
  * Footer language selector component.
  */
 const LanguageSelector = ({ items, initialSelectedItem, callback }) => {
-  const { ref } = useClickOutside();
-
   const [selectedItem, setSelectedItem] = useState(
-    initialSelectedItem || items[0]
-  );
-
-  const [lastSelectedItem, setLastSelectedItem] = useState(
     initialSelectedItem || items[0]
   );
 
@@ -38,50 +32,37 @@ const LanguageSelector = ({ items, initialSelectedItem, callback }) => {
   function _setSelectedItem(selectedItem) {
     setSelectedItem(selectedItem);
     callback(selectedItem);
-    if (selectedItem !== null) {
-      setLastSelectedItem(selectedItem);
-    }
-  }
-
-  /**
-   * Identifies the click outisde the language selector and resets its value to the previously selected
-   */
-  function useClickOutside() {
-    const ref = useRef(null);
-
-    const handleClickOutside = event => {
-      if (ref.current && !ref.current.contains(event.target)) {
-        setSelectedItem(lastSelectedItem);
-      }
-    };
-
-    useEffect(() => {
-      root.document.addEventListener('click', handleClickOutside, true);
-      return () => {
-        root.document.removeEventListener('click', handleClickOutside, true);
-      };
-    });
-
-    return { ref };
   }
 
   return (
-    <div className={`${prefix}--language-selector__container`} ref={ref}>
-      <ComboBox
-        id="dds-language-selector"
+    <div className={`${prefix}--language-selector__container`}>
+      <Select
+        defaultValue={selectedItem.id}
         data-autoid={`${stablePrefix}--language-selector`}
         className={`${prefix}--language-selector`}
-        onChange={({ selectedItem }) => _setSelectedItem(selectedItem)}
-        items={items}
-        itemToString={item => (item ? item.text : '')}
-        initialSelectedItem={initialSelectedItem}
-        selectedItem={selectedItem}
-        direction="top"
-        placeholder=""
-      />
+        onChange={evt => _setSelectedItem(evt)}
+        text={selectedItem.text}
+        hideLabel>
+        {renderSelectItems(items)}
+      </Select>
     </div>
   );
 };
+
+/**
+ * Iterate through and render a list of select items
+ *
+ * @param {Array} items A list of items to be rendered
+ * @returns {object} JSX object
+ */
+
+function renderSelectItems(items) {
+  const selectItems = [];
+  items.map(item => {
+    selectItems.push(<SelectItem value={item.id} text={item.text} />);
+  });
+  return selectItems;
+}
 
 LanguageSelector.propTypes = {
   /**

--- a/packages/react/src/components/Footer/LanguageSelector.js
+++ b/packages/react/src/components/Footer/LanguageSelector.js
@@ -19,16 +19,12 @@ const { prefix } = settings;
 /**
  * Footer language selector component.
  */
-<<<<<<< HEAD
-const LanguageSelector = ({ items, initialSelectedItem, callback }) => {
-=======
 const LanguageSelector = ({
   items,
   initialSelectedItem,
   callback,
   labelText,
 }) => {
->>>>>>> fix(a11y): add label to combobox and select
   const { ref } = useClickOutside();
 
   const [selectedItem, setSelectedItem] = useState(
@@ -88,10 +84,7 @@ const LanguageSelector = ({
         selectedItem={selectedItem}
         direction="top"
         placeholder=""
-<<<<<<< HEAD
-=======
         titleText={labelText}
->>>>>>> fix(a11y): add label to combobox and select
       />
       <Select
         defaultValue={selectedItem.id}

--- a/packages/react/src/components/Footer/LanguageSelector.js
+++ b/packages/react/src/components/Footer/LanguageSelector.js
@@ -66,7 +66,7 @@ function renderSelectItems(items) {
 
 LanguageSelector.propTypes = {
   /**
-   * Array of items to pass into ComboBox.
+   * Array of items to pass into Select.
    */
   items: PropTypes.arrayOf(
     PropTypes.shape({
@@ -76,7 +76,7 @@ LanguageSelector.propTypes = {
   ),
 
   /**
-   * Initial selected item for the ComboBox.
+   * Initial selected item for the Select.
    */
   initialSelectedItem: PropTypes.shape({
     id: PropTypes.string,

--- a/packages/react/src/components/Footer/LanguageSelector.js
+++ b/packages/react/src/components/Footer/LanguageSelector.js
@@ -19,7 +19,16 @@ const { prefix } = settings;
 /**
  * Footer language selector component.
  */
+<<<<<<< HEAD
 const LanguageSelector = ({ items, initialSelectedItem, callback }) => {
+=======
+const LanguageSelector = ({
+  items,
+  initialSelectedItem,
+  callback,
+  labelText,
+}) => {
+>>>>>>> fix(a11y): add label to combobox and select
   const { ref } = useClickOutside();
 
   const [selectedItem, setSelectedItem] = useState(
@@ -79,6 +88,10 @@ const LanguageSelector = ({ items, initialSelectedItem, callback }) => {
         selectedItem={selectedItem}
         direction="top"
         placeholder=""
+<<<<<<< HEAD
+=======
+        titleText={labelText}
+>>>>>>> fix(a11y): add label to combobox and select
       />
       <Select
         defaultValue={selectedItem.id}
@@ -86,7 +99,7 @@ const LanguageSelector = ({ items, initialSelectedItem, callback }) => {
         className={`${prefix}--language-selector`}
         onChange={evt => _setSelectedItem(evt)}
         text={selectedItem.text}
-        hideLabel>
+        labelText={labelText}>
         {renderSelectItems(items)}
       </Select>
     </div>
@@ -131,12 +144,18 @@ LanguageSelector.propTypes = {
    * Callback function when an item is selected.
    */
   callback: PropTypes.func,
+
+  /**
+   * Label text
+   */
+  labelText: PropTypes.string,
 };
 
 LanguageSelector.defaultProps = {
   items: null,
   initialSelectedItem: null,
   callback: () => {},
+  labelText: 'Choose a language',
 };
 
 export default LanguageSelector;

--- a/packages/react/src/components/Footer/README.stories.mdx
+++ b/packages/react/src/components/Footer/README.stories.mdx
@@ -70,9 +70,9 @@ type:
 - [Tall](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/react/src/components/Footer/__data__/footer-menu.json)
 - [Short](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/react/src/components/Footer/__data__/footer-thin.json)
 
-### Language Dropdown
+### Language selector
 
-The option to use a language dropdown is available in lieu of the locale
+The option to use a language selector is available in lieu of the locale
 button/selector.
 
 Example implementation:

--- a/packages/styles/scss/components/footer/_language-selector.scss
+++ b/packages/styles/scss/components/footer/_language-selector.scss
@@ -125,6 +125,13 @@
         display: block;
       }
     }
+
+    .#{$prefix}--label {
+      height: 0;
+      padding: 0;
+      margin: 0;
+      display: block;
+    }
   }
 }
 

--- a/packages/styles/scss/components/footer/_language-selector.scss
+++ b/packages/styles/scss/components/footer/_language-selector.scss
@@ -5,12 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import 'carbon-components/scss/components/combo-box/combo-box';
-@import 'carbon-components/scss/components/list-box/list-box';
-@import 'carbon-components/scss/components/text-input/text-input';
-@import '../../themes/expressive/components/combo-box';
-@import '../../themes/expressive/components/list-box';
-@import '../../themes/expressive/components/text-input';
+@import 'carbon-components/scss/components/select/select';
+@import '../../themes/expressive/components/select';
 
 /// Footer language selector
 /// @access private
@@ -22,12 +18,8 @@
       $carbon--theme--g90,
       feature-flag-enabled('enable-css-custom-properties')
     ) {
-      @include combo-box;
-      @include listbox;
-      @include text-input;
-      @include combo-box-expressive;
-      @include list-box-expressive;
-      @include text-input-expressive;
+      @include select;
+      @include select-expressive;
       @include carbon--make-col-ready;
       @include carbon--make-col(4, 4);
 
@@ -39,6 +31,7 @@
       .#{$prefix}--language-selector {
         max-width: 100%;
         width: 100%;
+        height: 3rem;
 
         @include carbon--breakpoint('md') {
           min-width: carbon--mini-units(27);
@@ -91,6 +84,20 @@
 
     .#{$prefix}--list-box__menu {
       z-index: 1;
+    }
+
+    .#{$prefix}--select-input__wrapper {
+      width: 100%;
+
+      .#{$prefix}--select-input {
+        width: 100%;
+        max-width: 100%;
+        height: $layout-04;
+      }
+    }
+
+    .#{$prefix}--form-item {
+      display: block;
     }
   }
 }

--- a/packages/styles/scss/components/footer/_language-selector.scss
+++ b/packages/styles/scss/components/footer/_language-selector.scss
@@ -5,8 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@import 'carbon-components/scss/components/combo-box/combo-box';
+@import 'carbon-components/scss/components/list-box/list-box';
 @import 'carbon-components/scss/components/select/select';
-@import '../../themes/expressive/components/select';
+@import 'carbon-components/scss/components/text-input/text-input';
+@import '../../themes/expressive/components/combo-box';
+@import '../../themes/expressive/components/list-box';
+@import '../../themes/expressive/components/text-input';
 
 /// Footer language selector
 /// @access private
@@ -18,8 +23,14 @@
       $carbon--theme--g90,
       feature-flag-enabled('enable-css-custom-properties')
     ) {
+      @include combo-box;
+      @include listbox;
       @include select;
+      @include text-input;
+      @include combo-box-expressive;
+      @include list-box-expressive;
       @include select-expressive;
+      @include text-input-expressive;
       @include carbon--make-col-ready;
       @include carbon--make-col(4, 4);
 
@@ -96,8 +107,23 @@
       }
     }
 
+    // Toggle views depending on breakpoint
+    // <Select /> for mobile/tablet
+    // <ComboBox /> for desktop
     .#{$prefix}--form-item {
       display: block;
+
+      @include carbon--breakpoint('lg') {
+        display: none;
+      }
+    }
+
+    .#{$prefix}--list-box__wrapper {
+      display: none;
+
+      @include carbon--breakpoint('lg') {
+        display: block;
+      }
     }
   }
 }

--- a/packages/styles/scss/components/footer/_legal-nav.scss
+++ b/packages/styles/scss/components/footer/_legal-nav.scss
@@ -99,7 +99,8 @@
         }
 
         .#{$prefix}--btn--secondary,
-        .#{$prefix}--list-box {
+        .#{$prefix}--list-box,
+        .#{$prefix}--select-input {
           background-color: $ui-background;
           max-width: 100%;
 
@@ -112,8 +113,13 @@
           }
         }
 
+        .#{$prefix}--select {
+          max-width: 100%;
+        }
+
         .#{$prefix}--text-input,
-        .#{$prefix}--list-box {
+        .#{$prefix}--list-box,
+        .#{$prefix}--select-input {
           border-bottom: none;
         }
       }


### PR DESCRIPTION
### Related Ticket(s)

#4330, #4331 

### Description

This change adds Carbon's `Select` component for the footer language selector in mobile/tablet breakpoints. Desktop views will continue to use `ComboBox`.

### Changelog

**Changed**

- `Footer` language selector now uses Carbon's `Select` instead of `ComboBox` for mobile/tablet breakpoints
- updated various styles for new component

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
