### PR TITLE
fix(Masthead): use specific selectors to remove tooltip

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -140,7 +140,8 @@
         }
       }
       // prevent tooltip from showing on hover
-      &.#{$prefix}--btn--icon-only {
+      &.#{$prefix}--btn--icon-only.#{$prefix}--tooltip--visible,
+      &.#{$prefix}--btn--icon-only.#{$prefix}--tooltip--a11y.#{$prefix}--tooltip__trigger {
         &::before,
         .#{$prefix}--assistive-text {
           display: none;


### PR DESCRIPTION
### Related Ticket(s)

NextJS page: Masthead Search bar - On hover search icon and close icon are hidden #5789

### Description

Make sure that the tooltip for the search icons are not displaying on hover and click of the icons. Need to use more specific selectors for the NextJS test pages.

### Changelog

**Changed**

- use more specific selectors

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
