### PR TITLE
chore(storybook): add file-loader for static images

### DIFF
--- a/packages/web-components/.storybook/webpack.config.js
+++ b/packages/web-components/.storybook/webpack.config.js
@@ -155,7 +155,7 @@ module.exports = ({ config, mode }) => {
     },
     {
       test: /\.(jpe?g|png|gif)(\?[a-z0-9=.]+)?$/,
-      loader: 'url-loader',
+      loader: 'file-loader',
     }
   );
 


### PR DESCRIPTION
### Related Ticket(s)

#4976 

### Description

This changes the `web-component` webpack to use `file-loader` instead of `url-loader`. The latter base64 encodes images, which interfere with Storybook when used in knobs.

### Changelog

**Changed**

- Web components webpack config now uses `file-loader`

<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
