### PR TITLE
fix(card-section-carousel): fixes horizontal scroll

### DIFF
--- a/packages/web-components/src/components/content-section/content-section.scss
+++ b/packages/web-components/src/components/content-section/content-section.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020
+// Copyright IBM Corp. 2020, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,4 +12,5 @@
 :host(#{$dds-prefix}-content-section-heading),
 :host(#{$dds-prefix}-content-section-copy) {
   display: block;
+  overflow-x: hidden;
 }


### PR DESCRIPTION
### Related Ticket(s)

#4781 

### Description

For Card Section Carousel, on 300% zoom you need to scroll both horizontally and vertically to see the full page contents. This fix gets rid of the horizontal scroll, bringing accessibility back in check. This will also fix horizontal scroll on all other web components that use Content Section

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
