### PR TITLE
fix(callout-data): background token fix

### DIFF
--- a/packages/styles/scss/components/callout-data/_callout-data.scss
+++ b/packages/styles/scss/components/callout-data/_callout-data.scss
@@ -38,6 +38,12 @@
       width: 90%;
       max-width: 640px;
     }
+
+    .#{$prefix}--callout__container {
+      @include carbon--theme($carbon--theme--white, true) {
+        background-color: $inverse-02;
+      }
+    }
   }
 
   :host(#{$dds-prefix}-callout-data-heading),
@@ -76,39 +82,6 @@
 
     padding-top: $spacing-03;
     color: $text-05;
-  }
-
-  :host(#{$dds-prefix}-callout-data-container) .#{$prefix}--callout__column {
-    background-color: $inverse-02;
-    height: auto;
-    display: flex;
-    flex-direction: column;
-
-    @include carbon--breakpoint('md') {
-      min-height: carbon--mini-units(40);
-    }
-
-    @include carbon--breakpoint('lg') {
-      min-height: carbon--mini-units(50);
-    }
-
-    @include carbon--breakpoint('xlg') {
-      min-height: carbon--mini-units(60);
-    }
-
-    @include carbon--breakpoint('max') {
-      min-height: carbon--mini-units(70);
-    }
-
-    .#{$prefix}--callout__content {
-      padding-left: 0;
-      margin-left: 0;
-      display: flex;
-      flex: 1;
-      flex-direction: column;
-      width: 90%;
-      max-width: 640px;
-    }
   }
 }
 @include exports('callout-data') {


### PR DESCRIPTION
### Related Ticket(s)

NextJS - Services Page - Callout data, text color is same as background. #5193

### Description

style(callout-data): fixing background

**Current**
<img width="1224" alt="Screen Shot 2021-03-05 at 12 21 04" src="https://user-images.githubusercontent.com/42848561/110135420-437cd200-7dad-11eb-9c7b-8cd59c83a065.png">

**This PR**
<img width="1178" alt="Screen Shot 2021-03-05 at 12 22 23" src="https://user-images.githubusercontent.com/42848561/110135586-72934380-7dad-11eb-8bc2-d72509130150.png">
