### PR TITLE
chore(card-group): same height by CSS in React

### DIFF
--- a/packages/react/src/components/CardGroup/CardGroup.js
+++ b/packages/react/src/components/CardGroup/CardGroup.js
@@ -5,14 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20';
 import { Card } from '../Card';
 import { CTA } from '../CTA';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import PropTypes from 'prop-types';
-import root from 'window-or-global';
-import sameHeight from '@carbon/ibmdotcom-utilities/es/utilities/sameHeight/sameHeight';
 import settings from 'carbon-components/es/globals/js/settings';
 
 const { stablePrefix } = ddsSettings;
@@ -22,43 +20,6 @@ const { prefix } = settings;
  */
 const CardGroup = ({ cards, cta }) => {
   const containerRef = useRef();
-  useEffect(() => {
-    setCardHeight();
-    root.addEventListener('resize', setCardHeight);
-    return () => root.removeEventListener('resize', setCardHeight);
-  }, []);
-
-  /**
-   * Set the cards to have the same height as the bigger one
-   */
-  const setCardHeight = () => {
-    root.requestAnimationFrame(() => {
-      const { current: containerNode } = containerRef;
-      if (containerNode) {
-        sameHeight(
-          containerNode.querySelectorAll(
-            `:not(.${prefix}--card__video) .${prefix}--card__heading`
-          ),
-          'md'
-        );
-        sameHeight(
-          containerNode.querySelectorAll(
-            `:not(.${prefix}--card__video) .${prefix}--card__copy`
-          ),
-          'md'
-        );
-        sameHeight(
-          containerNode.querySelectorAll(`.${prefix}--card__eyebrow`),
-          'md'
-        );
-        sameHeight(
-          containerNode.querySelectorAll(`.${prefix}--card--link`),
-          'md'
-        );
-      }
-    });
-  };
-
   return _renderCards(cards, containerRef, cta);
 };
 

--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -77,9 +77,28 @@
     }
   }
 
+  :host(#{$dds-prefix}-card-group),
   .#{$prefix}--card-group__row,
   .#{$prefix}--card-group__cards__row {
-    @include carbon--make-row;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-auto-rows: 1fr;
+
+    @include carbon--breakpoint('md') {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @include carbon--breakpoint('lg') {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .#{$prefix}--card-group__cards__row {
+    // `@include carbon--make-row()` has negative margin adjustment assuming that it's placed in Carbon grid.
+    // Such adjustment has adverse effect when card group is placed in non-Carbon-grid,
+    // but keeps it for React for backward-compatibility reason.
+    margin-left: calc(-1 * #{$carbon--grid-gutter} / 2);
+    margin-right: calc(-1 * #{$carbon--grid-gutter} / 2);
   }
 
   :host(#{$dds-prefix}-card-group),
@@ -99,17 +118,6 @@
     }
   }
 
-  .#{$prefix}--card-group__cards__col {
-    @include carbon--make-col-ready;
-
-    @include carbon--breakpoint('md') {
-      @include carbon--make-col(4, 8);
-    }
-    @include carbon--breakpoint('lg') {
-      @include carbon--make-col(1, 3);
-    }
-  }
-
   :host(#{$dds-prefix}-card-group-item),
   .#{$prefix}--card-group__cards__col {
     padding-left: $carbon--grid-gutter--condensed / 2;
@@ -125,6 +133,12 @@
     .#{$prefix}--card--inverse {
       height: 100%;
     }
+  }
+
+  .#{$prefix}--card-group__cards__col .#{$prefix}--card-group__card {
+    // React version of card group has `.bx--card-group__cards__col` surrounding `.bx--card-group__card`.
+    // Ensures that the former takes the whole height of card regardless of how high the card group row ends up with.
+    height: 100%;
   }
 
   .#{$prefix}--card-group.#{$prefix}--card-group--g10 {

--- a/packages/web-components/src/components/card-group/card-group.scss
+++ b/packages/web-components/src/components/card-group/card-group.scss
@@ -9,17 +9,3 @@
 
 @import '@carbon/ibmdotcom-styles/scss/components/card/index';
 @import '@carbon/ibmdotcom-styles/scss/components/card-group/card-group';
-
-:host(#{$dds-prefix}-card-group) {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-auto-rows: 1fr;
-
-  @include carbon--breakpoint('md') {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  @include carbon--breakpoint('lg') {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}


### PR DESCRIPTION
### Related Ticket(s)

Refs #4693.

### Description

Switches flex-box-bassed Carbon grid layout system to native CSS grid so we can apply same height to all cards upon card contents.

### Changelog

**Changed**

- A change to switch flex-box-bassed Carbon grid layout system to native CSS grid.