### PR TITLE
fix(button-group): fixed focus outline going past the buttons on web components

### DIFF
--- a/packages/web-components/src/components/button-group/button-group.scss
+++ b/packages/web-components/src/components/button-group/button-group.scss
@@ -6,3 +6,14 @@
 //
 
 @import '@carbon/ibmdotcom-styles/scss/components/buttongroup/buttongroup';
+
+#{$prefix}--buttongroup,
+:host(#{$dds-prefix}-button-group) {
+  align-items: flex-start;
+}
+
+.#{$prefix}--buttongroup-item,
+:host(#{$dds-prefix}-button-group-item) {
+  margin-right: 1rem;
+  padding-right: 0;
+}


### PR DESCRIPTION
### Related Ticket(s)

#4347 

### Description

In ButtonGroup, whenever the user focuses on any button (by pressing or tabbing), the focus outline extends past the button as pictured below.

Before:
![Screen Shot 2020-10-29 at 12 11 18 PM](https://user-images.githubusercontent.com/24970122/97622445-884cc280-19e1-11eb-8369-a7c621e9ea65.png)

After:

![Screen Shot 2020-10-29 at 12 23 43 PM](https://user-images.githubusercontent.com/24970122/97622503-9bf82900-19e1-11eb-9d8c-9e0737440f56.png)



### Changelog

**New**

- added new css properties for `button-group.scss` specific to the web components version

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
