### PR TITLE
fix(ToC): add property stickyOffset and update stories

### DIFF
--- a/packages/react/src/components/DotcomShell/__stories__/data/content.js
+++ b/packages/react/src/components/DotcomShell/__stories__/data/content.js
@@ -39,7 +39,7 @@ import React from 'react';
  */
 const Content = () => (
   <>
-    <TableOfContents menuLabel="Jump to" theme="white">
+    <TableOfContents menuLabel="Jump to" theme="white" stickyOffset="48">
       <a name="section-1" data-title="Lorem ipsum dolor sit amet" />
       <Layout type="2-1">
         <div>

--- a/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
@@ -94,7 +94,7 @@ const StoryContent = () => html`
     <div class="bx--grid">
       <div class="bx--row">
         <div class="bx--offset-lg-3 bx--col-lg-13">
-          <dds-table-of-contents>
+          <dds-table-of-contents stickyOffset="48">
             <a name="1" data-title="Lorem ipsum dolor sit amet"></a>
             <dds-leadspace-block>
               <dds-leadspace-block-heading>Lorem ipsum dolor sit amet</dds-leadspace-block-heading>

--- a/packages/web-components/src/components/table-of-contents/table-of-contents.scss
+++ b/packages/web-components/src/components/table-of-contents/table-of-contents.scss
@@ -40,10 +40,3 @@
     top: 48px;
   }
 }
-
-.#{$dds-prefix}-ce--table-of-contents__items-container {
-  @include carbon--breakpoint('lg') {
-    position: sticky;
-    top: 0;
-  }
-}

--- a/packages/web-components/src/components/table-of-contents/table-of-contents.ts
+++ b/packages/web-components/src/components/table-of-contents/table-of-contents.ts
@@ -10,7 +10,7 @@
 import { nothing } from 'lit-html';
 import { classMap } from 'lit-html/directives/class-map';
 import { ifDefined } from 'lit-html/directives/if-defined';
-import { html, internalProperty, query, customElement, LitElement } from 'lit-element';
+import { html, property, internalProperty, query, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import TableOfContents20 from 'carbon-web-components/es/icons/table-of-contents/20.js';
@@ -232,6 +232,12 @@ class DDSTableOfContents extends StableSelectorMixin(LitElement) {
     this._hasMobileContainerVisible = height > 0;
   };
 
+  /**
+   * The current 0px offset from the top of page.
+   */
+  @property({ type: Number })
+  stickyOffset = 0;
+
   connectedCallback() {
     super.connectedCallback();
     this._cleanAndCreateObserverResizeMobileContainer({ create: true });
@@ -259,6 +265,7 @@ class DDSTableOfContents extends StableSelectorMixin(LitElement) {
 
   render() {
     const {
+      stickyOffset,
       _currentTarget: currentTarget,
       _hasHeading: hasHeading,
       _hasMobileContainerVisible: hasMobileContainerVisible,
@@ -280,7 +287,10 @@ class DDSTableOfContents extends StableSelectorMixin(LitElement) {
                 </div>
               `}
           <div class="${prefix}--tableofcontents__mobile-top"></div>
-          <div class="${ddsPrefix}-ce--table-of-contents__items-container">
+          <div
+            class="${ddsPrefix}-ce--table-of-contents__items-container"
+            style="position: sticky; top: ${stickyOffset ? `${stickyOffset}px` : 0}"
+          >
             <div class="${prefix}--tableofcontents__desktop">
               <ul>
                 ${targets.map(item => {

--- a/packages/web-components/tests/snapshots/dds-table-of-contents.md
+++ b/packages/web-components/tests/snapshots/dds-table-of-contents.md
@@ -21,7 +21,10 @@
     </div>
     <div class="bx--tableofcontents__mobile-top">
     </div>
-    <div class="dds-ce--table-of-contents__items-container">
+    <div
+      class="dds-ce--table-of-contents__items-container"
+      style="position: sticky; top: 0"
+    >
       <div class="bx--tableofcontents__desktop">
         <ul>
         </ul>
@@ -60,7 +63,10 @@
     </div>
     <div class="bx--tableofcontents__mobile-top">
     </div>
-    <div class="dds-ce--table-of-contents__items-container">
+    <div
+      class="dds-ce--table-of-contents__items-container"
+      style="position: sticky; top: 0"
+    >
       <div class="bx--tableofcontents__desktop">
         <ul>
         </ul>
@@ -93,7 +99,10 @@
   >
     <div class="bx--tableofcontents__mobile-top">
     </div>
-    <div class="dds-ce--table-of-contents__items-container">
+    <div
+      class="dds-ce--table-of-contents__items-container"
+      style="position: sticky; top: 0"
+    >
       <div class="bx--tableofcontents__desktop">
         <ul>
         </ul>


### PR DESCRIPTION
### Related Ticket(s)

#5124

### Description

When scrolling in Dotcom Shell the table of contents sticks behind the masthead. This adds a stickyOffset, so that the TOC is visible when scrolling

![Screen Shot 2021-02-09 at 9 21 54 AM](https://user-images.githubusercontent.com/20210594/107401948-42ab9580-6ab8-11eb-90ed-28a139ae43fe.png)


### Changelog

**New**

- added `stickyOffset` property to ToC (wc)
- add `stickyOffset=48` to Dotcom shell storybook (wc & react)

**Changed**

- stickyOffset styles to inline styles in ToC  (wc)

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
