### PR TITLE
fix(Footer): update readme

### DIFF
--- a/packages/react/src/components/Footer/README.stories.mdx
+++ b/packages/react/src/components/Footer/README.stories.mdx
@@ -115,16 +115,17 @@ function App() {
 | `dds--footer-logo`            | Component   |
 | `dds--footer-logo__link`      | Interactive |
 | `dds--footer-locale-btn`      | Interactive |
+| `dds--privacy-cp`             | Component   |
 | `dds--legal-nav`              | Component   |
 | `dds--legal-nav__link`        | Interactive |
 | `dds--locale-modal`           | Component   |
 | `dds--language-selector`      | Component   |
 
-## Server Side Rendering
+## Server-Side Rendering
 
-To server side render the footer, the `Translation` service call needs to be
-made to retrieve navigation links. Make sure to pass in the `lc` and `cc` values
-as shown in the example below.
+For server-side rendering of the footer, the `Translation` service call needs to
+be made to retrieve navigation links. Make sure to pass in the `lc` and `cc`
+values as shown in the example below.
 
 ```javascript
 import { TranslationAPI } from '@carbon/ibmdotcom-services';

--- a/packages/web-components/src/components/footer/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/footer/__stories__/README.stories.mdx
@@ -77,7 +77,7 @@ document.addEventListener('click', event => {
   </dds-footer-nav>
   <dds-locale-button></dds-locale-button>
   <dds-legal-nav>
-    <dds-legal-nav-item href="https://www.ibm.com/contact/us/en/>Contact IBM</dds-legal-nav-item>
+    <dds-legal-nav-item href="https://www.ibm.com/contact/us/en/">Contact IBM</dds-legal-nav-item>
     <dds-legal-nav-item href="https://www.ibm.com/privacy/us/en/">Privacy</dds-legal-nav-item>
     <dds-legal-nav-item href="https://www.ibm.com/us-en/legal">Terms of use</dds-legal-nav-item>
   </dds-legal-nav>
@@ -146,5 +146,6 @@ See [our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/t
 | `<dds-footer-logo>`      | `data-autoid="dds--footer-logo"`       | Component   |
 | `<dds-locale-button>`    | `data-autoid="dds--footer-locale-btn"` | Interactive |
 | `<dds-legal-nav>`        | `data-autoid="dds--legal-nav"`         | Component   |
+| `<dds-privacy-cp>`       | `data-autoid="dds--privacy-cp"`        | Component   |
 
 <Description markdown={contributing} />

--- a/packages/web-components/src/components/footer/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/footer/__stories__/README.stories.mdx
@@ -146,6 +146,6 @@ See [our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/t
 | `<dds-footer-logo>`      | `data-autoid="dds--footer-logo"`       | Component   |
 | `<dds-locale-button>`    | `data-autoid="dds--footer-locale-btn"` | Interactive |
 | `<dds-legal-nav>`        | `data-autoid="dds--legal-nav"`         | Component   |
-| `<dds-privacy-cp>`       | `data-autoid="dds--privacy-cp"`        | Component   |
+| `<dds-legal-nav-cookie-preferences-placeholder>` | `data-autoid="dds--privacy-cp"`        | Component   |
 
 <Description markdown={contributing} />


### PR DESCRIPTION
### Related Ticket(s)

#4346 

### Description

Add `dds--privacy-cp` to stable selector documentation for both React and web components.

### Changelog

**New**

- `dds--privacy-cp` stable selector added to docs

**Changed**

- fixed typos in docs


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
