### PR TITLE
fix(link-list): make item role back to listitem

### DIFF
--- a/packages/web-components/src/components/link-list/link-list-item-card.ts
+++ b/packages/web-components/src/components/link-list/link-list-item-card.ts
@@ -23,7 +23,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 class DDSLinkListItem extends DDSCardLink {
   connectedCallback() {
     if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'link');
+      this.setAttribute('role', 'listitem');
     }
     super.connectedCallback();
   }

--- a/packages/web-components/src/components/link-list/link-list-item.ts
+++ b/packages/web-components/src/components/link-list/link-list-item.ts
@@ -23,7 +23,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 class DDSLinkListItem extends DDSLinkWithIcon {
   connectedCallback() {
     if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'link');
+      this.setAttribute('role', 'listitem');
     }
     super.connectedCallback();
   }


### PR DESCRIPTION
### Related Ticket(s)

Refs #4061.

### Description

Makes `<dds-link-list-item>`'s host element's a11y role back to `<listitem>` as the host element works as `<li>` and the `<a>` is rendered into Shadow DOM.

The earlier change that made `<dds-link-list-item>`'s host element's a11y role to `link` was from a testing from ChromeVox, but some links tell that ChromeVox does support Shadow DOM. Also, in native Chrome DevTools, the a11y tree inspector correctly shows `link` role in `<a>`, and in desktop/mobile Safari VoiceOver correctly announces the `<a>`s in Shadow DOM as links.

![image](https://user-images.githubusercontent.com/1259051/99326458-b6744280-28bb-11eb-82b0-7490e578317a.png)
![link-role](https://user-images.githubusercontent.com/1259051/99326439-ae1c0780-28bb-11eb-95a2-91b9e774cdf7.gif)

### Changelog

**Changed**

- `<dds-link-list-item>`'s host element's a11y role back to `listitem`