### PR TITLE
fix(Masthead): change side nav menu item role to menuitem

### DIFF
--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
@@ -186,10 +186,11 @@ export class SideNavMenu extends React.Component {
       [customClassName]: !!customClassName,
     });
     return (
+      // eslint-disable-next-line jsx-a11y/role-supports-aria-props
       <li
         className={className}
-        role="tab"
-        aria-selected={rest.selected ? 'true' : 'false'}>
+        role="menuitem"
+        aria-selected={rest.selected ? 'true' : ''}>
         <button
           aria-haspopup="true"
           aria-expanded={isExpanded}


### PR DESCRIPTION
### Related Ticket(s)

React: Masthead - On iPhone Voice over, sub menu options are not identified #4526

### Description

Change the `role` from tab to `menuitem` and also change `aria-selected` from `false` to empty string so the screenreader doesn't read "not selected" for every menu item.

### Changelog

**Changed**

- change role to menu item
- return empty string for `aria-selected`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
