### PR TITLE
fix(lerna): increasing max buffer for lerna ci-check

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run CI Checks
         run: |
           yarn ci-check
-          yarn lerna run --stream --ignore=@carbon/ibmdotcom-web-components ci-check
+          yarn lerna run --stream --ignore=@carbon/ibmdotcom-web-components --max-buffer=200000000 ci-check
   web-components:
     runs-on: ubuntu-16.04
     strategy:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Github actions is running into memory buffer issues, increasing the max
buffer in hopes that this will fix things.

### Changelog

**Changed**

- ci-check.yml
