### PR TITLE
fix(content-item-horizontal): fix heading styling

### DIFF
--- a/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
@@ -55,6 +55,7 @@
 
   :host(#{$dds-prefix}-content-item-horizontal) ::slotted([slot='heading']),
   .#{$prefix}--content-item-horizontal__item--heading {
+    display: block;
     color: $text-01;
     @include carbon--type-style('expressive-heading-03', true);
     @include carbon--breakpoint(sm) {


### PR DESCRIPTION
### Related Ticket(s)

#4400

### Description

heading needs additional styling for smaller breakpoints

### Changelog

**New**

- added display block so margin is correctly applied

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
