### PR TITLE
chore(staging): adding triggers for staging environments through GH

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,12 +41,6 @@ jobs:
           cf-app: ibmdotcom-react-staging
           cf-manifest: manifest-staging.yml
           deploy-dir: packages/react
-      - name: Deploy NextJS Staging
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          repository: carbon-design-system/carbon-for-ibm-dotcom-nextjs-test
-          token: ${{ secrets.GH_DISPATCH_TOKEN }}
-          event-type: deploy-staging
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}
@@ -86,12 +80,6 @@ jobs:
           cf-app: ibmdotcom-web-components-staging
           cf-manifest: manifest-staging.yml
           deploy-dir: packages/web-components
-      - name: Deploy Web Components HTML Staging
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          repository: carbon-design-system/carbon-for-ibm-dotcom-web-components-test
-          token: ${{ secrets.GH_DISPATCH_TOKEN }}
-          event-type: deploy-staging
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,6 +41,12 @@ jobs:
           cf-app: ibmdotcom-react-staging
           cf-manifest: manifest-staging.yml
           deploy-dir: packages/react
+      - name: Deploy NextJS Staging
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          repository: carbon-design-system/carbon-for-ibm-dotcom-nextjs-test
+          token: ${{ secrets.GH_DISPATCH_TOKEN }}
+          event-type: deploy-staging
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}
@@ -80,6 +86,12 @@ jobs:
           cf-app: ibmdotcom-web-components-staging
           cf-manifest: manifest-staging.yml
           deploy-dir: packages/web-components
+      - name: Deploy Web Components HTML Staging
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          repository: carbon-design-system/carbon-for-ibm-dotcom-web-components-test
+          token: ${{ secrets.GH_DISPATCH_TOKEN }}
+          event-type: deploy-staging
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,0 +1,34 @@
+name: publish-staging (Trigger staging environments to update)
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-16.04
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Deploy NextJS Staging
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          repository: carbon-design-system/carbon-for-ibm-dotcom-nextjs-test
+          token: ${{ secrets.GH_DISPATCH_TOKEN }}
+          event-type: deploy-staging
+      - name: Deploy Web Components HTML Staging
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          repository: carbon-design-system/carbon-for-ibm-dotcom-web-components-test
+          token: ${{ secrets.GH_DISPATCH_TOKEN }}
+          event-type: deploy-staging
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+        if: failure()


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Currently the staging trigger is through another CI. This is moving the
triggers from staging deployments directly from Github, similar to
canary releases through Github Actions and repository dispatches.

### Changelog

**New**

- `publish-staging.yml`