### PR TITLE
Feature card knobs bugs

### DIFF
--- a/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.ts
+++ b/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.ts
@@ -19,10 +19,10 @@ import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 
 export const Default = ({ parameters }) => {
-  const { heading, defaultSrc, alt, href } = parameters?.props?.['dds-feature-card'] ?? {};
+  const { heading, href } = parameters?.props?.['dds-feature-card'] ?? {};
   return html`
     <dds-feature-card href=${ifNonNull(href || undefined)}>
-      <dds-image slot="image" alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}"></dds-image>
+      <dds-image slot="image" alt="Image alt text" default-src="${imgLg1x1}"></dds-image>
       <dds-card-heading>${heading}</dds-card-heading>
       <dds-feature-card-footer>
         ${ArrowRight20({ slot: 'icon' })}

--- a/packages/web-components/src/components/feature-card/feature-card.scss
+++ b/packages/web-components/src/components/feature-card/feature-card.scss
@@ -16,6 +16,10 @@
   display: block;
   outline: none;
 
+  .#{$prefix}--card {
+    outline-offset: 1px;
+  }
+
   @include carbon--breakpoint-down('md') {
     .#{$prefix}--card__content {
       padding: 0;
@@ -28,7 +32,9 @@
   ::slotted(#{dds-prefix}-card-heading) {
     background-color: $ui-01;
     margin: 0;
+    width: 100%;
     padding: carbon--mini-units(2);
+    padding-right: 10%;
     padding-bottom: var(--cds-layout-03, 2rem);
   }
 

--- a/packages/web-components/src/components/feature-card/feature-card.scss
+++ b/packages/web-components/src/components/feature-card/feature-card.scss
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,8 +14,30 @@
 :host(#{$dds-prefix}-feature-card),
 :host(#{$dds-prefix}-feature-cta) {
   display: block;
-
   outline: none;
+
+  @include carbon--breakpoint-down('md') {
+    .#{$prefix}--card__content {
+      padding: 0;
+      justify-content: space-between;
+    }
+  }
+}
+
+@include carbon--breakpoint-down('md') {
+  ::slotted(#{dds-prefix}-card-heading) {
+    background-color: $ui-01;
+    margin: 0;
+    padding: carbon--mini-units(2);
+    padding-bottom: var(--cds-layout-03, 2rem);
+  }
+
+  ::slotted(#{$dds-prefix}-feature-car-footer) {
+    background-color: $ui-01;
+    padding: carbon--mini-units(2);
+    padding-top: 0;
+    margin-top: carbon--mini-units(-4);
+  }
 }
 
 :host(#{$dds-prefix}-feature-card-footer),


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5400

### Description

Multiple bug fixes, including corrected card overflow in smaller screens:
![feature-card](https://user-images.githubusercontent.com/4054756/111404867-2097cb00-8695-11eb-8fdc-c8f8f1e9a347.PNG)


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
