### PR TITLE
fix(profile): catch error for profile api and console log error

### DIFF
--- a/packages/services/src/services/Profile/Profile.js
+++ b/packages/services/src/services/Profile/Profile.js
@@ -50,7 +50,11 @@ class ProfileAPI {
         },
         withCredentials: true,
       })
-      .then(response => response.data);
+      .then(response => response.data)
+      .catch(error => {
+        console.log('Failed Profile Network Call', error);
+        return { user: 'Unauthenticated' };
+      });
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

[Unhandled Runtime Error #32](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-nextjs-template/issues/32)

### Description

Catch the profile api call error and console log it in attempt to prevent error overlay from appearing in nextjs template dev mode.

### Changelog

**Changed**

- catch error and console log while returning `Unauthenticated`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
