### PR TITLE
fix(SideNavMenu): remove role from li wrapper on menu item buttons

### DIFF
--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/role-supports-aria-props */
 /* istanbul ignore file */
 
 /**
@@ -186,14 +187,12 @@ export class SideNavMenu extends React.Component {
       [customClassName]: !!customClassName,
     });
     return (
-      // eslint-disable-next-line jsx-a11y/role-supports-aria-props
-      <li
-        className={className}
-        role="menuitem"
-        aria-selected={rest.selected ? 'true' : ''}>
+      <li className={className}>
         <button
+          // eslint-disable-next-line jsx-a11y/role-supports-aria-props
           aria-haspopup="true"
           aria-expanded={isExpanded}
+          aria-selected={rest.selected ? 'true' : ''}
           className={cx(`${prefix}--side-nav__submenu`, {
             [`${prefix}--masthead__side-nav--submemu--selected`]: rest.selected,
           })}

--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
@@ -189,7 +189,6 @@ export class SideNavMenu extends React.Component {
     return (
       <li className={className}>
         <button
-          // eslint-disable-next-line jsx-a11y/role-supports-aria-props
           aria-haspopup="true"
           aria-expanded={isExpanded}
           aria-selected={rest.selected ? 'true' : ''}

--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
@@ -186,10 +186,11 @@ export class SideNavMenu extends React.Component {
       [customClassName]: !!customClassName,
     });
     return (
+      // eslint-disable-next-line jsx-a11y/role-supports-aria-props
       <li
         className={className}
-        role="tab"
-        aria-selected={rest.selected ? 'true' : 'false'}>
+        role="menuitem"
+        aria-selected={rest.selected ? 'true' : ''}>
         <button
           aria-haspopup="true"
           aria-expanded={isExpanded}


### PR DESCRIPTION
### Related Ticket(s)

React: Masthead - On iPhone Voice over, sub menu options are not identified #4526

### Description

On iphone VO, with swipe, the focus goes to the `<li>` element instead of the button where the label to be read out is. Removing the `role` attribute from the `<li>` and moving the `aria-selected` attribute to the button instead allows for the focus to be on the button on swipe.

### Changelog

**Changed**

- set `aria-selected` attribute to the menu item button

**Removed**

- `role` attribute from wrapper `<li>` element 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
