### PR TITLE
fix(LinkList): fix card styles

### DIFF
--- a/packages/styles/scss/components/link-list/_link-list.scss
+++ b/packages/styles/scss/components/link-list/_link-list.scss
@@ -30,15 +30,6 @@
     }
 
     .#{$prefix}--card__wrapper {
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: center;
-
-      @include carbon--breakpoint('lg') {
-        flex-direction: column;
-        align-items: flex-start;
-      }
-
       .#{$prefix}--card__copy {
         margin-bottom: 0;
 
@@ -56,6 +47,19 @@
       @include carbon--breakpoint('sm') {
         padding-left: $carbon--spacing-07;
         padding-right: $carbon--spacing-07;
+      }
+
+      &::before,
+      &::after {
+        display: none;
+      }
+    }
+
+    .#{$prefix}--card__content {
+      flex-direction: row;
+      justify-content: space-between;
+      @include carbon--breakpoint('lg') {
+        flex-direction: column;
       }
     }
 


### PR DESCRIPTION
### Description

Fixes `card` styles used in `LinkList` that were affected by aspect ratio changes in https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/4542.

**incorrect aspect ratio styles being applied**
![image](https://user-images.githubusercontent.com/909118/99963302-94693d00-2d5f-11eb-964d-ac1827e7f67d.png)


### Changelog

**Changed**

- aspect ratio removed from `card` styles
- remove unused css

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
