### PR TITLE
chore(button-group): same width effect by CSS grid

### DIFF
--- a/packages/react/src/components/ButtonGroup/ButtonGroup.js
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { Fragment, useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import Button from '../../internal/vendor/carbon-components-react/components/Button/Button';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import PropTypes from 'prop-types';
@@ -18,93 +18,20 @@ const { prefix } = settings;
 /**
  * Button group.
  */
-const ButtonGroup = ({ buttons, enableSizeByContent }) => {
+const ButtonGroup = ({ buttons }) => {
   const groupRef = useRef(null);
-  const observedPseudoButtonNodesRef = useRef(new Set());
-  const shouldUseResizeObserver =
-    enableSizeByContent && typeof ResizeObserver !== 'undefined';
-  const resizeObserverButtonsRef = useRef(
-    !shouldUseResizeObserver
-      ? null
-      : new ResizeObserver(entries => {
-          const groups = entries.reduce((acc, entry) => {
-            const group = entry.target.closest('.bx--buttongroup');
-            if (group) {
-              acc.add(group);
-            }
-            return acc;
-          }, new Set());
-          groups.forEach(group => {
-            const width = Array.prototype.reduce.call(
-              group.querySelectorAll('.bx--buttongroup-item--pseudo .bx--btn'),
-              (acc, item) => Math.max(acc, item.offsetWidth),
-              0
-            );
-            const height = Array.prototype.reduce.call(
-              group.querySelectorAll('.bx--buttongroup-item--pseudo .bx--btn'),
-              (acc, item) => Math.max(acc, item.offsetHeight),
-              0
-            );
-            const hasWordWrap = height > 48;
-            const mobileWidth = root.innerWidth <= 320;
-            Array.prototype.forEach.call(
-              group.querySelectorAll(
-                '.bx--buttongroup-item:not(.bx--buttongroup-item--pseudo) .bx--btn'
-              ),
-              item => {
-                item.style.width = mobileWidth ? `100%` : `${width + 1}px`;
-                item.classList.toggle(`${prefix}--btn--multiline`, hasWordWrap);
-              }
-            );
-          });
-        })
-  );
-
-  useLayoutEffect(() => {
-    const { current: observedPseudoButtonNodes } = observedPseudoButtonNodesRef;
-    const { current: resizeObserverButtons } = resizeObserverButtonsRef;
-
-    if (shouldUseResizeObserver) {
-      const { current: groupNode } = groupRef;
-
-      observedPseudoButtonNodes.forEach(item => {
-        if (!groupNode.contains(item)) {
-          resizeObserverButtons.unobserve(item);
-          observedPseudoButtonNodes.delete(item);
-        }
-      });
-
-      const latestPseudoButtonNodes = groupNode.querySelectorAll(
-        '.bx--buttongroup-item--pseudo .bx--btn'
-      );
-      Array.prototype.forEach.call(latestPseudoButtonNodes, item => {
-        if (!observedPseudoButtonNodes.has(item)) {
-          resizeObserverButtons.observe(item);
-          observedPseudoButtonNodes.add(item);
-        }
-      });
-    } else {
-      observedPseudoButtonNodes.forEach(item => {
-        resizeObserverButtons.unobserve(item);
-        observedPseudoButtonNodes.delete(item);
-      });
-    }
-  }, [buttons, shouldUseResizeObserver]);
-
-  useEffect(() => {
-    return () => {
-      const { current: resizeObserverButtons } = resizeObserverButtonsRef;
-      if (resizeObserverButtons) {
-        resizeObserverButtons.disconnect();
-      }
-    };
-  }, []);
 
   useEffect(() => {
     if (buttons.length > 1) {
       setSameHeight();
       root.addEventListener('resize', setSameHeight);
       return () => root.removeEventListener('resize', setSameHeight);
+    }
+    if (groupRef.current) {
+      groupRef.current.style.setProperty(
+        `--${stablePrefix}--button-group--item-count`,
+        String(buttons.length)
+      );
     }
   }, [buttons]);
 
@@ -129,31 +56,15 @@ const ButtonGroup = ({ buttons, enableSizeByContent }) => {
       ref={groupRef}>
       {buttons.map((button, key) => {
         return (
-          <Fragment key={key}>
-            <li className={`${prefix}--buttongroup-item`}>
-              <Button
-                data-autoid={`${stablePrefix}--button-group-${key}`}
-                {...button}
-                type="button"
-                kind={key === buttons.length - 1 ? 'primary' : 'tertiary'}>
-                {button.copy}
-              </Button>
-            </li>
-            {!shouldUseResizeObserver ? (
-              undefined
-            ) : (
-              <li
-                className={`${prefix}--buttongroup-item ${prefix}--buttongroup-item--pseudo`}>
-                <Button
-                  tabIndex={-1}
-                  {...button}
-                  type="button"
-                  kind={key === buttons.length - 1 ? 'primary' : 'tertiary'}>
-                  {button.copy}
-                </Button>
-              </li>
-            )}
-          </Fragment>
+          <li key={key} className={`${prefix}--buttongroup-item`}>
+            <Button
+              data-autoid={`${stablePrefix}--button-group-${key}`}
+              {...button}
+              type="button"
+              kind={key === buttons.length - 1 ? 'primary' : 'tertiary'}>
+              {button.copy}
+            </Button>
+          </li>
         );
       })}
     </ol>
@@ -181,15 +92,6 @@ ButtonGroup.propTypes = {
       renderIcon: PropTypes.elementType,
     })
   ).isRequired,
-
-  /**
-   * `true` to make the buttons change their sizes by their contents.
-   */
-  enableSizeByContent: PropTypes.bool,
-};
-
-ButtonGroup.defaultProps = {
-  enableSizeByContent: true,
 };
 
 export default ButtonGroup;

--- a/packages/react/src/components/ButtonGroup/ButtonGroup.js
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.js
@@ -22,16 +22,16 @@ const ButtonGroup = ({ buttons }) => {
   const groupRef = useRef(null);
 
   useEffect(() => {
-    if (buttons.length > 1) {
-      setSameHeight();
-      root.addEventListener('resize', setSameHeight);
-      return () => root.removeEventListener('resize', setSameHeight);
-    }
     if (groupRef.current) {
       groupRef.current.style.setProperty(
         `--${stablePrefix}--button-group--item-count`,
         String(buttons.length)
       );
+    }
+    if (buttons.length > 1) {
+      setSameHeight();
+      root.addEventListener('resize', setSameHeight);
+      return () => root.removeEventListener('resize', setSameHeight);
     }
   }, [buttons]);
 

--- a/packages/styles/scss/components/buttongroup/_buttongroup.scss
+++ b/packages/styles/scss/components/buttongroup/_buttongroup.scss
@@ -15,17 +15,24 @@
 
   .#{$prefix}--buttongroup,
   :host(#{$dds-prefix}-button-group) {
+    --#{$dds-prefix}--button-group--item-count: 3;
+
     display: flex;
     flex-direction: column;
 
     @include carbon--breakpoint(lg) {
-      flex-flow: row wrap;
+      display: inline-grid;
+      grid-template-columns: repeat(
+        var(--#{$dds-prefix}--button-group--item-count),
+        1fr
+      );
+      grid-auto-rows: 1fr;
     }
 
     .#{$prefix}--btn {
       font-size: 1rem;
       position: relative;
-      width: auto;
+      width: 100%;
       height: 100%;
       word-break: break-word;
       transition: all $duration--fast-01 motion(entrance, productive), width 0s,
@@ -60,20 +67,6 @@
       top: 50%;
       transform: translateY(-50%);
       flex-shrink: 0;
-    }
-    .#{$prefix}--btn {
-      font-size: 1rem;
-      position: relative;
-      width: auto;
-      height: 100%;
-      word-break: break-word;
-      transition: all $duration--fast-01 motion(entrance, productive), width 0s,
-        height 0s;
-
-      .#{$prefix}--btn__icon {
-        width: auto;
-        height: auto;
-      }
     }
   }
 

