### PR TITLE
fix(card-group): same height by CSS grid

### DIFF
--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -77,15 +77,13 @@
     }
   }
 
-  :host(#{$dds-prefix}-card-group),
-  .#{$prefix}--card-group__row {
+  .#{$prefix}--card-group__row,
+  .#{$prefix}--card-group__cards__row {
     @include carbon--make-row;
   }
 
   :host(#{$dds-prefix}-card-group),
   .#{$prefix}--card-group__cards__row {
-    @include carbon--make-row;
-
     position: relative;
 
     &::after {
@@ -101,7 +99,6 @@
     }
   }
 
-  :host(#{$dds-prefix}-card-group-item),
   .#{$prefix}--card-group__cards__col {
     @include carbon--make-col-ready;
 
@@ -111,7 +108,10 @@
     @include carbon--breakpoint('lg') {
       @include carbon--make-col(1, 3);
     }
+  }
 
+  :host(#{$dds-prefix}-card-group-item),
+  .#{$prefix}--card-group__cards__col {
     padding-left: $carbon--grid-gutter--condensed / 2;
     padding-right: $carbon--grid-gutter--condensed / 2;
 

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.scss
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.scss
@@ -1,0 +1,20 @@
+//
+// Copyright IBM Corp. 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/breakpoint';
+
+.dds-ce-demo-devenv--container {
+  @include carbon--breakpoint('md') {
+    margin-left: calc(#{$carbon--grid-gutter} / 2);
+    margin-right: calc(#{$carbon--grid-gutter} / 2);
+  }
+
+  @include carbon--breakpoint('lg') {
+    margin-left: 12.5%;
+    margin-right: 12.5%;
+  }
+}

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -13,6 +13,7 @@ import { number } from '@storybook/addon-knobs';
 import readme from './README.stories.mdx';
 import '../card-group';
 import '../card-group-item';
+import styles from './card-group.stories.scss';
 
 const defaultCardGroupItem = html`
   <dds-card-group-item href="https://example.com">
@@ -117,13 +118,10 @@ export default {
   title: 'Components/Card Group',
   decorators: [
     story => html`
-      <div class="bx--grid bx--content-group-story dds-ce-demo-devenv--grid--stretch">
-        <div class="bx--row dds-ce-demo-devenv--grid-row">
-          <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2">
-            ${story()}
-          </div>
-        </div>
-      </div>
+      <style>
+        ${styles}
+      </style>
+      ${story()}
     `,
   ],
   parameters: {

--- a/packages/web-components/src/components/card-group/card-group.scss
+++ b/packages/web-components/src/components/card-group/card-group.scss
@@ -9,3 +9,17 @@
 
 @import '@carbon/ibmdotcom-styles/scss/components/card/index';
 @import '@carbon/ibmdotcom-styles/scss/components/card-group/card-group';
+
+:host(#{$dds-prefix}-card-group) {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-auto-rows: 1fr;
+
+  @include carbon--breakpoint('md') {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include carbon--breakpoint('lg') {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}


### PR DESCRIPTION
### Related Ticket(s)

Refs #4375.

### Description

Switches flex-box-bassed Carbon grid layout system to native CSS grid so we can apply same height to all cards upon card contents.

### Changelog

**Changed**

- Switches flex-box-bassed Carbon grid layout for `<dds-card-group>` to native CSS grid.