### PR TITLE
fix(masthead): recreate IntersectionObserver upon showing/hiding nav

### DIFF
--- a/packages/web-components/src/components/masthead/top-nav.ts
+++ b/packages/web-components/src/components/masthead/top-nav.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -247,8 +247,17 @@ class DDSTopNav extends StableSelectorMixin(HostListenerMixin(BXHeaderNav)) {
     super.disconnectedCallback();
   }
 
-  firstUpdated() {
-    this._cleanAndCreateIntersectionObserverContainer({ create: true });
+  shouldUpdate(changedProperties) {
+    if (changedProperties.has('_hideNav')) {
+      this._cleanAndCreateIntersectionObserverContainer();
+    }
+    return true;
+  }
+
+  updated(changedProperties) {
+    if (changedProperties.has('_hideNav')) {
+      this._cleanAndCreateIntersectionObserverContainer({ create: true });
+    }
   }
 
   render() {


### PR DESCRIPTION
### Related Ticket(s)

Refs #4814.

### Description

Ensures `IntersectionObserver` in `<dds-top-nav>` is re-created when the nav content is shown after it's hidden, to avoid stale DOM node references.

### Changelog

**Changed**

- A change to ensure `IntersectionObserver` in `<dds-top-nav>` is re-created when the nav content is shown after it's hidden.