### PR TITLE
fix(footer): added label to locale button for better description

### DIFF
--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -92,6 +92,12 @@ class DDSFooterComposite extends ModalRenderMixin(HybridRenderMixin(HostListener
   _setLanguage?: (language: string) => void;
 
   /**
+   * The aria-label to use for the locale-button
+   */
+  @property()
+  buttonLabel?: string;
+
+  /**
    * The g11n collator to use for sorting contry names.
    */
   @property({ attribute: false })
@@ -187,7 +193,7 @@ class DDSFooterComposite extends ModalRenderMixin(HybridRenderMixin(HostListener
   }
 
   renderLightDOM() {
-    const { langDisplay, size, links, legalLinks, _handleClickLocaleButton: handleClickLocaleButton } = this;
+    const { buttonLabel, langDisplay, size, links, legalLinks, _handleClickLocaleButton: handleClickLocaleButton } = this;
     return html`
       <dds-footer size="${ifNonNull(size)}">
         <dds-footer-logo></dds-footer-logo>
@@ -206,7 +212,9 @@ class DDSFooterComposite extends ModalRenderMixin(HybridRenderMixin(HostListener
         </dds-footer-nav>
         ${size !== FOOTER_SIZE.MICRO
           ? html`
-              <dds-locale-button @click="${handleClickLocaleButton}">${langDisplay}</dds-locale-button>
+              <dds-locale-button buttonLabel="${ifNonNull(buttonLabel)}" @click="${handleClickLocaleButton}"
+                >${langDisplay}</dds-locale-button
+              >
             `
           : html``}
         <dds-legal-nav size="${ifNonNull(size)}">
@@ -218,7 +226,11 @@ class DDSFooterComposite extends ModalRenderMixin(HybridRenderMixin(HostListener
           <dds-legal-nav-cookie-preferences-placeholder></dds-legal-nav-cookie-preferences-placeholder>
           ${size === FOOTER_SIZE.MICRO
             ? html`
-                <dds-locale-button size="${size}" slot="locale" @click="${handleClickLocaleButton}"
+                <dds-locale-button
+                  buttonLabel="${ifNonNull(buttonLabel)}"
+                  size="${size}"
+                  slot="locale"
+                  @click="${handleClickLocaleButton}"
                   >${langDisplay}</dds-locale-button
                 >
               `

--- a/packages/web-components/src/components/footer/locale-button.ts
+++ b/packages/web-components/src/components/footer/locale-button.ts
@@ -47,7 +47,11 @@ class DDSLocaleButton extends StableSelectorMixin(FocusMixin(LitElement)) {
 
   render() {
     return html`
-      <button id="button" class="${prefix}--btn ${prefix}--btn--secondary ${prefix}--locale-btn">
+      <button
+        id="button"
+        class="${prefix}--btn ${prefix}--btn--secondary ${prefix}--locale-btn"
+        aria-label="Select geographic area"
+      >
         <slot></slot>
         ${EarthFilled20()}
       </button>

--- a/packages/web-components/src/components/footer/locale-button.ts
+++ b/packages/web-components/src/components/footer/locale-button.ts
@@ -12,6 +12,7 @@ import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import FocusMixin from 'carbon-web-components/es/globals/mixins/focus.js';
 import EarthFilled20 from 'carbon-web-components/es/icons/earth--filled/20.js';
+import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null';
 import { FOOTER_SIZE } from './footer';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './footer.scss';
@@ -26,6 +27,12 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  */
 @customElement(`${ddsPrefix}-locale-button`)
 class DDSLocaleButton extends StableSelectorMixin(FocusMixin(LitElement)) {
+  /**
+   * Button label for accessibility.
+   */
+  @property()
+  buttonLabel = 'Select geographic area';
+
   /**
    * Size property to apply different styles.
    */
@@ -46,11 +53,12 @@ class DDSLocaleButton extends StableSelectorMixin(FocusMixin(LitElement)) {
   }
 
   render() {
+    const { buttonLabel } = this;
     return html`
       <button
         id="button"
         class="${prefix}--btn ${prefix}--btn--secondary ${prefix}--locale-btn"
-        aria-label="Select geographic area"
+        aria-label="${ifNonNull(buttonLabel)}"
       >
         <slot></slot>
         ${EarthFilled20()}


### PR DESCRIPTION
### Related Ticket(s)
#4667

### Description

Added `aria-label` to the locale button in order to provide an accessible description of its purpose in Web Components.

### Changelog

**New**

- added `aria-label="Select geographic area"` to `locale-button`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
