### PR TITLE
fix(megamenu): reduce padding in megamenu above view all link

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -243,7 +243,7 @@
     .#{$prefix}--link-with-icon {
       text-decoration: none;
       width: 100%;
-      margin: 0 $spacing-05;
+      margin: rem(-32px) $spacing-05 0;
       border-top: carbon--rem(1px) solid $ui-03;
       height: $spacing-09;
 


### PR DESCRIPTION
### Related Ticket(s)

React stand alone: Mega Menu MVP enhancement to accommodate HC + AI updates Visual QA #5136

### Description

Visual QA fix to reduce padding between megamenu categories and view all link to 32px

<img width="1250" alt="Screen Shot 2021-02-10 at 3 00 24 PM" src="https://user-images.githubusercontent.com/54281166/107564715-c0eb6300-6bb0-11eb-9283-0346ce0730d5.png">


### Changelog

**Changed**

- set `margin-top` to `-32px`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
