### PR TITLE
chore(linkList): revert changes to aria roles

### DIFF
--- a/packages/web-components/src/components/link-list/link-list-item-card.ts
+++ b/packages/web-components/src/components/link-list/link-list-item-card.ts
@@ -23,10 +23,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 class DDSLinkListItem extends DDSCardLink {
   connectedCallback() {
     if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'region');
-    }
-    if (this.innerText) {
-      this.setAttribute('aria-label', this.innerText);
+      this.setAttribute('role', 'listitem');
     }
     super.connectedCallback();
   }


### PR DESCRIPTION
### Related Ticket(s)

This is removing changes from this [PR](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/5010). 

### Description

After discussing in more detail it seems that this issue needs to be brought up with QA team wondering why it should read "region" vs "link" as the link list item is passed a `href` value
### Changelog

**Changed**

- `role: listitem`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
