### PR TITLE
chore(toc): fix autoid interpolation

### DIFF
--- a/packages/react/src/components/TableOfContents/TOCMobile.js
+++ b/packages/react/src/components/TableOfContents/TOCMobile.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -92,7 +92,7 @@ const renderOptions = (options, label) => {
       return (
         <option
           className={`${prefix}--tableofcontents__mobile__select__option`}
-          data-autoid={`${stablePrefix}}--tableofcontents__mobile__select__option-${option.id}`}
+          data-autoid={`${stablePrefix}--tableofcontents__mobile__select__option-${option.id}`}
           key={index}
           value={option.id}
           defaultValue={index === 0}


### PR DESCRIPTION
### Description

Removes extra character in `data-autoid` attribute.

### Changelog


**Removed**

- extra `}` in `TOC` mobile options

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
