### PR TITLE
fix(content-block-headlines): same height using CSS grid

### DIFF
--- a/packages/react/src/components/ContentBlockHeadlines/ContentBlockHeadlines.js
+++ b/packages/react/src/components/ContentBlockHeadlines/ContentBlockHeadlines.js
@@ -1,18 +1,16 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useEffect, useRef } from 'react';
 import ContentBlock from '../../internal/components/ContentBlock/ContentBlock';
 import { CTA } from '../CTA';
 import { DDS_CONTENTBLOCK_HEADLINES } from '../../internal/FeatureFlags';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import featureFlag from '@carbon/ibmdotcom-utilities/es/utilities/featureflag/featureflag';
 import PropTypes from 'prop-types';
-import root from 'window-or-global';
-import sameHeight from '@carbon/ibmdotcom-utilities/es/utilities/sameHeight/sameHeight';
+import React from 'react';
 import settings from 'carbon-components/es/globals/js/settings';
 
 const { stablePrefix } = ddsSettings;
@@ -22,38 +20,11 @@ const { prefix } = settings;
  * ContentBlockHeadlines pattern
  */
 const ContentBlockHeadlines = ({ heading, copy, items }) => {
-  const containerRef = useRef();
-
-  useEffect(() => {
-    setSameHeight();
-    root.addEventListener('resize', setSameHeight);
-
-    return () => root.removeEventListener('resize', setSameHeight);
-  }, []);
-
-  /**
-   * Function that activates the sameHeight utility
-   */
-  const setSameHeight = () => {
-    root.requestAnimationFrame(() => {
-      const { current: containerNode } = containerRef;
-      if (containerNode) {
-        sameHeight(
-          containerNode.getElementsByClassName(
-            `${prefix}--content-block-headlines__copy`
-          ),
-          'md'
-        );
-      }
-    });
-  };
-
   return featureFlag(
     DDS_CONTENTBLOCK_HEADLINES,
     <div
       data-autoid={`${stablePrefix}--content-block-headlines`}
-      className={`${prefix}--content-block-headlines`}
-      ref={containerRef}>
+      className={`${prefix}--content-block-headlines`}>
       <ContentBlock heading={heading} copy={copy} border={true}>
         <div className={`${prefix}--content-block-headlines__container`}>
           <div className={`${prefix}--content-block-headlines__row`}>
@@ -87,7 +58,12 @@ function renderItems(items) {
         <p className={`${prefix}--content-block-headlines__copy`}>
           {item.copy}
         </p>
-        {item.cta && <CTA {...item.cta} />}
+        {item.cta && (
+          <CTA
+            customClassName={`${prefix}--content-block-headlines__cta-container`}
+            {...item.cta}
+          />
+        )}
       </div>
     );
   });

--- a/packages/react/src/components/ContentBlockHeadlines/ContentBlockHeadlines.js
+++ b/packages/react/src/components/ContentBlockHeadlines/ContentBlockHeadlines.js
@@ -52,7 +52,7 @@ function renderItems(items) {
   items.forEach((item, index) => {
     headlineItems.push(
       <div className={`${prefix}--content-block-headlines__item`} key={index}>
-        <h4 className={`${prefix}--content-block-headlines__headline`}>
+        <h4 className={`${prefix}--content-block-headlines__heading`}>
           {item.headline}
         </h4>
         <p className={`${prefix}--content-block-headlines__copy`}>

--- a/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
+++ b/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
@@ -80,6 +80,9 @@
 
   :host(#{$dds-prefix}-content-block-headlines-item),
   .#{$prefix}--content-block-headlines__item {
+    display: flex;
+    flex-direction: column;
+
     border-top: 1px solid $ui-03;
     padding-top: $carbon--spacing-05;
     padding-bottom: $carbon--spacing-07;
@@ -101,6 +104,10 @@
     :host(#{$dds-prefix}-content-block-headlines-heading),
     .#{$prefix}--content-block-headlines__heading {
       @include carbon--type-style('display-02', true);
+    }
+
+    .#{$prefix}--content-block-headlines__cta-container {
+      margin-top: auto;
     }
 
     .#{$prefix}--link {


### PR DESCRIPTION
### Related Ticket(s)
#4694

### Description
The Headlines Item container currently uses `display: grid`, but each of the items' CTAs weren't properly aligned to the bottom. This PR addresses that, and also fixes a wrong class name for the heading element so the correct stylings are applied.

Before:
![Screen Shot 2021-03-01 at 2 30 19 PM](https://user-images.githubusercontent.com/24970122/109568046-2be6d600-7a9b-11eb-9337-78d3c5fa7710.png)

After:
![Screen Shot 2021-03-01 at 2 30 31 PM](https://user-images.githubusercontent.com/24970122/109568059-31dcb700-7a9b-11eb-906c-230a12769729.png)



### Changelog

**New**

- added `display: flex` and `flex-direction: columns` to the `headlines__item` class
- set custom class name to the previously unnamed CTA div container
- set `margin-top: auto` for the `CTA` div container to ensure proper alignment

**Changed**

- fixed a mislabeled class name for HeadlineItem's `<h4>` to apply proper styles

**Removed**

- removed the dynamic setting of height for the copy elements that used the `setHeight` utility function

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
