### PR TITLE
docs(README): updated webpack sass options to use relative paths

### DIFF
--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -116,7 +116,7 @@ module: {
           options: {
             implementation: require('node-sass'),
             sassOptions: {
-              includePaths: ['node_modules'],
+              includePaths: ['../node_modules', '../../../node_modules'],
               // `enable-css-custom-properties` and `grid-columns-16` feature flags
               // are requirements for Carbon for IBM.com styles
               data: `


### PR DESCRIPTION
### Related Ticket(s)
None.

### Description
Updated `includePaths` in the Webpack example to use relative pathing in order to help adopters avoid any potential importing errors coming from `carbon-components` if they build off their webpack configuration off our example.

### Changelog

**Changed**
- now using relative paths in `includePaths` for the Webpack example

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
