### PR TITLE
chore(content-block-media): add missing style imports

### DIFF
--- a/packages/react/examples/codesandbox/components/ContentBlockMedia/src/index.js
+++ b/packages/react/examples/codesandbox/components/ContentBlockMedia/src/index.js
@@ -125,7 +125,6 @@ const App = () => (
             },
           ]}
           cta={{
-            type: "feature",
             heading: "Feature Card",
             card: {
               heading: "Consectetur adipisicing elit",

--- a/packages/react/examples/codesandbox/components/ContentBlockMedia/src/index.js
+++ b/packages/react/examples/codesandbox/components/ContentBlockMedia/src/index.js
@@ -1,5 +1,5 @@
 /**
-  Copyright IBM Corp. 2016, 2020
+  Copyright IBM Corp. 2016, 2021
 
   This source code is licensed under the Apache-2.0 license found in the
   LICENSE file in the root directory of this source tree.
@@ -7,55 +7,144 @@
 
 import "./styles.scss";
 
+import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20';
 import React from "react";
 import ReactDom from "react-dom";
 
 import { ContentBlockMedia } from "@carbon/ibmdotcom-react";
 
 const App = () => (
-  <div>
-    <ContentBlockMedia
-      copy="dolor sit amet"
-      heading="Lorem ipsum"
-      items={[
-        {
-          mediaType: "image",
-          mediaData: {
-            heading: "Lorem ipsum dolor sit amet.",
-            image: {
-              sources: [
-                {
-                  src: "https://fpoimg.com/672x672?text=16:9&bg_color=ee5396&text_color=161616",
-                  breakpoint: 320
-                },
-                {
-                  src: "https://fpoimg.com/400x225?text=16:9&bg_color=ee5396&text_color=161616",
-                  breakpoint: 400
-                },
-                {
-                  src: "https://fpoimg.com/672x378?text=16:9&bg_color=ee5396&text_color=161616",
-                  breakpoint: 672
-                }
-              ],
-              alt: "Image alt text",
-              defaultSrc:
-                "https://fpoimg.com/672x378?text=16:9&bg_color=ee5396&text_color=161616"
-            }
-          },
-          heading: "Lorem ipsum dolor sit amet",
-          items: [
+  <div className="bx--grid">
+    <div className="bx--row">
+      <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+
+        <ContentBlockMedia
+          copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean
+              et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at
+              elit sollicitudin, sodales nulla quis, *consequat* libero. Phasellus at
+              elit sollicitudin, sodales nulla quis, consequat [libero](https://www.google.com)."
+          heading="Content Block - with Media"
+          items={[
             {
-              heading: "Lorem ipsum dolor sit amet.",
-              copy: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+              mediaType: "image",
+              mediaData: {
+                heading: "Lorem ipsum dolor sit amet.",
+                image: {
+                  sources: [
+                    {
+                      src:
+                        "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                      breakpoint: 320,
+                    },
+                    {
+                      src:
+                        "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                      breakpoint: 400,
+                    },
+                    {
+                      src:
+                        "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                      breakpoint: 672,
+                    },
+                  ],
+                  alt: "Image alt text",
+                  defaultSrc:
+                    "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                },
+              },
+              heading: "Lorem ipsum dolor sit amet",
+              items: [
+                {
+                  heading: "Lorem ipsum dolor sit amet.",
+                  copy:
+                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                },
+                {
+                  heading: "Lorem ipsum dolor sit amet.",
+                  copy:
+                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                },
+              ],
+              cta: {
+                cta: {
+                  href: "https://www.example.com",
+                },
+                style: "card",
+                type: "local",
+                copy: "Lorem ipsum dolor sit ametttt",
+              },
             },
             {
-              heading: "Lorem ipsum dolor sit amet.",
-              copy: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-            }
-          ]
-        }
-      ]}
-    />
+              mediaType: "image",
+              mediaData: {
+                heading: "Lorem ipsum dolor sit amet.",
+                image: {
+                  sources: [
+                    {
+                      src:
+                        "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                      breakpoint: 320,
+                    },
+                    {
+                      src:
+                        "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                      breakpoint: 400,
+                    },
+                    {
+                      src:
+                        "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                      breakpoint: 672,
+                    },
+                  ],
+                  alt: "Image alt text",
+                  defaultSrc:
+                    "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                },
+              },
+              heading: "Lorem ipsum dolor sit amet",
+              items: [
+                {
+                  heading: "Lorem ipsum dolor sit amet.",
+                  copy:
+                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                },
+                {
+                  heading: "Lorem ipsum dolor sit amet.",
+                  copy:
+                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                },
+              ],
+              cta: {
+                cta: {
+                  href: "https://www.example.com",
+                },
+                style: "card",
+                type: "local",
+                copy: "Lorem ipsum dolor sit ametttt",
+              },
+            },
+          ]}
+          cta={{
+            type: "feature",
+            heading: "Feature Card",
+            card: {
+              heading: "Consectetur adipisicing elit",
+              image: {
+                defaultSrc:
+                  "https://dummyimage.com/672x672/ee5396/161616&text=1x1",
+                alt: "Image alt text",
+              },
+              cta: {
+                href: 'https://www.example.com',
+                icon: {
+                  src: ArrowRight20,
+                },
+              },
+            },
+          }}
+        />
+      </div>
+    </div>
   </div>
 );
 

--- a/packages/react/src/components/ContentGroupSimple/__stories__/data/ContentGroupSimple.knobs.js
+++ b/packages/react/src/components/ContentGroupSimple/__stories__/data/ContentGroupSimple.knobs.js
@@ -89,7 +89,7 @@ const ContentGroupSimpleKnobs = {
     },
     style: 'card',
     type: 'local',
-    copy: 'Lorem ipsum dolor sit ametttt',
+    copy: 'Lorem ipsum dolor sit amet',
   },
 };
 

--- a/packages/react/src/internal/components/ContentBlock/ContentBlock.js
+++ b/packages/react/src/internal/components/ContentBlock/ContentBlock.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -52,7 +52,7 @@ const ContentBlock = ({
   );
 
   const title = (
-    <div>
+    <>
       {heading && (
         <h2
           data-autoid={`${stablePrefix}--content-block__heading`}
@@ -60,7 +60,7 @@ const ContentBlock = ({
           {heading}
         </h2>
       )}
-    </div>
+    </>
   );
 
   return (

--- a/packages/styles/scss/components/content-block-media/index.scss
+++ b/packages/styles/scss/components/content-block-media/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,6 +8,8 @@
 @import '../../globals/imports';
 @import '../../internal/content-block/content-block';
 @import '../../internal/content-group/content-group';
+@import '../../internal/content-item/content-item';
 @import '../card/index';
 @import '../content-group-simple/index';
+@import '../image-with-caption/image-with-caption';
 @import 'content-block-media';


### PR DESCRIPTION
### Related Ticket(s)
#5379 

### Description

Add missing style imports to `Content Block - Media`. Also updates the React Codesandbox example.

### Changelog

**New**

- stylesheet imports

**Changed**

- update React Codesandbox example

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
