### PR TITLE
chore(ci-check): extending ci-check to include lint and stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "lerna run build --stream --prefix --npm-client yarn",
-    "ci-check": "npm run format:diff && yarn lint:license",
+    "ci-check": "npm run format:diff && yarn lint:license && yarn lint && yarn lint:styles",
     "clean": "lerna run clean && lerna clean --yes && rimraf node_modules",
     "reset": "yarn cache clean && yarn clean && yarn install && yarn build",
     "doctoc": "doctoc --title '## Table of Contents' docs",


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Not sure if this was a decision made awhile ago to not include, but I
think ci-checks should include full lint and stylelint so these can be
caught early on rather than later when these checks are made during
preflight.

### Changelog

**Changed**

- Expanded ci-check