### PR TITLE
style(leadspace): added explicit height declaration for sections

### DIFF
--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -98,10 +98,7 @@ $btn-min-width: 26;
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-
-      @include carbon--breakpoint(lg) {
-        height: 100%;
-      }
+      height: 100%;
     }
 
     ::slotted(#{$dds-prefix}-image),
@@ -121,6 +118,7 @@ $btn-min-width: 26;
 
     .#{$prefix}--leadspace__container {
       position: relative;
+      height: 100%;
     }
 
     .#{$prefix}--leadspace__overlay {
@@ -133,6 +131,7 @@ $btn-min-width: 26;
       padding-top: $spacing-05;
       padding-bottom: $spacing-05;
       z-index: 1;
+      height: 100%;
       width: 100%;
       max-width: none;
     }


### PR DESCRIPTION
### Description

After the `::part` pseudo-element introduction (#4752) to change the leadspace height according to the Partner world landing page requirements, I've missed adding an explicit `height: 100%` declaration for the wrappers below it. This is causing the leadspace to be visually broken for the `md` and `sm` breakpoints. 

