### PR TITLE
fix(localeModal): e2e tests

### DIFF
--- a/packages/tests-e2e/__tests__/locale-modal/locale-modal.e2e.js
+++ b/packages/tests-e2e/__tests__/locale-modal/locale-modal.e2e.js
@@ -69,7 +69,7 @@ describe('LocaleModal', () => {
       region.click();
     } else {
       await page.waitForSelector(
-        '.bx--locale-modal__regions > div > div:nth-child(1) > a'
+        '.bx--locale-modal__regions > div > div:nth-child(1) > .bx--card > .bx--card__wrapper > .bx--card__content > a'
       );
       await page.click('[data-region="am"]');
     }


### PR DESCRIPTION
### Related Ticket(s)

none
### Description

Locale Modal e2e tests failing after update to react Card

### Changelog

**Changed**

- selector to reach the correct property

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
