### PR TITLE
fix(dotcom-shell): removing min-height from dotcom-shell

### DIFF
--- a/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
+++ b/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
@@ -15,7 +15,6 @@
   .#{$prefix}--dotcom-shell {
     display: flex;
     flex-direction: column;
-    min-height: 100vh;
     padding-top: $carbon--layout-04;
 
     .#{$prefix}--tableofcontents__sidebar {


### PR DESCRIPTION
### Description

This `min-height: 100vh` property was causing the `/build` page to be taller than it should. 

<img width="1548" alt="Screen Shot 2020-12-29 at 12 24 59" src="https://user-images.githubusercontent.com/42848561/103294655-06711980-49d1-11eb-89c7-bd0368960ab0.png">
