### PR TITLE
fix(leadspace): fix gradients

### DIFF
--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -28,7 +28,7 @@ $btn-min-width: 26;
       background-image: linear-gradient(
         to right,
         rgba($color, 0.95),
-        transparent 75%
+        rgba($color, 0) 75%
       );
     }
 
@@ -38,7 +38,7 @@ $btn-min-width: 26;
         $color,
         rgba($color, 0.8),
         rgba($color, 0.6),
-        transparent 80%
+        rgba($color, 0) 80%
       );
     }
   }
@@ -354,6 +354,59 @@ $btn-min-width: 26;
         feature-flag-enabled('enable-css-custom-properties')
       ) {
         @include themed-items(dark);
+      }
+    }
+
+    .#{$prefix}--leadspace__gradient {
+      display: none;
+
+      @include carbon--breakpoint(md) {
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+    }
+
+    .#{$prefix}--leadspace__gradient__rect {
+      fill: url(#stops);
+    }
+
+    .#{$prefix}--leadspace--centered .#{$prefix}--leadspace__gradient__stops {
+      transform: rotate(90deg);
+    }
+
+    .#{$prefix}--leadspace__gradient__stops stop {
+      stop-color: $ui-background;
+
+      &:nth-of-type(1) {
+        stop-opacity: 0.95;
+      }
+
+      &:nth-of-type(2) {
+        stop-opacity: 0;
+      }
+    }
+
+    .#{$prefix}--leadspace--centered
+      .#{$prefix}--leadspace__gradient__stops
+      stop {
+      &:nth-of-type(1) {
+        stop-opacity: 1;
+      }
+
+      &:nth-of-type(2) {
+        stop-opacity: 0.8;
+      }
+
+      &:nth-of-type(3) {
+        stop-opacity: 0.6;
+      }
+
+      &:nth-of-type(4) {
+        stop-opacity: 0;
       }
     }
   }

