### PR TITLE
fix(leavingIbm): max height limit to modal in landscape

### DIFF
--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm.scss
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm.scss
@@ -16,12 +16,10 @@
 :host(#{$dds-prefix}-leaving-ibm-modal) {
   @extend :host(#{$prefix}-modal);
 
+  max-height: 100%;
+
   &[open] {
     @extend :host(#{$prefix}-modal[open]);
-  }
-
-  @media (orientation: landscape) and (hover: none) and (pointer: coarse) {
-    max-height: 100%;
   }
 }
 

--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm.scss
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm.scss
@@ -19,6 +19,10 @@
   &[open] {
     @extend :host(#{$prefix}-modal[open]);
   }
+
+  @media (orientation: landscape) and (hover: none) and (pointer: coarse) {
+    max-height: 100%;
+  }
 }
 
 :host(#{$dds-prefix}-leaving-ibm-modal-heading) {


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5058

### Changes

Limited the max height of modal to screen height. Affects landscape mode for touch devices only.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
