### PR TITLE
fix(card): focus state outline is off

### DIFF
--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -102,6 +102,7 @@
     }
   }
 
+  :host(#{$dds-prefix}-card-cta),
   :host(#{$dds-prefix}-card-link) {
     outline: none;
   }

--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -102,6 +102,10 @@
     }
   }
 
+  :host(#{$dds-prefix}-card-link) {
+    outline: none;
+  }
+
   :host(#{$dds-prefix}-card-eyebrow),
   .#{$prefix}--card__eyebrow {
     @include carbon--type-style('label-01');

--- a/packages/web-components/src/components/card/card.scss
+++ b/packages/web-components/src/components/card/card.scss
@@ -42,6 +42,8 @@
 }
 
 :host(#{$dds-prefix}-card) {
+  outline: none;
+
   .#{$prefix}--card__pictogram {
     display: flex;
 


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5033

### Description

Dds-card and dds-card-link had 2 outlines showing at the same time. I removed the default outline behavior which caused the black rounded border.

### Changelog

**Added**

+ outline: none on /packages/styles/scss/components/card/index.scss
+ outline: none on /packages/web-components/src/components/card/card.scss


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
