### PR TITLE
fix(video-player): update caption styles

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -58,7 +58,7 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
   .#{$prefix}--video-player__video-caption {
     @include carbon--type-style('caption-01');
 
-    padding-top: var(--#{$dds-prefix}--video-caption--padding, $spacing-05);
+    padding-top: var(--#{$dds-prefix}--video-caption--padding, $spacing-03);
     color: var(--#{$dds-prefix}--video-caption--color, $text-05);
     max-width: 90%;
   }


### PR DESCRIPTION
### Related Ticket(s)

#5127 

### Description

Updates caption spacing for video player caption

### Changelog


**Changed**

- video player caption top spacing reduced to `8px`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
