### PR TITLE
fix(Footer): fixes language selector clear

### DIFF
--- a/packages/react/src/components/Footer/LanguageSelector.js
+++ b/packages/react/src/components/Footer/LanguageSelector.js
@@ -42,8 +42,10 @@ const LanguageSelector = ({
    * @private
    */
   function _setSelectedItem(selectedItem) {
-    setSelectedItem(selectedItem);
-    callback(selectedItem);
+    const item = selectedItem !== null ? selectedItem : '';
+    setSelectedItem(item);
+    callback(item);
+
     if (selectedItem !== null) {
       setLastSelectedItem(selectedItem);
     }
@@ -83,7 +85,7 @@ const LanguageSelector = ({
         initialSelectedItem={initialSelectedItem}
         selectedItem={selectedItem}
         direction="top"
-        placeholder=""
+        placeholder={labelText}
         titleText={labelText}
       />
       <Select


### PR DESCRIPTION
### Related Ticket(s)

#4550 

### Description

Fixes an error when clearing the current language selector value

![Nov-23-2020 15-55-26](https://user-images.githubusercontent.com/909118/100014443-5fcba480-2da4-11eb-9aed-d0cf0409be42.gif)


### Changelog

**New**

- add `placeholder` value to language selector text input

**Changed**

- check for `null` value when clearing language selector text input

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
