### PR TITLE
fix(megamenu): removes text-decoration on hover

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -290,6 +290,7 @@
     &:active,
     &:hover {
       background-color: $hover-ui;
+      text-decoration: none;
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

#5743 

### Description

Removes underline from **The Essentials** links on `hover`.

### Changelog

**New**

- `text-decoration: none` on `hover` for **The Essentials** links


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
