### PR TITLE
fix(masthead): overflow style fix

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -49,6 +49,7 @@
     width: 15px;
     height: $spacing-09;
     left: calc(-1rem - 1px);
+    top: -2px;
     background-color: $ui-background;
   }
 


### PR DESCRIPTION
### Related Ticket(s)

#4539 

### Description

Fix IPad ios13 issues with overflow menu items showing next to platform name. 
<img width="623" alt="Screen Shot 2020-11-20 at 8 18 36 AM" src="https://user-images.githubusercontent.com/20210594/99823258-03008d80-2b09-11eb-8bf2-6e03e3b34e5b.png">
### Changelog

**New**

- add top: -2px to ::after platform styles

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
