### PR TITLE
feat(footer): support forcing omitting locale button

### DIFF
--- a/packages/web-components/src/components/dotcom-shell/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/README.stories.mdx
@@ -32,6 +32,12 @@ import '@carbon/ibmdotcom-web-components/es/components/dotcom-shell/dotcom-shell
 </dds-dotcom-shell-container>
 ```
 
+## Props
+
+### `<dds-dotcom-shell-container>`/`<dds-dotcom-shell-composite>`
+
+<Props of="dds-dotcom-shell-composite" />
+
 ## Stable selectors
 
 See [our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components#stable-selectors-for-analytics-and-integratione2e-testing-in-web-components) to see how Web Components selector and `data-autoid` should be used.

--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
@@ -138,6 +138,12 @@ class DDSDotcomShellComposite extends LitElement {
   currentSearchResults: string[] = [];
 
   /**
+   * `true` to omit the locale switcher button.
+   */
+  @property({ attribute: 'disable-locale-button' })
+  disableLocaleButton = false;
+
+  /**
    * The throttle timeout to run query upon user input. This goes to masthead.
    */
   @property({ type: Number, attribute: 'input-timeout' })
@@ -262,6 +268,7 @@ class DDSDotcomShellComposite extends LitElement {
       brandName,
       collatorCountryName,
       currentSearchResults,
+      disableLocaleButton,
       mastheadAssistiveText,
       menuBarAssistiveText,
       menuButtonAssistiveTextActive,
@@ -319,6 +326,7 @@ class DDSDotcomShellComposite extends LitElement {
       pickBy(
         {
           collatorCountryName,
+          disableLocaleButton,
           language,
           langDisplay,
           legalLinks,

--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -104,6 +104,12 @@ class DDSFooterComposite extends ModalRenderMixin(HybridRenderMixin(HostListener
   collatorCountryName = new Intl.Collator();
 
   /**
+   * `true` to omit the locale switcher button.
+   */
+  @property({ attribute: 'disable-locale-button' })
+  disableLocaleButton = false;
+
+  /**
    * The language used for query.
    */
   @property()
@@ -193,7 +199,15 @@ class DDSFooterComposite extends ModalRenderMixin(HybridRenderMixin(HostListener
   }
 
   renderLightDOM() {
-    const { buttonLabel, langDisplay, size, links, legalLinks, _handleClickLocaleButton: handleClickLocaleButton } = this;
+    const {
+      buttonLabel,
+      disableLocaleButton,
+      langDisplay,
+      size,
+      links,
+      legalLinks,
+      _handleClickLocaleButton: handleClickLocaleButton,
+    } = this;
     return html`
       <dds-footer size="${ifNonNull(size)}">
         <dds-footer-logo></dds-footer-logo>
@@ -210,7 +224,7 @@ class DDSFooterComposite extends ModalRenderMixin(HybridRenderMixin(HostListener
             `
           )}
         </dds-footer-nav>
-        ${size !== FOOTER_SIZE.MICRO
+        ${!disableLocaleButton && size !== FOOTER_SIZE.MICRO
           ? html`
               <dds-locale-button buttonLabel="${ifNonNull(buttonLabel)}" @click="${handleClickLocaleButton}"
                 >${langDisplay}</dds-locale-button


### PR DESCRIPTION
### Related Ticket(s)

Refs #4684.

### Changelog

**New**

- `disable-locale-button` attribute to `<dds-footer-composite>` and `<dds-dotcom-shell-composite>`.