### PR TITLE
fix(masthead): avoid rendering L0 if L1 is there

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -558,8 +558,8 @@ class DDSMastheadComposite extends LitElement {
           : html`
               <dds-left-nav-name>${brandName}</dds-left-nav-name>
             `}
-        ${this.l1Data ? undefined : this._renderNavItems({ target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV })}
-        ${this.l1Data ? this._renderL1Items({ target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV }) : undefined}
+        ${l1Data ? undefined : this._renderNavItems({ target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV })}
+        ${l1Data ? this._renderL1Items({ target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV }) : undefined}
       </dds-left-nav>
       <dds-masthead aria-label="${ifNonNull(mastheadAssistiveText)}">
         <dds-masthead-menu-button
@@ -574,9 +574,13 @@ class DDSMastheadComposite extends LitElement {
           : html`
               <dds-top-nav-name>${brandName}</dds-top-nav-name>
             `}
-        <dds-top-nav ?hide-divider="${this.l1Data}" menu-bar-label="${ifNonNull(menuBarAssistiveText)}">
-          ${this.l1Data ? undefined : this._renderNavItems({ target: NAV_ITEMS_RENDER_TARGET.TOP_NAV })}
-        </dds-top-nav>
+        ${l1Data
+          ? undefined
+          : html`
+              <dds-top-nav menu-bar-label="${ifNonNull(menuBarAssistiveText)}">
+                ${this._renderNavItems({ target: NAV_ITEMS_RENDER_TARGET.TOP_NAV })}
+              </dds-top-nav>
+            `}
         <dds-masthead-search-composite
           ?active="${activateSearch}"
           input-timeout="${inputTimeout}"

--- a/packages/web-components/src/components/masthead/top-nav.ts
+++ b/packages/web-components/src/components/masthead/top-nav.ts
@@ -11,6 +11,7 @@ import { property, customElement, html, internalProperty } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import BXHeaderNav from 'carbon-web-components/es/components/ui-shell/header-nav.js';
+import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
 import HostListener from 'carbon-web-components/es/globals/decorators/host-listener.js';
 import HostListenerMixin from 'carbon-web-components/es/globals/mixins/host-listener.js';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
@@ -53,7 +54,7 @@ class DDSTopNav extends StableSelectorMixin(HostListenerMixin(BXHeaderNav)) {
       ? html``
       : html`
           <nav class="${prefix}--header__nav">
-            <ul role="menubar" class="${prefix}--header__menu-bar" aria-label="${this.menuBarLabel}">
+            <ul role="menubar" class="${prefix}--header__menu-bar" aria-label="${ifNonNull(this.menuBarLabel)}">
               <slot></slot>
             </ul>
           </nav>


### PR DESCRIPTION
### Related Ticket(s)

Refs #4677.

### Changelog

**Changed**

- A change to avoid rendering L0 if L1 is there.