### PR TITLE
test(bundle): update vendor build task to include @carbon/feature-flags

### DIFF
--- a/packages/react/gulp-tasks/config.js
+++ b/packages/react/gulp-tasks/config.js
@@ -52,23 +52,23 @@ module.exports = {
   iconsDir: path.dirname(require.resolve('@carbon/icons/lib')),
   testsDir: 'tests',
   tasksDir: 'gulp-tasks',
-  carbonComponetsReactESSrcDir: path.resolve(
+  carbonComponentsReactESSrcDir: path.resolve(
     path.dirname(require.resolve('carbon-components-react/package.json')),
     'es'
   ),
-  carbonComponetsReactCJSSrcDir: path.resolve(
+  carbonComponentsReactCJSSrcDir: path.resolve(
     path.dirname(require.resolve('carbon-components-react/package.json')),
     'lib'
   ),
-  carbonComponetsReactVendorSrcDir: path.resolve(
+  carbonComponentsReactVendorSrcDir: path.resolve(
     __dirname,
     '../src/internal/vendor/carbon-components-react'
   ),
-  carbonComponetsReactVendorESDstDir: path.resolve(
+  carbonComponentsReactVendorESDstDir: path.resolve(
     __dirname,
     '../es/internal/vendor/carbon-components-react'
   ),
-  carbonComponetsReactVendorCJSDstDir: path.resolve(
+  carbonComponentsReactVendorCJSDstDir: path.resolve(
     __dirname,
     '../lib/internal/vendor/carbon-components-react'
   ),

--- a/packages/react/gulp-tasks/vendor.js
+++ b/packages/react/gulp-tasks/vendor.js
@@ -18,11 +18,11 @@ const { base, simple } = require('acorn-walk');
 const { extend } = require('acorn-jsx-walk');
 const MagicString = require('magic-string');
 const {
-  carbonComponetsReactESSrcDir,
-  carbonComponetsReactCJSSrcDir,
-  carbonComponetsReactVendorSrcDir,
-  carbonComponetsReactVendorESDstDir,
-  carbonComponetsReactVendorCJSDstDir,
+  carbonComponentsReactESSrcDir,
+  carbonComponentsReactCJSSrcDir,
+  carbonComponentsReactVendorSrcDir,
+  carbonComponentsReactVendorESDstDir,
+  carbonComponentsReactVendorCJSDstDir,
 } = require('./config');
 
 const promisifyStream = promisify(asyncDone);
@@ -165,6 +165,7 @@ const generateTable = (() => {
     if (!promiseTable) {
       const table = {
         '@carbon/icons-react': {},
+        '@carbon/feature-flags': {},
         'carbon-components': {
           settings: 'es/globals/js/settings',
         },
@@ -187,53 +188,53 @@ const generateTable = (() => {
 /**
  * Generates `src/internal/vendor` contents.
  */
-const carbonComponetsReactVendorSrc = async () => {
+const carbonComponentsReactVendorSrc = async () => {
   const table = await generateTable();
   await promisifyStream(() =>
     gulp
       .src([
-        `${carbonComponetsReactESSrcDir}/**/*`,
+        `${carbonComponentsReactESSrcDir}/**/*`,
         '!**/*-{test,story}.js',
         '!**/stories/*',
       ])
       .pipe(convert({ table }))
-      .pipe(gulp.dest(carbonComponetsReactVendorSrcDir))
+      .pipe(gulp.dest(carbonComponentsReactVendorSrcDir))
   );
 };
 
 /**
  * Generate `es/internal/vendor` contents.
  */
-const carbonComponetsReactVendorESDst = async () => {
+const carbonComponentsReactVendorESDst = async () => {
   const table = await generateTable();
   await promisifyStream(() =>
     gulp
       .src([
-        `${carbonComponetsReactESSrcDir}/**/*`,
+        `${carbonComponentsReactESSrcDir}/**/*`,
         '!**/*-{test,story}.js',
         '!**/stories/*',
       ])
       .pipe(convert({ table }))
-      .pipe(gulp.dest(carbonComponetsReactVendorESDstDir))
+      .pipe(gulp.dest(carbonComponentsReactVendorESDstDir))
   );
 };
 
 /**
  * The Gulp stream to generate `lib/internal/vendor` contents.
  */
-const carbonComponetsReactVendorCJSDst = () =>
+const carbonComponentsReactVendorCJSDst = () =>
   gulp
     .src([
-      `${carbonComponetsReactCJSSrcDir}/**/*`,
+      `${carbonComponentsReactCJSSrcDir}/**/*`,
       '!**/*-{test,story}.js',
       '!**/stories/*',
     ])
-    .pipe(gulp.dest(carbonComponetsReactVendorCJSDstDir));
+    .pipe(gulp.dest(carbonComponentsReactVendorCJSDstDir));
 
 module.exports = {
   carbonComponentsReact: gulp.parallel(
-    carbonComponetsReactVendorSrc,
-    carbonComponetsReactVendorESDst,
-    carbonComponetsReactVendorCJSDst
+    carbonComponentsReactVendorSrc,
+    carbonComponentsReactVendorESDst,
+    carbonComponentsReactVendorCJSDst
   ),
 };

--- a/packages/react/tests/integration/bundle/bundle-size.test.js
+++ b/packages/react/tests/integration/bundle/bundle-size.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -119,6 +119,7 @@ const pseudoExports = {
   [moduleEntrypoint('react-dom')]: exportsWithFunctions(['render']),
   [moduleEntrypoint('react-is')]: exportsWithFunctions(['isForwardRef']),
   [moduleEntrypoint('@carbon/icons-react')]: moduleContentWithSideEffects,
+  [moduleEntrypoint('@carbon/feature-flags')]: moduleContentWithSideEffects,
   [moduleEntrypoint('carbon-components')]: moduleContentWithSideEffects,
   [moduleEntrypoint('carbon-components-react')]: moduleContentWithSideEffects,
   [moduleEntrypoint(

--- a/packages/react/tests/integration/bundle/bundle-size.test.js
+++ b/packages/react/tests/integration/bundle/bundle-size.test.js
@@ -119,7 +119,9 @@ const pseudoExports = {
   [moduleEntrypoint('react-dom')]: exportsWithFunctions(['render']),
   [moduleEntrypoint('react-is')]: exportsWithFunctions(['isForwardRef']),
   [moduleEntrypoint('@carbon/icons-react')]: moduleContentWithSideEffects,
-  [moduleEntrypoint('@carbon/feature-flags')]: moduleContentWithSideEffects,
+  [moduleEntrypoint('@carbon/feature-flags')]: exportsWithFunctions([
+    'enabled',
+  ]),
   [moduleEntrypoint('carbon-components')]: moduleContentWithSideEffects,
   [moduleEntrypoint('carbon-components-react')]: moduleContentWithSideEffects,
   [moduleEntrypoint(


### PR DESCRIPTION
### Related Ticket(s)

#5600 

### Description

This is an update to the way the vendor build task is done in order to include the `@carbon/feature-flags` library that was introduced last month in Carbon.

### Changelog

**Changed**

- Various updates to the gulp build task
