### PR TITLE
chore(deps): update examples carbon/icons-react to latest

### DIFF
--- a/packages/react/examples/codesandbox/components/ButtonGroup/package.json
+++ b/packages/react/examples/codesandbox/components/ButtonGroup/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/CTA/package.json
+++ b/packages/react/examples/codesandbox/components/CTA/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/CTASection/package.json
+++ b/packages/react/examples/codesandbox/components/CTASection/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/CalloutQuote/package.json
+++ b/packages/react/examples/codesandbox/components/CalloutQuote/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/CalloutWithMedia/package.json
+++ b/packages/react/examples/codesandbox/components/CalloutWithMedia/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/Card/package.json
+++ b/packages/react/examples/codesandbox/components/Card/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/CardGroup/package.json
+++ b/packages/react/examples/codesandbox/components/CardGroup/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/CardLink/package.json
+++ b/packages/react/examples/codesandbox/components/CardLink/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/CardSectionImages/package.json
+++ b/packages/react/examples/codesandbox/components/CardSectionImages/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/CardSectionSimple/package.json
+++ b/packages/react/examples/codesandbox/components/CardSectionSimple/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ContentBlockCards/package.json
+++ b/packages/react/examples/codesandbox/components/ContentBlockCards/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ContentBlockMedia/package.json
+++ b/packages/react/examples/codesandbox/components/ContentBlockMedia/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ContentBlockMixed/package.json
+++ b/packages/react/examples/codesandbox/components/ContentBlockMixed/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ContentBlockSegmented/package.json
+++ b/packages/react/examples/codesandbox/components/ContentBlockSegmented/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ContentBlockSimple/package.json
+++ b/packages/react/examples/codesandbox/components/ContentBlockSimple/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ContentGroupCards/package.json
+++ b/packages/react/examples/codesandbox/components/ContentGroupCards/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "1.7.0",
     "@carbon/ibmdotcom-styles": "1.7.0",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ContentGroupHorizontal/package.json
+++ b/packages/react/examples/codesandbox/components/ContentGroupHorizontal/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ContentGroupPictograms/package.json
+++ b/packages/react/examples/codesandbox/components/ContentGroupPictograms/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "@carbon/pictograms-react": "10.12.0",
     "react": "16.13.0",
     "react-dom": "16.13.0"

--- a/packages/react/examples/codesandbox/components/ContentGroupSimple/package.json
+++ b/packages/react/examples/codesandbox/components/ContentGroupSimple/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "1.7.0",
     "@carbon/ibmdotcom-styles": "1.7.0",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ContentItemHorizontal/package.json
+++ b/packages/react/examples/codesandbox/components/ContentItemHorizontal/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/DotcomShell/package.json
+++ b/packages/react/examples/codesandbox/components/DotcomShell/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ExpressiveModal/package.json
+++ b/packages/react/examples/codesandbox/components/ExpressiveModal/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/FadeInOut/package.json
+++ b/packages/react/examples/codesandbox/components/FadeInOut/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/FeatureCard/package.json
+++ b/packages/react/examples/codesandbox/components/FeatureCard/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/FeatureCardBlockLarge/package.json
+++ b/packages/react/examples/codesandbox/components/FeatureCardBlockLarge/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/FeatureCardBlockMedium/package.json
+++ b/packages/react/examples/codesandbox/components/FeatureCardBlockMedium/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/Footer/package.json
+++ b/packages/react/examples/codesandbox/components/Footer/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/HorizontalRule/package.json
+++ b/packages/react/examples/codesandbox/components/HorizontalRule/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/Image/package.json
+++ b/packages/react/examples/codesandbox/components/Image/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/ImageWithCaption/package.json
+++ b/packages/react/examples/codesandbox/components/ImageWithCaption/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/Layout/package.json
+++ b/packages/react/examples/codesandbox/components/Layout/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/LeadSpaceBlock/package.json
+++ b/packages/react/examples/codesandbox/components/LeadSpaceBlock/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/Leadspace/package.json
+++ b/packages/react/examples/codesandbox/components/Leadspace/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/LightboxMediaViewer/package.json
+++ b/packages/react/examples/codesandbox/components/LightboxMediaViewer/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/LinkList/package.json
+++ b/packages/react/examples/codesandbox/components/LinkList/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/LinkWithIcon/package.json
+++ b/packages/react/examples/codesandbox/components/LinkWithIcon/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/LocaleModal/package.json
+++ b/packages/react/examples/codesandbox/components/LocaleModal/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/LogoGrid/package.json
+++ b/packages/react/examples/codesandbox/components/LogoGrid/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/Masthead/package.json
+++ b/packages/react/examples/codesandbox/components/Masthead/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/MastheadL1/package.json
+++ b/packages/react/examples/codesandbox/components/MastheadL1/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "^16.13.0",
     "react-dom": "^16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/PictogramItem/package.json
+++ b/packages/react/examples/codesandbox/components/PictogramItem/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/Quote/package.json
+++ b/packages/react/examples/codesandbox/components/Quote/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/TableOfContents/package.json
+++ b/packages/react/examples/codesandbox/components/TableOfContents/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },

--- a/packages/react/examples/codesandbox/components/VideoPlayer/package.json
+++ b/packages/react/examples/codesandbox/components/VideoPlayer/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
-    "@carbon/icons-react": "10.13.0",
+    "@carbon/icons-react": "latest",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },


### PR DESCRIPTION
### Description

Update Codesandbox examples dependency version.

### Changelog

**Changed**

- update `@carbon/icons-react` to use `latest` tag

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
