### PR TITLE
fix(Masthead): make sure last selected menu item has selected styles in mobile nav

### DIFF
--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -37,6 +37,7 @@ const MastheadLeftNav = ({
    * @returns {*} Left side navigation
    */
   const sideNav = navigation.map((link, i) => {
+    const selected = rest.selectedMenuItem === link.titleEnglish;
     if (link.hasMenu || link.hasMegaPanel) {
       const autoid = `${stablePrefix}--masthead-${rest.navType}-sidenav__l0-nav${i}`;
       const dataTitle = link.titleEnglish
@@ -54,7 +55,7 @@ const MastheadLeftNav = ({
               backButtonText={backButtonText}
               key={i}
               autoid={autoid}
-              selected={rest.selectedMenuItem === link.titleEnglish}
+              selected={selected}
               navType={rest.navType}
               dataTitle={dataTitle}>
               {renderNavSections(
@@ -84,7 +85,7 @@ const MastheadLeftNav = ({
           backButtonText={backButtonText}
           key={i}
           autoid={autoid}
-          selected={rest.selectedMenuItem === link.titleEnglish}
+          selected={selected}
           navType={rest.navType}
           dataTitle={dataTitle}>
           {renderNavSections(
@@ -102,8 +103,7 @@ const MastheadLeftNav = ({
             <SideNavLink
               href={link.url}
               className={
-                rest.selected &&
-                `${prefix}--masthead__side-nav--submemu--selected`
+                selected && `${prefix}--masthead__side-nav--submemu--selected`
               }
               data-autoid={`${stablePrefix}--masthead-${rest.navType}-sidenav__l0-nav${i}`}
               key={i}>
@@ -127,8 +127,7 @@ const MastheadLeftNav = ({
         <SideNavLink
           href={link.url}
           className={
-            rest.selectedMenuItem === link.titleEnglish &&
-            `${prefix}--masthead__side-nav--submemu--selected`
+            selected && `${prefix}--masthead__side-nav--submemu--selected`
           }
           data-autoid={`${stablePrefix}--masthead-${rest.navType}-sidenav__l0-nav${i}`}
           key={i}>

--- a/packages/react/src/components/Masthead/__stories__/data/MastheadLinks.js
+++ b/packages/react/src/components/Masthead/__stories__/data/MastheadLinks.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -344,6 +344,7 @@ const mastheadLinks = [
   },
   {
     title: 'Sed cursus ante dapibus diam',
+    titleEnglish: 'Sed cursus ante dapibus diam',
     url: 'https://www.ibm.com/support/home/?lnk=msu_usen',
     hasMenu: false,
     hasMegapanel: false,

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -242,7 +242,8 @@
   .#{$prefix}--masthead__side-nav--submemu--selected {
     border-left: 3px solid $interactive-01;
 
-    .#{$prefix}--side-nav__submenu-title {
+    .#{$prefix}--side-nav__submenu-title,
+    &.#{$prefix}--side-nav__link .#{$prefix}--side-nav__link-text {
       font-weight: carbon--font-weight('semibold');
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

menu item doesn't show active state in hamburg menu in masthead #4971

### Description

If selected menu item is a link (not a dropdown or has megamenu panel) and is the last menu item in the nav, it currently does not get the selected styles applied on the mobile nav.

Compare correctly the titleEnglish and selected prop from adopter and set classname.

### Changelog

**Changed**

- create a `selected` const so we don't have the same comparison statement in multiple places
- add `titleEnglish` field to last menu item in the custom nav data json file so we can test on storybook

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
