### PR TITLE
fix(link-list): change role for link-list items to link

### DIFF
--- a/packages/web-components/src/components/link-list/link-list-item-card.ts
+++ b/packages/web-components/src/components/link-list/link-list-item-card.ts
@@ -23,7 +23,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 class DDSLinkListItem extends DDSCardLink {
   connectedCallback() {
     if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'listitem');
+      this.setAttribute('role', 'link');
     }
     super.connectedCallback();
   }

--- a/packages/web-components/src/components/link-list/link-list-item.ts
+++ b/packages/web-components/src/components/link-list/link-list-item.ts
@@ -23,7 +23,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 class DDSLinkListItem extends DDSLinkWithIcon {
   connectedCallback() {
     if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'listitem');
+      this.setAttribute('role', 'link');
     }
     super.connectedCallback();
   }


### PR DESCRIPTION
### Related Ticket(s)

Web component: Link List - In iPhone VO there is no role for the mentioned links #4061

### Description

Change the role to link from link-list item and card for screen readers. Previously it was set to `listitem` which does not let screen reader users know that it's actually a clickable link.

### Changelog

**Changed**

- change `role` for `link-list-item` and `link-list-card` to `link`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
