### PR TITLE
docs(ButtonGroup): add onClick prop and remove href & copy prop requirement

### DIFF
--- a/packages/react/src/components/ButtonGroup/ButtonGroup.js
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/react/src/components/ButtonGroup/ButtonGroup.js
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.js
@@ -58,6 +58,7 @@ ButtonGroup.propTypes = {
    * | Name         | Data Type | Description                                                                                                                    |
    * | ------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
    * | `href`       | String    | URL for the button item                                                                                                        |
+   * | `onClick`    | Function  | Function triggered on click of button                                                                                          |
    * | `copy`       | String    | Button copy                                                                                                                    |
    * | `renderIcon` | Object    | Provide an optional icon for the CTA from [Carbon's icon library](https://www.carbondesignsystem.com/guidelines/icons/library) |
    *
@@ -66,8 +67,9 @@ ButtonGroup.propTypes = {
    */
   buttons: PropTypes.arrayOf(
     PropTypes.shape({
-      copy: PropTypes.string.isRequired,
-      href: PropTypes.string.isRequired,
+      copy: PropTypes.string,
+      href: PropTypes.string,
+      onClick: PropTypes.func,
       renderIcon: PropTypes.elementType,
     })
   ).isRequired,

--- a/packages/react/src/components/ButtonGroup/README.stories.mdx
+++ b/packages/react/src/components/ButtonGroup/README.stories.mdx
@@ -99,7 +99,7 @@ function App() {
           <ButtonGroup
             buttons={[
               {
-                href: 'https://example.com',
+                onClick: () => alert('button clicked'),
                 copy: 'Secondary action button',
                 renderIcon: ArrowDown20,
               },
@@ -123,11 +123,12 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 ##### OPTIONAL 💡
 
-In addition, direct ES module imports can be used to speed up build compilation and have less reliance on tree-shaking determinations from build scripts:
+In addition, direct ES module imports can be used to speed up build compilation
+and have less reliance on tree-shaking determinations from build scripts:
 
-````js
+```js
 import ButtonGroup from '@carbon/ibmdotcom-react/es/components/ButtonGroup/ButtonGroup';
-````
+```
 
 ## Props
 


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Add `onClick` prop definition so adopters are aware that it can be passed in and remove the requirement from the `href` and `copy` props. 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
