### PR TITLE
fix(lightbox-media-viewer): scrollbar disabled fix

### DIFF
--- a/packages/web-components/src/components/expressive-modal/expressive-modal.scss
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal.scss
@@ -40,6 +40,8 @@
   .#{$prefix}--modal-content {
     display: grid;
     grid-template-rows: auto 1fr auto;
+    overflow: hidden;
+    overflow-y: overlay;
   }
 
   .#{$dds-prefix}-ce--modal__hedaer--with-body {


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/2460

### Description

This is a very unusual problem that only occurs at a very small resolution range and from my tests, only on chrome for windows since macos hides scrollbars while not in use. Might be a browser bug but I couldn't find anything online.

To replicate you need to resize the window until the content is about to overflow. It will show a disabled scrollbar for a small range until it actually needs to enable it even if `overflow-y` is set to `auto`, which shouldn't happen.

![scrollbar-bug](https://user-images.githubusercontent.com/4054756/112576897-d7442b80-8db8-11eb-81ac-0f4fc4fe48ed.gif)

The range is always 16px which is exactly the width of the scrollbar.

For example, I found this 2 ranges where it happens: 
`1002px x 749px` to `1018px x 749px`
`1200px x 687px` to `1216px x 687px`

It's happening on both lightbox media viewer stories:

![scrollbar-disabled](https://user-images.githubusercontent.com/4054756/112575471-ff7e5b00-8db5-11eb-9041-a09e7f982939.jpg)

![scrollbar-disabled-2](https://user-images.githubusercontent.com/4054756/112575626-4704e700-8db6-11eb-82db-1df0def5dee4.jpg)

The only way I found to fix it was to use the deprecated css rule `overflow-y: overlay` which overlays the scrollbar instead of taking up space. It's still fully supported by webkit/blink-based browsers and from my tests doesn't affect other browsers but content might appear behind the scrollbar. This had to be applied to the expressive modal container.
