### PR TITLE
feat(masthead): specify selected menu item style for L1 menu item 

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -45,7 +45,7 @@ const { prefix } = settings;
  * @param {string} props.title Title for the masthead L1
  * @param {string} props.eyebrowText Text for the eyebrow link in masthead L1
  * @param {string} props.eyebrowLink URL for the eyebrow link in masthead L1
- * @param {string} props.selectedMenuItem L0 menu item to render with selected state
+ * @param {string} props.selectedMenuItem L0/L1 menu item to render with selected state
  * @returns {*} Masthead component
  */
 const Masthead = ({
@@ -300,6 +300,7 @@ const Masthead = ({
                   {...mastheadL1Data}
                   isShort={isMastheadSticky}
                   navType={navType}
+                  selectedMenuItem={selectedMenuItem}
                 />
               </div>
             )}

--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -29,6 +29,7 @@ const MastheadL1 = ({ title, titleLink, navigationL1, ...rest }) => {
 
   const mastheadL1Links = navigationL1.map((link, index) => {
     const autoid = `${stablePrefix}--masthead-${rest.navType}__l1-nav${index}`;
+    const selected = link.titleEnglish === rest.selectedMenuItem;
     if (link.hasMenu || link.hasMegapanel) {
       return (
         <HeaderMenu
@@ -37,6 +38,7 @@ const MastheadL1 = ({ title, titleLink, navigationL1, ...rest }) => {
           className={cx({
             [`${prefix}--masthead__megamenu__l1-nav`]: link.hasMegapanel,
           })}
+          selected={selected}
           autoId={autoid}
           key={index}>
           {renderNav(link, rest.navType, autoid)}
@@ -44,7 +46,11 @@ const MastheadL1 = ({ title, titleLink, navigationL1, ...rest }) => {
       );
     } else {
       return (
-        <HeaderMenuItem href={link.url} data-autoid={autoid} key={index}>
+        <HeaderMenuItem
+          aria-selected={selected ? 'true' : 'false'}
+          href={link.url}
+          data-autoid={autoid}
+          key={index}>
           {link.title}
         </HeaderMenuItem>
       );

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -135,7 +135,7 @@ WithCustomNavigation.story = {
           ),
           selectedMenuItem: text(
             'selected menu item (selectedMenuItem)',
-            'Services & Consulting',
+            'Lorem ipsum dolor sit amet',
             groupId
           ),
         };
@@ -234,6 +234,11 @@ WithL1.story = {
             ),
             navigationL1: mastheadKnobs.navigation.custom,
           },
+          selectedMenuItem: text(
+            'selected menu item (selectedMenuItem)',
+            'Lorem ipsum dolor sit amet',
+            groupId
+          ),
         };
       },
     },

--- a/packages/web-components/src/components/masthead/__stories__/links.ts
+++ b/packages/web-components/src/components/masthead/__stories__/links.ts
@@ -53,23 +53,28 @@ const l1Data: MastheadL1 = {
   url: 'https://example.com',
   menuItems: [
     {
-      title: 'Lorem ipsum dolor',
+      title: 'Products & Solutions',
+      titleEnglish: 'Products & Solutions',
       url: 'https://example.com',
     },
     {
-      title: 'Lorem ipsum dolor',
+      title: 'Services & Consulting',
+      titleEnglish: 'Services & Consulting',
       url: 'https://example.com',
       menuItems: [
         {
-          title: 'Lorem ipsum dolor',
+          title: 'About IBM',
+          titleEnglish: 'About IBM',
           url: 'https://example.com',
         },
         {
-          title: 'Lorem ipsum dolor',
+          title: 'Partners',
+          titleEnglish: 'Partners',
           url: 'https://example.com',
         },
         {
-          title: 'Lorem ipsum dolor',
+          title: 'IBM Research',
+          titleEnglish: 'IBM Research',
           url: 'https://example.com',
         },
       ],

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -95,10 +95,11 @@ class DDSMastheadComposite extends LitElement {
         ? html`
             <dds-top-nav-l1>
               ${menuItems.map((elem, i) => {
+                const selected = selectedMenuItem && elem.titleEnglish === selectedMenuItem;
                 return elem.menuItems
                   ? html`
                       <dds-top-nav-menu
-                        ?active="${selectedMenuItem && elem.titleEnglish === selectedMenuItem}"
+                        ?active="${selected}"
                         menu-label="${elem.title}"
                         trigger-content="${elem.title}"
                         data-autoid="${ddsPrefix}--masthead__l1-nav--nav-${i}"
@@ -116,7 +117,7 @@ class DDSMastheadComposite extends LitElement {
                     `
                   : html`
                       <dds-top-nav-item
-                        ?active="${selectedMenuItem && elem.titleEnglish === selectedMenuItem}"
+                        ?active="${selected}"
                         href="${elem.url}"
                         title="${elem.title}"
                         data-autoid="${ddsPrefix}--masthead__l1-nav--nav-${i}"
@@ -125,11 +126,12 @@ class DDSMastheadComposite extends LitElement {
               })}
             </dds-top-nav-l1>
           `
-        : menuItems.map((elem, i) =>
-            elem.menuItems
+        : menuItems.map((elem, i) => {
+            const selected = selectedMenuItem && elem.titleEnglish === selectedMenuItem;
+            return elem.menuItems
               ? html`
                   <dds-left-nav-menu
-                    ?active="${selectedMenuItem && elem.titleEnglish === selectedMenuItem}"
+                    ?active="${selected}"
                     title="${elem.title}"
                     data-autoid="${ddsPrefix}--masthead__l1-sidenav--nav-${i}"
                   >
@@ -146,13 +148,13 @@ class DDSMastheadComposite extends LitElement {
                 `
               : html`
                   <dds-left-nav-item
-                    ?active="${selectedMenuItem && elem.titleEnglish === selectedMenuItem}"
+                    ?active="${selected}"
                     href="${elem.url}"
                     title="${elem.title}"
                     data-autoid="${ddsPrefix}--masthead__l1-sidenav--nav-${i}"
                   ></dds-left-nav-item>
-                `
-          );
+                `;
+          });
     }
 
     return undefined;
@@ -358,6 +360,7 @@ class DDSMastheadComposite extends LitElement {
       ? undefined
       : navLinks.map((link, i) => {
           const { menuSections = [], title, titleEnglish, url } = link;
+          const selected = selectedMenuItem && titleEnglish === selectedMenuItem;
           let sections;
           let mobileSections;
           if (link.hasMegapanel) {
@@ -389,7 +392,7 @@ class DDSMastheadComposite extends LitElement {
             if (sections.length === 0) {
               return html`
                 <dds-top-nav-item
-                  ?active="${selectedMenuItem && titleEnglish === selectedMenuItem}"
+                  ?active="${selected}"
                   href="${url}"
                   title="${title}"
                   data-autoid="${ddsPrefix}--masthead__l0-nav--nav-${i}"
@@ -399,7 +402,7 @@ class DDSMastheadComposite extends LitElement {
             if (link.hasMegapanel) {
               return html`
                 <dds-megamenu-top-nav-menu
-                  ?active="${selectedMenuItem && titleEnglish === selectedMenuItem}"
+                  ?active="${selected}"
                   menu-label="${title}"
                   trigger-content="${title}"
                   data-autoid="${ddsPrefix}--masthead__l0-nav--nav-${i}"
@@ -410,7 +413,7 @@ class DDSMastheadComposite extends LitElement {
             }
             return html`
               <dds-top-nav-menu
-                ?active="${selectedMenuItem && titleEnglish === selectedMenuItem}"
+                ?active="${selected}"
                 menu-label="${title}"
                 trigger-content="${title}"
                 data-autoid="${ddsPrefix}--masthead__l0-nav--nav-${i}"
@@ -422,7 +425,7 @@ class DDSMastheadComposite extends LitElement {
           return sections.length === 0
             ? html`
                 <dds-left-nav-item
-                  ?active="${selectedMenuItem && titleEnglish === selectedMenuItem}"
+                  ?active="${selected}"
                   href="${url}"
                   title="${title}"
                   data-autoid="${ddsPrefix}--masthead__l0-sidenav--nav-${i}"
@@ -430,7 +433,7 @@ class DDSMastheadComposite extends LitElement {
               `
             : html`
                 <dds-left-nav-menu
-                  ?active="${selectedMenuItem && titleEnglish === selectedMenuItem}"
+                  ?active="${selected}"
                   title="${title}"
                   data-autoid="${ddsPrefix}--masthead__l0-sidenav--nav-${i}"
                 >
@@ -672,7 +675,7 @@ class DDSMastheadComposite extends LitElement {
             )}
           </dds-masthead-profile>
         </dds-masthead-global-bar>
-        ${!l1Data ? undefined : this._renderL1()}
+        ${!l1Data ? undefined : this._renderL1({ selectedMenuItem })}
         <dds-megamenu-overlay></dds-megamenu-overlay>
       </dds-masthead>
     `;


### PR DESCRIPTION
### Related Ticket(s)

Corporate Masthead - Specify what is the currently selected element in a L1 menu #5302

### Description

The selected menu item state is currently only available for the L0 menu items. This PR adds that functionality to the L1 as well. NOTE: we have user passing in one `selectedMenuItem` prop - right now, usage is menu items only appear either L0 or L1 - not both.

REACT:
<img width="1377" alt="Screen Shot 2021-03-03 at 5 10 41 PM" src="https://user-images.githubusercontent.com/54281166/109884273-b02b8b80-7c4a-11eb-8f0f-d91a173acd59.png">

WEB COMPONENTS:
<img width="1393" alt="Screen Shot 2021-03-03 at 5 51 15 PM" src="https://user-images.githubusercontent.com/54281166/109884287-b6216c80-7c4a-11eb-8b39-788e0ed45377.png">


### Changelog

**New**

- copy over selected menu item logic to the masthead L1

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
