### PR TITLE
fix(masthead-search): overriding carbon core button styles

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -130,6 +130,15 @@
     .#{$prefix}--header__search--close {
       color: $icon-01;
 
+      background-color: $ui-background;
+      padding: 0;
+
+      &:hover {
+        background-color: $hover-ui;
+        svg[focusable='false'][aria-hidden='true'] {
+          fill: $icon-02;
+        }
+      }
       // prevent tooltip from showing on hover
       &.#{$prefix}--btn--icon-only {
         &::before,


### PR DESCRIPTION
### Related Ticket(s)

NextJS page: Masthead Search bar - On hover search icon and close icon are hidden #5789
