### PR TITLE
fix(expressive-modal): various style fixes

### DIFF
--- a/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
+++ b/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,11 +38,9 @@
     }
   }
 
-  :host(#{$dds-prefix}-expressive-modal-close-button),
-  #{$modal}--expressive {
+  :host(#{$dds-prefix}-expressive-modal-close-button) {
     #{$modal}-close {
-      top: 0;
-      right: 0;
+      position: fixed;
     }
   }
 

--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -46,11 +46,6 @@
       .#{$prefix}--model-container {
         padding-top: $carbon--layout-04;
         padding-bottom: $carbon--spacing-05;
-      }
-
-      .#{$prefix}--modal-close {
-        top: 0;
-        right: 0;
       }
     }
   }

--- a/packages/web-components/src/components/expressive-modal/expressive-modal.scss
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal.scss
@@ -19,9 +19,12 @@
 
   &[expressive-size='full-width'] {
     .#{$prefix}--modal-container {
-      width: calc(100% - 2rem);
-      height: calc(100% - 2rem);
       max-height: none;
+
+      @include carbon--breakpoint('md') {
+        width: calc(100% - 2rem);
+        height: calc(100% - 2rem);
+      }
 
       .#{$prefix}--modal-content {
         margin: $layout-04 $layout-03;


### PR DESCRIPTION
### Related Ticket(s)

#5348 

### Description

Fixes for `expressive-modal` close button positioning and responsive styles.

### Changelog

**Changed**

- adjust close button position for web component
- fix modal container responsive styles

**Removed**

- duplicate styles

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
