### PR TITLE
fix(scroll-animations): rename storybook title

### DIFF
--- a/packages/react/src/components/ScrollAnimations/__stories__/ScrollAnimations.stories.js
+++ b/packages/react/src/components/ScrollAnimations/__stories__/ScrollAnimations.stories.js
@@ -34,7 +34,7 @@ const selectorTargets = `
 `;
 
 export default {
-  title: 'Components|Fade In Out',
+  title: 'Components|Scroll Animations',
 
   parameters: {
     ...readme.parameters,


### PR DESCRIPTION
### Related Ticket(s)
None.

### Description
The React storybook variation for the new `ScrollAnimations` component was left unchanged from its previous title of `FadeInOut`. This PR addresses this issue and changes to the correct name for its title.

### Changelog

**Changed**

- changed `FadeInOut` Storybook title to `ScrollAnimations`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
