### PR TITLE
docs(masthead): fix to masthead styles import line in documentation

### DIFF
--- a/packages/react/src/components/Masthead/README.stories.mdx
+++ b/packages/react/src/components/Masthead/README.stories.mdx
@@ -26,7 +26,7 @@ Here's a quick example to get you started.
 @import '@carbon/type/scss/font-face/sans';
 @include carbon--font-face-mono();
 @include carbon--font-face-sans();
-@import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead';
+@import '@carbon/ibmdotcom-styles/scss/components/masthead/index';
 ```
 
 > 💡 Only import fonts once per usage. Don't forget to import the Masthead


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

An adopter spotted an issue where the React documentation is pointing to the incorrect scss import. This should fix the typo.

### Changelog

**Changed**

- Masthead README
