### PR TITLE
fix(footer): added aria-label to describe footer

### DIFF
--- a/packages/web-components/src/components/footer/footer.ts
+++ b/packages/web-components/src/components/footer/footer.ts
@@ -39,6 +39,10 @@ class DDSFooter extends StableSelectorMixin(LitElement) {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'footer');
     }
+
+    if (!this.hasAttribute('aria-label')) {
+      this.setAttribute('aria-label', 'footer');
+    }
     super.connectedCallback();
   }
 

--- a/packages/web-components/tests/snapshots/dds-footer-composite.md
+++ b/packages/web-components/tests/snapshots/dds-footer-composite.md
@@ -7,6 +7,7 @@
 ```
 <dds-footer-composite size="">
   <dds-footer
+    aria-label="footer"
     data-autoid="dds--footer"
     role="footer"
     size=""
@@ -42,6 +43,7 @@
   size=""
 >
   <dds-footer
+    aria-label="footer"
     data-autoid="dds--footer"
     role="footer"
     size=""


### PR DESCRIPTION
### Related Ticket(s)
#4890

### Description
Even though `<dds-footer>` has a `role='footer'`, it appears it's not being detected as such. Added an `aria-label='footer'` to accommodate for this.

### Changelog

**New**

- added `aria-label='footer'` to `<dds-footer>`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
