### PR TITLE
chore(ddo): removing redundant carbon in version text

### DIFF
--- a/docs/building-for-ibm-dotcom.md
+++ b/docs/building-for-ibm-dotcom.md
@@ -55,7 +55,7 @@ for your page:
             language: '', // e.g. en-US
             publishDate: '', // e.g. 2014-11-19
             publisher: '', // e.g. IBM Corporation
-            version: 'Carbon:Carbon for IBM.com',
+            version: 'Carbon for IBM.com',
             ibm: {
                 contentDelivery: '', // e.g. ECM/Filegen
                 contentProducer: '', // e.g. ECM/IConS Adopter 34 - GS83J2343G3H3ERG - 11/19/2014 05:14:02 PM

--- a/packages/utilities/src/utilities/settings/settings.js
+++ b/packages/utilities/src/utilities/settings/settings.js
@@ -15,7 +15,7 @@
  *
  */
 const settings = {
-  version: 'Carbon:Carbon for IBM.com v1.12.0',
+  version: 'Carbon for IBM.com v1.12.0',
   stablePrefix: 'dds',
 };
 


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

After renaming to `Carbon for IBM.com`, our version was renamed but
retained the `Carbon:` prefix as it was originally `Carbon:IBM.com
Library`. Now that we have Carbon in the name, it is a bit redundant to
have the prefix now.

### Changelog

**Changed**

- DDO version