### PR TITLE
Added babel core to devDependencies

### DIFF
--- a/packages/web-components/examples/codesandbox/components-react/carousel/package.json
+++ b/packages/web-components/examples/codesandbox/components-react/carousel/package.json
@@ -20,6 +20,7 @@
     "react-redux": "^7.2.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/preset-react": "^7.10.0",
     "@types/lodash-es": "^4.17.0",
     "@types/react": "^16.9.0",


### PR DESCRIPTION
### Description
The Carousel React Webcomponents codesandbox example failed to compile the example with 
Error: Cannot find module '@babel/core' babel-loader@8 requires Babel 7.x (the package '@babel/core'). If you'd like to use Babel 6.x ('babel-core'), you should install 'babel-loader@7'.

### Changelog

- Added babel core to package.json under devDependencies


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
