### PR TITLE
fix(Masthead): regular dropdown menu visible outside of masthead nav bar

### DIFF
--- a/packages/react/src/components/Masthead/__stories__/data/MastheadLinks.js
+++ b/packages/react/src/components/Masthead/__stories__/data/MastheadLinks.js
@@ -67,7 +67,6 @@ const mastheadLinks = [
     titleEnglish: 'Consectetur adipiscing elit',
     url: '',
     hasMenu: true,
-    hasMegapanel: true,
     menuSections: [
       {
         heading: '',

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -41,6 +41,7 @@ $search-transition-timing: 95ms;
   .#{$prefix}--masthead__l1-name {
     display: flex;
     height: 100%;
+    z-index: 1;
     background-color: $ui-02;
     color: $text-04;
     padding: 0 rem(12px);

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -16,6 +16,8 @@
   border: solid 2px transparent;
   transition: $button-transition;
   position: relative;
+  z-index: 1;
+  background-color: $ui-background;
 
   &:hover {
     background-color: $hover-ui;
@@ -38,6 +40,16 @@
     height: 1.5rem;
     width: 0.0625rem;
     background-color: #dcdcdc;
+  }
+
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    width: 15px;
+    height: $spacing-09;
+    left: calc(-1rem - 1px);
+    background-color: $ui-background;
   }
 
   @include carbon--breakpoint-down(800px) {

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -92,7 +92,7 @@
 
   .#{$prefix}--header__search:not(.#{$prefix}--masthead__header--search-active) {
     @include carbon--breakpoint(md) {
-      overflow-x: auto;
+      overflow-x: visible;
     }
   }
 

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -18,6 +18,8 @@ $search-transition-timing: 95ms;
 /// @access private
 @mixin masthead-logo {
   height: 100%;
+  z-index: 1;
+  background-color: $ui-background;
 
   a {
     display: flex;
@@ -229,7 +231,7 @@ $search-transition-timing: 95ms;
 
   .#{$prefix}--header__nav-container {
     height: 100%;
-    overflow-x: hidden;
+    overflow-x: visible;
     position: relative;
     @include carbon--breakpoint(md) {
       display: flex;
@@ -292,6 +294,7 @@ $search-transition-timing: 95ms;
   }
   .#{$prefix}--header__action {
     border: 2px solid transparent;
+    background-color: $ui-background;
     > {
       svg {
         position: relative;

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -16,21 +16,6 @@
 @import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead-megamenu';
 @import '../../globals/scss/box-sizing';
 
-// The masthead nav overflow feature made tweaks to overflow style so it can keep track of overflowed content.
-// It works with mega menu that "floats",
-// but Web Components masthead menu with classic menu style still relies on the overflow area being visible.
-:host(#{$dds-prefix}-masthead) {
-  .#{$prefix}--header__search {
-    @include carbon--breakpoint(md) {
-      overflow-x: visible;
-    }
-  }
-
-  .#{$prefix}--header__nav-container {
-    overflow-x: visible;
-  }
-}
-
 :host(#{$dds-prefix}-masthead-menu-button) {
   @extend :host(#{$prefix}-header-menu-button);
 


### PR DESCRIPTION
### Related Ticket(s)

[Masthead]: Dropdown menu items are appearing on scroll within the masthead nav bar #4504

### Description

The dropdown menu was appearing within the nav bar and user had to scroll within the nav bar to see the menu items. Setting the overflow to visible allows the dropdown to be visible outside of the nav bar

<img width="1460" alt="Screen Shot 2020-11-17 at 4 38 16 PM" src="https://user-images.githubusercontent.com/54281166/99456813-f8bb7500-28f7-11eb-94a8-adc280e39e8a.png">

### Changelog

**Changed**

- removed the `hasMegapanel` field from one of the nav links in the masthead story data file so this fix is easily testable in storybook (be sure to set the `navigation knob` to `custom` in order to test)
- set `bx--header__search` and `bx--header__nav-container` div `overflow-x` to `visible` so the dropdown is visible outside of the nav bar
- set the z-index and background colors for the IBM logo, search, and profile buttons so it doesn't clash with the overflowing nav items

**Removed**

- web-components specific styles for when the masthead only supported the regular dropdown, the code is now in the corresponding stylesheets

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
