### PR TITLE
feat(search): allow custom url with noSearchRedirect

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearchSuggestion.js
+++ b/packages/react/src/components/Masthead/MastheadSearchSuggestion.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -35,7 +35,8 @@ const MastheadSearchSuggestion = ({
         [`${prefix}--container-highlight-class`]: isHighlighted,
       })}
       tabIndex="-1"
-      data-autoid={`${stablePrefix}--masthead__searchresults--suggestion`}>
+      data-autoid={`${stablePrefix}--masthead__searchresults--suggestion`}
+      {...(suggestion.href ? { 'data-href': suggestion.href } : {})}>
       {parts.map((part, index) => (
         <span
           key={index}


### PR DESCRIPTION
### Related Ticket(s)

#4845 

### Description

This adds support for user-defined URLs when using the [`searchNoRedirect`](http://ibmdotcom-react.mybluemix.net/?path=/docs/components-masthead--default#searchnoredirect) option in the masthead search. If provided, a URL will be placed in a search element's `data-href` attribute. This is useful when a URL redirect is required, instead of using the search value as a query param.

**Note:** when using `searchNoRedirect`, all logic must be provided by the user.

### Changelog

**New**

- add custom URL support to search result elements


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
