### PR TITLE
fix(masthead): ensure search closes properly & close on blur

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-logo.ts
+++ b/packages/web-components/src/components/masthead/masthead-logo.ts
@@ -38,10 +38,12 @@ class DDSMastheadLogo extends FocusMixin(HostListenerMixin(BXLink)) {
    *
    * @param event The event.
    */
-  @HostListener('parentRoot:eventToggleSerch')
+  @HostListener('parentRoot:eventToggleSearch')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleSearchToggle = (event: Event) => {
-    this._hasSearchActive = (event as CustomEvent).detail.active;
+    if ((event as CustomEvent).detail.active !== undefined) {
+      this._hasSearchActive = (event as CustomEvent).detail.active;
+    }
   };
 
   /**
@@ -79,7 +81,7 @@ class DDSMastheadLogo extends FocusMixin(HostListenerMixin(BXLink)) {
   /**
    * The name of the custom event fired after the seach is toggled.
    */
-  static get eventToggleSerch() {
+  static get eventToggleSearch() {
     return `${ddsPrefix}-masthead-search-toggled`;
   }
 

--- a/packages/web-components/src/components/masthead/masthead-menu-button.ts
+++ b/packages/web-components/src/components/masthead/masthead-menu-button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -47,7 +47,9 @@ class DDSMastheadMenuButton extends HostListenerMixin(BXHeaderMenuButton) {
   @HostListener('parentRoot:eventToggleSearch')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleSearchToggle = (event: Event) => {
-    this._hasSearchActive = (event as CustomEvent).detail.active;
+    if ((event as CustomEvent).detail.active !== undefined) {
+      this._hasSearchActive = (event as CustomEvent).detail.active;
+    }
   };
 
   /**

--- a/packages/web-components/src/components/masthead/masthead-search.ts
+++ b/packages/web-components/src/components/masthead/masthead-search.ts
@@ -164,6 +164,18 @@ class DDSMastheadSearch extends BXDropdown {
     }
   }
 
+  @HostListener('focusin')
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  // @ts-ignore
+  private _handleFocusIn() {
+    this._handleUserInitiatedToggleActiveState(true);
+  }
+
+  protected _handleFocusOut(event: FocusEvent) {
+    super._handleFocusOut(event);
+    this._handleUserInitiatedToggleActiveState(false, false);
+  }
+
   /**
    * Handles `input` event in the search input.
    */
@@ -428,18 +440,6 @@ class DDSMastheadSearch extends BXDropdown {
         </button>
       </div>
     `;
-  }
-
-  @HostListener('focusin')
-  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
-  // @ts-ignore
-  private _handleFocusIn() {
-    this._handleUserInitiatedToggleActiveState(true);
-  }
-
-  protected _handleFocusOut(event: FocusEvent) {
-    super._handleFocusOut(event);
-    this._handleUserInitiatedToggleActiveState(false, false);
   }
 
   /**

--- a/packages/web-components/src/components/masthead/masthead-search.ts
+++ b/packages/web-components/src/components/masthead/masthead-search.ts
@@ -16,6 +16,7 @@ import Close20 from 'carbon-web-components/es/icons/close/20.js';
 import Search20 from 'carbon-web-components/es/icons/search/20.js';
 import BXDropdown, { DROPDOWN_KEYBOARD_ACTION } from 'carbon-web-components/es/components/dropdown/dropdown.js';
 import BXDropdownItem from 'carbon-web-components/es/components/dropdown/dropdown-item.js';
+import HostListener from 'carbon-web-components/es/globals/decorators/host-listener';
 import { forEach, indexOf } from '../../globals/internal/collection-helpers';
 import DDSMastheadSearchItem from './masthead-search-item';
 import styles from './masthead.scss';
@@ -427,6 +428,18 @@ class DDSMastheadSearch extends BXDropdown {
         </button>
       </div>
     `;
+  }
+
+  @HostListener('focusin')
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  // @ts-ignore
+  private _handleFocusIn() {
+    this._handleUserInitiatedToggleActiveState(true);
+  }
+
+  protected _handleFocusOut(event: FocusEvent) {
+    super._handleFocusOut(event);
+    this._handleUserInitiatedToggleActiveState(false, false);
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)
#5800

### Description
On Mobile view, the Masthead Search wasn't closing properly upon hitting the close button. This also happened when typing a space character on the search input. This ensures it closes properly, and fixes the space character bug. 

This PR also adds back "Closing search on blur" feature the Web Component Masthead used to have, and currently has in the React version, fixing another overflow issue happening.

### Changelog

**New**

- brought back the close on blur feature of the Masthead Search

**Changed**

- added a check to ensure the search toggle CustomEvent was defined before toggling the visibility of the Masthead Button and IBM Logo. 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
