### PR TITLE
fix(button-group): eliminate duplicate outline

### DIFF
--- a/packages/web-components/src/components/button-group/button-group.scss
+++ b/packages/web-components/src/components/button-group/button-group.scss
@@ -7,13 +7,6 @@
 
 @import '@carbon/ibmdotcom-styles/scss/components/buttongroup/buttongroup';
 
-#{$prefix}--buttongroup,
-:host(#{$dds-prefix}-button-group) {
-  align-items: flex-start;
-}
-
-.#{$prefix}--buttongroup-item,
 :host(#{$dds-prefix}-button-group-item) {
-  margin-right: 1rem;
-  padding-right: 0;
+  outline: none;
 }


### PR DESCRIPTION
### Related Ticket(s)

Refs #4348.

### Description

Fixes duplicate focus outline in `<dds-button-group-item>`, that made the focus outline too thick. Also given the earlier workaround for such duplicate focus outline issue is no longer needed, removed it.

### Changelog

**Removed**

- The redundant focus outline on `<dds-button-group-item>`
- The earlier workaround for above issue.