### PR TITLE
chore(back-to-top): fix typo in readme

### DIFF
--- a/packages/react/src/components/BackToTop/README.stories.mdx
+++ b/packages/react/src/components/BackToTop/README.stories.mdx
@@ -1,3 +1,3 @@
-# Carousel
+# Back to top
 
 This component is maintined in `@carbon/ibmdotcom-web-components` library with a [React wrapper](https://ibmdotcom-web-components-react.mybluemix.net/?path=/story/components-back-to-top--default).


### PR DESCRIPTION
### Description

Fixes incorrect component name in README.

### Changelog
**Changed**

- `Carousel` changed to `Back to top`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
