### PR TITLE
fix(locale-modal): replaced search placeholder color

### DIFF
--- a/packages/web-components/src/components/search/search.scss
+++ b/packages/web-components/src/components/search/search.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020
+// Copyright IBM Corp. 2020, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -30,5 +30,9 @@
 
   &[color-scheme='light'] {
     @extend .#{$prefix}--search--light;
+  }
+
+  ::placeholder {
+    color: $text-02;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)
#4802

### Description

The previous placeholder color for the Web Components version was failing contrast ratio testing. Changed the placeholder text to match the `$text-02` token used in the React version, where the contrast ratio has been fixed.

### Changelog

**Changed**

- `<dds-search>` placeholder color changed to `$text-02` to match React version

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
