### PR TITLE
fix(card): remove text decoration from active state

### DIFF
--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -67,6 +67,7 @@
     .#{$prefix}--card:active {
       position: relative;
       z-index: 2;
+      text-decoration: none;
 
       .#{$prefix}--image {
         position: relative;


### PR DESCRIPTION
### Related Ticket(s)

#5034 

### Description

Removes underline from `Card` active state 

### Changelog

**Changed**

- update card styles to remove underline when active


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
