### PR TITLE
test(e2e): fixes to table of contents and masthead e2e tests

### DIFF
--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -52,8 +52,12 @@ export default {
 export const ManuallyDefineMenuItems = ({ parameters }) => {
   const { menuItems, menuLabel, menuRule, headingContent } =
     parameters?.props?.TableOfContents ?? {};
+  const params = new URLSearchParams(window.location.search);
+  const themeParam = params.has('theme') ? params.get('theme') : null;
   const theme =
-    document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
+    themeParam ||
+    document.documentElement.getAttribute('storybook-carbon-theme') ||
+    'white';
   return (
     <TableOfContents
       theme={theme}

--- a/packages/tests-e2e/__tests__/callout-quote/callout-quote.e2e.js
+++ b/packages/tests-e2e/__tests__/callout-quote/callout-quote.e2e.js
@@ -56,8 +56,8 @@ describe('Callout quote', () => {
   it('should load g100 theme', async () => {
     page = await browser.newPage();
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     await page.evaluate(
@@ -72,8 +72,8 @@ describe('Callout quote', () => {
   it('should load g90 theme', async () => {
     page = await browser.newPage();
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     await page.evaluate(
@@ -88,8 +88,8 @@ describe('Callout quote', () => {
   it('should load g10 theme', async () => {
     page = await browser.newPage();
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
     await page.evaluate(
       'document.documentElement.setAttribute("storybook-carbon-theme","g10")'

--- a/packages/tests-e2e/__tests__/leadspace/leadspace.e2e.js
+++ b/packages/tests-e2e/__tests__/leadspace/leadspace.e2e.js
@@ -84,8 +84,8 @@ describe('Leadspace', () => {
     it('should load g100 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathDefaultNoImage}&theme=g100`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
 
       await page.evaluate(
@@ -104,8 +104,8 @@ describe('Leadspace', () => {
     it('should load g90 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathDefaultNoImage}&theme=g90`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
 
       await page.evaluate(
@@ -124,8 +124,8 @@ describe('Leadspace', () => {
     it('should load g10 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathDefaultNoImage}&theme=g10`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
       await page.evaluate(
         'document.documentElement.setAttribute("storybook-carbon-theme","g10")'
@@ -145,8 +145,8 @@ describe('Leadspace', () => {
     it('should load g100 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathDefaultImage}&theme=g100`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
 
       await page.evaluate(
@@ -165,8 +165,8 @@ describe('Leadspace', () => {
     it('should load g90 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathDefaultImage}&theme=g90`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
 
       await page.evaluate(
@@ -185,8 +185,8 @@ describe('Leadspace', () => {
     it('should load g90 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathDefaultImage}&theme=g10`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
 
       await page.evaluate(
@@ -207,8 +207,8 @@ describe('Leadspace', () => {
     it('should load g100 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathCenteredNoImage}&theme=g100`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
 
       await page.evaluate(
@@ -227,8 +227,8 @@ describe('Leadspace', () => {
     it('should load g90 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathCenteredNoImage}&theme=g90`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
 
       await page.evaluate(
@@ -247,8 +247,8 @@ describe('Leadspace', () => {
     it('should load g10 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathCenteredNoImage}&theme=g10`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
 
       await page.evaluate(
@@ -269,8 +269,8 @@ describe('Leadspace', () => {
     it('should load g100 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathCenteredImage}&theme=g100`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
 
       await page.evaluate(
@@ -289,8 +289,8 @@ describe('Leadspace', () => {
     it('should load g90 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathCenteredImage}&theme=g90`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
       await page.evaluate(
         'document.documentElement.setAttribute("storybook-carbon-theme","g90")'
@@ -308,8 +308,8 @@ describe('Leadspace', () => {
     it('should load g10 theme', async () => {
       page = await browser.newPage();
       await page.goto(`${_url}${_pathCenteredImage}&theme=g10`, {
-        waitUntil: 'load',
-        timeout: 30000,
+        waitUntil: 'networkidle0',
+        timeout: 100000,
       });
 
       await page.evaluate(

--- a/packages/tests-e2e/__tests__/locale-modal/locale-modal.e2e.js
+++ b/packages/tests-e2e/__tests__/locale-modal/locale-modal.e2e.js
@@ -55,7 +55,10 @@ describe('LocaleModal', () => {
 
   it('should load the Americas region', async () => {
     page = await browser.newPage();
-    await page.goto(`${_url}${_path}`, { waitUntil: 'load', timeout: 30000 });
+    await page.goto(`${_url}${_path}`, {
+      waitUntil: 'networkidle0',
+      timeout: 100000,
+    });
 
     await page.waitForSelector('[data-autoid="dds--locale-modal"]');
 
@@ -65,7 +68,9 @@ describe('LocaleModal', () => {
       );
       region.click();
     } else {
-      await page.waitForSelector('[data-region="am"]');
+      await page.waitForSelector(
+        '.bx--locale-modal__regions > div > div:nth-child(1) > a'
+      );
       await page.click('[data-region="am"]');
     }
 

--- a/packages/tests-e2e/__tests__/masthead/masthead.e2e.js
+++ b/packages/tests-e2e/__tests__/masthead/masthead.e2e.js
@@ -70,7 +70,7 @@ describe('Masthead: Default', () => {
     await browser.close();
   });
 
-  it('should take a snapshot of the megamenu', async () => {
+  it('should take a snapshot of the megamenu - first nav item', async () => {
     page = await browser.newPage();
     await page.setViewport({
       width: 1280,
@@ -101,13 +101,29 @@ describe('Masthead: Default', () => {
         widths: [1280],
       }
     );
+  });
+
+  it('should take a snapshot of the megamenu - second nav item', async () => {
+    page = await browser.newPage();
+    await page.setViewport({
+      width: 1280,
+      height: 780,
+    });
+
+    await page.goto(`${_url}${_pathDefault}`, {
+      waitUntil: 'load',
+      timeout: 30000,
+    });
 
     if (_webcomponentsTests) {
-      const nav1 = await page.evaluateHandle(
+      const nav0 = await page.evaluateHandle(
         `document.querySelector('dds-top-nav > dds-megamenu-top-nav-menu:nth-child(2)').shadowRoot.querySelector('a')`
       );
-      nav1.click();
+      nav0.click();
     } else {
+      await page.waitForSelector(
+        '[data-autoid="dds--masthead-default__l0-nav1"]'
+      );
       await page.click('[data-autoid="dds--masthead-default__l0-nav1"]');
     }
 
@@ -258,6 +274,7 @@ describe('Masthead: Default', () => {
       await page.waitForSelector(
         '[data-autoid="dds--masthead-default__l0-nav0"]'
       );
+      await page.waitForTimeout(1500); // still seeing flakiness in test results, adding additional wait to be safe
       await page.click('.bx--header__nav-caret-right');
     }
 

--- a/packages/tests-e2e/__tests__/masthead/masthead.e2e.js
+++ b/packages/tests-e2e/__tests__/masthead/masthead.e2e.js
@@ -78,8 +78,8 @@ describe('Masthead: Default', () => {
     });
 
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     if (_webcomponentsTests) {
@@ -111,8 +111,8 @@ describe('Masthead: Default', () => {
     });
 
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     if (_webcomponentsTests) {
@@ -144,8 +144,8 @@ describe('Masthead: Default', () => {
     });
 
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     if (_webcomponentsTests) {
@@ -177,8 +177,8 @@ describe('Masthead: Default', () => {
     });
 
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     if (_webcomponentsTests) {
@@ -206,8 +206,8 @@ describe('Masthead: Default', () => {
     });
 
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     if (_webcomponentsTests) {
@@ -256,8 +256,8 @@ describe('Masthead: Default', () => {
     });
 
     await page.goto(`${_url}${_pathCustom}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     // Removes the animation of the nav container
@@ -291,8 +291,8 @@ describe('Masthead: Default', () => {
     });
 
     await page.goto(`${_url}${_pathPlatform}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     if (_webcomponentsTests) {

--- a/packages/tests-e2e/__tests__/quote/quote.e2e.js
+++ b/packages/tests-e2e/__tests__/quote/quote.e2e.js
@@ -56,8 +56,8 @@ describe('Quote', () => {
   it('should load g100 theme', async () => {
     page = await browser.newPage();
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     await page.evaluate(
@@ -72,8 +72,8 @@ describe('Quote', () => {
   it('should load g90 theme', async () => {
     page = await browser.newPage();
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     await page.evaluate(
@@ -88,8 +88,8 @@ describe('Quote', () => {
   it('should load g10 theme', async () => {
     page = await browser.newPage();
     await page.goto(`${_url}${_pathDefault}`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
     await page.evaluate(
       'document.documentElement.setAttribute("storybook-carbon-theme","g10")'

--- a/packages/tests-e2e/__tests__/table-of-contents/table-of-contents.e2e.js
+++ b/packages/tests-e2e/__tests__/table-of-contents/table-of-contents.e2e.js
@@ -56,7 +56,7 @@ describe('Table of contents', () => {
 
   it('should load g100 theme', async () => {
     page = await browser.newPage();
-    await page.goto(`${_url}${_pathManual}`, {
+    await page.goto(`${_url}${_pathManual}&theme=g100`, {
       waitUntil: 'load',
       timeout: 30000,
     });
@@ -72,7 +72,7 @@ describe('Table of contents', () => {
 
   it('should load g90 theme', async () => {
     page = await browser.newPage();
-    await page.goto(`${_url}${_pathManual}`, {
+    await page.goto(`${_url}${_pathManual}&theme=g90`, {
       waitUntil: 'load',
       timeout: 30000,
     });
@@ -88,7 +88,7 @@ describe('Table of contents', () => {
 
   it('should load g10 theme', async () => {
     page = await browser.newPage();
-    await page.goto(`${_url}${_pathManual}`, {
+    await page.goto(`${_url}${_pathManual}&theme=g10`, {
       waitUntil: 'load',
       timeout: 30000,
     });

--- a/packages/tests-e2e/__tests__/table-of-contents/table-of-contents.e2e.js
+++ b/packages/tests-e2e/__tests__/table-of-contents/table-of-contents.e2e.js
@@ -57,8 +57,8 @@ describe('Table of contents', () => {
   it('should load g100 theme', async () => {
     page = await browser.newPage();
     await page.goto(`${_url}${_pathManual}&theme=g100`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     await page.evaluate(
@@ -73,8 +73,8 @@ describe('Table of contents', () => {
   it('should load g90 theme', async () => {
     page = await browser.newPage();
     await page.goto(`${_url}${_pathManual}&theme=g90`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
 
     await page.evaluate(
@@ -89,8 +89,8 @@ describe('Table of contents', () => {
   it('should load g10 theme', async () => {
     page = await browser.newPage();
     await page.goto(`${_url}${_pathManual}&theme=g10`, {
-      waitUntil: 'load',
-      timeout: 30000,
+      waitUntil: 'networkidle0',
+      timeout: 100000,
     });
     await page.evaluate(
       'document.documentElement.setAttribute("storybook-carbon-theme","g10")'

--- a/packages/tests-e2e/jest.config.js
+++ b/packages/tests-e2e/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   testMatch: ['<rootDir>/**/__tests__/**/*.e2e.js'],
   testRunner: 'jest-circus/runner',
   testURL: 'http://localhost',
-  testTimeout: 30000,
+  testTimeout: 100000,
   moduleFileExtensions: ['js', 'json'],
   setupFiles: ['dotenv/config'],
 };


### PR DESCRIPTION
### Related Ticket(s)

Refs #5474 

### Description

The table of contents was not properly passing in the theme into the
component, which is causing some rendering issues.

The masthead is also noticing some flakiness in the renders regardless
of await commands for selectors. This adds in some additional time for
the overflow to render fully. In addition, the visual check between the
first and second mega menu nav items were separated out into two
separate tests as keeping them in one looked to have errors.

And fundamentally, the configuration for page load has been changed to detect for no more network traffic in order to continue. This will allow for completed rendering of network calls, etc.

### Changelog

**Changed**

- e2e tests for percy