### PR TITLE
fix(Masthead): remove pseudo element from platform name

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -45,17 +45,6 @@
     background-color: #dcdcdc;
   }
 
-  &::after {
-    content: '';
-    display: block;
-    position: absolute;
-    width: 15px;
-    height: $spacing-09;
-    left: calc(-1rem - 1px);
-    top: -2px;
-    background-color: $ui-background;
-  }
-
   @include carbon--breakpoint-down(800px) {
     display: none;
   }


### PR DESCRIPTION
### Related Ticket(s)

Masthead with Platform - Divider activates hover state on platform #5484

### Description

Space between the platform name and divider is clickable - removing the anchor link pseudo element resolves this.

BEFORE:
![BEFORE](https://user-images.githubusercontent.com/54281166/115441916-705f3a00-a1df-11eb-984d-f4fba2759f81.gif)

AFTER:
![AFTER](https://user-images.githubusercontent.com/54281166/115441927-72c19400-a1df-11eb-99ec-7c45ff0b0f57.gif)


### Changelog

**Removed**

- remove anchor link `after` pseudo element

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
