### PR TITLE
chore(fade-in-out): added percy skips

### DIFF
--- a/packages/react/src/components/FadeInOut/__stories__/FadeInOut.stories.js
+++ b/packages/react/src/components/FadeInOut/__stories__/FadeInOut.stories.js
@@ -61,6 +61,9 @@ Default.story = {
   // to avoid jest errors with Intersection Observer
   parameters: {
     storyshots: { disable: true },
+    percy: {
+      skip: true,
+    },
   },
 };
 
@@ -82,5 +85,8 @@ WithContinuousAnimations.story = {
   // to avoid jest errors with Intersection Observer
   parameters: {
     storyshots: { disable: true },
+    percy: {
+      skip: true,
+    },
   },
 };


### PR DESCRIPTION
### Related Ticket(s)
none

### Description
The FadeInOut component story gets the content from the DotcomShell story, but Percy is detecting changes within the FadeInOut story that may have to do with the fade animation. Since these two stories are the same, we will now be skipping these.

### Changelog

**New**

- added percy skip to the `FadeInOut` component story

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
