### PR TITLE
fix(locale-modal): replaced href target to avoid storybook refresh

### DIFF
--- a/packages/react/src/components/LocaleModal/LocaleModal.js
+++ b/packages/react/src/components/LocaleModal/LocaleModal.js
@@ -114,7 +114,7 @@ const LocaleModal = ({ isOpen, setIsOpen, localeData, localeDisplay }) => {
         <ModalHeader
           data-autoid={`${stablePrefix}--locale-modal__region-back`}
           label={[
-            <LinkWithIcon href="javascript:void(null);" iconPlacement={'left'}>
+            <LinkWithIcon href="#" iconPlacement={'left'}>
               <span>{modalLabels.headerTitle}</span>
               {
                 <ArrowLeft20

--- a/packages/react/src/components/LocaleModal/LocaleModal.js
+++ b/packages/react/src/components/LocaleModal/LocaleModal.js
@@ -114,7 +114,7 @@ const LocaleModal = ({ isOpen, setIsOpen, localeData, localeDisplay }) => {
         <ModalHeader
           data-autoid={`${stablePrefix}--locale-modal__region-back`}
           label={[
-            <LinkWithIcon href="#" iconPlacement={'left'}>
+            <LinkWithIcon href="javascript:void(null);" iconPlacement={'left'}>
               <span>{modalLabels.headerTitle}</span>
               {
                 <ArrowLeft20

--- a/packages/react/src/components/LocaleModal/LocaleModalRegions.js
+++ b/packages/react/src/components/LocaleModal/LocaleModalRegions.js
@@ -150,14 +150,16 @@ export const addLocaleBackBtnListeners = (
         : returnButtonLabel
     );
 
-    btn.addEventListener('click', function click() {
+    btn.addEventListener('click', function click(e) {
       localeBackActive(btn, setIsFiltering, setClearResults);
       btn.removeEventListener('click', click);
+      e.preventDefault();
     });
     btn.addEventListener('keyup', function keyup(e) {
       if (e.keyCode === 32 || e.keyCode === 13) {
         localeBackActive(btn, setIsFiltering, setClearResults);
         btn.removeEventListener('keyup', keyup);
+        e.preventDefault();
       }
     });
   });

--- a/packages/web-components/src/components/locale-modal/locale-modal.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal.ts
@@ -45,8 +45,9 @@ class DDSLocaleModal extends DDSExpressiveModal {
   /**
    * Handles `click` event on the back button.
    */
-  private _handleClickBackButton() {
+  private _handleClickBackButton(e) {
     this._currentRegion = undefined;
+    e.preventDefault();
   }
 
   /**
@@ -92,7 +93,7 @@ class DDSLocaleModal extends DDSExpressiveModal {
   private _renderLocaleSelectorHeading() {
     const { headerTitle, _currentRegion: currentRegion, _handleClickBackButton: handleClickBackButton } = this;
     return html`
-      <dds-link-with-icon icon-placement="${ICON_PLACEMENT.LEFT}" href="javascript:void(null);" @click="${handleClickBackButton}">
+      <dds-link-with-icon icon-placement="${ICON_PLACEMENT.LEFT}" href="#" @click="${handleClickBackButton}">
         ${headerTitle}${ArrowLeft20({ slot: 'icon', class: `${prefix}--locale-modal__label-arrow` })}
       </dds-link-with-icon>
       <p class="bx--modal-header__heading bx--type-beta" tabindex="0">${currentRegion}</p>

--- a/packages/web-components/src/components/locale-modal/locale-modal.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal.ts
@@ -92,7 +92,7 @@ class DDSLocaleModal extends DDSExpressiveModal {
   private _renderLocaleSelectorHeading() {
     const { headerTitle, _currentRegion: currentRegion, _handleClickBackButton: handleClickBackButton } = this;
     return html`
-      <dds-link-with-icon icon-placement="${ICON_PLACEMENT.LEFT}" href="#" ?disabled="false" @click="${handleClickBackButton}">
+      <dds-link-with-icon icon-placement="${ICON_PLACEMENT.LEFT}" href="javascript:void(null);" @click="${handleClickBackButton}">
         ${headerTitle}${ArrowLeft20({ slot: 'icon', class: `${prefix}--locale-modal__label-arrow` })}
       </dds-link-with-icon>
       <p class="bx--modal-header__heading bx--type-beta" tabindex="0">${currentRegion}</p>

--- a/packages/web-components/tests/snapshots/dds-locale-modal.md
+++ b/packages/web-components/tests/snapshots/dds-locale-modal.md
@@ -113,9 +113,8 @@
       </dds-expressive-modal-close-button>
       <dds-expressive-modal-heading>
         <dds-link-with-icon
-          ?disabled="false"
           data-autoid="dds--link-with-icon"
-          href="#"
+          href="javascript:void(null);"
           icon-placement="left"
         >
           header-title-foo

--- a/packages/web-components/tests/snapshots/dds-locale-modal.md
+++ b/packages/web-components/tests/snapshots/dds-locale-modal.md
@@ -114,7 +114,7 @@
       <dds-expressive-modal-heading>
         <dds-link-with-icon
           data-autoid="dds--link-with-icon"
-          href="javascript:void(null);"
+          href="#"
           icon-placement="left"
         >
           header-title-foo


### PR DESCRIPTION
### Description

Fixed the bug where Storybook refreshes entire page upon clicking the `LinkWithIcon` component to go back to the Selection geographic area menu.

It was caused by using `href='#`, which made the page redirect to the `iframe` address url over Storybook's. With this change, the component will stop the `href` from activating and fall back to the original functionality.

### Changelog

**New**
-- added `e.preventDefault()` to the event handlers

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
