### PR TITLE
fix(logo-grid): changing story styles to adhere to react version

### DIFF
--- a/packages/web-components/src/components/logo-grid/__stories__/logo-grid.stories.ts
+++ b/packages/web-components/src/components/logo-grid/__stories__/logo-grid.stories.ts
@@ -46,7 +46,7 @@ export default {
     story => html`
       <div style="width: 100%" class="bx--grid dds-ce-demo-devenv--grid--stretch">
         <div class="bx--row">
-          <div class="bx--col-lg-8 bx--offset-lg-2 bx--col-sm-4">
+          <div class="bx--col-sm-4 bx--col-md-8 bx--col-lg-12 bx--offset-lg-2">
             ${story()}
           </div>
         </div>


### PR DESCRIPTION
### Related Ticket(s)

#4427 

### Description

The Web Components story version of `LogoGrid` was using different layout classes than the React version, making the cards appear smaller. The updated story now includes the same classes as the React version, now showing their size as intended.

### Changelog

**Changed**

- changed story grid layouts to match the React story version of `LogoGrid`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
