### PR TITLE
chore(percy): skip percy testing of the fade component

### DIFF
--- a/packages/react/src/components/FadeInOut/__stories__/FadeInOut.stories.js
+++ b/packages/react/src/components/FadeInOut/__stories__/FadeInOut.stories.js
@@ -40,6 +40,9 @@ export default {
   parameters: {
     ...readme.parameters,
     'carbon-theme': { disabled: true },
+    percy: {
+      skip: true,
+    },
   },
 };
 

--- a/packages/web-components/src/components/fade-in-out/__stories__/fade-in-out.stories.ts
+++ b/packages/web-components/src/components/fade-in-out/__stories__/fade-in-out.stories.ts
@@ -161,6 +161,9 @@ export default {
   parameters: {
     ...readme.parameters,
     useRawContainer: true,
+    percy: {
+      skip: true,
+    },
     props: (() => {
       // Lets `<dds-masthead-container>` load the nav links and lets `<dds-footer-container>` load the footer links
       const useMock = inPercy() || new URLSearchParams(window.location.search).has('mock');


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The fade component storybook snapshots are causing false positives in our automated visual regression tests. As this is not a necessary test for visual regression, this PR adds the flag to skip these tests in Percy.

### Changelog

**Changed**

- fade component percy configuration