### PR TITLE
fix(megamenu): capitalize content in custom navigation

### DIFF
--- a/packages/react/src/components/Masthead/__stories__/data/MastheadLinks.js
+++ b/packages/react/src/components/Masthead/__stories__/data/MastheadLinks.js
@@ -43,8 +43,8 @@ const mastheadLinks = [
                       'https://www.ibm.com/cloud/learn/hybrid-cloud?lnk=hpmps_ess',
                   },
                   {
-                    title: 'Hybrid cloud solutions',
-                    titleEnglish: 'Hybrid cloud solutions',
+                    title: 'Hybrid Cloud solutions',
+                    titleEnglish: 'Hybrid Cloud solutions',
                     highlightedLink: true,
                     url: 'https://www.ibm.com/cloud/go-hybrid?lnk=hpmps_ess',
                   },
@@ -217,8 +217,8 @@ const mastheadLinks = [
                     url: 'https://www.ibm.com/analytics?lnk=hpmps_buda',
                   },
                   {
-                    title: 'Hybrid cloud',
-                    titleEnglish: 'Hybrid cloud',
+                    title: 'Hybrid Cloud',
+                    titleEnglish: 'Hybrid Cloud',
                     url: 'https://www.ibm.com/cloud/hybrid?lnk=hpmps_bucl',
                   },
                   {

--- a/packages/web-components/src/components/masthead/__stories__/links.ts
+++ b/packages/web-components/src/components/masthead/__stories__/links.ts
@@ -1564,8 +1564,8 @@ const customLinks: MastheadLink[] = [
                     url: 'https://www.ibm.com/cloud/learn/hybrid-cloud?lnk=hpmps_ess',
                   },
                   {
-                    title: 'Hybrid cloud solutions',
-                    titleEnglish: 'Hybrid cloud solutions',
+                    title: 'Hybrid Cloud solutions',
+                    titleEnglish: 'Hybrid Cloud solutions',
                     highlightedLink: true,
                     url: 'https://www.ibm.com/cloud/go-hybrid?lnk=hpmps_ess',
                   },
@@ -1731,8 +1731,8 @@ const customLinks: MastheadLink[] = [
                     url: 'https://www.ibm.com/analytics?lnk=hpmps_buda',
                   },
                   {
-                    title: 'Hybrid cloud',
-                    titleEnglish: 'Hybrid cloud',
+                    title: 'Hybrid Cloud',
+                    titleEnglish: 'Hybrid Cloud',
                     url: 'https://www.ibm.com/cloud/hybrid?lnk=hpmps_bucl',
                   },
                   {


### PR DESCRIPTION
### Related Ticket(s)

P&S mega menu: some capitalization fixes #5163

### Description

Capitalize the `c` in `Hybrid Cloud` for megamenu custom navigation content

### Changelog

**Changed**

- capitalize `c` in `hybrid cloud` for 2nd link in Hybrid Cloud highlighted category and link under the Solutions category

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
