### PR TITLE
docs(examples): add JS extension

### DIFF
--- a/packages/web-components/examples/codesandbox/components/button-group/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/button-group/src/index.js
@@ -7,5 +7,5 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group';
-import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group-item';
+import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group.js';
+import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group-item.js';

--- a/packages/web-components/examples/codesandbox/components/button/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/button/src/index.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/button/button';
+import '@carbon/ibmdotcom-web-components/es/components/button/button.js';

--- a/packages/web-components/examples/codesandbox/components/callout-data/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/callout-data/src/index.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data';
+import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data.js';

--- a/packages/web-components/examples/codesandbox/components/callout-quote/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/callout-quote/src/index.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/callout-quote/callout-quote';
+import '@carbon/ibmdotcom-web-components/es/components/callout-quote/callout-quote.js';

--- a/packages/web-components/examples/codesandbox/components/callout-with-media/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/callout-with-media/src/index.js
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading';
-import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-copy';
-import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media';
-import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media-image';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-copy.js';
+import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media.js';
+import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media-image.js';

--- a/packages/web-components/examples/codesandbox/components/card-group/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/card-group/src/index.js
@@ -7,6 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group';
-import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group-item';
-import '@carbon/ibmdotcom-web-components/es/components/card/card-footer';
+import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group.js';
+import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/card/card-footer.js';

--- a/packages/web-components/examples/codesandbox/components/card-link/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/card-link/src/index.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link';
+import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link.js';

--- a/packages/web-components/examples/codesandbox/components/card/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/card/src/index.js
@@ -7,5 +7,5 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/card/card';
-import '@carbon/ibmdotcom-web-components/es/components/card/card-footer';
+import '@carbon/ibmdotcom-web-components/es/components/card/card.js';
+import '@carbon/ibmdotcom-web-components/es/components/card/card-footer.js';

--- a/packages/web-components/examples/codesandbox/components/content-item-horizontal/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/content-item-horizontal/src/index.js
@@ -7,8 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/content-item-horizontal/content-item-horizontal';
-import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-heading';
-import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-copy';
-import '@carbon/ibmdotcom-web-components/es/components/link-list/link-list';
-import '@carbon/ibmdotcom-web-components/es/components/cta/link-list-item-cta';
+import '@carbon/ibmdotcom-web-components/es/components/content-item-horizontal/content-item-horizontal.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-copy.js';
+import '@carbon/ibmdotcom-web-components/es/components/link-list/link-list.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta/link-list-item-cta.js';

--- a/packages/web-components/examples/codesandbox/components/cta-section/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/cta-section/src/index.js
@@ -7,6 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading';
-import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section';
-import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section.js';
+import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group.js';

--- a/packages/web-components/examples/codesandbox/components/expressive-modal/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/expressive-modal/src/index.js
@@ -7,10 +7,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/button/button';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-header';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-heading';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-close-button';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-body';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-footer';
+import '@carbon/ibmdotcom-web-components/es/components/button/button.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-header.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-close-button.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-body.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-footer.js';

