### PR TITLE
fix(content-block-segmented): fixed spacing issues

### DIFF
--- a/packages/styles/scss/components/content-block-segmented/_content-block-segmented.scss
+++ b/packages/styles/scss/components/content-block-segmented/_content-block-segmented.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -28,9 +28,8 @@
     margin-top: $carbon--layout-05;
     margin-bottom: $carbon--layout-05;
 
-    @include carbon--breakpoint('lg') {
-      margin-top: $carbon--layout-06;
-      margin-bottom: $carbon--layout-06;
+    &:last-of-type {
+      margin-bottom: 0;
     }
   }
 }

--- a/packages/web-components/src/components/content-block-segmented/content-block-segmented.scss
+++ b/packages/web-components/src/components/content-block-segmented/content-block-segmented.scss
@@ -12,11 +12,10 @@
     display: block;
     margin-top: $carbon--layout-05;
     margin-bottom: $carbon--layout-05;
+  }
 
-    @include carbon--breakpoint('lg') {
-      margin-top: $carbon--layout-06;
-      margin-bottom: $carbon--layout-06;
-    }
+  ::slotted(:not([slot]):last-of-type) {
+    margin-bottom: 0;
   }
 
   ::slotted(#{$dds-prefix}-content-block-complementary) {


### PR DESCRIPTION
### Related Ticket(s)
#5619 
#5622

### Description
Fixed the spacing in Content Block Segmented found within the Dotcom Shell and Back to Top. 

### Changelog

**New**

- removed `margin-bottom` for the last `content-block-segmented-item`

**Removed**

- wrong margin styles for each `content-block-segmented-item`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
