### PR TITLE
fix(megamenu): add padding between category desc and link

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -171,7 +171,7 @@
     ::slotted(#{$dds-prefix}-megamenu-category-group-copy) {
       color: $text-01;
       margin-top: rem(-6px);
-      padding: 0 $spacing-05 1px $spacing-05;
+      padding: 0 $spacing-05 $spacing-03 $spacing-05;
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

Web component: Mega Menu MVP - accommodations for HC + AI updates - Visual QA (Firefox, Chrome) #5089

### Description

Add padding between the category description and first link.

### Changelog

**Changed**

- set 8px bottom padding to category copy

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
