### PR TITLE
fix(masthead/dotcom-shell): update stories

### DIFF
--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -149,7 +149,6 @@ export const SearchOpenByDefault = ({ parameters }) => (
 );
 
 SearchOpenByDefault.story = {
-  name: 'Search open by default',
   parameters: {
     knobs: { escapeHTML: false, ...Default.story.parameters.knobs },
   },
@@ -245,12 +244,11 @@ WithL1.story = {
   },
 };
 
-export const WithAlternateLogo = ({ parameters }) => (
+export const WithAlternateLogoAndTooltip = ({ parameters }) => (
   <Masthead {...(parameters?.props?.Masthead ?? {})} />
 );
 
-WithAlternateLogo.story = {
-  name: 'With logo data',
+WithAlternateLogoAndTooltip.story = {
   parameters: {
     knobs: {
       escapeHTML: false,
@@ -289,7 +287,7 @@ WithAlternateLogo.story = {
           mastheadLogo: select(
             'masthead logo data (mastheadLogo)',
             mastheadKnobs.mastheadLogo,
-            mastheadKnobs.mastheadLogo.defaultNoTooltip,
+            mastheadKnobs.mastheadLogo.alternateWithTooltip,
             groupId
           ),
         };

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -8,7 +8,7 @@
  */
 
 import { html } from 'lit-element';
-import { select } from '@storybook/addon-knobs';
+import { boolean, select, object } from '@storybook/addon-knobs';
 import on from 'carbon-components/es/globals/js/misc/on';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
 import inPercy from '@percy-io/in-percy';
@@ -18,7 +18,8 @@ import '../dotcom-shell-container';
 import { authenticatedProfileItems, unauthenticatedProfileItems } from '../../masthead/__stories__/profile-items';
 import mastheadStyles from '../../masthead/__stories__/masthead.stories.scss';
 import { FOOTER_SIZE } from '../../footer/footer';
-import mastheadLinks from '../../masthead/__stories__/links';
+import mastheadLinks, { l1Data } from '../../masthead/__stories__/links';
+import mockLangList from '../../footer/__stories__/language-list';
 import mockFooterLinks from '../../footer/__stories__/links';
 import mockLegalLinks from '../../footer/__stories__/legal-links';
 import mockLocaleList from '../../locale-modal/__stories__/locale-data.json';
@@ -42,15 +43,31 @@ import '../../quote/quote-source-copy';
 import '../../quote/quote-source-heading';
 import readme from './README.stories.mdx';
 import StoryContent from './data/content';
+import { UNAUTHENTICATED_STATUS } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI';
+
+const userStatuses = {
+  authenticated: 'test.user@ibm.com',
+  unauthenticated: UNAUTHENTICATED_STATUS,
+};
+
+/**
+ * platform knob data
+ */
+const platformData = {
+  name: 'IBM Cloud',
+  url: 'https://www.ibm.com/cloud',
+};
 
 const footerSizes = {
   Default: FOOTER_SIZE.REGULAR,
   [`Short (${FOOTER_SIZE.SHORT})`]: FOOTER_SIZE.SHORT,
+  [`Micro (${FOOTER_SIZE.MICRO})`]: FOOTER_SIZE.MICRO,
 };
 
 export const Default = ({ parameters }) => {
-  const { platform, userStatus, navLinks } = parameters?.props?.MastheadComposite ?? {};
-  const { langDisplay, language, size: footerSize, legalLinks, links: footerLinks, localeList } =
+  const { platform, profile, userStatus, navLinks, search, searchPlaceholder, selectedMenuItem } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { langDisplay, language, footerSize, legalLinks, links: footerLinks, localeList } =
     parameters?.props?.FooterComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
@@ -61,15 +78,20 @@ export const Default = ({ parameters }) => {
       ? html`
           <dds-dotcom-shell-composite
             platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
             language="${ifNonNull(language)}"
             lang-display="${ifNonNull(langDisplay)}"
             footer-size="${ifNonNull(footerSize)}"
             user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+            selected-menu-item="${ifNonNull(selectedMenuItem)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
             .legalLinks="${ifNonNull(legalLinks)}"
             .localeList="${ifNonNull(localeList)}"
             .footerLinks="${ifNonNull(footerLinks)}"
             .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
           >
             ${StoryContent()}
@@ -78,14 +100,541 @@ export const Default = ({ parameters }) => {
       : html`
           <dds-dotcom-shell-container
             platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
             language="${ifNonNull(language)}"
             lang-display="${ifNonNull(langDisplay)}"
-            size="short"
+            footer-size="${ifNonNull(footerSize)}"
             user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+            selected-menu-item="${ifNonNull(selectedMenuItem)}"
             .legalLinks="${ifNonNull(legalLinks)}"
             .localeList="${ifNonNull(localeList)}"
             .footerLinks="${ifNonNull(footerLinks)}"
             .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-container>
+        `}
+  `;
+};
+
+Default.story = {
+  parameters: {
+    knobs: {
+      FooterComposite: ({ groupId }) => ({
+        footerSize: select('Size (footer-size)', footerSizes, FOOTER_SIZE.REGULAR, groupId),
+      }),
+    },
+  },
+};
+
+export const DefaultFooterLanguageOnly = ({ parameters }) => {
+  const { platform, profile, userStatus, navLinks, search, searchPlaceholder, selectedMenuItem } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { langDisplay, language, legalLinks, links: footerLinks, localeList, langList } =
+    parameters?.props?.FooterComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
+  return html`
+    <style>
+      ${mastheadStyles}
+    </style>
+    ${useMock
+      ? html`
+          <dds-dotcom-shell-composite
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            language-selector-label="Choose a language"
+            clear-selection-label="Clear language selection"
+            selected-language="English"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+            selected-menu-item="${ifNonNull(selectedMenuItem)}"
+            user-status="${ifNonNull(userStatus)}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .langList="${langList}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-composite>
+        `
+      : html`
+          <dds-dotcom-shell-container
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            language-selector-label="Choose a language"
+            clear-selection-label="Clear language selection"
+            selected-language="English"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+            selected-menu-item="${ifNonNull(selectedMenuItem)}"
+            user-status="${ifNonNull(userStatus)}"
+            .langList="${langList}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-container>
+        `}
+  `;
+};
+
+DefaultFooterLanguageOnly.story = {
+  parameters: {
+    knobs: {
+      FooterComposite: ({ groupId }) => ({
+        langList: object('langlist', mockLangList, groupId),
+      }),
+    },
+  },
+};
+
+export const searchOpen = ({ parameters }) => {
+  const { platform, profile, userStatus, navLinks, search, searchPlaceholder, selectedMenuItem } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { langDisplay, language, legalLinks, links: footerLinks, localeList } = parameters?.props?.FooterComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
+  return html`
+    <style>
+      ${mastheadStyles}
+    </style>
+    ${useMock
+      ? html`
+          <dds-dotcom-shell-composite
+            activate-search="true"
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-composite>
+        `
+      : html`
+          <dds-dotcom-shell-container
+            activate-search="true"
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            language-selector-label="Choose a language"
+            clear-selection-label="Clear language selection"
+            selected-language="English"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .langList="${mockLangList}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-container>
+        `}
+  `;
+};
+
+export const withPlatform = ({ parameters }) => {
+  const { profile, userStatus, navLinks, search, searchPlaceholder, selectedMenuItem } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { langDisplay, language, legalLinks, links: footerLinks, localeList } = parameters?.props?.FooterComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
+  return html`
+    <style>
+      ${mastheadStyles}
+    </style>
+    ${useMock
+      ? html`
+          <dds-dotcom-shell-composite
+            platform=${platformData.name}
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-composite>
+        `
+      : html`
+          <dds-dotcom-shell-container
+            platform=${platformData.name}
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-container>
+        `}
+  `;
+};
+
+withPlatform.story = {
+  parameters: {
+    knobs: {
+      MastheadComposite: ({ groupId }) => ({
+        profile: boolean('show the profile functionality (profile)', true, groupId),
+        search: boolean('show the search functionality (search)', true, groupId),
+        searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
+        selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
+        userStatus: select('The user authenticated status (user-status)', userStatuses, userStatuses.unauthenticated, groupId),
+      }),
+    },
+  },
+};
+
+export const withShortFooter = ({ parameters }) => {
+  const { platform, profile, userStatus, navLinks, search, searchPlaceholder, selectedMenuItem } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { langDisplay, language, legalLinks, links: footerLinks, localeList } = parameters?.props?.FooterComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
+  return html`
+    <style>
+      ${mastheadStyles}
+    </style>
+    ${useMock
+      ? html`
+          <dds-dotcom-shell-composite
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            footer-size="short"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-composite>
+        `
+      : html`
+          <dds-dotcom-shell-container
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            footer-size="short"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-container>
+        `}
+  `;
+};
+
+export const withShortFooterLanguageOnly = ({ parameters }) => {
+  const { platform, profile, userStatus, navLinks, search, searchPlaceholder, selectedMenuItem } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { langDisplay, language, legalLinks, links: footerLinks, localeList, langList } =
+    parameters?.props?.FooterComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
+  return html`
+    <style>
+      ${mastheadStyles}
+    </style>
+    ${useMock
+      ? html`
+          <dds-dotcom-shell-composite
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            footer-size="short"
+            language-selector-label="Choose a language"
+            clear-selection-label="Clear language selection"
+            selected-language="English"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .langList="${langList}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-composite>
+        `
+      : html`
+          <dds-dotcom-shell-container
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            footer-size="short"
+            language-selector-label="Choose a language"
+            clear-selection-label="Clear language selection"
+            selected-language="English"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .langList="${langList}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-container>
+        `}
+  `;
+};
+
+withShortFooterLanguageOnly.story = {
+  parameters: {
+    knobs: {
+      FooterComposite: ({ groupId }) => ({
+        langList: object('langlist', mockLangList, groupId),
+      }),
+    },
+  },
+};
+
+export const withMicroFooter = ({ parameters }) => {
+  const { platform, profile, userStatus, navLinks, search, searchPlaceholder, selectedMenuItem } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { langDisplay, language, legalLinks, links: footerLinks, localeList } = parameters?.props?.FooterComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
+  return html`
+    <style>
+      ${mastheadStyles}
+    </style>
+    ${useMock
+      ? html`
+          <dds-dotcom-shell-composite
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            footer-size="micro"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-composite>
+        `
+      : html`
+          <dds-dotcom-shell-container
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            footer-size="micro"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-container>
+        `}
+  `;
+};
+
+export const withMicroFooterLanguageOnly = ({ parameters }) => {
+  const { platform, profile, userStatus, navLinks, search, searchPlaceholder, selectedMenuItem } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { langDisplay, language, legalLinks, links: footerLinks, localeList, langList } =
+    parameters?.props?.FooterComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
+  return html`
+    <style>
+      ${mastheadStyles}
+    </style>
+    ${useMock
+      ? html`
+          <dds-dotcom-shell-composite
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            footer-size="micro"
+            language-selector-label="Choose a language"
+            clear-selection-label="Clear language selection"
+            selected-language="English"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .langList="${langList}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-composite>
+        `
+      : html`
+          <dds-dotcom-shell-container
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            footer-size="micro"
+            language-selector-label="Choose a language"
+            clear-selection-label="Clear language selection"
+            selected-language="English"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            user-status="${ifNonNull(userStatus)}"
+            .langList="${langList}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-container>
+        `}
+  `;
+};
+
+withMicroFooterLanguageOnly.story = {
+  parameters: {
+    knobs: {
+      FooterComposite: ({ groupId }) => ({
+        langList: object('langlist', mockLangList, groupId),
+      }),
+    },
+  },
+};
+
+export const withL1 = ({ parameters }) => {
+  const { platform, profile, userStatus, navLinks, search, searchPlaceholder, selectedMenuItem } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { langDisplay, language, legalLinks, links: footerLinks, localeList } = parameters?.props?.FooterComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
+  console.log('l1data', l1Data);
+  return html`
+    <style>
+      ${mastheadStyles}
+    </style>
+    ${useMock
+      ? html`
+          <dds-dotcom-shell-composite
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .l1Data="${l1Data}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+          >
+            ${StoryContent()}
+          </dds-dotcom-shell-composite>
+        `
+      : html`
+          <dds-dotcom-shell-container
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            language="${ifNonNull(language)}"
+            lang-display="${ifNonNull(langDisplay)}"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceHolder="${searchPlaceholder}"
+            selected-menu-item="${selectedMenuItem}"
+            .legalLinks="${ifNonNull(legalLinks)}"
+            .localeList="${ifNonNull(localeList)}"
+            .footerLinks="${ifNonNull(footerLinks)}"
+            .l1Data="${l1Data}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
           >
             ${StoryContent()}
           </dds-dotcom-shell-container>
@@ -112,12 +661,14 @@ export default {
     ...readme.parameters,
     useRawContainer: true,
     knobs: {
+      escapeHTML: false,
       MastheadComposite: ({ groupId }) => ({
-        platform: textNullable('Platform (platform)', '', groupId),
-        logoHref: 'https://www.ibm.com',
-      }),
-      FooterComposite: ({ groupId }) => ({
-        footerSize: select('Size (footer-size)', footerSizes, null, groupId),
+        platform: select('Platform (platform)', { none: null, platform: platformData.name }, null, groupId),
+        profile: boolean('show the profile functionality (profile)', true, groupId),
+        search: boolean('show the search functionality (search)', true, groupId),
+        searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
+        selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
+        userStatus: select('The user authenticated status (user-status)', userStatuses, userStatuses.unauthenticated, groupId),
       }),
     },
     props: (() => {

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -80,7 +80,7 @@ export const Default = ({ parameters }) => {
             platform="${ifNonNull(platform)}"
             language="${ifNonNull(language)}"
             lang-display="${ifNonNull(langDisplay)}"
-            footer-size="${ifNonNull(footerSize)}"
+            size="short"
             user-status="${ifNonNull(userStatus)}"
             .legalLinks="${ifNonNull(legalLinks)}"
             .localeList="${ifNonNull(localeList)}"

--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
@@ -14,6 +14,7 @@ import { LocaleList } from '../../internal/vendor/@carbon/ibmdotcom-services-sto
 import {
   BasicLink,
   BasicLinkSet,
+  MastheadL1,
   MastheadLink,
   MastheadProfileItem,
   Translation,
@@ -104,6 +105,18 @@ class DDSDotcomShellComposite extends LitElement {
   _setLanguage?: (language: string) => void;
 
   /**
+   * `true` if there is a profile.
+   */
+  @property({ type: Boolean, attribute: 'profile' })
+  profile = true;
+
+  /**
+   * `true` if there is a search.
+   */
+  @property({ type: Boolean, attribute: 'search' })
+  search = true;
+
+  /**
    * `true` to activate the search box. This goes to masthead.
    */
   @property({ type: Boolean, attribute: 'activate-search' })
@@ -122,6 +135,20 @@ class DDSDotcomShellComposite extends LitElement {
    */
   @property({ attribute: 'platform' })
   platform?: string;
+
+  /**
+   * The platform url.
+   */
+  @property({ attribute: 'platform-url' })
+  platformUrl?: string;
+
+  /**
+   * The clear button label for language selector.
+   *
+   * @internal
+   */
+  @property({ attribute: 'clear-selection-label' })
+  clearSelectionLabel?: string;
 
   /**
    * The g11n collator to use for sorting contry names. This goes to footer.
@@ -166,12 +193,36 @@ class DDSDotcomShellComposite extends LitElement {
   langDisplay?: string;
 
   /**
+   * The placeholder label for language selector.
+   *
+   * @internal
+   */
+  @property({ attribute: 'language-selector-label' })
+  languageSelectorLabel?: string;
+
+  /**
+   * The initial selected language in the selector.
+   *
+   * @internal
+   */
+  @property({ attribute: 'selected-language' })
+  selectedLanguage?: string;
+
+  /**
    * The language used for query. This goes to masthead and footer.
    * The data typically comes from `@carbon/ibmdotcom-services` and thus you don't need to set this property by default,
    * but if you need an alternate way of integration (e.g. rendering Web Components tags in server-side) this property helps.
    */
   @property()
   language?: string;
+
+  /**
+   * Placeholder list of languages to populate language selector
+   *
+   * @internal
+   */
+  @property({ attribute: false })
+  langList?: string[];
 
   /**
    * The legal nav links. This goes to footer.
@@ -228,7 +279,7 @@ class DDSDotcomShellComposite extends LitElement {
   /**
    * Footer size. This goes to footer.
    */
-  @property({ reflect: true, attribute: 'size' })
+  @property({ reflect: true, attribute: 'footer-size' })
   footerSize?: FOOTER_SIZE;
 
   /**
@@ -248,12 +299,24 @@ class DDSDotcomShellComposite extends LitElement {
   unauthenticatedProfileItems?: MastheadProfileItem[];
 
   /**
+   * Data for l1.
+   */
+  @property({ attribute: false })
+  l1Data?: MastheadL1;
+
+  /**
    * The navigation links. This goes to masthead.
    * The data typically comes from `@carbon/ibmdotcom-services` and thus you don't need to set this property by default,
    * but if you need an alternate way of integration (e.g. rendering Web Components tags in server-side) this property helps.
    */
   @property({ attribute: false })
   navLinks?: MastheadLink[];
+
+  /**
+   * Value to display when the input has an empty `value`.
+   */
+  @property()
+  searchPlaceholder?: string;
 
   /**
    * The user authentication status. This goes to masthead.
@@ -272,8 +335,10 @@ class DDSDotcomShellComposite extends LitElement {
       activateSearch,
       authenticatedProfileItems,
       platform,
+      platformUrl,
       collatorCountryName,
       currentSearchResults,
+      clearSelectionLabel,
       disableLocaleButton,
       mastheadAssistiveText,
       menuBarAssistiveText,
@@ -281,8 +346,11 @@ class DDSDotcomShellComposite extends LitElement {
       menuButtonAssistiveTextInactive,
       unauthenticatedProfileItems,
       inputTimeout,
+      l1Data,
       language,
+      languageSelectorLabel,
       langDisplay,
+      langList,
       legalLinks,
       localeList,
       footerLinks,
@@ -290,6 +358,10 @@ class DDSDotcomShellComposite extends LitElement {
       openLocaleModal,
       openSearchDropdown,
       navLinks,
+      profile,
+      search,
+      searchPlaceholder,
+      selectedLanguage,
       selectedMenuItem,
       userStatus,
       _loadLangDisplay,
@@ -306,6 +378,7 @@ class DDSDotcomShellComposite extends LitElement {
           activateSearch,
           authenticatedProfileItems,
           platform,
+          platformUrl,
           currentSearchResults,
           mastheadAssistiveText,
           menuBarAssistiveText,
@@ -313,8 +386,12 @@ class DDSDotcomShellComposite extends LitElement {
           menuButtonAssistiveTextInactive,
           unauthenticatedProfileItems,
           inputTimeout,
+          l1Data,
           language,
           navLinks,
+          profile,
+          search,
+          searchPlaceholder,
           openSearchDropdown,
           selectedMenuItem,
           userStatus,
@@ -333,14 +410,18 @@ class DDSDotcomShellComposite extends LitElement {
       this._footerRenderRoot,
       pickBy(
         {
+          clearSelectionLabel,
           collatorCountryName,
           disableLocaleButton,
           language,
+          languageSelectorLabel,
           langDisplay,
+          langList,
           legalLinks,
           links: footerLinks,
           localeList,
           openLocaleModal,
+          selectedLanguage,
           size: footerSize,
           _loadLangDisplay,
           _loadLocaleList,

--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
@@ -228,7 +228,7 @@ class DDSDotcomShellComposite extends LitElement {
   /**
    * Footer size. This goes to footer.
    */
-  @property({ reflect: true, attribute: 'footer-size' })
+  @property({ reflect: true, attribute: 'size' })
   footerSize?: FOOTER_SIZE;
 
   /**

--- a/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
@@ -40,6 +40,19 @@ const links = [...menu items...];
 document.getElementById('masthead-container').navLinks = links;
 ```
 
+#### Using L1 nav
+
+To use L1 nav, set `l1Data` prop. `l1Data` prop should be an
+object that contains the navigation data of L1 nav:
+
+```javascipt
+const l1Data = {
+  title: 'Stock Charts',
+  url: 'https://example.com',
+  menuItems: (The nav links),
+}
+```
+
 ```html
 <dds-masthead-container id="masthead-container"></dds-masthead-container>
 ```

--- a/packages/web-components/src/components/masthead/__stories__/links.ts
+++ b/packages/web-components/src/components/masthead/__stories__/links.ts
@@ -1862,342 +1862,104 @@ const customLinks: MastheadLink[] = [
     ],
   },
   {
-    title: 'Services & Consulting',
-    titleEnglish: 'Services & Consulting',
+    title: 'Lorem ipsum dolor sit amet',
+    titleEnglish: 'Lorem ipsum dolor sit amet',
     url: '',
     hasMenu: true,
     hasMegapanel: true,
     menuSections: [
       {
+        heading: 'Explore',
+        menuItems: [
+          {
+            title: 'Link 1',
+            url: '',
+            megapanelContent: {
+              headingTitle: '',
+              headingUrl: '',
+              description: '',
+              quickLinks: {
+                title: 'Title',
+                links: [
+                  {
+                    title: 'Subnav 1',
+                    url: '',
+                  },
+                  {
+                    title: 'Subnav 2',
+                    url: '',
+                  },
+                  {
+                    title: 'Subnav 3',
+                    url: '',
+                  },
+                  {
+                    title: 'Subnav 4',
+                    url: '',
+                  },
+                ],
+              },
+              feature: {
+                heading: '',
+                imageUrl: '',
+                linkTitle: '',
+                linkUrl: '',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Consectetur adipiscing elit',
+    titleEnglish: 'Consectetur adipiscing elit',
+    url: '',
+    hasMenu: true,
+    menuSections: [
+      {
         heading: '',
         menuItems: [
           {
-            title: 'Business process services',
-            titleEnglish: 'Business process services',
-            url: 'https://www.ibm.com/services/process?lnk=hpmsc_bups&lnk2=link',
+            title: 'Link 2',
+            titleEnglish: 'Link 2',
+            url: '',
+          },
+          {
+            title: 'Financing',
+            url: 'https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn',
             megapanelContent: {
-              headingTitle: 'Business process services',
-              headingUrl: 'https://www.ibm.com/services/process?lnk=hpmsc_bups',
-              description: '',
+              headingTitle: 'Financing',
+              headingUrl: 'https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn',
+              description: 'Funding options that fit your business',
               quickLinks: {
-                title: '',
+                title: 'Quicklinks',
                 links: [
                   {
-                    title: 'Artificial intelligence services',
-                    titleEnglish: 'Artificial intelligence services',
-                    url: 'https://www.ibm.com/services/artificial-intelligence?lnk=hpmsc_bups&lnk2=learn',
+                    title: 'Subnav 1',
+                    url: '',
                   },
                   {
-                    title: 'Automation',
-                    titleEnglish: 'Automation',
-                    url: 'https://www.ibm.com/automation/services?lnk=hpmsc_bups&lnk2=learn',
+                    title: 'Subnav 2',
+                    url: '',
                   },
                   {
-                    title: 'Big data & data platform',
-                    titleEnglish: 'Big data & data platform',
-                    url: 'https://www.ibm.com/services/big-data-services?lnk=hpmsc_bups&lnk2=learn',
+                    title: 'Subnav 3',
+                    url: '',
                   },
                   {
-                    title: 'Business process outsourcing',
-                    titleEnglish: 'Business process outsourcing',
-                    url: 'https://www.ibm.com/services/process/outsourcing?lnk=hpmsc_bups&lnk2=learn',
-                  },
-                  {
-                    title: 'Edge consulting',
-                    titleEnglish: 'Edge consulting',
-                    url: 'https://www.ibm.com/services/process/edge-services?lnk=hpmsc_bups&lnk2=learn',
-                  },
-                  {
-                    title: 'Finance transformation',
-                    titleEnglish: 'Finance transformation',
-                    url: 'https://www.ibm.com/services/process/finance?lnk=hpmsc_bups&lnk2=learn',
-                  },
-                  {
-                    title: 'IoT consulting',
-                    titleEnglish: 'IoT consulting',
-                    url: 'https://www.ibm.com/services/process/iot-consulting?lnk=hpmsc_bups&lnk2=learn',
-                  },
-                  {
-                    title: 'Procurement & strategic sourcing',
-                    titleEnglish: 'Procurement & strategic sourcing',
-                    url: 'https://www.ibm.com/services/process/procurement?lnk=hpmsc_bups&lnk2=learn',
-                  },
-                  {
-                    title: 'Risk consulting & fraud management',
-                    titleEnglish: 'Risk consulting & fraud management',
-                    url: 'https://www.ibm.com/services/process/risk?lnk=hpmsc_bups&lnk2=learn',
-                  },
-                  {
-                    title: 'Supply chain',
-                    titleEnglish: 'Supply chain',
-                    url: 'https://www.ibm.com/services/process/supply-chain?lnk=hpmsc_bups&lnk2=learn',
+                    title: 'Subnav 4',
+                    url: '',
                   },
                 ],
               },
               feature: {
-                heading: '',
-                imageUrl: 'https://1.dam.s81c.com/m/79a6c3cde7dd0665/original/megamenu-pictogram-business-process-service.png',
-                linkTitle: '',
-                linkUrl: '',
+                heading: 'Cloud financing strategies that work for your business',
+                imageUrl: 'https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1',
+                linkTitle: 'Committed to cloud? Make the most of your cash flow.',
+                linkUrl: 'https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn',
               },
             },
-          },
-          {
-            title: 'Design & business strategy',
-            titleEnglish: 'Design & business strategy',
-            url: 'https://www.ibm.com/services/ibmix/?lnk=hpmsc_budbs&lnk2=link',
-            megapanelContent: {
-              headingTitle: 'Design & business strategy',
-              headingUrl: 'https://www.ibm.com/services/ibmix/?lnk=hpmsc_bubs',
-              description: '',
-              quickLinks: {
-                title: '',
-                links: [
-                  {
-                    title: 'Digital strategy',
-                    titleEnglish: 'Digital strategy',
-                    url: 'https://www.ibm.com/services/business/digital?lnk=hpmsc_bubs&lnk2=learn',
-                  },
-                  {
-                    title: 'Experience strategy',
-                    titleEnglish: 'Experience strategy',
-                    url: 'https://www.ibm.com/services/ibmix/experience-strategy?lnk=hpmsc_bubs&lnk2=learn',
-                  },
-                  {
-                    title: 'Marketing platforms',
-                    titleEnglish: 'Marketing platforms',
-                    url: 'https://www.ibm.com/services/ibmix/marketing-platforms?lnk=hpmsc_bubs&lnk2=learn',
-                  },
-                  {
-                    title: 'Salesforce consulting',
-                    titleEnglish: 'Salesforce consulting',
-                    url: 'https://www.ibm.com/services/salesforce?lnk=hpmsc_bubs&lnk2=learn',
-                  },
-                ],
-              },
-              feature: {
-                heading: '',
-                imageUrl: 'https://1.dam.s81c.com/m/1b7522c50ea39ca/original/megamenu-pictogram-design-business-strategy.png',
-                linkTitle: '',
-                linkUrl: '',
-              },
-            },
-          },
-          {
-            title: 'Hybrid multicloud services',
-            titleEnglish: 'Hybrid multicloud services',
-            url: 'https://www.ibm.com/services/cloud?lnk=hpmsc_buhs?lnk=hpmsc_buhs',
-            megapanelContent: {
-              headingTitle: 'Hybrid multicloud services',
-              headingUrl: 'https://www.ibm.com/services/cloud?lnk=hpmsc_buhs',
-              description: '',
-              quickLinks: {
-                title: '',
-                links: [
-                  {
-                    title: 'Business continuity & resiliency',
-                    titleEnglish: 'Business continuity & resiliency',
-                    url: 'https://www.ibm.com/services/business-continuity?lnk=hpmsc_buhs&lnk2=learn',
-                  },
-                  {
-                    title: 'Cloud services',
-                    titleEnglish: 'Cloud services',
-                    url: 'https://www.ibm.com/services/cloud?lnk=hpmsc_buhs&lnk2=learn',
-                  },
-                  {
-                    title: 'Network',
-                    titleEnglish: 'Network',
-                    url: 'https://www.ibm.com/services/network?lnk=hpmsc_buhs&lnk2=learn',
-                  },
-                  {
-                    title: 'Workplace services',
-                    titleEnglish: 'Workplace services',
-                    url: 'https://www.ibm.com/services/digital-workplace?lnk=hpmsc_buhs&lnk2=learn',
-                  },
-                ],
-              },
-              feature: {
-                heading: '',
-                imageUrl: 'https://1.dam.s81c.com/m/5daa9dce872913ea/original/megamenu-pictogram-hybrid-multi-cloud-services.png',
-                linkTitle: '',
-                linkUrl: '',
-              },
-            },
-          },
-          {
-            title: 'Talent & transformation',
-            titleEnglish: 'Talent & transformation',
-            url: 'https://www.ibm.com/talent-management?lnk=hpmsc_buta&lnk2=link',
-            megapanelContent: {
-              headingTitle: 'Talent & transformation',
-              headingUrl: 'https://www.ibm.com/talent-management?lnk=hpmsc_buta',
-              description: '',
-              quickLinks: {
-                title: '',
-                links: [
-                  {
-                    title: 'HR transformation',
-                    titleEnglish: 'HR transformation',
-                    url: 'https://www.ibm.com/services/process/talent/human-resources?lnk=hpmsc_buta&lnk2=learn',
-                  },
-                  {
-                    title: 'Talent acquisition',
-                    titleEnglish: 'Talent acquisition',
-                    url: 'https://www.ibm.com/talent-management/talent-acquisition?lnk=hpmsc_buta&lnk2=learn',
-                  },
-                  {
-                    title: 'Talent development',
-                    titleEnglish: 'Talent development',
-                    url: 'https://www.ibm.com/services/process/talent/development?lnk=hpmsc_buta&lnk2=learn',
-                  },
-                ],
-              },
-              feature: {
-                heading: '',
-                imageUrl: 'https://1.dam.s81c.com/m/69e350b141e12bd5/original/megamenu-pictogram-talent-and-transformation.png',
-                linkTitle: '',
-                linkUrl: '',
-              },
-            },
-          },
-          {
-            title: 'Application services',
-            titleEnglish: 'Application services',
-            url: 'https://www.ibm.com/services/applications?lnk=hpmsc_buas&lnk2=link',
-            megapanelContent: {
-              headingTitle: 'Application services',
-              headingUrl: 'https://www.ibm.com/services/applications?lnk=hpmsc_buas',
-              description: '',
-              quickLinks: {
-                title: '',
-                links: [
-                  {
-                    title: 'Application development',
-                    titleEnglish: 'Application development',
-                    url: 'https://www.ibm.com/services/applications/development?lnk=hpmsc_buas&lnk2=learn',
-                  },
-                  {
-                    title: 'Application Modernization',
-                    titleEnglish: 'Application Modernization',
-                    url: 'https://www.ibm.com/services/cloud/modernize-applications?lnk=hpmsc_buas&lnk2=learn',
-                  },
-                  {
-                    title: 'Enterprise application management',
-                    titleEnglish: 'Enterprise application management',
-                    url: 'https://www.ibm.com/services/cloud/enterprise-application-management?lnk=hpmsc_buas&lnk2=learn',
-                  },
-                  {
-                    title: 'Enterprise applications strategy',
-                    titleEnglish: 'Enterprise applications strategy',
-                    url: 'https://www.ibm.com/services/applications/enterprise?lnk=hpmsc_buas&lnk2=learn',
-                  },
-                ],
-              },
-              feature: {
-                heading: '',
-                imageUrl: 'https://1.dam.s81c.com/m/2b7c180c68557dcb/original/megamenu-pictogram-application-services.png',
-                linkTitle: '',
-                linkUrl: '',
-              },
-            },
-          },
-          {
-            title: 'Security services',
-            titleEnglish: 'Security services',
-            url: 'https://www.ibm.com/security/services?lnk=hpmsc_buse&lnk2=link',
-            megapanelContent: {
-              headingTitle: 'Security services',
-              headingUrl: 'https://www.ibm.com/security/services?lnk=hpmsc_buse',
-              description: '',
-              quickLinks: {
-                title: '',
-                links: [
-                  {
-                    title: 'Application security',
-                    titleEnglish: 'Application security',
-                    url: 'https://www.ibm.com/security/services/application-security-services?lnk=hpmsc_buse&lnk2=learn',
-                  },
-                  {
-                    title: 'Cloud security',
-                    titleEnglish: 'Cloud security',
-                    url: 'https://www.ibm.com/security/services/cloud-security-services?lnk=hpmsc_buse&lnk2=learn',
-                  },
-                  {
-                    title: 'Data security',
-                    titleEnglish: 'Data security',
-                    url: 'https://www.ibm.com/security/services/data-security?lnk=hpmsc_buse&lnk2=learn',
-                  },
-                  {
-                    title: 'Identity & access management',
-                    titleEnglish: 'Identity & access management',
-                    url: 'https://www.ibm.com/security/services/identity-access-management?lnk=hpmsc_buse&lnk2=learn',
-                  },
-                  {
-                    title: 'Managed security',
-                    titleEnglish: 'Managed security',
-                    url: 'https://www.ibm.com/security/services/managed-security-services?lnk=hpmsc_buse&lnk2=learn',
-                  },
-                  {
-                    title: 'Security governance',
-                    titleEnglish: 'Security governance',
-                    url: 'https://www.ibm.com/security/services/security-governance?lnk=hpmsc_buse&lnk2=learn',
-                  },
-                ],
-              },
-              feature: {
-                heading: '',
-                imageUrl: 'https://1.dam.s81c.com/m/6ecec25a8489cf82/original/megamenu-pictogram-security-services.png',
-                linkTitle: '',
-                linkUrl: '',
-              },
-            },
-          },
-          {
-            title: 'Services for tech support',
-            titleEnglish: 'Services for tech support',
-            url: 'https://www.ibm.com/services/technology-support?lnk=hpmsc_busv&lnk2=link',
-            megapanelContent: {
-              headingTitle: 'Services for tech support',
-              headingUrl: 'https://www.ibm.com/services/technology-support?lnk=hpmsc_busv',
-              description: '',
-              quickLinks: {
-                title: '',
-                links: [
-                  {
-                    title: 'Open source',
-                    titleEnglish: 'Open source',
-                    url: 'https://www.ibm.com/services/technology-support/open-source?lnk=hpmsc_busv&lnk2=learn',
-                  },
-                  {
-                    title: 'Third party & multivendor',
-                    titleEnglish: 'Third party & multivendor',
-                    url: 'https://www.ibm.com/services/technology-support/multivendor-it?lnk=hpmsc_busv&lnk2=learn',
-                  },
-                  {
-                    title: 'IBM warranties and maintenance',
-                    titleEnglish: 'IBM warranties and maintenance',
-                    url: 'https://www.ibm.com/services/technology-support/hardware-software?lnk=hpmsc_busv&lnk2=learn',
-                  },
-                ],
-              },
-              feature: {
-                heading: '',
-                imageUrl: 'https://1.dam.s81c.com/m/7056e2b83b04133e/original/megamenu-pictogram-services-for-tech-support.png',
-                linkTitle: '',
-                linkUrl: '',
-              },
-            },
-          },
-          {
-            title: 'Payment plans for Services & Consulting',
-            titleEnglish: 'Payment plans for Services & Consulting',
-            url: 'https://www.ibm.com/financing/solutions/it-services-financing?lnk=hpmsc_bufi&lnk2=link',
-          },
-          {
-            title: 'View all services',
-            titleEnglish: 'View all services',
-            url: 'https://www.ibm.com/services?lnk=hpmsc_buall&lnk2=link',
-            megaPanelViewAll: true,
           },
         ],
       },
@@ -2207,6 +1969,171 @@ const customLinks: MastheadLink[] = [
     title: 'Nulla quis sem at nibh elementum imperdiet',
     titleEnglish: 'Nulla quis sem at nibh elementum imperdiet',
     url: 'https://www.ibm.com/industries?lnk=min',
+    hasMenu: false,
+    hasMegapanel: false,
+    menuSections: [],
+  },
+  {
+    title: 'Fusce nec tellus sed augue semper porta',
+    titleEnglish: 'Fusce nec tellus sed augue semper porta',
+    url: '',
+    hasMenu: true,
+    hasMegapanel: true,
+    menuSections: [
+      {
+        heading: '',
+        menuItems: [
+          {
+            title: 'IBM Developer',
+            url: 'https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn',
+            megapanelContent: {
+              headingTitle: 'IBM Developer',
+              headingUrl: 'https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn',
+              description: '',
+              quickLinks: {
+                title: 'Quicklinks',
+                links: [
+                  {
+                    title: 'Subnav 1',
+                    url: '',
+                  },
+                  {
+                    title: 'Subnav 2',
+                    url: '',
+                  },
+                  {
+                    title: 'Subnav 3',
+                    url: '',
+                  },
+                  {
+                    title: 'Subnav 4',
+                    url: '',
+                  },
+                ],
+              },
+              feature: {
+                heading: 'IBM Developer newsletters',
+                imageUrl: 'https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg',
+                linkTitle: 'Technical info on popular software development topics, including AI, Blockchain, Java and more',
+                linkUrl: 'https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn',
+              },
+            },
+          },
+          {
+            title: 'Blockchain',
+            url: 'https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn',
+            megapanelContent: {
+              headingTitle: 'Blockchain',
+              headingUrl: 'https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn',
+              description: '',
+              quickLinks: {
+                title: 'Quicklinks',
+                links: [
+                  {
+                    title: 'Subnav 1',
+                    url: '',
+                  },
+                  {
+                    title: 'Subnav 2',
+                    url: '',
+                  },
+                  {
+                    title: 'Subnav 3',
+                    url: '',
+                  },
+                  {
+                    title: 'Subnav 4',
+                    url: '',
+                  },
+                ],
+              },
+              feature: {
+                heading: 'Blockchain 101',
+                imageUrl: 'https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3',
+                linkTitle:
+                  'Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan',
+                linkUrl:
+                  'https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn',
+              },
+            },
+          },
+          {
+            title: 'Containers',
+            url: 'https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn',
+            megapanelContent: {
+              headingTitle: 'Containers',
+              headingUrl: 'https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn',
+              description: '',
+              quickLinks: {
+                title: 'Quicklinks',
+                links: [
+                  {
+                    title: 'Code patterns',
+                    url: 'https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn',
+                  },
+                  {
+                    title: 'Tutorials',
+                    url: 'https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn',
+                  },
+                  {
+                    title: 'Events',
+                    url: 'https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn',
+                  },
+                ],
+              },
+              feature: {
+                heading: 'Make sense of Kubernetes',
+                imageUrl: 'https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2',
+                linkTitle: 'Deploy a simple Python application with Kubernetes',
+                linkUrl: 'https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn',
+              },
+            },
+          },
+          {
+            title: 'Analytics',
+            url: 'https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn',
+            megapanelContent: {
+              headingTitle: 'Analytics',
+              headingUrl: 'https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn',
+              description: '',
+              quickLinks: {
+                title: 'Quicklinks',
+                links: [
+                  {
+                    title: 'Code patterns',
+                    url: 'https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn',
+                  },
+                  {
+                    title: 'Tutorials',
+                    url: 'https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn',
+                  },
+                  {
+                    title: 'Events',
+                    url: 'https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn',
+                  },
+                  {
+                    title: 'Developer community',
+                    url: 'https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn',
+                  },
+                ],
+              },
+              feature: {
+                heading: 'Train your data no matter where it lives',
+                imageUrl: 'https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg',
+                linkTitle: 'Easily and securely connect to your data source for initial model training and continuous learning',
+                linkUrl:
+                  'https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Sed cursus ante dapibus diam',
+    titleEnglish: 'Sed cursus ante dapibus diam',
+    url: 'https://www.ibm.com/support/home/?lnk=msu_usen',
     hasMenu: false,
     hasMegapanel: false,
     menuSections: [],

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -22,8 +22,8 @@ import { authenticatedProfileItems, unauthenticatedProfileItems } from './profil
 import readme from './README.stories.mdx';
 
 const userStatuses = {
-  [`Authenticated`]: 'test.user@ibm.com',
-  [`Unauthenticated`]: UNAUTHENTICATED_STATUS,
+  authenticated: 'test.user@ibm.com',
+  unauthenticated: UNAUTHENTICATED_STATUS,
 };
 
 /**
@@ -97,20 +97,40 @@ export const WithCustomNavigation = ({ parameters }) => {
 export const searchOpenByDefault = ({ parameters }) => {
   const { platform, selectedMenuItem, userStatus, searchPlaceholder, profile, search, navLinks } =
     parameters?.props?.MastheadComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
   return html`
     <style>
       ${styles}
     </style>
-    <dds-masthead-container
-      activate-search="true"
-      platform="${ifNonNull(platform)}"
-      selected-menu-item="${ifNonNull(selectedMenuItem)}"
-      user-status="${ifNonNull(userStatus)}"
-      searchPlaceholder="${ifNonNull(searchPlaceholder)}"
-      .navLinks="${navLinks}"
-      .profile="${profile}"
-      .search="${search}"
-    ></dds-masthead-container>
+    ${useMock
+      ? html`
+          <dds-masthead-composite
+            activate-search="true"
+            platform="${ifNonNull(platformData.name)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            selected-menu-item="${ifNonNull(selectedMenuItem)}"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+          ></dds-masthead-composite>
+        `
+      : html`
+          <dds-masthead-container
+            activate-search="true"
+            platform="${ifNonNull(platform)}"
+            platform-url="${ifNonNull(platformData.url)}"
+            selected-menu-item="${ifNonNull(selectedMenuItem)}"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+            .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
+          ></dds-masthead-container>
+        `}
   `;
 };
 
@@ -160,7 +180,7 @@ withPlatform.story = {
         search: boolean('show the search functionality (search)', true, groupId),
         searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
-        userStatus: select('The user authenticated status (user-status)', userStatuses, null, groupId),
+        userStatus: select('The user authenticated status (user-status)', userStatuses, userStatuses.unauthenticated, groupId),
       }),
     },
   },
@@ -206,7 +226,7 @@ export const withL1 = ({ parameters }) => {
 };
 
 export const withAlternateLogoAndTooltip = ({ parameters }) => {
-  const { platform, selectedMenuItem, userStatus, navLinks, profile, search, searchPlaceholder } =
+  const { platform, selectedMenuItem, userStatus, navLinks, profile, search, searchPlaceholder, mastheadLogo } =
     parameters?.props?.MastheadComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
@@ -225,7 +245,7 @@ export const withAlternateLogoAndTooltip = ({ parameters }) => {
             .profile="${profile}"
             .search="${search}"
             .navLinks="${navLinks}"
-            .logoData="${logoData}"
+            .logoData="${mastheadLogo}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
           ></dds-masthead-composite>
         `
@@ -237,7 +257,7 @@ export const withAlternateLogoAndTooltip = ({ parameters }) => {
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .navLinks="${navLinks}"
-            .logoData="${logoData}"
+            .logoData="${mastheadLogo}"
             .profile="${profile}"
             .search="${search}"
           ></dds-masthead-container>
@@ -249,12 +269,18 @@ withAlternateLogoAndTooltip.story = {
   parameters: {
     knobs: {
       MastheadComposite: ({ groupId }) => ({
+        platform: select('Platform (platform)', { none: null, platform: platformData.name }, null, groupId),
         profile: boolean('show the profile functionality (profile)', true, groupId),
         search: boolean('show the search functionality (search)', true, groupId),
         searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
-        mastheadLogo: select('select', { defaultWithNoTooltip: null, alternateWithTooltip: logoData }, groupId),
-        userStatus: select('The user authenticated status (user-status)', userStatuses, null, groupId),
+        mastheadLogo: select(
+          'masthead logo data (logoData)',
+          { defaultWithNoTooltip: null, alternateWithTooltip: logoData },
+          logoData,
+          groupId
+        ),
+        userStatus: select('The user authenticated status (user-status)', userStatuses, userStatuses.unauthenticated, groupId),
       }),
     },
   },
@@ -281,12 +307,12 @@ export default {
     knobs: {
       escapeHTML: false,
       MastheadComposite: ({ groupId }) => ({
-        platform: select('Platform (platform)', { none: null, platform: platformData.name }, platformData.name, groupId),
+        platform: select('Platform (platform)', { none: null, platform: platformData.name }, null, groupId),
         profile: boolean('show the profile functionality (profile)', true, groupId),
         search: boolean('show the search functionality (search)', true, groupId),
         searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
-        userStatus: select('The user authenticated status (user-status)', userStatuses, null, groupId),
+        userStatus: select('The user authenticated status (user-status)', userStatuses, userStatuses.unauthenticated, groupId),
       }),
     },
     props: (() => {

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -8,7 +8,7 @@
  */
 
 import { html } from 'lit-element';
-import { select } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import on from 'carbon-components/es/globals/js/misc/on';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
 import inPercy from '@percy-io/in-percy';
@@ -35,7 +35,8 @@ const platformData = {
 };
 
 export const Default = ({ parameters }) => {
-  const { platform, selectedMenuItem, userStatus, navLinks } = parameters?.props?.MastheadComposite ?? {};
+  const { platform, profile, search, selectedMenuItem, searchPlaceholder, userStatus, navLinks } =
+    parameters?.props?.MastheadComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
     <style>
@@ -48,9 +49,11 @@ export const Default = ({ parameters }) => {
             platform-url="${ifNonNull(platformData.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .profile="${profile}"
+            .search="${search}"
             .navLinks="${navLinks}"
-            .logoData="${logoData}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
           ></dds-masthead-composite>
         `
@@ -60,14 +63,18 @@ export const Default = ({ parameters }) => {
             platform-url="${ifNonNull(platformData.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
           ></dds-masthead-container>
         `}
   `;
 };
 
-export const WithCustomData = ({ parameters }) => {
-  const { platform, selectedMenuItem, userStatus } = parameters?.props?.MastheadComposite ?? {};
+export const WithCustomNavigation = ({ parameters }) => {
+  const { platform, selectedMenuItem, userStatus, searchPlaceholder, profile, search } =
+    parameters?.props?.MastheadComposite ?? {};
   return html`
     <style>
       ${styles}
@@ -77,15 +84,39 @@ export const WithCustomData = ({ parameters }) => {
       platform-url="${ifNonNull(platformData.url)}"
       selected-menu-item="${ifNonNull(selectedMenuItem)}"
       user-status="${ifNonNull(userStatus)}"
+      searchPlaceholder="${ifNonNull(searchPlaceholder)}"
       .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
       .navLinks="${customLinks}"
+      .profile="${profile}"
+      .search="${search}"
       .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
     ></dds-masthead-composite>
   `;
 };
 
+export const searchOpenByDefault = ({ parameters }) => {
+  const { platform, selectedMenuItem, userStatus, searchPlaceholder, profile, search, navLinks } =
+    parameters?.props?.MastheadComposite ?? {};
+  return html`
+    <style>
+      ${styles}
+    </style>
+    <dds-masthead-container
+      activate-search="true"
+      platform="${ifNonNull(platform)}"
+      selected-menu-item="${ifNonNull(selectedMenuItem)}"
+      user-status="${ifNonNull(userStatus)}"
+      searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+      .navLinks="${navLinks}"
+      .profile="${profile}"
+      .search="${search}"
+    ></dds-masthead-container>
+  `;
+};
+
 export const withPlatform = ({ parameters }) => {
-  const { selectedMenuItem, userStatus, navLinks } = parameters?.props?.MastheadComposite ?? {};
+  const { selectedMenuItem, userStatus, navLinks, profile, search, searchPlaceholder } =
+    parameters?.props?.MastheadComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
     <style>
@@ -98,8 +129,11 @@ export const withPlatform = ({ parameters }) => {
             platform-url="${ifNonNull(platformData.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
             .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
           ></dds-masthead-composite>
         `
@@ -109,7 +143,10 @@ export const withPlatform = ({ parameters }) => {
             platform-url="${ifNonNull(platformData.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .navLinks="${navLinks}"
+            .profile="${profile}"
+            .search="${search}"
           ></dds-masthead-container>
         `}
   `;
@@ -119,16 +156,19 @@ withPlatform.story = {
   parameters: {
     knobs: {
       MastheadComposite: ({ groupId }) => ({
+        profile: boolean('show the profile functionality (profile)', true, groupId),
+        search: boolean('show the search functionality (search)', true, groupId),
+        searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
         userStatus: select('The user authenticated status (user-status)', userStatuses, null, groupId),
-        logoHref: textNullable('Logo href (logo-href)', 'https://www.ibm.com', groupId),
       }),
     },
   },
 };
 
 export const withL1 = ({ parameters }) => {
-  const { platform, selectedMenuItem, userStatus, navLinks } = parameters?.props?.MastheadComposite ?? {};
+  const { platform, selectedMenuItem, userStatus, navLinks, profile, search, searchPlaceholder } =
+    parameters?.props?.MastheadComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
     <style>
@@ -140,8 +180,11 @@ export const withL1 = ({ parameters }) => {
             platform="${ifNonNull(platform)}"
             platform-url="${ifNonNull(platformData.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             user-status="${ifNonNull(userStatus)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            .profile="${profile}"
+            .search="${search}"
             .l1Data="${l1Data}"
             .navLinks="${navLinks}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
@@ -153,6 +196,8 @@ export const withL1 = ({ parameters }) => {
             platform-url="${ifNonNull(platformData.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
+            .profile="${profile}"
+            .search="${search}"
             .l1Data="${l1Data}"
             .navLinks="${navLinks}"
           ></dds-masthead-container>
@@ -161,7 +206,8 @@ export const withL1 = ({ parameters }) => {
 };
 
 export const withAlternateLogoAndTooltip = ({ parameters }) => {
-  const { platform, selectedMenuItem, userStatus, navLinks } = parameters?.props?.MastheadComposite ?? {};
+  const { platform, selectedMenuItem, userStatus, navLinks, profile, search, searchPlaceholder } =
+    parameters?.props?.MastheadComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
     <style>
@@ -174,8 +220,10 @@ export const withAlternateLogoAndTooltip = ({ parameters }) => {
             platform-url="${ifNonNull(platformData.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
-            .l1Data="${l1Data}"
+            .profile="${profile}"
+            .search="${search}"
             .navLinks="${navLinks}"
             .logoData="${logoData}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
@@ -187,12 +235,29 @@ export const withAlternateLogoAndTooltip = ({ parameters }) => {
             platform-url="${ifNonNull(platformData.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
-            .l1Data="${l1Data}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .navLinks="${navLinks}"
             .logoData="${logoData}"
+            .profile="${profile}"
+            .search="${search}"
           ></dds-masthead-container>
         `}
   `;
+};
+
+withAlternateLogoAndTooltip.story = {
+  parameters: {
+    knobs: {
+      MastheadComposite: ({ groupId }) => ({
+        profile: boolean('show the profile functionality (profile)', true, groupId),
+        search: boolean('show the search functionality (search)', true, groupId),
+        searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
+        selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
+        mastheadLogo: select('select', { defaultWithNoTooltip: null, alternateWithTooltip: logoData }, groupId),
+        userStatus: select('The user authenticated status (user-status)', userStatuses, null, groupId),
+      }),
+    },
+  },
 };
 
 export default {
@@ -214,11 +279,14 @@ export default {
     ...readme.parameters,
     'carbon-theme': { disabled: true },
     knobs: {
+      escapeHTML: false,
       MastheadComposite: ({ groupId }) => ({
-        platform: select('Platform (platform)', { none: null, platform: platformData.name }, null, groupId),
+        platform: select('Platform (platform)', { none: null, platform: platformData.name }, platformData.name, groupId),
+        profile: boolean('show the profile functionality (profile)', true, groupId),
+        search: boolean('show the search functionality (search)', true, groupId),
+        searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
         userStatus: select('The user authenticated status (user-status)', userStatuses, null, groupId),
-        logoHref: textNullable('Logo href (logo-href)', 'https://www.ibm.com', groupId),
       }),
     },
     props: (() => {

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -472,6 +472,18 @@ class DDSMastheadComposite extends LitElement {
   _setLanguage?: (language: string) => void;
 
   /**
+   * `true` if there is a profile.
+   */
+  @property({ type: Boolean, attribute: 'profile' })
+  profile = true;
+
+  /**
+   * `true` if there is a search.
+   */
+  @property({ type: Boolean, attribute: 'search' })
+  search = true;
+
+  /**
    * `true` to activate the search box.
    */
   @property({ type: Boolean, attribute: 'activate-search' })
@@ -486,7 +498,7 @@ class DDSMastheadComposite extends LitElement {
   /**
    * The platform name.
    */
-  @property()
+  @property({ attribute: 'platform' })
   platform!: string;
 
   /**
@@ -629,6 +641,7 @@ class DDSMastheadComposite extends LitElement {
       currentSearchResults,
       platform,
       platformUrl,
+      profile,
       inputTimeout,
       mastheadAssistiveText,
       menuBarAssistiveText,
@@ -636,6 +649,7 @@ class DDSMastheadComposite extends LitElement {
       menuButtonAssistiveTextInactive,
       language,
       openSearchDropdown,
+      search,
       searchPlaceholder,
       selectedMenuItem,
       unauthenticatedProfileItems,
@@ -676,24 +690,32 @@ class DDSMastheadComposite extends LitElement {
                 ${this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.TOP_NAV })}
               </dds-top-nav>
             `}
-        <dds-masthead-search-composite
-          ?active="${activateSearch}"
-          input-timeout="${inputTimeout}"
-          language="${ifNonNull(language)}"
-          ?open="${openSearchDropdown}"
-          placeholder="${ifNonNull(searchPlaceholder)}"
-          .currentSearchResults="${ifNonNull(currentSearchResults)}"
-          ._loadSearchResults="${ifNonNull(loadSearchResults)}"
-        ></dds-masthead-search-composite>
+        ${!search
+          ? undefined
+          : html`
+              <dds-masthead-search-composite
+                ?active="${activateSearch}"
+                input-timeout="${inputTimeout}"
+                language="${ifNonNull(language)}"
+                ?open="${openSearchDropdown}"
+                placeholder="${ifNonNull(searchPlaceholder)}"
+                .currentSearchResults="${ifNonNull(currentSearchResults)}"
+                ._loadSearchResults="${ifNonNull(loadSearchResults)}"
+              ></dds-masthead-search-composite>
+            `}
         <dds-masthead-global-bar>
-          <dds-masthead-profile ?authenticated="${authenticated}">
-            ${profileItems?.map(
-              ({ title, url }) =>
-                html`
-                  <dds-masthead-profile-item href="${ifNonNull(url)}">${title}</dds-masthead-profile-item>
-                `
-            )}
-          </dds-masthead-profile>
+          ${!profile
+            ? undefined
+            : html`
+                <dds-masthead-profile ?authenticated="${authenticated}">
+                  ${profileItems?.map(
+                    ({ title, url }) =>
+                      html`
+                        <dds-masthead-profile-item href="${ifNonNull(url)}">${title}</dds-masthead-profile-item>
+                      `
+                  )}
+                </dds-masthead-profile>
+              `}
         </dds-masthead-global-bar>
         ${!l1Data ? undefined : this._renderL1({ selectedMenuItem })}
         <dds-megamenu-overlay></dds-megamenu-overlay>

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -182,10 +182,6 @@
   }
 }
 
-//:host(#{$dds-prefix}-top-nav) {
-//  overflow: visible;
-//}
-
 :host(#{$dds-prefix}-top-nav-l1) {
   overflow: visible;
 }

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -114,6 +114,7 @@
 }
 
 :host(#{$dds-prefix}-masthead-profile) {
+  background-color: $ui-background;
   a.#{$prefix}--header__menu-item {
     padding-left: calc((#{mini-units(6)} - #{$icon-size-01}) / 2 - #{rem(2px)});
     padding-right: calc((#{mini-units(6)} - #{$icon-size-01}) / 2 - #{rem(2px)});
@@ -181,9 +182,9 @@
   }
 }
 
-:host(#{$dds-prefix}-top-nav) {
-  overflow: hidden;
-}
+//:host(#{$dds-prefix}-top-nav) {
+//  overflow: visible;
+//}
 
 :host(#{$dds-prefix}-top-nav-l1) {
   overflow: visible;

--- a/packages/web-components/src/components/masthead/top-nav.ts
+++ b/packages/web-components/src/components/masthead/top-nav.ts
@@ -350,7 +350,7 @@ class DDSTopNav extends StableSelectorMixin(HostListenerMixin(BXHeaderNav)) {
   }
 
   /**
-   * The name of the custom event fired after the seach is toggled.
+   * The name of the custom event fired after the search is toggled.
    */
   static get eventToggleSearch() {
     return `${ddsPrefix}-masthead-search-toggled`;


### PR DESCRIPTION
### Related Ticket(s)

#5045 

### Description

Align masthead and dotcom-shell component storybook examples with react. 


### Changelog

**New**

- add properties to masthead so users can toggle on and off profile and search
- add properties to dotcom-shell to include multiple properties from masthead and footer
- update masthead stories to include the same knobs as react
- update custom nav links to match react
- update dotcom-shell storybook with multiple variations of the masthead and footer

**Changed**

- update README with L1 info

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