--- a/packages/web-components/.storybook/config.ts
+++ b/packages/web-components/.storybook/config.ts
@@ -106,6 +106,7 @@ let preservedTheme;
 
 addDecorator((story, { parameters }) => {
   const root = document.documentElement;
+  root.toggleAttribute('storybook-carbon-theme-prevent-reload', parameters['carbon-theme']?.preventReload);
   if (parameters['carbon-theme']?.disabled) {
     root.setAttribute('storybook-carbon-theme', '');
   } else {
@@ -116,7 +117,10 @@ addDecorator((story, { parameters }) => {
 
 addons.getChannel().on(CURRENT_THEME, theme => {
   document.documentElement.setAttribute('storybook-carbon-theme', (preservedTheme = theme));
-  addons.getChannel().emit(coreEvents.FORCE_RE_RENDER);
+  // Re-rendering upon theme change causes adverse effect for some stories
+  if (!document.documentElement.hasAttribute('storybook-carbon-theme-prevent-reload')) {
+    addons.getChannel().emit(coreEvents.FORCE_RE_RENDER);
+  }
 });
 
 const reqDocs = require.context('../docs', true, /\.stories\.mdx$/);

--- a/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
+++ b/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
@@ -177,6 +177,7 @@ export default {
   ],
   parameters: {
     ...readme.parameters,
+    'carbon-theme': { preventReload: true },
     hasGrid: true,
     hasVerticalSpacingInComponent: true,
     knobs: {

--- a/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
+++ b/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
@@ -13,18 +13,27 @@ import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20.js';
 import ArrowDown20 from 'carbon-web-components/es/icons/arrow--down/20.js';
 import Pdf20 from 'carbon-web-components/es/icons/PDF/20.js';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
+/* eslint-disable import/no-duplicates */
+import { LEADSPACE_GRADIENT_STYLE_SCHEME } from '../leadspace';
+// Above import is interface-only ref and thus code won't be brought into the build
 import '../leadspace';
+/* eslint-enable import/no-duplicates */
+
 import '../../image/image';
 import '../../button-group/button-group';
 import '../../button-group/button-group-item';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 import readme from './README.stories.mdx';
 
+const gradientStyleSchemes = {
+  [`Without gradient (${LEADSPACE_GRADIENT_STYLE_SCHEME.NONE})`]: LEADSPACE_GRADIENT_STYLE_SCHEME.NONE,
+  [`With gradient (${LEADSPACE_GRADIENT_STYLE_SCHEME.WITH_GRADIENT})`]: LEADSPACE_GRADIENT_STYLE_SCHEME.WITH_GRADIENT,
+};
+
 export const DefaultWithNoImage = ({ parameters }) => {
   const { alt, defaultSrc, title, copy, buttons } = parameters?.props?.LeadSpace ?? {};
-  const theme = document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
   return html`
-    <dds-leadspace theme="${ifNonNull(theme)}" alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}">
+    <dds-leadspace alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}">
       <span slot="title">${ifNonNull(title)}</span>
       <span slot="copy">${ifNonNull(copy)}</span>
       <dds-button-group slot="buttons">
@@ -39,12 +48,10 @@ export const DefaultWithNoImage = ({ parameters }) => {
 };
 
 export const DefaultWithImage = ({ parameters }) => {
-  const { alt, defaultSrc, gradient, title, copy, buttons } = parameters?.props?.LeadSpace ?? {};
-  const theme = document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
+  const { alt, defaultSrc, gradientStyleScheme, title, copy, buttons } = parameters?.props?.LeadSpace ?? {};
   return html`
     <dds-leadspace
-      theme="${ifNonNull(theme)}"
-      ?gradient="${ifNonNull(gradient)}"
+      gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
       default-src="${ifNonNull(defaultSrc)}"
     >
@@ -67,9 +74,8 @@ export const DefaultWithImage = ({ parameters }) => {
 
 export const Centered = ({ parameters }) => {
   const { title, copy, buttons } = parameters?.props?.LeadSpace ?? {};
-  const theme = document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
   return html`
-    <dds-leadspace theme="${ifNonNull(theme)}" type="centered">
+    <dds-leadspace type="centered">
       <span slot="title">${ifNonNull(title)}</span>
       <span slot="copy">${ifNonNull(copy)}</span>
       <dds-button-group slot="buttons">
@@ -85,10 +91,8 @@ export const Centered = ({ parameters }) => {
 
 export const CenteredWithImage = ({ parameters }) => {
   const { alt, defaultSrc, gradient, title, copy, buttons } = parameters?.props?.LeadSpace ?? {};
-  const theme = document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
   return html`
     <dds-leadspace
-      theme="${ifNonNull(theme)}"
       ?gradient="${ifNonNull(gradient)}"
       alt="${ifNonNull(alt)}"
       default-src="${ifNonNull(defaultSrc)}"
@@ -113,9 +117,8 @@ export const CenteredWithImage = ({ parameters }) => {
 
 export const Small = ({ parameters }) => {
   const { alt, defaultSrc, title, copy, buttons } = parameters?.props?.LeadSpace ?? {};
-  const theme = document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
   return html`
-    <dds-leadspace theme="${ifNonNull(theme)}" alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}" type="small">
+    <dds-leadspace alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}" type="small">
       <span slot="title">${ifNonNull(title)}</span>
       <span slot="copy">${ifNonNull(copy)}</span>
       <dds-button-group slot="buttons">
@@ -131,15 +134,8 @@ export const Small = ({ parameters }) => {
 
 export const SmallWithImage = ({ parameters }) => {
   const { alt, defaultSrc, gradient, title, copy, buttons } = parameters?.props?.LeadSpace ?? {};
-  const theme = document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
   return html`
-    <dds-leadspace
-      theme="${ifNonNull(theme)}"
-      ?gradient="${ifNonNull(gradient)}"
-      alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}"
-      type="small"
-    >
+    <dds-leadspace ?gradient="${ifNonNull(gradient)}" alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}" type="small">
       <span slot="title">${ifNonNull(title)}</span>
       <span slot="copy">${ifNonNull(copy)}</span>
       <dds-button-group slot="buttons">
@@ -188,6 +184,12 @@ export default {
         title: text('title (title):', 'Lead space title', groupId),
         copy: text('copy (copy):', 'Use this area for a short line of copy to support the title', groupId),
         gradient: boolean('gradient overlay (gradient)', true, groupId),
+        gradientStyleScheme: select(
+          'Gradient style scheme (gradient-style-scheme)',
+          gradientStyleSchemes,
+          LEADSPACE_GRADIENT_STYLE_SCHEME.WITH_GRADIENT,
+          groupId
+        ),
         buttons: Array.from({
           length: number('Number of buttons', 2, {}, groupId),
         }).map((_, i) => ({

--- a/packages/web-components/src/components/leadspace/leadspace.scss
+++ b/packages/web-components/src/components/leadspace/leadspace.scss
@@ -10,4 +10,12 @@
 
 :host(#{$dds-prefix}-leadspace) {
   display: block;
+
+  @include carbon--breakpoint(md) {
+    // Uses `<svg>` rather than CSS for gradient, to support CSS custom properties
+    .#{$prefix}--leadspace--gradient,
+    .#{$prefix}--leadspace__section.#{$prefix}--leadspace--centered .#{$prefix}--leadspace--gradient {
+      background: none;
+    }
+  }
 }

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { customElement, html, property, LitElement } from 'lit-element';
+import { customElement, html, svg, property, LitElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
@@ -38,18 +38,18 @@ export enum LEADSPACE_TYPE {
 }
 
 /**
- * Leadspace theme
+ * Gradient style scheme.
  */
-export enum LEADSPACE_THEME {
+export enum LEADSPACE_GRADIENT_STYLE_SCHEME {
   /**
-   * Carbon White theme (default)
+   * No gradient.
    */
-  WHITE = 'white',
+  NONE = '',
 
   /**
-   *  Carbon Gray 100 theme
+   * With gradient.
    */
-  G100 = 'g100',
+  WITH_GRADIENT = 'with-gradient',
 }
 
 /**
@@ -71,7 +71,7 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
    */
   protected _getGradientClass() {
     return classMap({
-      [`${prefix}--leadspace--gradient`]: this.gradient,
+      [`${prefix}--leadspace--gradient`]: this.gradientStyleScheme === LEADSPACE_GRADIENT_STYLE_SCHEME.WITH_GRADIENT,
       [`${prefix}--leadspace__overlay`]: true,
     });
   }
@@ -84,7 +84,6 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
       [`${prefix}--leadspace--centered`]: this.type === LEADSPACE_TYPE.CENTERED,
       [`${prefix}--leadspace--centered__image`]: this.type === LEADSPACE_TYPE.CENTERED && this.defaultSrc,
       [`${prefix}--leadspace--productive`]: this.type === LEADSPACE_TYPE.SMALL,
-      [`${prefix}--leadspace--${this.theme}`]: true,
       [`${prefix}--leadspace__section`]: true,
     });
   }
@@ -149,6 +148,12 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
   copy = '';
 
   /**
+   * The gradient style sceheme.
+   */
+  @property({ reflect: true, attribute: 'gradient-style-scheme' })
+  gradientStyleScheme = LEADSPACE_GRADIENT_STYLE_SCHEME.WITH_GRADIENT;
+
+  /**
    * The leadspace title.
    */
   @property()
@@ -160,23 +165,42 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
   @property({ reflect: true })
   type = LEADSPACE_TYPE.LEFT;
 
-  /**
-   * Carbon color theme of the Leadspace
-   */
-  @property({ reflect: true })
-  theme = LEADSPACE_THEME.WHITE;
-
-  /**
-   * `true` to hide the divider.
-   */
-  @property({ type: Boolean, reflect: true })
-  gradient = true;
-
   render() {
+    const { gradientStyleScheme, type } = this;
     return html`
       <section style="${this._getBackgroundImage()}" class="${this._getTypeClass()}">
         <div class="${prefix}--leadspace__container">
           <div class="${this._getGradientClass()}">
+            ${gradientStyleScheme === LEADSPACE_GRADIENT_STYLE_SCHEME.NONE
+              ? undefined
+              : svg`
+                <svg
+                  class="${prefix}--leadspace__gradient"
+                  viewBox="0 0 100 100"
+                  preserveAspectRatio="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:xlink="http://www.w3.org/1999/xlink"
+                >
+                  <defs>
+                    <linearGradient id="stops" class="${prefix}--leadspace__gradient__stops">
+                      ${
+                        type === LEADSPACE_TYPE.CENTERED
+                          ? svg`
+                          <stop offset="0%" />
+                          <stop offset="27%" />
+                          <stop offset="53%" />
+                          <stop offset="80%" />
+                        `
+                          : svg`
+                          <stop offset="0%" />
+                          <stop offset="75%" />
+                        `
+                      }
+                    </linearGradient>
+                  </defs>
+                  <rect class="${prefix}--leadspace__gradient__rect" width="100" height="100" />
+                </svg>
+              `}
             <div class="${prefix}--leadspace--content__container">
               <div class="${prefix}--leadspace__row">
                 <h1 class="${prefix}--leadspace__title">${this._renderTitle()}</h1>

--- a/packages/web-components/tests/snapshots/dds-leadspace.md
+++ b/packages/web-components/tests/snapshots/dds-leadspace.md
@@ -6,7 +6,7 @@
 
 ```
 <section
-  class="bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">
@@ -44,7 +44,7 @@
 
 ```
 <section
-  class="bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">
@@ -84,7 +84,7 @@
 
 ```
 <section
-  class="bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">
@@ -122,7 +122,7 @@
 
 ```
 <section
-  class="bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">
@@ -162,7 +162,7 @@
 
 ```
 <section
-  class="bx--leadspace--centered bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace--centered bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">
@@ -207,7 +207,7 @@
 
 ```
 <section
-  class="bx--leadspace--centered bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace--centered bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">
@@ -254,7 +254,7 @@
 
 ```
 <section
-  class="bx--leadspace--centered bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace--centered bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">
@@ -299,7 +299,7 @@
 
 ```
 <section
-  class="bx--leadspace--centered bx--leadspace--centered__image bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace--centered bx--leadspace--centered__image bx--leadspace__section"
   style="background-image: url(http://fpoimg.com/1056x480?bg_color=ee5396&text_color=161616)"
 >
   <div class="bx--leadspace__container">
@@ -346,7 +346,7 @@
 
 ```
 <section
-  class="bx--leadspace--productive bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace--productive bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">
@@ -384,7 +384,7 @@
 
 ```
 <section
-  class="bx--leadspace--productive bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace--productive bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">
@@ -424,7 +424,7 @@
 
 ```
 <section
-  class="bx--leadspace--productive bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace--productive bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">
@@ -462,7 +462,7 @@
 
 ```
 <section
-  class="bx--leadspace--productive bx--leadspace--white bx--leadspace__section"
+  class="bx--leadspace--productive bx--leadspace__section"
   style=""
 >
   <div class="bx--leadspace__container">


### PR DESCRIPTION
### Related Ticket(s)

Refs #4250.
Refs #4285.

### Description

Made the following enhancements/fixes to the gradient in `<dds-leadspace>`:

* Auto-updates the gradient color upon `--cds-ui-background` CSS custom property, by using `<svg>` instead of CSS `background-image`. Upon this change, `theme` attribute is removed from `<dds-leadspace>`.
* Workarounds Safari's issue where `trasnparent` means `rgba(0, 0, 0, 0)`.

Also changes `gradient` boolean attribute to `gradient-style-scheme`, to make sure the code is forward-compatible with additional options.

### Changelog

**Changed**

- Switch to `<svg>` for gradient, so that `<dds-leadspace>` auto-switches the gradient upon theme change.
- A change to workaround Safari's issue where `trasnparent` means `rgba(0, 0, 0, 0)`.
- `gradient` boolean attribute to `gradient-style-scheme`.

**Removed**

- `theme` attribute from `<dds-leadspace>`.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
