### PR TITLE
fix(masthead): update tabindex

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -192,7 +192,7 @@ class DDSMastheadComposite extends LitElement {
     const useAlternateLogo = MastheadLogoAPI.setMastheadLogo(this.logoData);
     const { tooltip, svg } = this.logoData;
     return html`
-      <dds-masthead-logo ?hasTooltip="${tooltip}" aria-label="${ifNonNull(tooltip)}"
+      <dds-masthead-logo ?hasTooltip="${tooltip}" aria-label="${ifNonNull(tooltip)}" tabIndex="0"
         >${useAlternateLogo ? unsafeSVG(svg) : nothing}</dds-masthead-logo
       >
     `;

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -192,7 +192,7 @@ class DDSMastheadComposite extends LitElement {
     const useAlternateLogo = MastheadLogoAPI.setMastheadLogo(this.logoData);
     const { tooltip, svg } = this.logoData;
     return html`
-      <dds-masthead-logo ?hasTooltip="${tooltip}" aria-label="${ifNonNull(tooltip)}" tabIndex="0"
+      <dds-masthead-logo ?hasTooltip="${tooltip}" aria-label="${ifNonNull(tooltip)}"
         >${useAlternateLogo ? unsafeSVG(svg) : nothing}</dds-masthead-logo
       >
     `;

--- a/packages/web-components/src/components/masthead/masthead-logo.ts
+++ b/packages/web-components/src/components/masthead/masthead-logo.ts
@@ -72,6 +72,10 @@ class DDSMastheadLogo extends FocusMixin(HostListenerMixin(BXLink)) {
     }
   }
 
+  firstUpdated() {
+    this.tabIndex = 0;
+  }
+
   /**
    * The name of the custom event fired after the seach is toggled.
    */


### PR DESCRIPTION
### Related Ticket(s)

#4800

### Description

tab accessibility for firefox on masthead logo tooltip

### Changelog

**New**

- update tabIndex to 0

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
