### PR TITLE
fix(locale-modal): remove listbox role for accessibility

### DIFF
--- a/packages/web-components/src/components/locale-modal/locale-search.ts
+++ b/packages/web-components/src/components/locale-modal/locale-search.ts
@@ -205,7 +205,7 @@ class DDSLocaleSearch extends ThrottedInputMixin(LitElement) {
             ${hasAvailableItem ? availabilityLabelText : unavailabilityLabelText}
           </p>
         </div>
-        <div role="listbox" class="${prefix}--locale-modal__list">
+        <div class="${prefix}--locale-modal__list">
           <slot></slot>
         </div>
       </div>

--- a/packages/web-components/tests/snapshots/dds-locale-search.md
+++ b/packages/web-components/tests/snapshots/dds-locale-search.md
@@ -21,10 +21,7 @@
       This page is available in the following locations and languages
     </p>
   </div>
-  <div
-    class="bx--locale-modal__list"
-    role="listbox"
-  >
+  <div class="bx--locale-modal__list">
     <slot>
     </slot>
   </div>
@@ -51,10 +48,7 @@
       availability-label-text-foo
     </p>
   </div>
-  <div
-    class="bx--locale-modal__list"
-    role="listbox"
-  >
+  <div class="bx--locale-modal__list">
     <slot>
     </slot>
   </div>


### PR DESCRIPTION
### Related Ticket(s)

Web component: Locale selector - list of options (locations and languages) are not identified by the screen reader. Only a "List box" is identified #4668

### Description

Remove the "listbox" role from the locale modal options as screen reader user will think it is a dropdown and try to navigate using up/down arrow keys.

### Changelog

**Removed**

- remove "listbox" role from locale modal language options list

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
