### PR TITLE
fix(Footer): swap out translation host default endpoint for FF

### DIFF
--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,7 +17,7 @@ import root from 'window-or-global';
 const _host =
   (process &&
     (process.env.REACT_APP_TRANSLATION_HOST || process.env.TRANSLATION_HOST)) ||
-  'https://www.ibm.com';
+  'https://1.www.s81c.com';
 
 /**
  * Sets the default location if nothing is returned

--- a/packages/services/src/services/Translation/Translation.js
+++ b/packages/services/src/services/Translation/Translation.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,7 +16,7 @@ import root from 'window-or-global';
 const _host =
   (process &&
     (process.env.REACT_APP_TRANSLATION_HOST || process.env.TRANSLATION_HOST)) ||
-  'https://www.ibm.com';
+  'https://1.www.s81c.com';
 
 /**
  * Translation API endpoint


### PR DESCRIPTION
### Related Ticket(s)

Footers not displaying properly in FF incognito #4737

### Description

Firefox's private window has tracking protection enabled by default that blocks the ibm.com endpoint api calls so users don't see the footer or masthead populated when using the private window.

Solution is to swap the translation host from ibm.com to the akamai endpoint instead.

### Changelog

**Changed**

- set the default host for Locale and Translation api to akamai

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
