### PR TITLE
fix(masthead): menu-item styles

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -266,6 +266,10 @@ $search-transition-timing: 95ms;
   }
 
   .#{$prefix}--header__nav {
+    li {
+      z-index: 0;
+    }
+
     a.#{$prefix}--header__menu-item {
       @include masthead-top-nav-link;
     }

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -266,15 +266,12 @@ $search-transition-timing: 95ms;
   }
 
   .#{$prefix}--header__nav {
-    li {
-      z-index: 0;
-    }
-
     a.#{$prefix}--header__menu-item {
       @include masthead-top-nav-link;
     }
 
     .#{$prefix}--header__menu-title[role='menuitem'][aria-expanded='true'] {
+      z-index: 0;
       background-color: $ui-01;
       + .#{$prefix}--header__menu {
         background-color: $ui-02;


### PR DESCRIPTION
### Related Ticket(s)

#4525 

### Description

add styles so menu-items that are partially hidden stay hidden when clicked

### Changelog

**New**

- `z-index: 0` to `li`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
