### PR TITLE
fix(masthead-top-nav-menu-item): removing the dark background

### DIFF
--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -208,6 +208,10 @@
 :host(#{$dds-prefix}-masthead-profile-item) {
   @extend :host(#{$prefix}-header-menu-item);
   @include masthead-top-nav-menu-item;
+  a.#{$prefix}--header__menu-item[role='menuitem']:hover {
+    background-color: transparent;
+    color: $text-01;
+  }
 }
 
 :host(#{$dds-prefix}-top-nav-item),


### PR DESCRIPTION
### Related Ticket(s)

Web component: Masthead - On hover over the menu options, background color is black #4734

### Description

Removing the dark background from `dds-top-nav-menu-item`