### PR TITLE
fix(tableofcontents): fix top positions in dotcomshell

### DIFF
--- a/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
+++ b/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
@@ -17,6 +17,10 @@
     flex-direction: column;
     min-height: 100vh;
     padding-top: $carbon--layout-04;
+
+    .#{$prefix}--tableofcontents__sidebar {
+      top: 49px;
+    }
   }
 
   .#{$prefix}--dotcom-shell__content {

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -177,7 +177,26 @@ $search-transition-timing: 95ms;
   }
 
   .#{$prefix}--masthead--sticky.#{$prefix}--masthead--sticky__l1 {
-    top: -48px;
+    @include carbon--breakpoint-up(800px) {
+      top: -48px;
+    }
+  }
+
+  .#{$prefix}--masthead--sticky__l1 + .#{$prefix}--dotcom-shell {
+    @include carbon--breakpoint-up(800px) {
+      .#{$prefix}--tableofcontents__sidebar {
+        top: 98px;
+      }
+    }
+  }
+
+  .#{$prefix}--masthead--sticky__l1.#{$prefix}--masthead--sticky
+    + .#{$prefix}--dotcom-shell {
+    .#{$prefix}--tableofcontents__sidebar {
+      @include carbon--breakpoint-up(800px) {
+        top: 48px;
+      }
+    }
   }
 
   .#{$prefix}--masthead__l0 {


### PR DESCRIPTION
### Related Ticket(s)

#4334 

### Description

This addresses various `TableOfContents` CSS issues when it is contained in the `DotcomShell`.

## `L0`
![Nov-17-2020 10-24-26](https://user-images.githubusercontent.com/909118/99411137-410b7080-28c1-11eb-95d4-9b36785b25f6.gif)

## `L1`
![Nov-17-2020 10-29-17](https://user-images.githubusercontent.com/909118/99411239-5da7a880-28c1-11eb-977b-0d827c733746.gif)


### Changelog


**Changed**

- update `TOC` styles to position itself correctly when contained in the `DotcomShell`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
