### PR TITLE
style(button-group): fixing alignment for icons on iOS

### DIFF
--- a/packages/styles/scss/components/buttongroup/_buttongroup.scss
+++ b/packages/styles/scss/components/buttongroup/_buttongroup.scss
@@ -57,6 +57,8 @@
     ::slotted([slot='icon']) {
       position: absolute;
       right: 1rem;
+      top: 13px;
+      bottom: 13px;
       flex-shrink: 0;
     }
     .#{$prefix}--btn {

--- a/packages/styles/scss/components/buttongroup/_buttongroup.scss
+++ b/packages/styles/scss/components/buttongroup/_buttongroup.scss
@@ -57,8 +57,8 @@
     ::slotted([slot='icon']) {
       position: absolute;
       right: 1rem;
-      top: 13px;
-      bottom: 13px;
+      top: 50%;
+      transform: translateY(-50%);
       flex-shrink: 0;
     }
     .#{$prefix}--btn {


### PR DESCRIPTION
### Description

The explicit declaration of `top` and `bottom` positioning fixed the icon's alignment on iOS devices.

**Previous**
<img width="532" alt="Screen Shot 2020-11-03 at 17 57 46" src="https://user-images.githubusercontent.com/42848561/98039828-166be300-1dfe-11eb-83f5-5944c550070b.png">

**Current**
<img width="502" alt="Screen Shot 2020-11-03 at 17 57 01" src="https://user-images.githubusercontent.com/42848561/98039873-28e61c80-1dfe-11eb-8e66-f19497749cf9.png">


### Changelog

**New**

- `bottom` and `top` set to `13px` at the button's icons. 