### PR TITLE
fix(file-uploader): icon size fix

### DIFF
--- a/packages/styles/scss/themes/expressive/components/_file-uploader.scss
+++ b/packages/styles/scss/themes/expressive/components/_file-uploader.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,7 +14,7 @@
 /// @access private
 /// @group file-uploader-expressive
 @mixin file-uploader-expressive {
-  .#{$prefix}--file__state-container .#{$prefix}--file-close {
+  .#{$prefix}--file__state-container .#{$prefix}--file-close svg {
     height: rem(20px);
     width: rem(20px);
   }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5614

### Description

Width and height properties were pointing at parent. Pointed to svg (doesn't have a class name).

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
