### PR TITLE
fix(contentBlockMedia): align to non-gutter grid

### DIFF
--- a/packages/web-components/examples/codesandbox/components/content-block-media/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-media/index.html
@@ -27,11 +27,11 @@ LICENSE file in the root directory of this source tree.
             <dds-content-block-heading>
               Curabitur malesuada varius mi eu posuere
             </dds-content-block-heading>
-            <dds-content-block-paragraph>
+            <dds-content-block-copy size="lg">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
               Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Phasellus at elit sollicitudin, sodales nulla quis,
               consequat libero.
-            </dds-content-block-paragraph>
+            </dds-content-block-copy>
             <dds-content-block-media-content>
               <dds-content-group-heading>
                 Lorem ipsum dolor sit amet

--- a/packages/web-components/examples/codesandbox/components/content-block-media/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/content-block-media/src/index.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@
 import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media-content.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-paragraph.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-copy.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-group/content-group-heading.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-heading.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-copy.js';

--- a/packages/web-components/src/components/content-block-media/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-media/__stories__/README.stories.mdx
@@ -20,7 +20,7 @@ Here's a quick example to get you started.
 import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media-content.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-paragraph.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-copy.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-group/content-group-heading.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-heading.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-copy.js';
@@ -34,11 +34,11 @@ import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item
   <dds-content-block-heading>
     Curabitur malesuada varius mi eu posuere
   </dds-content-block-heading>
-  <dds-content-block-paragraph>
+  <dds-content-block-copy size="lg">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
     Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Phasellus at elit sollicitudin, sodales nulla quis,
     consequat libero.
-  </dds-content-block-paragraph>
+  </dds-content-block-copy>
   <dds-content-block-media-content>
     <dds-content-group-heading>
       Lorem ipsum dolor sit amet

--- a/packages/web-components/src/components/content-block-media/__stories__/content-block-media.stories.ts
+++ b/packages/web-components/src/components/content-block-media/__stories__/content-block-media.stories.ts
@@ -9,7 +9,7 @@
 
 import '../content-block-media';
 import '../../content-block/content-block-heading';
-import '../../content-block/content-block-paragraph';
+import '../../content-block/content-block-copy';
 import '../../content-group/content-group-heading';
 import '../../content-item/content-item-heading';
 import '../../content-item/content-item-copy';
@@ -19,13 +19,25 @@ import '../../card/card-heading';
 import '../../card-link/card-link';
 import '../../feature-card/feature-card';
 import '../../feature-card/feature-card-footer';
+import '../../link-list/link-list';
+import '../../link-list/link-list-heading';
 import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 import { html } from 'lit-element';
+import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
+import { select } from '@storybook/addon-knobs';
+import textNullable from '../../../../.storybook/knob-text-nullable';
 import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--002.jpg';
 import imgLg1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x720--004.jpg';
 import imgMd16x9 from '../../../../../storybook-images/assets/480/fpo--16x9--480x270--002.jpg';
 import imgSm16x9 from '../../../../../storybook-images/assets/320/fpo--16x9--320x180--002.jpg';
 import readme from './README.stories.mdx';
+import { CONTENT_BLOCK_COMPLEMENTARY_STYLE_SCHEME } from '../../content-block/defs';
+
+const complementaryStyleSchemes = {
+  'Regular style scheme': null,
+  // eslint-disable-next-line max-len
+  [`With border (${CONTENT_BLOCK_COMPLEMENTARY_STYLE_SCHEME.WITH_BORDER})`]: CONTENT_BLOCK_COMPLEMENTARY_STYLE_SCHEME.WITH_BORDER,
+};
 
 const heading = 'Lorem ipsum dolor sit amet.';
 
@@ -69,91 +81,195 @@ const items = [
   },
 ];
 
