### PR TITLE
fix(translation): support for running in node.js environment

### DIFF
--- a/packages/services/src/services/Translation/Translation.js
+++ b/packages/services/src/services/Translation/Translation.js
@@ -135,10 +135,12 @@ class TranslationAPI {
           .then(response => this.transformData(response.data))
           .then(data => {
             data['timestamp'] = Date.now();
-            sessionStorage.setItem(
-              `${_sessionTranslationKey}-${country}-${lang}`,
-              JSON.stringify(data)
-            );
+            if (typeof sessionStorage !== 'undefined') {
+              sessionStorage.setItem(
+                `${_sessionTranslationKey}-${country}-${lang}`,
+                JSON.stringify(data)
+              );
+            }
             return data;
           });
       }


### PR DESCRIPTION
### Description

Another fix to support our translation service to run in node.js environment, by using session storage only if it's available.

### Changelog

**Changed**

- A change to our translation service code to use session storage only if it's available.