### PR TITLE
fix(video-player): remove usage of React classnames

### DIFF
--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -8,7 +8,7 @@
  */
 
 import { html, property, customElement, LitElement } from 'lit-element';
-import cx from 'classnames';
+import { classMap } from 'lit-html/directives/class-map';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
@@ -141,8 +141,8 @@ class DDSVideoPlayer extends FocusMixin(LitElement) {
   render() {
     const { aspectRatio, duration, formatCaption, formatDuration, hideCaption, name } = this;
 
-    const aspectRatioClass = cx({
-      [`${prefix}--video-player__aspect-ratio--${aspectRatio}`]: aspectRatio,
+    const aspectRatioClass = classMap({
+      [`${prefix}--video-player__aspect-ratio--${aspectRatio}`]: !!aspectRatio,
     });
 
     return html`

--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -142,11 +142,12 @@ class DDSVideoPlayer extends FocusMixin(LitElement) {
     const { aspectRatio, duration, formatCaption, formatDuration, hideCaption, name } = this;
 
     const aspectRatioClass = classMap({
+      [`${prefix}--video-player__video-container`]: true,
       [`${prefix}--video-player__aspect-ratio--${aspectRatio}`]: !!aspectRatio,
     });
 
     return html`
-      <div class="${prefix}--video-player__video-container ${aspectRatioClass}">
+      <div class="${aspectRatioClass}">
         ${this._renderContent()}
       </div>
       ${hideCaption


### PR DESCRIPTION
### Related Ticket(s)

Refs #5342.

### Description

Replaces usage of React `classnames` library with `lit-html`'s `classMap`, given the latter is the library we use for
`@carbon/ibmdotcom-web-components` and thus our user's environment of `@carbon/ibmdotcom-web-components` won't have React `classnames`.

### Changelog

**Changed**

- Replaces usage of React `classnames` library with `lit-html`'s `classMap`.