### PR TITLE
chore(github-template): adding `Contribution Request` issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report 🐛
 about: Something isn't working as expected? Here is the right place to report.
 labels: bug
-assignees: jeffchew, wonilsuhibm, ljcarot, RobertaJHahn, andysherman2121, IgnacioBecerra
+assignees: jeffchew, wonilsuhibm, ljcarot, RobertaJHahn, andysherman2121, RaphaelAmadeu, IgnacioBecerra
 ---
 
 <!-- Feel free to remove sections that aren't relevant.

--- a/.github/ISSUE_TEMPLATE/contribution_request.md
+++ b/.github/ISSUE_TEMPLATE/contribution_request.md
@@ -1,0 +1,40 @@
+---
+name: Contribution Request 💓
+about: Contribute things large and small—of code, design, ideas, and guidance.
+title: ''
+labels: contribution
+assignees: jeffchew, wonilsuhibm, ljcarot, RobertaJHahn
+
+---
+
+## Contribution Request 💓
+
+Thank you for contributing to Carbon for IBM.com. Before you submit your contribution, please visit the [Contribution section](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/contributing/overview/) on our website to understand the process and requirements.
+
+### Contribution type (please select one):
+
+[ ] Documentation
+[ ] Components
+[ ] Patterns
+[ ] Others {{please describe}}
+
+### Intent
+
+{{A clear and concise description of what the need or user problem this new contribution is trying to meet or solve (ex. I'm always frustrated when...).}}
+
+### Solution
+
+{{A clear and concise description of what you want your contribution to happen}}
+Contribution information and required documentations
+
+{{Please add any supporting or required documentations here with a short description to help us get started with your contribution inquiry (ex. Design spec document.)}}
+
+- For Documentation contribution, please visit the [Documentation contribution website page](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/contributions/documentation/) for detail on what information you need to provide.
+- For Components contribution, please visit the [Components contribution website page](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/contributing/components) for detail on what information you need to provide.
+- For Patterns contribution, please visit the [Patterns contribution website page](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/contributing/patterns) for detail on what information you need to provide.
+
+### Additional information
+
+{{Please let us know which IBM Organization or Company you are part of or any additional information that can help us collaborate with you better, and reach out to us on Slack at #carbon-for-ibm-dotcom and provide us the link to this contribution request issue. )}}
+
+IBM Organization or Company you are part of: 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature Request 💡
 about: Suggest a new idea for the project.
 title: ''
 labels: Feature request
-assignees: jeffchew, wonilsuhibm, andysherman2121, IgnacioBecerra
+assignees: jeffchew, wonilsuhibm, ljcarot, RobertaJHahn, andysherman2121, RaphaelAmadeu, IgnacioBecerra
 ---
 
 <!-- replace _{{...}}_ with your own words -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question 🤔
 about: Usage question or discussion about Carbon for IBM.com.
 labels: question
-assignees: jeffchew, wonilsuhibm, ljcarot, RobertaJHahn, andysherman2121, IgnacioBecerra
+assignees: jeffchew, wonilsuhibm, ljcarot, RobertaJHahn, andysherman2121, RaphaelAmadeu, IgnacioBecerra
 ---
 
 <!--


### PR DESCRIPTION
### Related Ticket(s)

Refs https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/4605

### Description

This adds a new issue template for contributors wishing to contribute to `Carbon for IBM.com`, and tracking its work.

### Changelog

**New**

- `contribution_request.md`

**Changed**

- updated roster for other issue templates