### PR TITLE
fix(content-group-cards): fixed bold outline

### DIFF
--- a/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
+++ b/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
@@ -39,6 +39,10 @@
     margin-bottom: $carbon--grid-gutter--condensed / 2;
     padding-left: $carbon--grid-gutter--condensed / 2;
     padding-right: $carbon--grid-gutter--condensed / 2;
+
+    &:focus {
+      outline: none;
+    }
   }
 }
 @include exports('content-group-cards') {


### PR DESCRIPTION
### Related Ticket(s)
#5732

### Description
Removed additional outline that was present when focusing on the `ContentGroupCardItem`

### Changelog

**Changed**

- `outline: none` when focused on `<dds-content-group-card-item>`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
