### PR TITLE
fix(masthead-search): removed focus on first item prop

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -494,7 +494,6 @@ const MastheadSearch = ({
             getSuggestionValue={_getSuggestionValue} // Name of suggestion
             renderSuggestion={renderSuggestion} // How to display a suggestion
             onSuggestionSelected={onSuggestionSelected} // When a suggestion is selected
-            highlightFirstSuggestion // First suggestion is highlighted by default
             inputProps={inputProps}
             renderInputComponent={renderInputComponent}
             shouldRenderSuggestions={shouldRenderSuggestions}


### PR DESCRIPTION
### Related Ticket(s)

#5287 

### Description

I've removed the prop that makes Autosuggest focus on the first suggested item, this prop was causing a bug where the typed content would be overwritten by the first suggested item when enter is pressed.