### PR TITLE
fix(content-block-headlines): aligning CTA at the bottom

### DIFF
--- a/packages/web-components/src/components/content-block-headlines/content-block-headlines.scss
+++ b/packages/web-components/src/components/content-block-headlines/content-block-headlines.scss
@@ -8,5 +8,9 @@
 @import '@carbon/ibmdotcom-styles/scss/components/content-block-headlines/content-block-headlines';
 
 :host(#{$dds-prefix}-content-block-headlines-item) {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  ::slotted([slot='footer']) {
+    margin-top: auto;
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

Web component: Content block headlines - 'Link text' links are not aligned on sections #4860

### Description

Aligning CTA at the bottom.

[web-components experimental](http://ibmdotcom-web-components-experimental.mybluemix.net/?path=/story/components-content-block-headlines--default)
<img width="801" alt="Screen Shot 2021-02-26 at 11 19 01" src="https://user-images.githubusercontent.com/42848561/109311313-6f83da80-7824-11eb-8670-c3d46e2427c6.png">

This PR
<img width="772" alt="Screen Shot 2021-02-26 at 11 19 46" src="https://user-images.githubusercontent.com/42848561/109311387-8a564f00-7824-11eb-8174-78483a8c1c93.png">
