### PR TITLE
fix(MastheadSearch): remove tooltip from search button

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -562,16 +562,14 @@ const MastheadSearch = ({
           }
           className={`${prefix}--header__search--search`}
           data-autoid={`${stablePrefix}--masthead-${navType}__l0-search`}
-          tabIndex="0"
-          tooltipAlignment="end">
+          tabIndex="0">
           <Search20 />
         </HeaderGlobalAction>
         <HeaderGlobalAction
           onClick={closeBtnAction}
           aria-label="Close"
           className={`${prefix}--header__search--close`}
-          data-autoid={`${stablePrefix}--masthead-${navType}__l0-search--close`}
-          tooltipAlignment="end">
+          data-autoid={`${stablePrefix}--masthead-${navType}__l0-search--close`}>
           <Close20 />
         </HeaderGlobalAction>
       </div>

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -129,6 +129,14 @@
     .#{$prefix}--header__search--search,
     .#{$prefix}--header__search--close {
       color: $icon-01;
+
+      // prevent tooltip from showing on hover
+      &.#{$prefix}--btn--icon-only {
+        &::before,
+        .#{$prefix}--assistive-text {
+          display: none;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

Custom Masthead searchbar tooltip text #5778

### Description

Hide the tooltip from the masthead search buttons

### Changelog

**Changed**

- set tooltip to `display: none`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
