### PR TITLE
fix(content-block-simple): added max-width to media components

### DIFF
--- a/packages/web-components/src/components/content-block-simple/content-block-simple.scss
+++ b/packages/web-components/src/components/content-block-simple/content-block-simple.scss
@@ -14,9 +14,14 @@
 
 :host(#{$dds-prefix}-content-block-simple) {
   display: block;
+
   ::slotted(#{$dds-prefix}-content-block-complementary) {
     @include carbon--breakpoint-down('lg') {
       margin: $layout-05 0;
     }
+  }
+
+  ::slotted([slot='media']) {
+    max-width: rem(640px);
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

#5423 

### Description

I've added max-width to the slotted media components on `ContentBlockSimple`.
This change affects React and Web Components.