### PR TITLE
docs(footer): add autoid doc for cookie preferences

### DIFF
--- a/packages/react/src/components/Footer/README.stories.mdx
+++ b/packages/react/src/components/Footer/README.stories.mdx
@@ -119,6 +119,7 @@ function App() {
 | `dds--legal-nav__link`        | Interactive |
 | `dds--locale-modal`           | Component   |
 | `dds--language-selector`      | Component   |
+| `dds--privacy-cp`             | Component   |
 
 ## Server Side Rendering
 

--- a/packages/web-components/src/components/footer/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/footer/__stories__/README.stories.mdx
@@ -138,13 +138,14 @@ document.addEventListener('click', event => {
 
 See [our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components#stable-selectors-for-analytics-and-integratione2e-testing-in-web-components) to see how Web Components selector and `data-autoid` should be used.
 
-| Web Components selector  | Compatibility selector                 | Description |
-| ------------------------ | -------------------------------------- | ----------- |
-| `<dds-footer>`           | `data-autoid="dds--footer"`            | Component   |
-| `<dds-footer-nav>`       | `data-autoid="dds--footer-nav"`        | Component   |
-| `<dds-footer-nav-group>` | `data-autoid="dds--footer-nav-group"`  | Component   |
-| `<dds-footer-logo>`      | `data-autoid="dds--footer-logo"`       | Component   |
-| `<dds-locale-button>`    | `data-autoid="dds--footer-locale-btn"` | Interactive |
-| `<dds-legal-nav>`        | `data-autoid="dds--legal-nav"`         | Component   |
+| Web Components selector                          | Compatibility selector                 | Description |
+| ------------------------------------------------ | -------------------------------------- | ----------- |
+| `<dds-footer>`                                   | `data-autoid="dds--footer"`            | Component   |
+| `<dds-footer-nav>`                               | `data-autoid="dds--footer-nav"`        | Component   |
+| `<dds-footer-nav-group>`                         | `data-autoid="dds--footer-nav-group"`  | Component   |
+| `<dds-footer-logo>`                              | `data-autoid="dds--footer-logo"`       | Component   |
+| `<dds-locale-button>`                            | `data-autoid="dds--footer-locale-btn"` | Interactive |
+| `<dds-legal-nav>`                                | `data-autoid="dds--legal-nav"`         | Component   |
+| `<dds-legal-nav-cookie-preferences-placeholder>` | `data-autoid="dds--privacy-cp"`        | Component   |
 
 <Description markdown={contributing} />


### PR DESCRIPTION
### Related Ticket(s)

Refs #4346.

### Changelog

**New**

- Documentation for `data-autoid` for cookie preference placeholder component.