### PR TITLE
fix(cta-section): aligning link list with other text elements

### DIFF
--- a/packages/web-components/src/components/link-list/link-list.scss
+++ b/packages/web-components/src/components/link-list/link-list.scss
@@ -71,12 +71,6 @@
 
   &.#{$prefix}--link-list__split {
     @include carbon--breakpoint('md') {
-      @include carbon--breakpoint('lg') {
-        ul {
-          padding-left: $layout-01;
-        }
-      }
-
       ul {
         display: block;
         columns: 2;


### PR DESCRIPTION
### Related Ticket(s)

#3366

### Description

The horizontal rules from LinkList now overhang in order to make the links match with the text above.

![](https://user-images.githubusercontent.com/30183447/98694133-165c6d80-233f-11eb-84ff-4c6ec768a47d.png)

### Changelog

**Removed**

- unnecessary left padding that made horizontal rules align with text instead of overhanging

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
