### PR TITLE
fix(video-player): import image component within video-player component

### DIFF
--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -19,6 +19,7 @@ import {
 import FocusMixin from 'carbon-web-components/es/globals/mixins/focus.js';
 import PlayVideo from '@carbon/ibmdotcom-styles/icons/svg/play-video.svg';
 import { VIDEO_PLAYER_CONTENT_STATE } from './defs';
+import '../image/image';
 import styles from './video-player.scss';
 
 export { VIDEO_PLAYER_CONTENT_STATE };


### PR DESCRIPTION
### Related Ticket(s)

Video Player Web Component not rendering video thumbnail #5615

### Description

Video player needs the image import otherwise the video image overlay does not appear.

### Changelog

**Changed**

- add image component import


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
