### PR TITLE
docs(content-block): update JSDoc

### DIFF
--- a/packages/web-components/src/components/content-block-segmented/content-block-segmented.ts
+++ b/packages/web-components/src/components/content-block-segmented/content-block-segmented.ts
@@ -21,7 +21,6 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * Simple version of content block.
  *
  * @element dds-content-block-segmented
- * @slot media - The media content.
  */
 @customElement(`${ddsPrefix}-content-block-segmented`)
 class DDSContentBlockSegmented extends StableSelectorMixin(DDSContentBlock) {

--- a/packages/web-components/src/components/content-block-simple/content-block-simple.ts
+++ b/packages/web-components/src/components/content-block-simple/content-block-simple.ts
@@ -21,7 +21,6 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * Simple version of content block.
  *
  * @element dds-content-block-simple
- * @slot media - The media content.
  */
 @customElement(`${ddsPrefix}-content-block-simple`)
 class DDSContentBlockSimple extends StableSelectorMixin(DDSContentBlock) {

--- a/packages/web-components/src/components/content-group-cards/content-group-cards.ts
+++ b/packages/web-components/src/components/content-group-cards/content-group-cards.ts
@@ -21,8 +21,6 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * Content group cards.
  *
  * @element dds-content-group-cards
- * @slot copy - The copy
- * @slot content - The card items content
  */
 @customElement(`${ddsPrefix}-content-group-cards`)
 class DDSContentGroupCards extends StableSelectorMixin(DDSContentGroup) {


### PR DESCRIPTION
### Description

Fixes stale `@slot` JSDoc comments of `<dds-content-block>` descendants by re-using the JSDoc comments of `<dds-content-block>` themselves.

### Changelog

**Changed**

- Fixes stale `@slot` JSDoc comments of `<dds-content-block>` descendants.