### PR TITLE
fix(LocaleModale): region card layout

### DIFF
--- a/packages/web-components/src/components/locale-modal/locale-modal.scss
+++ b/packages/web-components/src/components/locale-modal/locale-modal.scss
@@ -71,6 +71,8 @@
     @extend .#{$prefix}--tile--clickable;
     @extend .#{$prefix}--card;
 
+    padding: $carbon--spacing-05;
+
     .#{$prefix}--card__wrapper .bx--card__footer svg {
       color: $ui-05;
     }

--- a/packages/web-components/src/components/locale-modal/locale-modal.scss
+++ b/packages/web-components/src/components/locale-modal/locale-modal.scss
@@ -71,8 +71,6 @@
     @extend .#{$prefix}--tile--clickable;
     @extend .#{$prefix}--card;
 
-    padding: $carbon--spacing-05;
-
     .#{$prefix}--card__wrapper .bx--card__footer svg {
       color: $ui-05;
     }

--- a/packages/web-components/src/components/locale-modal/region-item.ts
+++ b/packages/web-components/src/components/locale-modal/region-item.ts
@@ -64,11 +64,13 @@ class DDSRegionItem extends HostListenerMixin(DDSLink) {
     const { invalid, name } = this;
     return html`
       <div class="${prefix}--card__wrapper">
-        <h3 class="${prefix}--card__heading">
-          <slot>${name}</slot>
-        </h3>
-        <div class="${prefix}--card__footer">
-          ${(invalid ? Error20 : ArrowRight20)({ class: `${prefix}--card__cta` })}
+        <div class="${prefix}--card__content">
+          <h3 class="${prefix}--card__heading">
+            <slot>${name}</slot>
+          </h3>
+          <div class="${prefix}--card__footer">
+            ${(invalid ? Error20 : ArrowRight20)({ class: `${prefix}--card__cta` })}
+          </div>
         </div>
       </div>
     `;

--- a/packages/web-components/tests/snapshots/dds-region-item.md
+++ b/packages/web-components/tests/snapshots/dds-region-item.md
@@ -11,12 +11,14 @@
   id="link"
 >
   <div class="bx--card__wrapper">
-    <h3 class="bx--card__heading">
-      <slot>
-        name-foo
-      </slot>
-    </h3>
-    <div class="bx--card__footer">
+    <div class="bx--card__content">
+      <h3 class="bx--card__heading">
+        <slot>
+          name-foo
+        </slot>
+      </h3>
+      <div class="bx--card__footer">
+      </div>
     </div>
   </div>
 </a>
@@ -32,12 +34,14 @@
   id="link"
 >
   <div class="bx--card__wrapper">
-    <h3 class="bx--card__heading">
-      <slot>
-        name-foo
-      </slot>
-    </h3>
-    <div class="bx--card__footer">
+    <div class="bx--card__content">
+      <h3 class="bx--card__heading">
+        <slot>
+          name-foo
+        </slot>
+      </h3>
+      <div class="bx--card__footer">
+      </div>
     </div>
   </div>
 </a>


### PR DESCRIPTION
### Related Ticket(s)

#4628 

### Description

Add missing markup structure of `region-item` that was affecting layout of region cards

### Changelog


**Changed**

- add missing `content` div


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
