### PR TITLE
fix(legal-nav): align cookie preference to other nav items

### DIFF
--- a/packages/web-components/src/components/footer/footer.scss
+++ b/packages/web-components/src/components/footer/footer.scss
@@ -93,7 +93,8 @@
 }
 
 :host(#{$dds-prefix}-legal-nav[size='micro']) {
-  ::slotted(#{$dds-prefix}-legal-nav-item) {
+  ::slotted(#{$dds-prefix}-legal-nav-item),
+  ::slotted(#{$dds-prefix}-legal-nav-cookie-preferences-placeholder) {
     display: flex;
     align-items: center;
     padding: 0;


### PR DESCRIPTION
### Related Ticket(s)

Refs #4676.

### Description

Adds a change to align the style of cookie preference link in micro footer to other legal nav items.

### Changelog

**Changed**

- A change to align the style of cookie preference link in micro footer to other legal nav items.