### PR TITLE
fix(ci-check): rebuilding snapshot file

### DIFF
--- a/packages/react/config/jest/__mocks__/ProfileAPI.js
+++ b/packages/react/config/jest/__mocks__/ProfileAPI.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2020, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+  getUserStatus: jest.fn(() => Promise.resolve({ user: 'Unauthenticated' })),
+};

--- a/packages/react/config/jest/setup.js
+++ b/packages/react/config/jest/setup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,6 +24,9 @@ global.window.location = {
 
 jest.mock('@carbon/ibmdotcom-services/lib/services/Locale/Locale', () =>
   require('./__mocks__/LocaleAPI')
+);
+jest.mock('@carbon/ibmdotcom-services/lib/services/Profile/Profile', () =>
+  require('./__mocks__/ProfileAPI')
 );
 jest.mock(
   '@carbon/ibmdotcom-services/lib/services/VideoPlayer/VideoPlayer',

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,12 +9,8 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: [
     'src/components/**/*.js',
-    'src/patterns/blocks/**/*.js',
-    'src/patterns/sections/**/*.js',
     'src/internal/components/**/*.js',
     '!src/components/**/*.stories.js',
-    '!src/patterns/blocks/**/*.stories.js',
-    '!src/patterns/sections/**/*.stories.js',
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'html'],


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The ci-checks were failing in React, which seems to be related to the Jest snapshot tests. This PR rebuilds the snapshot file to see if this fixes the issue.

### Changelog

**Changed**

- React jest snapshot file
