### PR TITLE
docs(carousel): stories for different grid cells usage

### DIFF
--- a/packages/web-components/src/components/carousel/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/carousel/__stories__/README.stories.mdx
@@ -89,6 +89,27 @@ import '@carbon/ibmdotcom-web-components/es/components/content-section/content-s
 </dds-carousel>
 ```
 
+### SCSS
+
+While `<dds-carousel>` has `page-size` attribute, `<dds-carousel>` also looks at `--dds--carousel--page-size` CSS custom property to determine the number of cards per page.
+This is useful for setting different number of cards for different breakpoints.
+
+```scss
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/breakpoint';
+
+dds-carousel {
+  --dds--carousel--page-size: 1;
+
+  @include carbon--breakpoint(md) {
+    --dds--carousel--page-size: 2;
+  }
+
+  @include carbon--breakpoint(lg) {
+    --dds--carousel--page-size: 3;
+  }
+}
+```
+
 ## Props
 
 <Props of="dds-carousel" />

--- a/packages/web-components/src/components/carousel/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/carousel/__stories__/README.stories.react.mdx
@@ -48,6 +48,27 @@ function App() {
 }
 ```
 
+### SCSS
+
+While `<dds-carousel>` has `page-size` attribute, `<dds-carousel>` also looks at `--dds--carousel--page-size` CSS custom property to determine the number of cards per page.
+This is useful for setting different number of cards for different breakpoints.
+
+```scss
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/breakpoint';
+
+dds-carousel {
+  --dds--carousel--page-size: 1;
+
+  @include carbon--breakpoint(md) {
+    --dds--carousel--page-size: 2;
+  }
+
+  @include carbon--breakpoint(lg) {
+    --dds--carousel--page-size: 3;
+  }
+}
+```
+
 ## Props
 
 <Props of={PropTypesRef} />

--- a/packages/web-components/src/components/carousel/__stories__/carousel.stories.react.tsx
+++ b/packages/web-components/src/components/carousel/__stories__/carousel.stories.react.tsx
@@ -7,6 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { select } from '@storybook/addon-knobs';
+import classnames from 'classnames';
 import React from 'react';
 import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20.js';
 // Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
@@ -19,6 +21,7 @@ import DDSCardHeading from '@carbon/ibmdotcom-web-components/es/components-react
 import DDSCardFooter from '@carbon/ibmdotcom-web-components/es/components-react/card/card-footer';
 // @ts-ignore
 import DDSCarousel from '@carbon/ibmdotcom-web-components/es/components-react/carousel/carousel';
+import styles from './carousel.stories.scss';
 import readme from './README.stories.react.mdx';
 
 const hrefDefault = 'https://www.ibm.com/standards/web/carbon-for-ibm-dotcom';
@@ -28,6 +31,16 @@ const copyOdd = `
   ${copyDefault}
   Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
 `;
