### PR TITLE
fix(locale-modal): prefix selector for input focus

### DIFF
--- a/packages/web-components/src/components/locale-modal/locale-search.ts
+++ b/packages/web-components/src/components/locale-modal/locale-search.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -216,7 +216,7 @@ class DDSLocaleSearch extends ThrottedInputMixin(LitElement) {
    * A selector selecting the locale item,
    */
   static get selectorTabable() {
-    return `${prefix}-search`;
+    return `${ddsPrefix}-search`;
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

#5817 

### Description

Fixes incorrect prefix variable being used to target `locale-modal` search input filter in the web components version. This was causing the input to not receive initial focus.

### Changelog

**Changed**

- `${prefix}` to `${ddsPrefix}` for locale search's `selectorTabable`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