--- a/packages/web-components/examples/codesandbox/components/footer/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/footer/src/index.js
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/footer/footer-container';
+import '@carbon/ibmdotcom-web-components/es/components/footer/footer-container.js';
 
 window.digitalData = {
   page: {

--- a/packages/web-components/examples/codesandbox/components/horizontal-rule/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/horizontal-rule/src/index.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/horizontal-rule/horizontal-rule';
+import '@carbon/ibmdotcom-web-components/es/components/horizontal-rule/horizontal-rule.js';

--- a/packages/web-components/examples/codesandbox/components/image/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/image/src/index.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/image/image';
+import '@carbon/ibmdotcom-web-components/es/components/image/image.js';

--- a/packages/web-components/examples/codesandbox/components/lightbox-media-viewer/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/lightbox-media-viewer/src/index.js
@@ -7,11 +7,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import VideoPlayerAPI from '@carbon/ibmdotcom-services/es/services/VideoPlayer/VideoPlayer';
-import '@carbon/ibmdotcom-web-components/es/components/button/button';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-close-button';
-import '@carbon/ibmdotcom-web-components/es/components/lightbox-media-viewer/lightbox-video-player';
+import VideoPlayerAPI from '@carbon/ibmdotcom-services/es/services/VideoPlayer/VideoPlayer.js';
+import '@carbon/ibmdotcom-web-components/es/components/button/button.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-close-button.js';
+import '@carbon/ibmdotcom-web-components/es/components/lightbox-media-viewer/lightbox-video-player.js';
 
 document.addEventListener('click', async event => {
   if (event.target.id === 'open-modal-btn') {

--- a/packages/web-components/examples/codesandbox/components/link-with-icon/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/link-with-icon/src/index.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/link-with-icon/link-with-icon';
+import '@carbon/ibmdotcom-web-components/es/components/link-with-icon/link-with-icon.js';

--- a/packages/web-components/examples/codesandbox/components/locale-modal/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/src/index.js
@@ -7,5 +7,5 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/button/button';
-import '@carbon/ibmdotcom-web-components/es/components/locale-modal/locale-modal-container';
+import '@carbon/ibmdotcom-web-components/es/components/button/button.js';
+import '@carbon/ibmdotcom-web-components/es/components/locale-modal/locale-modal-container.js';

--- a/packages/web-components/examples/codesandbox/components/logo-grid/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/logo-grid/src/index.js
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid';
-import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-item';
-import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-link';
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading';
+import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid.js';
+import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-link.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';

--- a/packages/web-components/examples/codesandbox/components/masthead/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/masthead/src/index.js
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/masthead/masthead-container';
+import '@carbon/ibmdotcom-web-components/es/components/masthead/masthead-container.js';
 import './index.scss';
 
 window.digitalData = {

--- a/packages/web-components/examples/codesandbox/components/quote/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/quote/src/index.js
@@ -7,6 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/quote/quote';
-import '@carbon/ibmdotcom-web-components/es/components/link-with-icon/link-with-icon';
+import '@carbon/ibmdotcom-web-components/es/components/quote/quote.js';
+import '@carbon/ibmdotcom-web-components/es/components/link-with-icon/link-with-icon.js';
 import 'carbon-web-components/es/icons/arrow--right/20.js';

--- a/packages/web-components/src/components/button-group/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/button-group/__stories__/README.stories.mdx
@@ -17,19 +17,9 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group';
-import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group-item';
+import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group.js';
+import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group-item.js';
 import 'carbon-web-components/es/icons/arrow--right/20.js';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/button-group/button-group.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/button-group/button-group-item.js';
-  import 'https://jspm.dev/carbon-web-components/es/icons/arrow--right/20.js';
-</script>
 ```
 
 ### HTML

--- a/packages/web-components/src/components/button/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/button/__stories__/README.stories.mdx
@@ -21,15 +21,7 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/button/button';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/button/button.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/button/button.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/callout-data/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/callout-data/__stories__/README.stories.mdx
@@ -17,15 +17,7 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/callout-data/callout-data.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/callout-quote/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/callout-quote/__stories__/README.stories.mdx
@@ -17,15 +17,7 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/callout-quote/callout-quote';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/callout-quote/callout-quote.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/callout-quote/callout-quote.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/callout-with-media/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/callout-with-media/__stories__/README.stories.mdx
@@ -18,15 +18,7 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/callout-with-media/callout-with-media.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/card-group/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-group/__stories__/README.stories.mdx
@@ -17,17 +17,9 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group';
-import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group-item';
-import '@carbon/ibmdotcom-web-components/es/components/card/card-footer';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/card-group/card-group.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group.js';
+import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/card/card-footer.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/card-link/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-link/__stories__/README.stories.mdx
@@ -17,15 +17,7 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/card-link/card-link.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card/__stories__/README.stories.mdx
@@ -17,15 +17,7 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/card/card';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/card/card.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/card/card.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/cta-section/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/cta-section/__stories__/README.stories.mdx
@@ -18,14 +18,14 @@ Here's a quick example to get you started.
 
 ```javascript
 
-import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section';
-import '@carbon/ibmdtocom-web-components/es/components/cta-section/cta-section-copy';
-import '@carbon/ibmdtocom-web-components/es/components/cta-section/cta-section-item';
-import '@carbon/ibmdtocom-web-components/es/components/cta-section/cta-section-heading';
-import '@carbon/ibmdtocom-web-components/es/components/cta-section/cta-section-item-copy';
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading';
-import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group';
-import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group-item';
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section.js';
+import '@carbon/ibmdtocom-web-components/es/components/cta-section/cta-section-copy.js';
+import '@carbon/ibmdtocom-web-components/es/components/cta-section/cta-section-item.js';
+import '@carbon/ibmdtocom-web-components/es/components/cta-section/cta-section-heading.js';
+import '@carbon/ibmdtocom-web-components/es/components/cta-section/cta-section-item-copy.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group.js';
+import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group-item.js';
 
 ```
 

--- a/packages/web-components/src/components/cta/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/cta/__stories__/README.stories.mdx
@@ -25,15 +25,7 @@ import '../feature-cta';
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/cta/text-cta';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/cta/text-cta.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/cta/text-cta.js';
 ```
 
 ### HTML
@@ -61,15 +53,7 @@ or with [JSPM](https://jspm.org)
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/cta/card-cta';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/cta/card-cta.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/cta/card-cta.js';
 ```
 
 ### HTML
@@ -97,17 +81,8 @@ or with [JSPM](https://jspm.org)
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/cta/feature-cta';
-import '@carbon/ibmdotcom-web-components/es/components/image/image';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/cta/feature-cta.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/image/image.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/cta/feature-cta.js';
+import '@carbon/ibmdotcom-web-components/es/components/image/image.js';
 ```
 
 ### HTML
@@ -156,11 +131,11 @@ video player component and working with our video player service API to put the
 video data into the video player component:
 
 ```javascript
-import VideoPlayerAPI from '@carbon/ibmdotcom-services/es/services/VideoPlayer/VideoPlayer';
-import '@carbon/ibmdotcom-web-components/es/components/cta/text-cta';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-close-button';
-import '@carbon/ibmdotcom-web-components/es/components/lightbox-media-viewer/lightbox-video-player';
+import VideoPlayerAPI from '@carbon/ibmdotcom-services/es/services/VideoPlayer/VideoPlayer.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta/text-cta.js.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-close-button.js';
+import '@carbon/ibmdotcom-web-components/es/components/lightbox-media-viewer/lightbox-video-player.js';
 
 ...
 

--- a/packages/web-components/src/components/dotcom-shell/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/README.stories.mdx
@@ -21,7 +21,7 @@ import contributing from '../../../../../../docs/contributing-license.md';
 #### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/dotcom-shell/dotcom-shell-container';
+import '@carbon/ibmdotcom-web-components/es/components/dotcom-shell/dotcom-shell-container.js';
 ```
 
 #### HTML
@@ -39,7 +39,7 @@ You can also render the footer content on your own, e.g. for server-side renderi
 #### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/dotcom-shell/dotcom-shell';
+import '@carbon/ibmdotcom-web-components/es/components/dotcom-shell/dotcom-shell.js';
 ```
 
 #### HTML

--- a/packages/web-components/src/components/expressive-modal/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/expressive-modal/__stories__/README.stories.mdx
@@ -21,25 +21,12 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-header';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-heading';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-close-button';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-body';
-import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-footer';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/expressive-modal/expressive-modal.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/expressive-modal/expressive-modal-header.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/expressive-modal/expressive-modal-heading.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/expressive-modal/expressive-modal-close-button.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/expressive-modal/expressive-modal-body.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/expressive-modal/expressive-modal-footer.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-header.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-close-button.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-body.js';
+import '@carbon/ibmdotcom-web-components/es/components/expressive-modal/expressive-modal-footer.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/feature-card-block-large/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/feature-card-block-large/__stories__/README.stories.mdx
@@ -21,15 +21,6 @@ import '@carbon/ibmdotcom-web-components/es/components/featuer-card/feature-card
 import '@carbon/ibmdotcom-web-components/es/components/feature-card-block-large/feature-card-block-large.js';
 ```
 
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/feature-card/feature-card-block-large-footer.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/feature-card-block-large/feature-card-block-large.js';
-</script>
-```
-
 ### HTML
 
 ```html

--- a/packages/web-components/src/components/feature-card-block-medium/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/feature-card-block-medium/__stories__/README.stories.mdx
@@ -24,18 +24,6 @@ import '@carbon/ibmdotcom-web-components/es/components/feature-card-block-medium
 import '@carbon/ibmdotcom-web-components/es/components/feature-card-block-medium/feature-card-block-medium-card.js';
 ```
 
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/feature-card/feature-card-footer.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/image/image.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/feature-card-block-medium/feature-card-block-medium.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/feature-card-block-medium/feature-card-block-medium-heading.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/feature-card-block-medium/feature-card-block-medium-card.js';
-</script>
-```
-
 ### HTML
 
 ```html

--- a/packages/web-components/src/components/feature-card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/feature-card/__stories__/README.stories.mdx
@@ -21,15 +21,6 @@ import '@carbon/ibmdotcom-web-components/es/components/feature-card/feature-card
 import '@carbon/ibmdotcom-web-components/es/components/feature-card/feature-card.js';
 ```
 
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/feature-card/feature-card-footer.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/feature-card/feature-card.js';
-</script>
-```
-
 ### HTML
 
 ```html

--- a/packages/web-components/src/components/footer/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/footer/__stories__/README.stories.mdx
@@ -43,14 +43,14 @@ You can also render the footer content by your own, e.g. for server-side renderi
 ##### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/footer/footer';
-import '@carbon/ibmdotcom-web-components/es/components/footer/footer-logo';
-import '@carbon/ibmdotcom-web-components/es/components/footer/footer-nav';
-import '@carbon/ibmdotcom-web-components/es/components/footer/footer-nav-group';
-import '@carbon/ibmdotcom-web-components/es/components/footer/footer-nav-item';
-import '@carbon/ibmdotcom-web-components/es/components/footer/legal-nav';
-import '@carbon/ibmdotcom-web-components/es/components/footer/legal-nav-item';
-import '@carbon/ibmdotcom-web-components/es/components/footer/locale-button';
+import '@carbon/ibmdotcom-web-components/es/components/footer/footer.js';
+import '@carbon/ibmdotcom-web-components/es/components/footer/footer-logo.js';
+import '@carbon/ibmdotcom-web-components/es/components/footer/footer-nav.js';
+import '@carbon/ibmdotcom-web-components/es/components/footer/footer-nav-group.js';
+import '@carbon/ibmdotcom-web-components/es/components/footer/footer-nav-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/footer/legal-nav.js';
+import '@carbon/ibmdotcom-web-components/es/components/footer/legal-nav-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/footer/locale-button.js';
 
 document.addEventListener('click', event => {
   if (event.target.matches('dds-locale-button')) {

--- a/packages/web-components/src/components/horizontal-rule/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/horizontal-rule/__stories__/README.stories.mdx
@@ -17,15 +17,7 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/horizontal-rule/horizontal-rule';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/horizontal-rule/horizontal-rule.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/horizontal-rule/horizontal-rule.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/image-with-caption/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/image-with-caption/__stories__/README.stories.mdx
@@ -19,21 +19,22 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/imagewithcaption/imagewithcaption';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/imagewithcaption/imagewithcaption.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/image-with-caption/image-with-caption.js';
 ```
 
 ### HTML
 
 ```html
-    <dds-image-with-caption default-src='https://dummyimage.com/672x336/ee5396/161616&text=2x1' heading="this is a heading" copy="lorum ipsum" ?lightbox={true} />
+<dds-image-with-caption
+  default-src='https://dummyimage.com/672x336/ee5396/161616&text=2x1'
+  heading="this is a heading"
+  copy="lorum ipsum"
+  lightbox
+>
+  <dds-image-item media="(min-wiidth:672px)" href="https://dummyimage.com/672x336/ee5396/161616&text=2x1"> </dds-image-item>
+  <dds-image-item media="(min-wiidth:400px)" href="https://dummyimage.com/672x336/ee5396/161616&text=2x1"> </dds-image-item>
+  <dds-image-item media="(min-wiidth:320px)" href="https://dummyimage.com/672x336/ee5396/161616&text=2x1"> </dds-image-item>
+</dds-image-with-caption>
 ```
 
 ## Props

--- a/packages/web-components/src/components/image/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/image/__stories__/README.stories.mdx
@@ -21,15 +21,7 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/image/image';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/image/image.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/image/image.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/leadspace/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/leadspace/__stories__/README.stories.mdx
@@ -17,22 +17,11 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/leadspace/leadspace';
-import '@carbon/ibmdotcom-web-components/es/components/image/image';
-import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
-import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group';
-import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group-item';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/leadspace/leadspace.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/image/image.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/button-group/button-group.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/button-group/button-group-item.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/leadspace/leadspace.js';
+import '@carbon/ibmdotcom-web-components/es/components/image/image.js';
+import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20.js';
+import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group.js';
+import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group-item.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/lightbox-media-viewer/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/lightbox-media-viewer/__stories__/README.stories.mdx
@@ -12,22 +12,12 @@ import '../lightbox-video-player';
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/modal/modal';
-import '@carbon/ibmdotcom-web-components/es/components/modal/modal-close-button';
-import '@carbon/ibmdotcom-web-components/es/components/lightbox-media-viewer/lightbox-image-viewer';
+import '@carbon/ibmdotcom-web-components/es/components/modal/modal.js';
+import '@carbon/ibmdotcom-web-components/es/components/modal/modal-close-button.js';
+import '@carbon/ibmdotcom-web-components/es/components/lightbox-media-viewer/lightbox-image-viewer.js';
 
 // Opens the lightbox image viewer
 document.getElementById('my-lightbox').open = true;
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/modal/modal.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/modal/modal-close-button.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/lightbox-media-viewer/lightbox-image-viewer.js';
-</script>
 ```
 
 ### HTML
@@ -53,18 +43,10 @@ or with [JSPM](https://jspm.org)
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/lightbox-media-viewer/lightbox-video-player-container';
+import '@carbon/ibmdotcom-web-components/es/components/lightbox-media-viewer/lightbox-video-player-container.js';
 
 // Opens the lightbox media viewer
 document.getElementById('my-video').open = true;
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/lightbox-media-viewer/lightbox-video-player-container.js';
-</script>
 ```
 
 ### HTML
@@ -102,11 +84,11 @@ See [our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/t
 When application code opens the lightbox, it can work with our video player service API to put the video data into the video player component:
 
 ```javascript
-import 'carbon-web-components/es/components/modal/modal-close-button';
-import VideoPlayerAPI from '@carbon/ibmdotcom-services/es/services/VideoPlayer/VideoPlayer';
-import '@carbon/ibmdotcom-web-components/es/components/button/button';
-import '@carbon/ibmdotcom-web-components/es/components/modal/modal';
-import '@carbon/ibmdotcom-web-components/es/components/lightbox-media-viewer/lightbox-video-player';
+import 'carbon-web-components/es/components/modal/modal-close-button.js';
+import VideoPlayerAPI from '@carbon/ibmdotcom-services/es/services/VideoPlayer/VideoPlayer.js';
+import '@carbon/ibmdotcom-web-components/es/components/button/button.js';
+import '@carbon/ibmdotcom-web-components/es/components/modal/modal.js';
+import '@carbon/ibmdotcom-web-components/es/components/lightbox-media-viewer/lightbox-video-player.js';
 
 ...
 

--- a/packages/web-components/src/components/link-list/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/link-list/__stories__/README.stories.mdx
@@ -17,19 +17,9 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/link-list/link-list';
-import '@carbon/ibmdotcom-web-components/es/components/link-list/link-list-item';
-import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/link-list/link-list.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/link-list/link-list-item.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/card-link/card-link.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/link-list/link-list.js';
+import '@carbon/ibmdotcom-web-components/es/components/link-list/link-list-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/link-with-icon/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/link-with-icon/__stories__/README.stories.mdx
@@ -19,15 +19,7 @@ import '../link-with-icon';
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/link-with-icon/link-with-icon';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/link-with-icon/link-with-icon.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/link-with-icon/link-with-icon.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/locale-modal/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/locale-modal/__stories__/README.stories.mdx
@@ -24,15 +24,7 @@ import contributing from '../../../../../../docs/contributing-license.md';
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/locale-modal/locale-modal-container';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/locale-modal/locale-modal-container.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/locale-modal/locale-modal-container.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/logo-grid/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/logo-grid/__stories__/README.stories.mdx
@@ -17,22 +17,11 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid';
-import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-item';
-import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-link';
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading';
+import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid.js';
+import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-link.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';
 
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/logo-grid/logo-grid.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/logo-grid/logo-grid-item.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/logo-grid/logo-grid-link.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/content-block/content-block-heading.js';
-</script>
 ```
 
 ### HTML

--- a/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
@@ -18,7 +18,7 @@ import contributing from '../../../../../../docs/contributing-license.md';
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/masthead/masthead-container';
+import '@carbon/ibmdotcom-web-components/es/components/masthead/masthead-container.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/pictogram-item/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/pictogram-item/__stories__/README.stories.mdx
@@ -18,15 +18,7 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/pictogram-item/pictogram-item';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/pictogram-item/pictogram-item.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/pictogram-item/pictogram-item.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/quote/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/quote/__stories__/README.stories.mdx
@@ -17,17 +17,8 @@ Here's a quick example to get you started.
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/quote/quote';
-import '@carbon/ibmdotcom-web-components/es/components/link-with-icon/link-with-icon';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/quote/quote.js';
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/link-with-icon/link-with-icon.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/quote/quote.js';
+import '@carbon/ibmdotcom-web-components/es/components/link-with-icon/link-with-icon.js';
 ```
 
 ### HTML

--- a/packages/web-components/src/components/table-of-contents/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/README.stories.mdx
@@ -22,7 +22,7 @@ Here's a quick example to get you started.
 ##### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/table-of-contents/table-of-contents';
+import '@carbon/ibmdotcom-web-components/es/components/table-of-contents/table-of-contents.js';
 ```
 
 ##### SCSS

--- a/packages/web-components/src/components/video-player/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/video-player/__stories__/README.stories.mdx
@@ -9,15 +9,7 @@ import '../video-player';
 ### JS
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/es/components/video-player/video-player-container';
-```
-
-or with [JSPM](https://jspm.org)
-
-```html
-<script type="module">
-  import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/video-player/video-player-container.js';
-</script>
+import '@carbon/ibmdotcom-web-components/es/components/video-player/video-player-container.js';
 ```
 
 ### HTML
@@ -32,7 +24,7 @@ or with [JSPM](https://jspm.org)
 With `@carbon/ibmdotcom-services`, you can keep track of the readiness of [Kaltura API](http://player.kaltura.com/docs/api) and use it when it is ready. Here is an example of stopping the video player when it is hidden in DOM:
 
 ```javascript
-import VideoPlayerAPI from '@carbon/ibmdotcom-services/es/services/VideoPlayer/VideoPlayer';
+import VideoPlayerAPI from '@carbon/ibmdotcom-services/es/services/VideoPlayer/VideoPlayer.js';
 
 // Keeps track of element resize and detect if the element of our interest is hidden
 const resizeObserver = new ResizeObserver(entries => {


### PR DESCRIPTION
### Related Ticket(s)

Refs #4436.

### Description

Adds `.js` extensions to the `import`s in CodeSandbox example as well as our READMEs, because some module bundlers work with latest Node module resolution algorithm that disallows ESM imports without `.js`.

Also removes JSPM instructions from READMEs because we have seen issues with it (likely in JSPM side) and our adaptors have reported it even.

It's worth re-evaluating JSPM usage in future, though, when such issue will potentially be resolved.

### Changelog

**Changed**

- Adds `.js` extensions to the `import`s in CodeSandbox example as well as our READMEs

**Removed**

- JSPM instructions.