### PR TITLE
style(feature-card): fixing img aspect ratio

### DIFF
--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -93,6 +93,7 @@
 
       @include carbon--breakpoint('md') {
         width: 50%;
+        height: 100%;
       }
     }
   }


### PR DESCRIPTION
### Description

There are some cases where the `feature-card` image aspect ratio mixin is bugging the image height. Define an explicit `height: 100%` would solve the problem.

<img width="461" alt="Screen Shot 2020-12-21 at 10 42 03" src="https://user-images.githubusercontent.com/42848561/102783083-2bcea980-4379-11eb-8086-96c8ca820bd3.png">

<img width="787" alt="Screen Shot 2020-12-21 at 10 45 00" src="https://user-images.githubusercontent.com/42848561/102783384-954eb800-4379-11eb-9100-5a482ba0842f.png">


### Changelog

**Changed**

- Explicit `height: 100%` to `feature-card` image. 
