### PR TITLE
fix(masthead): update L1 responsive breakpoint

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -26,7 +26,7 @@ $search-transition-timing: 95ms;
     transition-timing-function: $search-transition;
     overflow: visible;
 
-    @include carbon--breakpoint-down(800px) {
+    @include carbon--breakpoint-down(799.98px) {
       display: none;
     }
 


### PR DESCRIPTION
### Related Ticket(s)

#4920 

### Description

Changes the target breakpoint in the media query to not include the breakpoint itself. This was causing the `L1` to be hidden in all conditions. See [this](https://github.com/carbon-design-system/carbon/pull/5791) PR for more details.

### Changelog

**Changed**

- change `L1` responsive breakpoint to `799.98px` to exclude the breakpoint target (`800px`)


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
