### PR TITLE
fix(datatable): fix expansion spacing styles

### DIFF
--- a/packages/styles/scss/themes/expressive/components/_data-table.scss
+++ b/packages/styles/scss/themes/expressive/components/_data-table.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -29,8 +29,7 @@
     width: rem(20px);
   }
   .#{$prefix}--data-table tbody td {
-    &.#{$prefix}--table-column-checkbox,
-    &.#{$prefix}--table-expand {
+    &.#{$prefix}--table-column-checkbox {
       padding-right: $spacing-05;
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5056

### Description

Fixes spacing issues introduced in latest Carbon upgrade (10.27)

### Changelog

**Removed**

- `padding-right` for expansion variants

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
