### PR TITLE
fix(LanguageSelector): set language selector label visibility to hidden

### DIFF
--- a/packages/styles/scss/components/footer/_language-selector.scss
+++ b/packages/styles/scss/components/footer/_language-selector.scss
@@ -130,6 +130,7 @@
       height: 0;
       padding: 0;
       margin: 0;
+      display: block;
       visibility: hidden;
     }
   }

--- a/packages/styles/scss/components/footer/_language-selector.scss
+++ b/packages/styles/scss/components/footer/_language-selector.scss
@@ -130,7 +130,7 @@
       height: 0;
       padding: 0;
       margin: 0;
-      display: block;
+      visibility: hidden;
     }
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

React: Footer - Short language only - label is displayed in the background. #4551

### Description

Set the Language Selector label to visibility hidden

### Changelog

BEFORE:
<img width="1433" alt="Screen Shot 2020-11-23 at 11 10 31 AM" src="https://user-images.githubusercontent.com/54281166/99986765-9f32ca80-2d7d-11eb-8e50-39447fb53a1e.png">


AFTER:
<img width="1432" alt="Screen Shot 2020-11-23 at 11 10 39 AM" src="https://user-images.githubusercontent.com/54281166/99986757-9b06ad00-2d7d-11eb-8f2e-944c56e4908a.png">


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
