### PR TITLE
fix(card): remove aria-hidden from copy

### DIFF
--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -78,7 +78,7 @@ class DDSCard extends StableSelectorMixin(BXLink) {
   protected _renderCopy(): TemplateResult | string | void {
     const { _hasCopy: hasCopy } = this;
     return html`
-      <div ?hidden="${!hasCopy}" class="${prefix}--card__copy" aria-hidden="true">
+      <div ?hidden="${!hasCopy}" class="${prefix}--card__copy">
         <slot @slotchange="${this._handleSlotChange}"></slot>
       </div>
     `;

--- a/packages/web-components/tests/snapshots/dds-card-cta.md
+++ b/packages/web-components/tests/snapshots/dds-card-cta.md
@@ -19,7 +19,6 @@
     <slot name="heading">
     </slot>
     <div
-      aria-hidden="true"
       class="bx--card__copy"
       hidden=""
     >

--- a/packages/web-components/tests/snapshots/dds-card.md
+++ b/packages/web-components/tests/snapshots/dds-card.md
@@ -19,7 +19,6 @@
     <slot name="heading">
     </slot>
     <div
-      aria-hidden="true"
       class="bx--card__copy"
       hidden=""
     >
@@ -50,7 +49,6 @@
     <slot name="heading">
     </slot>
     <div
-      aria-hidden="true"
       class="bx--card__copy"
       hidden=""
     >

--- a/packages/web-components/tests/snapshots/dds-feature-card-block-large.md
+++ b/packages/web-components/tests/snapshots/dds-feature-card-block-large.md
@@ -20,7 +20,6 @@
       <slot name="heading">
       </slot>
       <div
-        aria-hidden="true"
         class="bx--card__copy"
         hidden=""
       >
@@ -59,7 +58,6 @@
         <slot name="heading">
         </slot>
         <div
-          aria-hidden="true"
           class="bx--card__copy"
           hidden=""
         >

--- a/packages/web-components/tests/snapshots/dds-feature-card.md
+++ b/packages/web-components/tests/snapshots/dds-feature-card.md
@@ -19,7 +19,6 @@
     <slot name="heading">
     </slot>
     <div
-      aria-hidden="true"
       class="bx--card__copy"
       hidden=""
     >
@@ -56,7 +55,6 @@
       <slot name="heading">
       </slot>
       <div
-        aria-hidden="true"
         class="bx--card__copy"
         hidden=""
       >

--- a/packages/web-components/tests/snapshots/dds-feature-cta.md
+++ b/packages/web-components/tests/snapshots/dds-feature-cta.md
@@ -19,7 +19,6 @@
     <slot name="heading">
     </slot>
     <div
-      aria-hidden="true"
       class="bx--card__copy"
       hidden=""
     >


### PR DESCRIPTION
### Related Ticket(s)

#5194 

### Description

remove aria-hidden from copy. Reads copy text in carasoul

### Changelog

**Removed**

- `aria-hidden: true`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
