### PR TITLE
fix(content-item-horizontal): remove extra padding for link listfocus

### DIFF
--- a/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
@@ -100,7 +100,7 @@
 
     .#{$prefix}--link-list li {
       @include carbon--breakpoint(md) {
-        padding-bottom: $carbon--spacing-05;
+        margin-bottom: $carbon--spacing-05;
       }
     }
   }

--- a/packages/styles/scss/components/link-list/_link-list.scss
+++ b/packages/styles/scss/components/link-list/_link-list.scss
@@ -102,10 +102,10 @@
     ::slotted(#{$dds-prefix}-link-list-item-cta),
     ::slotted(#{$dds-prefix}-link-list-item-card-cta),
     .#{$prefix}--link-list__list__CTA {
-      padding-bottom: $carbon--spacing-05;
+      margin-bottom: $carbon--spacing-05;
 
       &:last-of-type {
-        padding-bottom: 0;
+        margin-bottom: 0;
       }
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

Web component: Content item horizontal - With tab/shift tab we are able to reach to the mentioned elements but there is no visual focus at all. #4439

### Description

There is visual focus on the content item horizontal link list items, but there seems to be extra padding.

BEFORE:
<img width="897" alt="Screen Shot 2020-11-30 at 4 53 57 PM" src="https://user-images.githubusercontent.com/54281166/100672366-d7af4700-332f-11eb-81b8-17b95aff7550.png">

AFTER:
<img width="1044" alt="Screen Shot 2020-11-30 at 4 53 37 PM" src="https://user-images.githubusercontent.com/54281166/100672374-dbdb6480-332f-11eb-8b74-f7ab84613b13.png">

### Changelog

**Changed**

- change `padding-bottom` to `margin-bottom` instead


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
