### PR TITLE
fix(expressive-modal): remove voiceover focus from close button

### DIFF
--- a/packages/web-components/src/components/expressive-modal/expressive-modal.scss
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal.scss
@@ -17,6 +17,10 @@
     @extend :host(#{$prefix}-modal[open]);
   }
 
+  &:not([open]) {
+    display: none;
+  }
+
   &[expressive-size='full-width'] {
     .#{$prefix}--modal-container {
       width: calc(100% - 2rem);


### PR DESCRIPTION
### Related Ticket(s)
#4744

### Description

Using iOS Voiceover, the focus was stuck on the (invisible) close button after the modal had already been closed. This change ensures the modal cannot be accessed or seen in any way by screen readers if it's been closed.

### Changelog

**New**

- `display:none` when `dds-expressive-modal` has been closed 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
