### PR TITLE
fix(masthead): using correct token for essentials description text

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -155,7 +155,7 @@
   :host(#{$dds-prefix}-megamenu-category-group-copy) {
     display: block;
     @include use-carbon-productive-tokens();
-    @include type-style('body-short-01');
+    @include type-style('body-long-01');
 
     color: $text-02;
     padding: rem(6px) $spacing-05 rem(10px);
@@ -173,6 +173,8 @@
 
     .#{$prefix}--masthead__megamenu__copy,
     ::slotted(#{$dds-prefix}-megamenu-category-group-copy) {
+      @include type-style('body-long-01');
+
       color: $text-01;
       margin-top: rem(-6px);
       padding: 0 $spacing-05 $spacing-03 $spacing-05;


### PR DESCRIPTION
### Related Ticket(s)
#5181 

### Description
The previous token was `$body-short-01` while it should've been `$body-long-01`.

### Changelog

**Changed**

- changed the slotted `dds-megamenu-category-group-copy` type from `$body-short-01` to `$body-long-01`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
