### PR TITLE
fix(footer): update micro language only styles

### DIFF
--- a/packages/styles/scss/components/footer/_language-selector.scss
+++ b/packages/styles/scss/components/footer/_language-selector.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,13 +31,16 @@
       @include list-box-expressive;
       @include select-expressive;
       @include text-input-expressive;
-      @include carbon--make-col-ready;
-      @include carbon--make-col(4, 4);
 
       margin-top: $spacing-05;
       padding-left: 0;
       padding-right: 0;
       order: 0;
+
+      @include carbon--breakpoint('md') {
+        @include carbon--make-col-ready;
+        @include carbon--make-col(4, 4);
+      }
 
       .#{$prefix}--language-selector {
         max-width: 100%;


### PR DESCRIPTION
### Related Ticket(s)

#5178 

### Description

Fixes responsive styling for `Footer: micro footer with language selector`

**Changed**

- micro footer language only responsive styles

![Untitled-1](https://user-images.githubusercontent.com/909118/108094570-f4b10780-704c-11eb-9eca-78c26e84b616.png)


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
