### PR TITLE
fix(cta-section): same height by CSS for copy text

### DIFF
--- a/packages/web-components/src/components/cta-section/cta-section.scss
+++ b/packages/web-components/src/components/cta-section/cta-section.scss
@@ -78,17 +78,10 @@
 }
 
 :host(#{$dds-prefix}-cta-section-item-copy) {
-  display: inline;
-  margin-bottom: $carbon--spacing-05;
-  height: carbon--rem(48px);
-
-  ::slotted(p) {
-    width: 100%;
-
-    @include carbon--breakpoint('md') {
-      width: 90%;
-      max-width: 32rem;
-    }
+  ::slotted(#{$dds-prefix}-content-item-paragraph) {
+    display: grid;
+    height: 100%;
+    margin-bottom: -$carbon--spacing-05;
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)
#4472
#4474

### Description

Different copy text caused uneven height between the two components. This PR uses CSS `grid` feature to make both elements be the same height without any complicated or time-consuming code.

### Changelog

**New**

- added `display: grid` for `cta-section-item-paragraph` to match sibling element's height

**Removed**

- unused styles for `slotted(p)` within `cta-section-item-copy`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
