### PR TITLE
fix(footer): removed top border in micro footer

### DIFF
--- a/packages/styles/scss/components/footer/_footer.scss
+++ b/packages/styles/scss/components/footer/_footer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -41,6 +41,10 @@
   :host(#{$dds-prefix}-footer[size='micro']),
   .#{$prefix}--footer--micro {
     padding-top: 0;
+
+    .#{$prefix}--legal-nav {
+      border-top: 0;
+    }
   }
 
   :host(#{$dds-prefix}-footer-nav-item),

--- a/packages/web-components/src/components/footer/footer.scss
+++ b/packages/web-components/src/components/footer/footer.scss
@@ -134,6 +134,10 @@
     height: 3rem;
   }
 
+  .#{$prefix}--legal-nav {
+    border-top: 0;
+  }
+
   // The style of legal nav deviates from the one of React, so we can make the markup simpler.
   // FIXME: Once the style is stabilized, change the markup of React, too, so we can share the style
   .#{$prefix}--legal-nav__list {


### PR DESCRIPTION
### Related Ticket(s)
#4615

### Description

There was a small inconsistency where a top border added an extra pixel of height in the Micro Footer, which this PR removes.

### Changelog

**Removed**

- removed `border-top` value in `bx--legal-nav`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
