### PR TITLE
chore(components): replace slot in light DOM

### DIFF
--- a/packages/web-components/examples/codesandbox/components/card/index.html
+++ b/packages/web-components/examples/codesandbox/components/card/index.html
@@ -24,8 +24,8 @@ LICENSE file in the root directory of this source tree.
 <h1>Hello World! 👋</h1>
 <div id="app">
   <dds-card href="https://example.com">
-    <slot slot="eyebrow">eyebrow text</slot>
-    <slot slot="heading">Lorem ipsum dolor sit amet</slot>
+    <span slot="eyebrow">eyebrow text</span>
+    <span slot="heading">Lorem ipsum dolor sit amet</span>
     <dds-card-footer slot="footer">
       Card cta text
       <svg

--- a/packages/web-components/examples/codesandbox/components/content-item-horizontal/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-item-horizontal/index.html
@@ -24,7 +24,7 @@ LICENSE file in the root directory of this source tree.
 <h1>Hello World! 👋</h1>
 <div id="app">
   <dds-content-item-horizontal .copy="Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.">
-    <slot slot="eyebrow">Lorem ipsum</slot>
+    <span slot="eyebrow">Lorem ipsum</span>
     <dds-content-item-heading>Aliquam condimentum</dds-content-item-heading>
     <dds-link-list slot="cta" type="vertical">
       <dds-link-list-item-cta

--- a/packages/web-components/examples/codesandbox/components/feature-card-block-large/index.html
+++ b/packages/web-components/examples/codesandbox/components/feature-card-block-large/index.html
@@ -36,7 +36,7 @@ LICENSE file in the root directory of this source tree.
       <dds-image-item media="(min-width: 320px)" srcset="https://dummyimage.com/320x160/ee5396/161616&text=2:1">
       </dds-image-item>
     </dds-image>
-    <slot slot="eyebrow">This is an eyebrow</slot>
+    <span slot="eyebrow">This is an eyebrow</span>
     <h3 slot="heading">Explore AI use cases in all industries</h3>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
     <svg

--- a/packages/web-components/src/components/card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card/__stories__/README.stories.mdx
@@ -32,14 +32,14 @@ or with [JSPM](https://jspm.org)
 
 ```html
 <dds-card href="https://example.com">
-    <slot slot="eyebrow">eyebrow text</slot>
-    <slot slot="heading">Lorem ipsum dolor sit amet</slot>
-    <dds-card-footer slot="footer">
-      Card cta text
-      <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
-        <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
-      </svg>
-    </dds-card-footer>
+  <span slot="eyebrow">eyebrow text</span>
+  <span slot="heading">Lorem ipsum dolor sit amet</span>
+  <dds-card-footer slot="footer">
+    Card cta text
+    <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+      <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+    </svg>
+  </dds-card-footer>
 </dds-card>
 ```
 

--- a/packages/web-components/src/components/card/__stories__/card.stories.ts
+++ b/packages/web-components/src/components/card/__stories__/card.stories.ts
@@ -26,8 +26,8 @@ export const Default = ({ parameters }) => {
             <dds-image slot="image" alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}"></dds-image>
           `
         : ``}
-      <slot slot="eyebrow">${eyebrow}</slot>
-      <slot slot="heading">${heading}</slot>
+      <span slot="eyebrow">${eyebrow}</span>
+      <span slot="heading">${heading}</span>
       ${copy
         ? html`
             <p>${copy}</p>

--- a/packages/web-components/src/components/content-item-horizontal/__stories__/content-item-horizontal.stories.ts
+++ b/packages/web-components/src/components/content-item-horizontal/__stories__/content-item-horizontal.stories.ts
@@ -30,7 +30,7 @@ export const Default = ({ parameters }) => {
     parameters?.props?.ContentItemHorizontal ?? {};
   return html`
     <dds-content-item-horizontal .copy=${ifNonNull(copy)}>
-      <slot slot="eyebrow">${eyebrow}</slot>
+      <span slot="eyebrow">${eyebrow}</span>
       <dds-content-item-heading>${heading}</dds-content-item-heading>
       <dds-link-list slot="cta" type="vertical">
         <dds-link-list-item-cta

--- a/packages/web-components/src/components/content-item-horizontal/__tests__/content-item-horizontal.test.ts
+++ b/packages/web-components/src/components/content-item-horizontal/__tests__/content-item-horizontal.test.ts
@@ -35,7 +35,7 @@ describe('dds-content-item-horizontal', function() {
         template({
           copy: 'copy-foo',
           children: html`
-            <slot slot="eyebrow">eyebrow-foo</slot>
+            <span slot="eyebrow">eyebrow-foo</span>
             <dds-content-item-heading>heading-foo</dds-content-item-heading>
             <dds-link-list slot="cta" type="vertical">
               <dds-link-list-item-cta

--- a/packages/web-components/src/components/feature-card-block-large/__stories__/feature-card-block-large.stories.ts
+++ b/packages/web-components/src/components/feature-card-block-large/__stories__/feature-card-block-large.stories.ts
@@ -30,8 +30,8 @@ export const Default = ({ parameters }) => {
         <dds-image-item media="(min-width: 320px)" srcset="https://dummyimage.com/320x160/ee5396/161616&amp;text=2:1">
         </dds-image-item>
       </dds-image>
-      <slot slot="eyebrow">${eyebrow}</slot>
-      <slot slot="heading">${heading}</slot>
+      <span slot="eyebrow">${eyebrow}</span>
+      <span slot="heading">${heading}</span>
       <p>${copy}</p>
       ${ArrowRight20({ slot: 'footer' })}
     </dds-feature-card-block-large>

--- a/packages/web-components/src/components/feature-card-block-medium/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/feature-card-block-medium/__stories__/README.stories.mdx
@@ -37,7 +37,7 @@ or with [JSPM](https://jspm.org)
   </dds-feature-card-block-medium-heading>
   <dds-feature-card-block-medium-card href="https://example.com">
     <dds-image slot="image" alt="Image alt text" default-src="https://dummyimage.com/672x672/ee5396/161616&amp;amp;text=1x1"></dds-image>
-    <slot slot="heading">Explore AI use cases in all industries</slot>
+    <span slot="heading">Explore AI use cases in all industries</span>
     <svg slot="footer" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
       <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
     </svg>

--- a/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.ts
+++ b/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.ts
@@ -19,7 +19,7 @@ export const Default = ({ parameters }) => {
   return html`
     <dds-feature-card href=${ifNonNull(href || undefined)}>
       <dds-image slot="image" alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}"></dds-image>
-      <slot slot="heading">${heading}</slot>
+      <span slot="heading">${heading}</span>
       ${ArrowRight20({ slot: 'footer' })}
     </dds-feature-card>
   `;


### PR DESCRIPTION
### Description

Replaces `<slot>` elements used in light DOM with `<span>`, as `<slot>` is for defining a placeholder in Shadow DOM, instead of using such placeholder.

### Changelog

**Changed**

- Replaces `<slot>` elements used in light DOM with `<span>`.