### PR TITLE
fix(card): update aria labels and add test stories

### DIFF
--- a/packages/react/src/components/CTA/CTA.js
+++ b/packages/react/src/components/CTA/CTA.js
@@ -52,11 +52,7 @@ const CTA = ({
     ...otherProps,
   };
 
-  const label = `${otherProps?.copy}${
-    ariaLabel ? ariaLabel : CTALogic.getDefaultLabel(type)
-  }`;
   const ariaProps = style === ('card' || 'text') && {
-    'aria-label': label,
     role: `${ariaRole ? ariaRole : 'region'}`,
   };
 

--- a/packages/react/src/components/Card/Card.js
+++ b/packages/react/src/components/Card/Card.js
@@ -129,7 +129,10 @@ function renderFooter(cta, copy, heading, pictogram) {
           [`${prefix}--card__footer__icon-left`]: cta?.iconPlacement === 'left',
           [`${prefix}--card__footer__copy`]: cta?.copy,
         })}
-        aria-label={cta?.copy ? '' : heading ? heading : copy}>
+        aria-label={
+          (cta?.copy ? '' : heading ? heading : copy) +
+          CTALogic.getDefaultLabel(cta?.type)
+        }>
         {cta?.copy && !pictogram && (
           <span className={`${prefix}--card__cta__copy`}>{cta?.copy}</span>
         )}

--- a/packages/react/src/components/Card/Card.js
+++ b/packages/react/src/components/Card/Card.js
@@ -85,9 +85,13 @@ export const Card = ({
               {eyebrow}
             </p>
           )}
-          {heading && <h3 className={`${prefix}--card__heading`}>{heading}</h3>}
+          {heading && (
+            <h3 className={`${prefix}--card__heading`} aria-hidden={true}>
+              {heading}
+            </h3>
+          )}
           {optionalContent(copy)}
-          {renderFooter(cta, pictogram)}
+          {renderFooter(cta, heading, pictogram)}
         </div>
       </div>
     </TileType>
@@ -106,7 +110,8 @@ function optionalContent(copy) {
       className={`${prefix}--card__copy`}
       dangerouslySetInnerHTML={{
         __html: markdownToHtml(copy, { bold: false }),
-      }}></div>
+      }}
+      aria-hidden={true}></div>
   );
 }
 
@@ -116,18 +121,17 @@ function optionalContent(copy) {
  * @param {object} cta cta object
  * @returns {object} JSX object
  */
-function renderFooter(cta, pictogram) {
+function renderFooter(cta, heading, pictogram) {
   return (
     cta && (
       <div
         className={classNames(`${prefix}--card__footer`, {
           [`${prefix}--card__footer__icon-left`]: cta?.iconPlacement === 'left',
           [`${prefix}--card__footer__copy`]: cta?.copy,
-        })}>
+        })}
+        aria-label={cta?.copy ? '' : heading}>
         {cta?.copy && !pictogram && (
-          <span className={`${prefix}--card__cta__copy`} aria-hidden={true}>
-            {cta?.copy}
-          </span>
+          <span className={`${prefix}--card__cta__copy`}>{cta?.copy}</span>
         )}
         {cta?.icon?.src && !pictogram && (
           <cta.icon.src className={`${prefix}--card__cta`} {...cta?.icon} />

--- a/packages/react/src/components/Card/Card.js
+++ b/packages/react/src/components/Card/Card.js
@@ -91,7 +91,7 @@ export const Card = ({
             </h3>
           )}
           {optionalContent(copy)}
-          {renderFooter(cta, heading, pictogram)}
+          {renderFooter(cta, copy, heading, pictogram)}
         </div>
       </div>
     </TileType>
@@ -121,7 +121,7 @@ function optionalContent(copy) {
  * @param {object} cta cta object
  * @returns {object} JSX object
  */
-function renderFooter(cta, heading, pictogram) {
+function renderFooter(cta, copy, heading, pictogram) {
   return (
     cta && (
       <div
@@ -129,7 +129,7 @@ function renderFooter(cta, heading, pictogram) {
           [`${prefix}--card__footer__icon-left`]: cta?.iconPlacement === 'left',
           [`${prefix}--card__footer__copy`]: cta?.copy,
         })}
-        aria-label={cta?.copy ? '' : heading}>
+        aria-label={cta?.copy ? '' : heading ? heading : copy}>
         {cta?.copy && !pictogram && (
           <span className={`${prefix}--card__cta__copy`}>{cta?.copy}</span>
         )}

--- a/packages/react/src/components/Card/__stories__/Card.stories.js
+++ b/packages/react/src/components/Card/__stories__/Card.stories.js
@@ -75,3 +75,60 @@ export const Default = ({ parameters }) => {
     </div>
   );
 };
+
+const card = {
+  eyebrow: 'eyebrow text',
+  heading: 'Lorem ipsum dolor sit amet',
+  copy: 'hello',
+};
+
+const ctaWithCopy = {
+  type: 'local',
+  href: 'https://example.com',
+  copy: 'cta copy',
+  icon: {
+    src: ArrowRight20,
+  },
+};
+const ctaWithoutCopy = {
+  type: 'local',
+  href: 'https://example.com',
+  copy: '',
+  icon: {
+    src: ArrowRight20,
+  },
+};
+
+export const testWithLinkCopy = () => {
+  const theme =
+    document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
+
+  return (
+    <div className={`bx--card--${theme}`}>
+      <div className="bx--grid bx--grid--card">
+        <div className="bx--row">
+          <div className="bx--col-sm-4 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter">
+            <Card cta={ctaWithCopy} {...card} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const testWithoutLinkCopy = () => {
+  const theme =
+    document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
+
+  return (
+    <div className={`bx--card--${theme}`}>
+      <div className="bx--grid bx--grid--card">
+        <div className="bx--row">
+          <div className="bx--col-sm-4 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter">
+            <Card cta={ctaWithoutCopy} {...card} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/react/src/components/CardGroup/CardGroup.js
+++ b/packages/react/src/components/CardGroup/CardGroup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,11 +38,7 @@ const _renderCards = (cards, containerRef, cta) => (
     ref={containerRef}>
     {cards.map((card, index) => {
       return (
-        <div
-          key={index}
-          className={`${prefix}--card-group__cards__col`}
-          role="region"
-          aria-label={card.heading}>
+        <div key={index} className={`${prefix}--card-group__cards__col`}>
           <CTA
             style="card"
             key={index}


### PR DESCRIPTION
### Related Ticket(s)

#4613 

### Description

Testing react aria-labels in card  


### Changelog

**New**

- {{new thing}}

**Changed**

- aria label to only read cta copy and if there is no cta copy then it uses the heading and if not heading then copy
- add ctaLogic label to card and remove from outer div
- remove card groups additional region role and label.

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
