### PR TITLE
fix(linkwithicon): remove inverse styles

### DIFF
--- a/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
+++ b/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
@@ -88,19 +88,6 @@
   :host(#{$dds-prefix}-link-with-icon),
   .#{$prefix}--link-with-icon__container {
     display: table;
-
-    &__inverse {
-      .#{$prefix}--link {
-        color: $inverse-link;
-      }
-
-      @include carbon--theme(
-        $carbon--theme--g100,
-        feature-flag-enabled('enable-css-custom-properties')
-      ) {
-        @include link;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
### Description

Removes unused style that is also causing compile errors for web components.

### Changelog

**Removed**

- `inverse` styling. It is not being used and the scss concatenation is not supported with `:host` pseudo-classes.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
