### PR TITLE
chore(percy): removing chore branch from percy update github action

### DIFF
--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release/*
-      - chore/carbon-10.31.0-upgrade
 
 jobs:
   react:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Now that the chore branch has been successfully merged down, this branch for updating the percy baseline for that particular branch is no longer needed.

### Changelog

**Changed**

- `percy-update-base.yml`
