### PR TITLE
fix(card-group): random title percy check

### DIFF
--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -19,6 +19,7 @@ import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 import { html } from 'lit-element';
 import { select, number } from '@storybook/addon-knobs';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
+import inPercy from '@percy-io/in-percy';
 // eslint-disable-next-line sort-imports
 import imgXlg4x3 from '../../../../../storybook-images/assets/1312/fpo--4x3--1312x984--003.jpg';
 import imgXlg16x9 from '../../../../../storybook-images/assets/1312/fpo--16x9--1312x738--005.jpg';
@@ -29,7 +30,7 @@ import styles from './card-group.stories.scss';
 
 import readme from './README.stories.mdx';
 
-const cardRandomPhrase = () => {
+const cardRandomPhrase = randomTitles => {
   const phraseArray = [
     'Lorem ipsum dolor sit amet',
     'Nunc convallis lobortis',
@@ -37,7 +38,10 @@ const cardRandomPhrase = () => {
     'Te sint disputando pri, at his aliquip corrumpit',
   ];
 
-  const randomSampleText = phraseArray[Math.floor(Math.random() * phraseArray.length)];
+  const randomSampleText = randomTitles
+    ? 'Lorem ipsum dolor sit amet, consectetur'
+    : phraseArray[Math.floor(Math.random() * phraseArray.length)];
+
   const defaultCardGroupItem = html`
     <dds-card-group-item href="https://example.com">
       <dds-card-heading>${randomSampleText}</dds-card-heading>
@@ -243,7 +247,7 @@ export default {
       CardGroup: ({ groupId }) => ({
         cards: Array.from({
           length: number('Number of cards', 5, {}, groupId),
-        }).map(() => cardRandomPhrase()),
+        }).map(() => cardRandomPhrase(inPercy())),
       }),
     },
     decorators: [

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -30,7 +30,7 @@ import styles from './card-group.stories.scss';
 
 import readme from './README.stories.mdx';
 
-const cardRandomPhrase = randomTitles => {
+const cardRandomPhrase = () => {
   const phraseArray = [
     'Lorem ipsum dolor sit amet',
     'Nunc convallis lobortis',
@@ -38,7 +38,7 @@ const cardRandomPhrase = randomTitles => {
     'Te sint disputando pri, at his aliquip corrumpit',
   ];
 
-  const randomSampleText = randomTitles
+  const randomSampleText = !inPercy()
     ? 'Lorem ipsum dolor sit amet, consectetur'
     : phraseArray[Math.floor(Math.random() * phraseArray.length)];
 
@@ -247,7 +247,7 @@ export default {
       CardGroup: ({ groupId }) => ({
         cards: Array.from({
           length: number('Number of cards', 5, {}, groupId),
-        }).map(() => cardRandomPhrase(inPercy())),
+        }).map(() => cardRandomPhrase()),
       }),
     },
     decorators: [

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -38,7 +38,7 @@ const cardRandomPhrase = () => {
     'Te sint disputando pri, at his aliquip corrumpit',
   ];
 
-  const randomSampleText = !inPercy()
+  const randomSampleText = inPercy()
     ? 'Lorem ipsum dolor sit amet, consectetur'
     : phraseArray[Math.floor(Math.random() * phraseArray.length)];
 

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -38,7 +38,7 @@ const phraseArray = [
   'Disputando lorem covallis',
 ];
 
-const cardsDiffLenghtPhrase = () => {
+const cardsDiffLengthPhrase = () => {
   const defaultCardGroupItem = html`
     <dds-card-group-item href="https://example.com">
       <dds-card-heading>${phraseArray[count]}</dds-card-heading>
@@ -246,7 +246,7 @@ export default {
       CardGroup: ({ groupId }) => ({
         cards: Array.from({
           length: number('Number of cards', 5, {}, groupId),
-        }).map(() => cardsDiffLenghtPhrase()),
+        }).map(() => cardsDiffLengthPhrase()),
       }),
     },
     decorators: [

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -19,7 +19,6 @@ import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 import { html } from 'lit-element';
 import { select, number } from '@storybook/addon-knobs';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
-import inPercy from '@percy-io/in-percy';
 // eslint-disable-next-line sort-imports
 import imgXlg4x3 from '../../../../../storybook-images/assets/1312/fpo--4x3--1312x984--003.jpg';
 import imgXlg16x9 from '../../../../../storybook-images/assets/1312/fpo--16x9--1312x738--005.jpg';
@@ -30,21 +29,19 @@ import styles from './card-group.stories.scss';
 
 import readme from './README.stories.mdx';
 
-const cardRandomPhrase = () => {
-  const phraseArray = [
-    'Lorem ipsum dolor sit amet',
-    'Nunc convallis lobortis',
-    'Lorem ipsum dolor sit amet, consectetur.',
-    'Te sint disputando pri, at his aliquip corrumpit',
-  ];
+let count = 0;
+const phraseArray = [
+  'Lorem ipsum dolor sit amet',
+  'Nunc convallis lobortis',
+  'Lorem ipsum dolor sit amet, consectetur.',
+  'Te sint disputando pri, at his aliquip corrumpit',
+  'Disputando lorem covallis',
+];
 
-  const randomSampleText = inPercy()
-    ? 'Lorem ipsum dolor sit amet, consectetur'
-    : phraseArray[Math.floor(Math.random() * phraseArray.length)];
-
+const cardsDiffLenghtPhrase = () => {
   const defaultCardGroupItem = html`
     <dds-card-group-item href="https://example.com">
-      <dds-card-heading>${randomSampleText}</dds-card-heading>
+      <dds-card-heading>${phraseArray[count]}</dds-card-heading>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.'
       </p>
@@ -53,6 +50,8 @@ const cardRandomPhrase = () => {
       </dds-card-footer>
     </dds-card-group-item>
   `;
+
+  count = count > 3 ? 0 : count + 1;
   return defaultCardGroupItem;
 };
 
@@ -247,7 +246,7 @@ export default {
       CardGroup: ({ groupId }) => ({
         cards: Array.from({
           length: number('Number of cards', 5, {}, groupId),
-        }).map(() => cardRandomPhrase()),
+        }).map(() => cardsDiffLenghtPhrase()),
       }),
     },
     decorators: [


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5415

### Description

Added `inPercy` check for random title lengths.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