-export const Default = () => {
+export const Default = ({ parameters }) => {
+  const { blockHeading, featureCard } = parameters?.props?.ContentBlockMedia ?? {};
   return html`
-    <dds-content-block-heading>
-      Curabitur malesuada varius mi eu posuere
-    </dds-content-block-heading>
-    <dds-content-block-paragraph>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-      Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Phasellus at elit sollicitudin, sodales nulla quis,
-      consequat libero.
-    </dds-content-block-paragraph>
-    <dds-content-block-media-content>
-      <dds-content-group-heading>
-        Lorem ipsum dolor sit amet
-      </dds-content-group-heading>
-      <dds-image-with-caption slot="media" alt="Image alt text" default-src="${imgLg16x9}" heading="Lorem ipsum">
-        <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}"> </dds-image-item>
-        <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}"> </dds-image-item>
-        <dds-image-item media="(min-width: 320px)" srcset="${imgSm16x9}"> </dds-image-item>
-      </dds-image-with-caption>
-      ${items.map(
-        ({ heading: itemHeading, copy: itemCopy }) => html`
-          <dds-content-item>
-            <dds-content-item-heading>${itemHeading}</dds-content-item-heading>
-            <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
-          </dds-content-item>
-        `
-      )}
-      <dds-card-link slot="footer" href="https://example.com">
-        <p>Lorem ipsum dolor sit amet</p>
-        <dds-card-footer>
-          ${ArrowRight20({ slot: 'icon' })}
-        </dds-card-footer>
-      </dds-card-link>
-    </dds-content-block-media-content>
-    <dds-content-block-media-content>
-      <dds-content-group-heading>
-        Lorem ipsum dolor sit amet
-      </dds-content-group-heading>
-      <dds-image-with-caption slot="media" alt="Image alt text" default-src="${imgLg16x9}" heading="Lorem ipsum">
-        <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}"> </dds-image-item>
-        <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}"> </dds-image-item>
-        <dds-image-item media="(min-width: 320px)" srcset="${imgSm16x9}"> </dds-image-item>
-      </dds-image-with-caption>
-      ${items.map(
-        ({ heading: itemHeading, copy: itemCopy }) => html`
-          <dds-content-item>
-            <dds-content-item-heading>${itemHeading}</dds-content-item-heading>
-            <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
-          </dds-content-item>
-        `
-      )}
-      <dds-card-link slot="footer" href="https://example.com">
-        <p>Lorem ipsum dolor sit amet</p>
-        <dds-card-footer>
-          ${ArrowRight20({ slot: 'icon' })}
-        </dds-card-footer>
-      </dds-card-link>
-    </dds-content-block-media-content>
-    <dds-content-block-media-content>
-      <dds-content-group-heading>
-        Lorem ipsum dolor sit amet
-      </dds-content-group-heading>
-      <dds-feature-card href="https://example.com">
-        <dds-image slot="image" alt="Feature card image" default-src="${imgLg1x1}"></dds-image>
-        <dds-card-heading>Consectetur adipisicing elit</dds-card-heading>
-        <dds-feature-card-footer>
-          ${ArrowRight20({ slot: 'icon' })}
-        </dds-feature-card-footer>
-      </dds-feature-card>
-    </dds-content-block-media-content>
+    <dds-content-block-media>
+      <dds-content-block-heading>
+        ${blockHeading}
+      </dds-content-block-heading>
+      <dds-content-block-copy size="lg"
+        >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec
+        hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Phasellus at elit sollicitudin, sodales
+        nulla quis, consequat libero.
+      </dds-content-block-copy>
+      <dds-content-block-media-content>
+        <dds-content-group-heading>
+          Lorem ipsum dolor sit amet
+        </dds-content-group-heading>
+        <dds-image-with-caption slot="media" alt="Image alt text" default-src="${imgLg16x9}" heading="Lorem ipsum">
+          <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}"> </dds-image-item>
+          <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}"> </dds-image-item>
+          <dds-image-item media="(min-width: 320px)" srcset="${imgSm16x9}"> </dds-image-item>
+        </dds-image-with-caption>
+        ${items.map(
+          ({ heading: itemHeading, copy: itemCopy }) => html`
+            <dds-content-item>
+              <dds-content-item-heading>${itemHeading}</dds-content-item-heading>
+              <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
+            </dds-content-item>
+          `
+        )}
+        <dds-card-link slot="footer" href="https://example.com">
+          <p>Lorem ipsum dolor sit amet</p>
+          <dds-card-footer>
+            ${ArrowRight20({ slot: 'icon' })}
+          </dds-card-footer>
+        </dds-card-link>
+      </dds-content-block-media-content>
+      <dds-content-block-media-content>
+        <dds-content-group-heading>
+          Lorem ipsum dolor sit amet
+        </dds-content-group-heading>
+        <dds-image-with-caption slot="media" alt="Image alt text" default-src="${imgLg16x9}" heading="Lorem ipsum">
+          <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}"> </dds-image-item>
+          <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}"> </dds-image-item>
+          <dds-image-item media="(min-width: 320px)" srcset="${imgSm16x9}"> </dds-image-item>
+        </dds-image-with-caption>
+        ${items.map(
+          ({ heading: itemHeading, copy: itemCopy }) => html`
+            <dds-content-item>
+              <dds-content-item-heading>${itemHeading}</dds-content-item-heading>
+              <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
+            </dds-content-item>
+          `
+        )}
+        <dds-card-link slot="footer" href="https://example.com">
+          <p>Lorem ipsum dolor sit amet</p>
+          <dds-card-footer>
+            ${ArrowRight20({ slot: 'icon' })}
+          </dds-card-footer>
+        </dds-card-link>
+      </dds-content-block-media-content>
+      <dds-content-block-media-content>
+        ${featureCard === 'cta'
+          ? html`
+              <dds-content-group-heading>
+                Lorem ipsum dolor sit amet
+              </dds-content-group-heading>
+              <dds-feature-card href="https://example.com">
+                <dds-image slot="image" alt="Feature card image" default-src="${imgLg1x1}"></dds-image>
+                <dds-card-heading>Consectetur adipisicing elit</dds-card-heading>
+                <dds-feature-card-footer>
+                  ${ArrowRight20({ slot: 'icon' })}
+                </dds-feature-card-footer>
+              </dds-feature-card>
+            `
+          : ``}
+      </dds-content-block-media-content>
+    </dds-content-block-media>
   `;
+};
+
+export const withAsideElements = ({ parameters }) => {
+  const { linkListHeading, complementaryStyleScheme } = parameters?.props?.ContentBlockMedia ?? {};
+  return html`
+    <dds-content-block-media complementary-style-scheme="${ifNonNull(complementaryStyleScheme)}">
+      <dds-content-block-heading>
+        Curabitur malesuada varius mi eu posuere
+      </dds-content-block-heading>
+      <dds-content-block-copy size="lg"
+        >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec
+        hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Phasellus at elit sollicitudin, sodales
+        nulla quis, consequat libero.
+      </dds-content-block-copy>
+      <dds-content-block-media-content>
+        <dds-content-group-heading>
+          Lorem ipsum dolor sit amet
+        </dds-content-group-heading>
+        <dds-image-with-caption slot="media" alt="Image alt text" default-src="${imgLg16x9}" heading="Lorem ipsum">
+          <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}"> </dds-image-item>
+          <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}"> </dds-image-item>
+          <dds-image-item media="(min-width: 320px)" srcset="${imgSm16x9}"> </dds-image-item>
+        </dds-image-with-caption>
+        ${items.map(
+          ({ heading: itemHeading, copy: itemCopy }) => html`
+            <dds-content-item>
+              <dds-content-item-heading>${itemHeading}</dds-content-item-heading>
+              <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
+            </dds-content-item>
+          `
+        )}
+        <dds-card-link slot="footer" href="https://example.com">
+          <p>Lorem ipsum dolor sit amet</p>
+          <dds-card-footer>
+            ${ArrowRight20({ slot: 'icon' })}
+          </dds-card-footer>
+        </dds-card-link>
+      </dds-content-block-media-content>
+      <dds-content-block-media-content>
+        <dds-content-group-heading>
+          Lorem ipsum dolor sit amet
+        </dds-content-group-heading>
+        <dds-image-with-caption slot="media" alt="Image alt text" default-src="${imgLg16x9}" heading="Lorem ipsum">
+          <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}"> </dds-image-item>
+          <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}"> </dds-image-item>
+          <dds-image-item media="(min-width: 320px)" srcset="${imgSm16x9}"> </dds-image-item>
+        </dds-image-with-caption>
+        ${items.map(
+          ({ heading: itemHeading, copy: itemCopy }) => html`
+            <dds-content-item>
+              <dds-content-item-heading>${itemHeading}</dds-content-item-heading>
+              <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
+            </dds-content-item>
+          `
+        )}
+        <dds-card-link slot="footer" href="https://example.com">
+          <p>Lorem ipsum dolor sit amet</p>
+          <dds-card-footer>
+            ${ArrowRight20({ slot: 'icon' })}
+          </dds-card-footer>
+        </dds-card-link>
+      </dds-content-block-media-content>
+      <dds-content-block-media-content>
+        <dds-content-group-heading>
+          Lorem ipsum dolor sit amet
+        </dds-content-group-heading>
+        <dds-feature-card href="https://example.com">
+          <dds-image slot="image" alt="Feature card image" default-src="${imgLg1x1}"></dds-image>
+          <dds-card-heading>Consectetur adipisicing elit</dds-card-heading>
+          <dds-feature-card-footer>
+            ${ArrowRight20({ slot: 'icon' })}
+          </dds-feature-card-footer>
+        </dds-feature-card>
+      </dds-content-block-media-content>
+      <dds-link-list type="default" slot="complementary">
+        <dds-link-list-heading>${linkListHeading}</dds-link-list-heading>
+        <dds-link-list-item-card-cta href="https://example.com" cta-type="local">
+          <p>Containerization A Complete Guide</p>
+          <dds-card-cta-footer></dds-card-cta-footer>
+        </dds-link-list-item-card-cta>
+        <dds-link-list-item-card-cta href="https://example.com" cta-type="external">
+          <p>Why should you use microservices and containers</p>
+          <dds-card-cta-footer></dds-card-cta-footer>
+        </dds-link-list-item-card-cta>
+      </dds-link-list>
+    </dds-content-block-media>
+  `;
+};
+
+withAsideElements.story = {
+  parameters: {
+    gridContentClasses: 'dds-ce-demo-devenv--simple-grid--content-layout--with-complementary',
+    knobs: {
+      ContentBlockMedia: () => ({
+        linkListHeading: textNullable('Link list heading (heading)', 'Tutorials'),
+        complementaryStyleScheme: select(
+          'Complementary style scheme (complementary-style-scheme)',
+          complementaryStyleSchemes,
+          null
+        ),
+      }),
+    },
+  },
 };
 
 export default {
   title: 'Components/Content Block Media',
   decorators: [
-    story => html`
-      <div class="bx--grid dds-ce-demo-devenv--grid--stretch">
-        <div class="bx--row dds-ce-demo-devenv--grid-row">
-          <div class="bx--col-sm-4 bx--col-lg-8">
-            <dds-content-block-media>
-              ${story()}
-            </dds-content-block-media>
-          </div>
-        </div>
+    (story, { parameters }) => html`
+      <div class="dds-ce-demo-devenv--simple-grid ${parameters.gridContentClasses}">
+        ${story()}
       </div>
     `,
   ],
@@ -161,5 +277,13 @@ export default {
     ...readme.parameters,
     hasGrid: true,
     hasVerticalSpacingInComponent: true,
+    gridContentClasses: 'dds-ce-demo-devenv--simple-grid--content-layout',
+    knobs: {
+      ContentBlockMedia: () => ({
+        blockHeading: textNullable('Heading (required)', 'Curabitur malesuada varius mi eu posuere'),
+        simpleGroupHeading: textNullable('Simple Group Heading (required)', 'Lorem ipsum dolor sit amet'),
+        featureCard: select('FeatureCard (optional)', ['cta', 'none'], 'cta'),
+      }),
+    },
   },
 };

--- a/packages/web-components/src/components/content-block-media/content-block-media.scss
+++ b/packages/web-components/src/components/content-block-media/content-block-media.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020
+// Copyright IBM Corp. 2020, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -21,4 +21,15 @@
     margin-right: -1rem;
     display: block;
   }
+
+  ::slotted(#{$dds-prefix}-content-block-complementary) {
+    @include carbon--breakpoint-down('lg') {
+      margin: $layout-05 0;
+    }
+  }
+}
+
+:host(#{$dds-prefix}-content-block-media-content) ::slotted(*) {
+  margin-left: $carbon--spacing-05;
+  margin-right: $carbon--spacing-05;
 }

--- a/packages/web-components/src/components/content-block-media/content-block-media.ts
+++ b/packages/web-components/src/components/content-block-media/content-block-media.ts
@@ -9,8 +9,7 @@
 
 import { css, customElement } from 'lit-element';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import StableSelectorMixin from '../../globals/mixins/stable-selector';
-import DDSContentBlock from '../content-block/content-block';
+import DDSContentBlockSimple from '../content-block-simple/content-block-simple';
 import styles from './content-block-media.scss';
 
 const { stablePrefix: ddsPrefix } = ddsSettings;
@@ -21,7 +20,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * @element dds-content-block-media
  */
 @customElement(`${ddsPrefix}-content-block-media`)
-class DDSContentBlockMedia extends StableSelectorMixin(DDSContentBlock) {
+class DDSContentBlockMedia extends DDSContentBlockSimple {
   static get stableSelector() {
     return `${ddsPrefix}--content-block-media`;
   }

--- a/packages/web-components/src/components/content-block-segmented/__stories__/content-block-segmented.stories.ts
+++ b/packages/web-components/src/components/content-block-segmented/__stories__/content-block-segmented.stories.ts
@@ -82,7 +82,7 @@ const contentItemCopy =
   'elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.';
 
 export const Default = ({ parameters }) => {
-  const { heading, copy, ctaStyle, ctaType } = parameters?.props?.ContentBlockSimple ?? {};
+  const { heading, copy, ctaStyle, ctaType } = parameters?.props?.ContentBlockSegmented ?? {};
   return html`
     <dds-content-block-segmented>
       <dds-content-block-heading>${heading}</dds-content-block-heading>
@@ -120,7 +120,7 @@ export const Default = ({ parameters }) => {
 };
 
 export const withVideo = ({ parameters }) => {
-  const { heading, copy, ctaStyle, ctaType } = parameters?.props?.ContentBlockSimple ?? {};
+  const { heading, copy, ctaStyle, ctaType } = parameters?.props?.ContentBlockSegmented ?? {};
   return html`
     <dds-content-block-segmented>
       <dds-content-block-heading>${heading}</dds-content-block-heading>
@@ -158,7 +158,7 @@ export const withVideo = ({ parameters }) => {
 };
 
 export const withAsideElements = ({ parameters }) => {
-  const { heading, copy, ctaStyle, ctaType, complementaryStyleScheme } = parameters?.props?.ContentBlockSimple ?? {};
+  const { heading, copy, ctaStyle, ctaType, complementaryStyleScheme } = parameters?.props?.ContentBlockSegmented ?? {};
   return html`
     <dds-content-block-segmented complementary-style-scheme="${ifNonNull(complementaryStyleScheme)}">
       <dds-content-block-heading>Lorem ipsum dolor sit amet.</dds-content-block-heading>
@@ -210,7 +210,7 @@ withAsideElements.story = {
   parameters: {
     gridContentClasses: 'dds-ce-demo-devenv--simple-grid--content-layout--with-complementary',
     knobs: {
-      ContentBlockSimple: () => ({
+      ContentBlockSegmented: () => ({
         heading: textNullable('Link list heading (heading)', 'Tutorials'),
         ctaStyle: select('CTA style (cta-style)', ctaStyles, null),
         ctaType: select('CTA type (cta-type)', ctaTypes, CTA_TYPE.LOCAL),
@@ -239,7 +239,7 @@ export default {
     hasVerticalSpacingInComponent: true,
     gridContentClasses: 'dds-ce-demo-devenv--simple-grid--content-layout',
     knobs: {
-      ContentBlockSimple: () => ({
+      ContentBlockSegmented: () => ({
         heading: textNullable('Heading (required)', 'Lorem ipsum dolor sit amet.'),
         copy: textNullable(
           'copy',

--- a/packages/web-components/tests/snapshots/dds-content-block-media.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-media.md
@@ -5,64 +5,54 @@
 ####   `should render with minimum attributes`
 
 ```
-<slot name="heading">
-</slot>
-<slot name="copy">
-</slot>
-<div
-  class="bx--content-block__children"
-  hidden=""
->
-  <slot>
+<div class="bx--content-layout">
+  <slot name="heading">
   </slot>
-  <div hidden="">
+  <div
+    class="bx--content-layout__body"
+    hidden=""
+  >
+    <slot name="copy">
+    </slot>
+    <slot>
+    </slot>
     <slot name="media">
     </slot>
+    <div hidden="">
+      <slot name="footer">
+      </slot>
+    </div>
   </div>
+  <slot name="complementary">
+  </slot>
 </div>
-<div
-  class="bx--content-block__cta-row"
-  hidden=""
->
-  <div class="bx--content-block__cta bx--content-block__cta-col">
-    <slot name="footer">
-    </slot>
-  </div>
-</div>
-<slot name="complementary">
-</slot>
 
 ```
 
 ####   `should render with various attributes`
 
 ```
-<slot name="heading">
-</slot>
-<slot name="copy">
-</slot>
-<div
-  class="bx--content-block__children"
-  hidden=""
->
-  <slot>
+<div class="bx--content-layout">
+  <slot name="heading">
   </slot>
-  <div hidden="">
+  <div
+    class="bx--content-layout__body"
+    hidden=""
+  >
+    <slot name="copy">
+    </slot>
+    <slot>
+    </slot>
     <slot name="media">
     </slot>
+    <div hidden="">
+      <slot name="footer">
+      </slot>
+    </div>
   </div>
+  <slot name="complementary">
+  </slot>
 </div>
-<div
-  class="bx--content-block__cta-row"
-  hidden=""
->
-  <div class="bx--content-block__cta bx--content-block__cta-col">
-    <slot name="footer">
-    </slot>
-  </div>
-</div>
-<slot name="complementary">
-</slot>
 
 ```
 


### PR DESCRIPTION
### Related Ticket(s)

#4961 

### Description

Align to non-gutter grid line. Also updated stories to match react storybook options. 

### Changelog

**Changed**

- use CSS grid for layout for `<dds-content-block-media>`.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