--- a/packages/styles/scss/components/carousel/_carousel.scss
+++ b/packages/styles/scss/components/carousel/_carousel.scss
@@ -19,14 +19,14 @@
     $type-tokens: (),
     $component-tokens: ()
   );
-  --#{$dds-prefix}-carousel-page-size: 1;
+  --#{$dds-prefix}--carousel--page-size: 1;
 
   @include carbon--breakpoint(md) {
-    --#{$dds-prefix}-carousel-page-size: 2;
+    --#{$dds-prefix}--carousel--page-size: 2;
   }
 
   @include carbon--breakpoint(lg) {
-    --#{$dds-prefix}-carousel-page-size: 3;
+    --#{$dds-prefix}--carousel--page-size: 3;
   }
 
   display: flex;
@@ -40,8 +40,8 @@
     flex: 0 0
       calc(
         (
-            100% - (var(--#{$dds-prefix}-carousel-page-size, 1) - 1) * #{$spacing-05}
-          ) / var(--#{$dds-prefix}-carousel-page-size, 1)
+            100% - (var(--#{$dds-prefix}--carousel--page-size, 1) - 1) * #{$spacing-05}
+          ) / var(--#{$dds-prefix}--carousel--page-size, 1)
       );
     height: auto;
     margin-right: $spacing-05;

--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -59,8 +59,8 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
     @include use-carbon-productive-tokens();
     @include carbon--type-style(body-long-01, true);
 
-    padding-top: var(--#{$dds-prefix}-video-caption-padding, $spacing-05);
-    color: var(--#{$dds-prefix}-video-caption-color, $text-05);
+    padding-top: var(--#{$dds-prefix}--video-caption--padding, $spacing-05);
+    color: var(--#{$dds-prefix}--video-caption--color, $text-05);
     max-width: 90%;
   }
 

--- a/packages/web-components/src/components/button-group/button-group.ts
+++ b/packages/web-components/src/components/button-group/button-group.ts
@@ -50,6 +50,9 @@ class DDSButtonGroup extends LitElement {
       (elem as HTMLElement).setAttribute('kind', index !== childItems.length - 1 ? BUTTON_TYPES.ALTERNATE : BUTTON_TYPES.DEFAULT);
     });
 
+    const { customPropertyItemCount } = this.constructor as typeof DDSButtonGroup;
+    this.style.setProperty(customPropertyItemCount, String(childItems.length));
+
     setTimeout(() => {
       sameHeight(childItems, 'md');
     });
@@ -64,6 +67,13 @@ class DDSButtonGroup extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.setAttribute('role', 'list');
+  }
+
+  /**
+   * The CSS custom property name for the live button group item cout.
+   */
+  static get customPropertyItemCount() {
+    return `--${ddsPrefix}--button-group--item-count`;
   }
 
   /**

--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -63,7 +63,7 @@ class DDSCarousel extends LitElement {
 
   /**
    * The page size that is automatically calculated upon viewport size
-   * via `--dds-carousel-page-size` CSS custom property.
+   * via `--dds--carousel--page-size` CSS custom property.
    * If `page-size` attribute is set, this value is ignored.
    */
   @internalProperty()
@@ -191,8 +191,8 @@ class DDSCarousel extends LitElement {
 
   /**
    * Number of items per page.
-   * If `--dds-carousel-page-size` CSS custom property is set to `<div class="bx--carousel__scroll-container">`
-   * or its ancestor (e.g. the host `<dds-carousel>`), this is set automatically from `--dds-carousel-page-size`.
+   * If `--dds--carousel--page-size` CSS custom property is set to `<div class="bx--carousel__scroll-container">`
+   * or its ancestor (e.g. the host `<dds-carousel>`), this is set automatically from `--dds--carousel--page-size`.
    */
   @property({ type: Number, attribute: 'page-size' })
   get pageSize() {
@@ -279,7 +279,7 @@ class DDSCarousel extends LitElement {
    * or its ancestor (e.g. the host `<dds-carousel>`), this is set automatically from the CSS custom property.
    */
   static get customPropertyPageSize() {
-    return `--${ddsPrefix}-carousel-page-size`;
+    return `--${ddsPrefix}--carousel--page-size`;
   }
 
   static styles = styles;

--- a/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
+++ b/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
@@ -56,7 +56,8 @@ class DDSMegaMenuTopNavMenu extends BXHeaderMenu {
     const { contentRect } = records[records.length - 1];
     // A workaround for Safari bug where `100vw` in Shadow DOM causes delayed rendering
     // https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/4493
-    this.style.setProperty(`--${ddsPrefix}-ce--viewport-width`, `${contentRect.width}px`);
+    const { customPropertyViewportWidth } = this.constructor as typeof DDSMegaMenuTopNavMenu;
+    this.style.setProperty(customPropertyViewportWidth, `${contentRect.width}px`);
   };
 
   connectedCallback() {
@@ -86,6 +87,13 @@ class DDSMegaMenuTopNavMenu extends BXHeaderMenu {
         doc?.body?.classList.remove(`${prefix}--body__lock-scroll`);
       }
     }
+  }
+
+  /**
+   * The CSS custom property name for the live viewport width.
+   */
+  static get customPropertyViewportWidth() {
+    return `--${ddsPrefix}-ce--viewport-width`;
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

Refs #4375.

### Description

Uses CSS grid for the same width effect for better performance and fix FOUC.

### Changelog

**New**

- A static property to `<dds-megamenu-top-nav-menu>` for its component-level CSS custom properties, to align the coding pattern to the rest of the codebase.

**Changed**

- Switches from JavaScript code to CSS grid for the same width effect.
- Renamed component-level CSS custom properties to unify their format.

**Removed**

- A prop in React `<ButtonGroup>` that enables/disables JavaScript-based same width effect.
- Some redundant CSS rules in button group.