### PR TITLE
docs(readme): fix to the web components README.md

### DIFF
--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -1,4 +1,4 @@
-A IBM.com Design System variant that iss as easy to use as native HTML elements, with no framework tax, no framework silo.
+A `Carbon for IBM.com` variant that is as easy to use as native HTML elements, with no framework tax, no framework silo.
 
 # `@carbon/ibmdotcom-web-components`
 


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

There was a typo in the first line of the README, this is also a slight
adjustment to the wording.

### Changelog

**Changed**

- minor tweak to `README.md` in web components