### PR TITLE
chore(github-workflow): add profile host env var to various testing envs

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
+          PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
           DDS_FLAGS_ALL: true
       - name: Building @carbon/ibmdotcom-react (experimental) storybook
         run: yarn build-storybook
@@ -105,6 +106,7 @@ jobs:
         env:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
+          PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
           REACT_STORYBOOK_USE_RTL: true
       - name: Building @carbon/ibmdotcom-react (RTL) storybook
         run: yarn build-storybook
@@ -144,6 +146,7 @@ jobs:
         env:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
+          PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
       - name: Building @carbon/ibmdotcom-web-components storybook
         run: yarn build-storybook
         working-directory: packages/web-components
@@ -182,6 +185,7 @@ jobs:
         env:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
+          PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
           STORYBOOK_IBMDOTCOM_WEB_COMPONENTS_USE_RTL: true
       - name: Building @carbon/ibmdotcom-web-components RTL storybook
         run: yarn build-storybook
@@ -221,6 +225,7 @@ jobs:
         env:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
+          PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
           DDS_FLAGS_ALL: true
       - name: Building @carbon/ibmdotcom-web-components experimental storybook
         run: yarn build-storybook
@@ -260,6 +265,7 @@ jobs:
         env:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
+          PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
       - name: Building @carbon/ibmdotcom-web-components react wrapper storybook
         run: yarn build-storybook:react
         working-directory: packages/web-components
@@ -298,6 +304,7 @@ jobs:
         env:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
+          PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
       - name: Building @carbon/ibmdotcom-services JSDocs
         run: yarn jsdoc
         working-directory: packages/services

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
+          PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
       - name: Building @carbon/ibmdotcom-web-components (staging) storybook
         run: yarn build-storybook
         working-directory: packages/web-components


### PR DESCRIPTION
### Related Ticket(s)

Change profile endpoint on Carbon Masthead for signed in state #4701

### Description

Add the profile host env var to various testing envs
previously added the variable to only react testing envs

deploy-canary:
- react-experimental
- react-rtl
- web-components
- web-components-rtl
- web-components-experimental
- web-components-react
- services

deploy-staging:
- web-components