### PR TITLE
fix(feature-card): fixed multiple style mismatches from specs

### DIFF
--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -77,6 +77,10 @@
 
     &:hover {
       background-color: $hover-ui;
+
+      .#{$prefix}--card__wrapper {
+        background-color: $hover-ui;
+      }
     }
 
     .#{$prefix}--card__img {

--- a/packages/styles/scss/components/feature-card-block-large/_feature-card-block-large.scss
+++ b/packages/styles/scss/components/feature-card-block-large/_feature-card-block-large.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -117,6 +117,10 @@ $fcb-breakpoint-up--lg: map-get(
         }
       }
 
+      .#{$prefix}--card__content {
+        padding: 0;
+      }
+
       .#{$prefix}--card__eyebrow,
       ::slotted(#{$dds-prefix}-card-eyebrow) {
         margin: 0 0 $spacing-05 0;
@@ -139,7 +143,7 @@ $fcb-breakpoint-up--lg: map-get(
     }
 
     .#{$prefix}--card__footer {
-      flex-direction: row-reverse;
+      flex-direction: row;
     }
 
     // special breakpoint for no copy present

--- a/packages/web-components/src/components/feature-card-block-large/__stories__/feature-card-block-large.stories.ts
+++ b/packages/web-components/src/components/feature-card-block-large/__stories__/feature-card-block-large.stories.ts
@@ -50,7 +50,7 @@ export default {
     story => html`
       <div class="bx--grid dds-ce-demo-devenv--grid--stretch">
         <div class="bx--row dds-ce-demo-devenv--grid-row">
-          <div class="bx--col-sm-4 bx--col-lg-9 bx--offset-lg-2">
+          <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2">
             ${story()}
           </div>
         </div>

--- a/packages/web-components/src/components/feature-card-block-large/feature-card-block-large.scss
+++ b/packages/web-components/src/components/feature-card-block-large/feature-card-block-large.scss
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,4 +13,9 @@
 
 :host(#{$dds-prefix}-feature-card-block-large) {
   display: block;
+}
+
+:host(#{$dds-prefix}-feature-card-block-large-footer) {
+  display: flex;
+  justify-content: flex-start;
 }

--- a/packages/web-components/src/components/feature-card-block-medium/__stories__/feature-card-block-medium.stories.ts
+++ b/packages/web-components/src/components/feature-card-block-medium/__stories__/feature-card-block-medium.stories.ts
@@ -15,7 +15,7 @@ import '../feature-card-block-medium-block-heading';
 import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20.js';
 import { html } from 'lit-element';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
-import imgLg1x1 from '../../../../../storybook-images/assets/720/fpo--2x1--720x360--001.jpg';
+import imgLg1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x720--004.jpg';
 import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 


### PR DESCRIPTION
### Related Ticket(s)
#4925 
#4938 
#5092 

### Description
Addressing:
* `FeatureCardBlockLarge` specs mismatches where there was extra padding within the content
* `FeatureBlockCard` and `FeatureCardBlockMedium` color not changing on hover
* some Storybook-related issues where the image's dimensions clashed with the story wrapper, making `FeatureCard` looks weird

### Changelog

**Changed**

- `FeatureCardBlockLarge` arrow icon now moved to the left of the card
- slight Storybook layout and image changes to accommodate `FeatureCard` dimensions

** Removed **
- removed `padding` within `FeatureCardBlockLarge` contents

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
