### PR TITLE
fix(masthead): search icon does nothing when input empty

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -312,6 +312,9 @@ const MastheadSearch = ({
       });
 
       event.currentTarget.dispatchEvent(onOpenSearch);
+
+      dispatch({ type: 'setSearchOpen' });
+      handleChangeSearchActive();
     }
 
     // emit custom event for search icon click when search is open
@@ -332,7 +335,6 @@ const MastheadSearch = ({
       }
     } else {
       dispatch({ type: 'setSearchOpen' });
-      handleChangeSearchActive();
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

#5819 

### Description

Fixes an issue in the `default` React masthead where clicking the search icon while the search component is open with no search value would close the entire component. The expected behavior is for the search component to remain open and do nothing.

### Changelog

**Changed**

- search visibility behavior in `MastheadSearch`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
