### PR TITLE
fix(ui-shell): adjust ui shell for expressive from carbon update

### DIFF
--- a/packages/styles/scss/themes/expressive/components/_ui-shell.scss
+++ b/packages/styles/scss/themes/expressive/components/_ui-shell.scss
@@ -22,6 +22,7 @@
     .#{$prefix}--header__menu
     a.#{$prefix}--header__menu-item,
   .#{$prefix}--side-nav__submenu[aria-haspopup='true'],
+  .#{$prefix}--side-nav__submenu[aria-expanded='false'],
   .#{$prefix}--side-nav__link,
   .#{$prefix}--switcher__item,
   .#{$prefix}--switcher__item-link {


### PR DESCRIPTION
### Related Ticket(s)

Visual Regression | Carbon Expressive | UI Shell Sidenav item heights are smaller #3524

### Description

Height for UI Shell sidenav changed when upgrading carbon, this pr adjusts the heights back to the expected expressive height.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
