### PR TITLE
chore(dependencies): downgrade TypeScript

### DIFF
--- a/packages/services-store/package.json
+++ b/packages/services-store/package.json
@@ -78,7 +78,7 @@
     "redux-mock-store": "^1.5.0",
     "strip-comments": "^1.0.0",
     "through2": "^3.0.0",
-    "typescript": "~3.9.0"
+    "typescript": "~3.7.0"
   },
   "prettier": {
     "jsxBracketSameLine": true,

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -234,7 +234,7 @@
     "through2": "^3.0.0",
     "ts-loader": "^6.0.0",
     "tsickle": "^0.37.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.7.0",
     "web-component-analyzer": "^1.0.0",
     "webpack": "^4.28.0"
   },

--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -102,7 +102,7 @@ class DDSCarousel extends LitElement {
         // TODO: Wait for `.d.ts` update to support `ResizeObserver`
         // @ts-ignore
         this._observerResizeRoot = new ResizeObserver(this._observeResizeRoot);
-        this._observerResizeRoot.observe(this.ownerDocument.documentElement);
+        this._observerResizeRoot.observe(this.ownerDocument!.documentElement);
         // TODO: Wait for `.d.ts` update to support `ResizeObserver`
         // @ts-ignore
         this._observerResizeContainer = new ResizeObserver(this._observeResizeContainer);
@@ -155,7 +155,7 @@ class DDSCarousel extends LitElement {
   private _observeResizeRoot = () => {
     const { customPropertyPageSize } = this.constructor as typeof DDSCarousel;
     const { _contentsNode: contentsNode } = this;
-    const { defaultView: w } = this.ownerDocument;
+    const { defaultView: w } = this.ownerDocument!;
     this._pageSizeAuto = Number(w!.getComputedStyle(contentsNode!).getPropertyValue(customPropertyPageSize));
   };
 

--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -47,7 +47,7 @@ class DDSDotcomShellComposite extends LitElement {
    * @returns The render root of the footer contents.
    */
   private _createFooterRenderRoot() {
-    const footer = this.ownerDocument.createElement(`${ddsPrefix}-footer-composite`);
+    const footer = this.ownerDocument!.createElement(`${ddsPrefix}-footer-composite`);
     this.parentNode?.insertBefore(footer, this.nextSibling);
     return footer;
   }
@@ -56,7 +56,7 @@ class DDSDotcomShellComposite extends LitElement {
    * @returns The render root of the masthead contents.
    */
   private _createMastheadRenderRoot() {
-    const masthead = this.ownerDocument.createElement(`${ddsPrefix}-masthead-composite`);
+    const masthead = this.ownerDocument!.createElement(`${ddsPrefix}-masthead-composite`);
     this.parentNode?.insertBefore(masthead, this);
     return masthead;
   }

--- a/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
+++ b/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -45,7 +45,7 @@ class DDSMegaMenuTopNavMenu extends DDSTopNavMenu {
       // TODO: Wait for `.d.ts` update to support `ResizeObserver`
       // @ts-ignore
       this._observerResizeRoot = new ResizeObserver(this._observeResizeRoot);
-      this._observerResizeRoot.observe(this.ownerDocument.documentElement);
+      this._observerResizeRoot.observe(this.ownerDocument!.documentElement);
     }
   }
 

--- a/packages/web-components/src/components/table-of-contents/table-of-contents.ts
+++ b/packages/web-components/src/components/table-of-contents/table-of-contents.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -195,7 +195,7 @@ class DDSTableOfContents extends StableSelectorMixin(LitElement) {
    * @param target The hash name.
    */
   private _handleUserInitiatedJump(target: string) {
-    this.ownerDocument.defaultView!.location.hash = target;
+    this.ownerDocument!.defaultView!.location.hash = target;
     const elem = this.querySelector(`a[name="${target}"]`);
     if (elem) {
       elem.setAttribute('tabindex', '0');

--- a/packages/web-components/src/components/video-player/video-player-container.ts
+++ b/packages/web-components/src/components/video-player/video-player-container.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -163,7 +163,7 @@ export const DDSVideoPlayerContainerMixin = <T extends Constructor<HTMLElement>>
       }
       videoPlayer.appendChild(div);
       const embedVideoHandle = await VideoPlayerAPI.embedVideo(videoId, playerId, true);
-      doc.getElementById(playerId)!.dataset.videoId = videoId;
+      doc!.getElementById(playerId)!.dataset.videoId = videoId;
       return embedVideoHandle.kWidget();
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25763,10 +25763,10 @@ typescript@^3.5.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
   integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
-typescript@~3.9.0:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@~3.7.0:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
### Related Ticket(s)

Refs #4101.

### Description

To `3.7`, to cover Angular8 users with minimum effort in user side.

### Changelog

**Changed**

- Downgrades TypeScript to `3.7`.