### PR TITLE
fix(leadspace): fixes carbon theme issue on small breakpoints

### DIFF
--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -435,16 +435,12 @@ $btn-min-width: 26;
     }
 
     .#{$prefix}--leadspace__gradient {
-      display: none;
-
-      @include carbon--breakpoint(md) {
-        display: block;
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
     }
 
     .#{$prefix}--leadspace__gradient__rect {

--- a/packages/web-components/src/components/leadspace/leadspace.scss
+++ b/packages/web-components/src/components/leadspace/leadspace.scss
@@ -7,10 +7,15 @@
 
 @import '@carbon/ibmdotcom-styles/scss/globals/vars';
 @import '@carbon/ibmdotcom-styles/scss/components/leadspace/leadspace';
-@import '../../../../styles/scss/components/leadspace/leadspace';
 
 :host(#{$dds-prefix}-leadspace) {
   display: block;
+
+  @include carbon--breakpoint(sm) {
+    .#{$prefix}--leadspace--gradient {
+      background: none;
+    }
+  }
 
   @include carbon--breakpoint(sm) {
     .#{$prefix}--leadspace__section.#{$prefix}--leadspace--centered .#{$prefix}--leadspace--gradient {


### PR DESCRIPTION
### Related Ticket(s)

#5503 

### Description

Fixes heading and copy text not being visible on g90 and g100 theme

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
