### PR TITLE
fix(masthead): customtypeahead api fix

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -399,9 +399,7 @@ const MastheadSearch = ({
     if (request.reason === 'input-changed') {
       // if the search input has changed
       let response = rest.customTypeaheadApi
-        ? rest.customTypeaheadApi(
-            await SearchTypeaheadAPI.getResults(searchValue)
-          )
+        ? await rest.customTypeaheadApi(searchValue)
         : await SearchTypeaheadAPI.getResults(searchValue);
 
       if (response !== undefined) {
@@ -461,7 +459,9 @@ const MastheadSearch = ({
    * @returns {string} Section title
    */
   function renderSectionTitle(section) {
-    return section.title ? <span>{section.title}</span> : null;
+    return section.items.length > 1 && section.title ? (
+      <span>{section.title}</span>
+    ) : null;
   }
 
   /**

--- a/packages/react/src/components/Masthead/README.stories.mdx
+++ b/packages/react/src/components/Masthead/README.stories.mdx
@@ -159,21 +159,17 @@ ${SEARCH_REDIRECT_ENDPOINT}&q=${encodeURIComponent(value)}&lang=${state.lc}&cc=$
 
 **Custom typeahead API**
 
-To use a custom typeahead API, set the endpoint by adding these environment
-variables.
-
-```
-SEARCH_TYPEAHEAD_HOST=https://www.custom-typeahead-api.com
-SEARCH_TYPEAHEAD_API=/custom/api
-```
-
-Then use the `customTypeaheadApi` to get the response of the custom API
+To use a custom endpoint, pass `customTypeaheadApi` to get the response 
 and transform the data if needed.
 
 ```javascript
-let customTypeaheadApi = results => {
-  // transform results
-  return results;
+async function customTypeaheadApi(searchVal) {
+  return await fetch(`https://<fetch-url>?query=${searchVal}&foo=foo&bar=bar`)
+    .then(response => response.json())
+    .then(data => {
+      // transform results
+      return searchResults;
+    });
 }
 
 <Masthead customTypeaheadApi={customTypeaheadApi} />;
@@ -199,10 +195,14 @@ here is how the response should be structured:
 
 The masthead search can display groups of results with the `multiSection` prop:
 ```javascript
-let customTypeaheadApi = results => {
-  // transform results
-  return searchResults;
-} 
+async function customTypeaheadApi(searchVal) {
+  return await fetch(`https://<fetch-url>?query=${searchVal}&foo=foo&bar=bar`)
+    .then(response => response.json())
+    .then(data => {
+      // transform results with multiple sections
+      return searchResults;
+    });
+}
 
 <Masthead customTypeaheadApi={customTypeaheadApi} multiSection />;
 

--- a/packages/services/src/services/SearchTypeahead/SearchTypeahead.js
+++ b/packages/services/src/services/SearchTypeahead/SearchTypeahead.js
@@ -4,32 +4,26 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
 import axios from 'axios';
 import { LocaleAPI } from '../Locale';
-
 /**
- * @constant {string | string} Host API host
+ * @constant {string | string} Host for the API calls
  * @private
  */
 const _host =
-  (process && process.env.SEARCH_TYPEAHEAD_HOST) || 'https://www-api.ibm.com';
-
+  (process && process.env.SEARCH_TYPEAHEAD_API) || 'https://www-api.ibm.com';
 /**
- * @constant {string | string} API API path
+ * @constant {string | string} API version
  * @private
  */
-const _api =
-  (process && process.env.SEARCH_TYPEAHEAD_API) || '/search/typeahead/v1';
-
+const _version = (process && process.env.SEARCH_TYPEAHEAD_VERSION) || 'v1';
 /**
  * SearchTypeahead endpoint
  *
  * @type {string}
  * @private
  */
-const _endpoint = `${_host}${_api}`;
-
+const _endpoint = `${_host}/search/typeahead/${_version}`;
 /**
  * SearchTypeahead API class with methods of fetching search results for
  * ibm.com
@@ -56,17 +50,13 @@ class SearchTypeaheadAPI {
       `query=${encodeURIComponent(query)}`,
     ].join('&');
     const url = `${_endpoint}?${urlQuery}`;
-
     return await axios
       .get(url, {
         headers: {
           'Content-Type': 'application/json; charset=utf-8',
         },
       })
-      // TODO: KC returns response.data. Look to change to uniform
-      // response in the future for all calls, e.g. response.data.response
-      .then(response => response.data.response || response.data);
+      .then(response => response.data.response);
   }
 }
-
 export default SearchTypeaheadAPI;

--- a/packages/services/src/services/SearchTypeahead/__tests__/SearchTypeahead.test.js
+++ b/packages/services/src/services/SearchTypeahead/__tests__/SearchTypeahead.test.js
@@ -28,7 +28,7 @@ describe('SearchTypeaheadAPI', () => {
 
   it('should search for ibm.com results', async () => {
     const query = 'red hat';
-    const endpoint = `${process.env.SEARCH_TYPEAHEAD_HOST}${process.env.SEARCH_TYPEAHEAD_API}`;
+    const endpoint = `${process.env.SEARCH_TYPEAHEAD_API}/search/typeahead/${process.env.SEARCH_TYPEAHEAD_VERSION}`;
     const fetchUrl = `${endpoint}?lang=${_lc}&cc=${_cc}&query=${encodeURIComponent(
       query
     )}`;

--- a/tasks/jest/env.js
+++ b/tasks/jest/env.js
@@ -6,11 +6,9 @@
  */
 
 const _host = 'https://ibm.com';
-const _api = '/search/typeahead';
 const _version = 'v1';
 
-process.env.SEARCH_TYPEAHEAD_HOST = process.env.SEARCH_TYPEAHEAD_HOST || _host;
-process.env.SEARCH_TYPEAHEAD_API = process.env.SEARCH_TYPEAHEAD_API || _api;
+process.env.SEARCH_TYPEAHEAD_API = process.env.SEARCH_TYPEAHEAD_API || _host;
 process.env.SEARCH_TYPEAHEAD_VERSION =
   process.env.SEARCH_TYPEAHEAD_VERSION || _version;
 process.env.MARKETING_SEARCH_HOST = process.env.MARKETING_SEARCH_HOST || _host;


### PR DESCRIPTION
### Description

Updates masthead search `customTypeAheadApi` to be fully on the application side. When using a custom API, it will no longer pass through `SearchTypeaheadAPI` at all. This allows users to pass a full API including any necessary query params that were not defined in `SearchTypeaheadAPI`. With this change the use of environment variables is no longer necessary.

### Changelog

**Changed**

- moves `customTypeAheadApi` out of `SearchTypeaheadAPI`
- update jest environment variables
- section titles no longer appear when there are no section items


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
