### PR TITLE
chore(percy): setting blank search placeholder in percy

### DIFF
--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -179,7 +179,7 @@ withPlatform.story = {
       MastheadComposite: ({ groupId }) => ({
         hasProfile: boolean('show the profile functionality (has-profile)', true, groupId),
         hasSearch: boolean('show the search functionality (has-search)', true, groupId),
-        searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
+        searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', inPercy() ? '' : 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
         userStatus: select('The user authenticated status (user-status)', userStatuses, userStatuses.unauthenticated, groupId),
       }),


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Percy was generating false positives with the placeholder text in
snapshots, specifically for the story with the masthead search open.
This will blank out the placeholder text in Percy only.

### Changelog

**Changed**

- Blank masthead search placeholder for Percy