+
+const cardSizes16 = {
+  '1 for sm, 2 for md, 4 for lg and beyond': '',
+  '1 for sm and md, 2 for lg and beyond': 'dds-ce-demo-devenv--carousel--full-16--large',
+};
+
+const cardSizes8 = {
+  '1 for sm and md, 2 for lg and beyond': '',
+  '1 for all breakpoints': 'dds-ce-demo-devenv--carousel--center-8--large',
+};
 
 const Card = ({ copy = copyDefault, heading = headingDefault, href = hrefDefault } = {}) => (
   <DDSCard href={href}>
@@ -39,9 +52,14 @@ const Card = ({ copy = copyDefault, heading = headingDefault, href = hrefDefault
   </DDSCard>
 );
 
-export const Default = () => {
+export const Default = ({ parameters }) => {
+  const { cardSize } = parameters?.props?.Carousel ?? {};
+  const classes = classnames({
+    [cardSize]: cardSize,
+  });
+  // `className` is not supported by our React wrapper
   return (
-    <DDSCarousel>
+    <DDSCarousel class={classes}>
       <Card />
       <Card copy={copyOdd} />
       <Card />
@@ -51,9 +69,66 @@ export const Default = () => {
   );
 };
 
+Default.story = {
+  parameters: {
+    gridCarouselClass: 'dds-ce-demo-devenv--simple-grid--carousel--full-16',
+    knobs: {
+      Carousel: ({ groupId }) => ({
+        cardSize: select(
+          'Number of cards per page (--dds--carousel-page-size CSS custom property)',
+          cardSizes16,
+          cardSizes16['1 for sm, 2 for md, 4 for lg and beyond'],
+          groupId
+        ),
+      }),
+    },
+  },
+};
+
+export const Right12Columns = context => Default(context);
+
+Right12Columns.story = {
+  parameters: {
+    gridCarouselClass: 'dds-ce-demo-devenv--simple-grid--carousel--right-12',
+  },
+};
+
+export const Center8Columns = context => Default(context);
+
+Center8Columns.story = {
+  parameters: {
+    gridCarouselClass: 'dds-ce-demo-devenv--simple-grid--carousel--center-8',
+    knobs: {
+      Carousel: ({ groupId }) => ({
+        cardSize: select(
+          'Number of cards per page (--dds--carousel-page-size CSS custom property)',
+          cardSizes8,
+          cardSizes8['1 for sm and md, 2 for lg and beyond'],
+          groupId
+        ),
+      }),
+    },
+  },
+};
+
 export default {
   title: 'Components/Carousel',
+  decorators: [
+    (story, { parameters }) => {
+      const { gridCarouselClass } = parameters;
+      const classes = classnames('dds-ce-demo-devenv--simple-grid', 'dds-ce-demo-devenv--simple-grid--carousel', {
+        [gridCarouselClass]: gridCarouselClass,
+      });
+      return (
+        <>
+          <style type="text/css">{styles.cssText}</style>
+          <div className={classes}>{story()}</div>
+        </>
+      );
+    },
+  ],
   parameters: {
     ...readme.parameters,
+    hasGrid: true,
   },
 };

--- a/packages/web-components/src/components/carousel/__stories__/carousel.stories.scss
+++ b/packages/web-components/src/components/carousel/__stories__/carousel.stories.scss
@@ -1,0 +1,74 @@
+//
+// @license
+//
+// Copyright IBM Corp. 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/breakpoint';
+
+.dds-ce-demo-devenv--simple-grid--carousel > * {
+  grid-column: 1 / span 4;
+
+  @include carbon--breakpoint('md') {
+    grid-column: 1 / span 8;
+  }
+}
+
+.dds-ce-demo-devenv--simple-grid--carousel--full-16 {
+  > * {
+    @include carbon--breakpoint('lg') {
+      grid-column: 1 / span 16;
+    }
+  }
+
+  /* stylelint-disable-next-line selector-type-no-unknown */
+  dds-carousel {
+    @include carbon--breakpoint(lg) {
+      --dds--carousel--page-size: 4;
+    }
+  }
+}
+
+/* stylelint-disable-next-line selector-type-no-unknown */
+dds-carousel.dds-ce-demo-devenv--carousel--full-16--large {
+  --dds--carousel--page-size: 1;
+
+  @include carbon--breakpoint(lg) {
+    --dds--carousel--page-size: 2;
+  }
+}
+
+.dds-ce-demo-devenv--simple-grid--carousel--right-12 {
+  > * {
+    @include carbon--breakpoint('lg') {
+      grid-column: 5 / span 12;
+    }
+  }
+}
+
+.dds-ce-demo-devenv--simple-grid--carousel--center-8 {
+  > * {
+    @include carbon--breakpoint('lg') {
+      grid-column: 5 / span 8;
+    }
+  }
+
+  /* stylelint-disable-next-line selector-type-no-unknown */
+  dds-carousel {
+    @include carbon--breakpoint(md) {
+      --dds--carousel--page-size: 1;
+    }
+
+    @include carbon--breakpoint(lg) {
+      --dds--carousel--page-size: 2;
+    }
+  }
+}
+
+/* stylelint-disable-next-line selector-type-no-unknown */
+dds-carousel.dds-ce-demo-devenv--carousel--center-8--large {
+  --dds--carousel--page-size: 1;
+}

--- a/packages/web-components/src/components/carousel/__stories__/carousel.stories.ts
+++ b/packages/web-components/src/components/carousel/__stories__/carousel.stories.ts
@@ -7,6 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { select } from '@storybook/addon-knobs';
+import { classMap } from 'lit-html/directives/class-map';
 import { html } from 'lit-element';
 // Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
@@ -21,6 +23,7 @@ import '../../content-section/content-section-copy';
 import '../../content-section/content-section-heading';
 import '../../link-with-icon/link-with-icon';
 import '../carousel';
+import styles from './carousel.stories.scss';
 import readme from './README.stories.mdx';
 
 const hrefDefault = 'https://www.ibm.com/standards/web/carbon-for-ibm-dotcom';
@@ -30,6 +33,16 @@ const copyOdd = `
   ${copyDefault}
   Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
 `;
+
+const cardSizes16 = {
+  '1 for sm, 2 for md, 4 for lg and beyond': '',
+  '1 for sm and md, 2 for lg and beyond': 'dds-ce-demo-devenv--carousel--full-16--large',
+};
+
+const cardSizes8 = {
+  '1 for sm and md, 2 for lg and beyond': '',
+  '1 for all breakpoints': 'dds-ce-demo-devenv--carousel--center-8--large',
+};
 
 const Card = ({ copy = copyDefault, heading = headingDefault, href = hrefDefault } = {}) => html`
   <dds-card href="${ifNonNull(href)}">
@@ -41,17 +54,82 @@ const Card = ({ copy = copyDefault, heading = headingDefault, href = hrefDefault
   </dds-card>
 `;
 
-export const Default = () => {
+export const Default = ({ parameters }) => {
+  const { cardSize } = parameters?.props?.Carousel ?? {};
+  const classes = classMap({
+    [cardSize]: cardSize,
+  });
   return html`
-    <dds-carousel>
+    <dds-carousel class="${classes}">
       ${Card()}${Card({ copy: copyOdd })}${Card()}${Card({ copy: copyOdd })}${Card()}
     </dds-carousel>
   `;
 };
 
+Default.story = {
+  parameters: {
+    gridCarouselClass: 'dds-ce-demo-devenv--simple-grid--carousel--full-16',
+    knobs: {
+      Carousel: ({ groupId }) => ({
+        cardSize: select(
+          'Number of cards per page (--dds--carousel-page-size CSS custom property)',
+          cardSizes16,
+          cardSizes16['1 for sm, 2 for md, 4 for lg and beyond'],
+          groupId
+        ),
+      }),
+    },
+  },
+};
+
+export const Right12Columns = context => Default(context);
+
+Right12Columns.story = {
+  parameters: {
+    gridCarouselClass: 'dds-ce-demo-devenv--simple-grid--carousel--right-12',
+  },
+};
+
+export const Center8Columns = context => Default(context);
+
+Center8Columns.story = {
+  parameters: {
+    gridCarouselClass: 'dds-ce-demo-devenv--simple-grid--carousel--center-8',
+    knobs: {
+      Carousel: ({ groupId }) => ({
+        cardSize: select(
+          'Number of cards per page (--dds--carousel-page-size CSS custom property)',
+          cardSizes8,
+          cardSizes8['1 for sm and md, 2 for lg and beyond'],
+          groupId
+        ),
+      }),
+    },
+  },
+};
+
 export default {
   title: 'Components/Carousel',
+  decorators: [
+    (story, { parameters }) => {
+      const { gridCarouselClass } = parameters;
+      const classes = classMap({
+        'dds-ce-demo-devenv--simple-grid': true,
+        'dds-ce-demo-devenv--simple-grid--carousel': true,
+        [gridCarouselClass]: gridCarouselClass,
+      });
+      return html`
+        <style>
+          ${styles}
+        </style>
+        <div class="${classes}">
+          ${story()}
+        </div>
+      `;
+    },
+  ],
   parameters: {
     ...readme.parameters,
+    hasGrid: true,
   },
 };


### PR DESCRIPTION
### Related Ticket(s)

Refs #4940.

### Description

Adds a couple of stories, one takes up 12 Carbon grid cells (of `lg` and beyond breakpoint) at the right, and another takes up 8 Carbon grid cells at the center.

Also adds knobs to select alternate number of cards per page, for those stories/breakpoints combinations.

### Changelog

**New**

- Stories for `<dds-carousel>`, one takes up 12 Carbon grid cells (of `lg` and beyond breakpoint) at the right, and another takes up 8 Carbon grid cells at the center.
- Knobs to select alternate number of cards per page.