### PR TITLE
fix(masthead-search): increasing css selectors specificity

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -125,6 +125,11 @@
     position: absolute;
     top: 0;
     right: 0;
+
+    .#{$prefix}--header__search--search,
+    .#{$prefix}--header__search--close {
+      color: #000000;
+    }
   }
 
   // search container
@@ -138,6 +143,10 @@
       z-index: 999;
       width: 100%;
       margin-left: 0;
+
+      button.#{$prefix}--header__search--close.#{$prefix}--header__action[aria-label='Close'] {
+        display: inline-flex;
+      }
 
       .#{$prefix}--header__search--actions {
         z-index: 10001;

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -128,7 +128,7 @@
 
     .#{$prefix}--header__search--search,
     .#{$prefix}--header__search--close {
-      color: #000000;
+      color: $icon-01;
     }
   }
 

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -576,7 +576,7 @@ $search-transition-timing: 95ms;
     }
   }
 
-  .#{$prefix}--header__search--close {
+  button.#{$prefix}--header__search--close.#{$prefix}--header__action[aria-label='Close'] {
     overflow: hidden;
     width: 0;
     border: none;


### PR DESCRIPTION
### Related Ticket(s)

[Carbon v10.31.0 Upgrade | React] Masthead icons are white #5596

### Description

The Carbon upgrade added some new selectors to the `HeaderGlobalAction` component that were overriding the styles set at the `MastheadSearch` buttons. This was fixed by increasing the specificity of the previous selectors. 