### PR TITLE
fix(masthead-search): ensure clicking on suggestion works

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-search.ts
+++ b/packages/web-components/src/components/masthead/masthead-search.ts
@@ -173,7 +173,9 @@ class DDSMastheadSearch extends BXDropdown {
 
   protected _handleFocusOut(event: FocusEvent) {
     super._handleFocusOut(event);
-    this._handleUserInitiatedToggleActiveState(false, false);
+    if (!(event.currentTarget as HTMLElement).contains(event.relatedTarget as HTMLElement)) {
+      this._handleUserInitiatedToggleActiveState(false, false);
+    }
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)
#5850

### Description
This PR ensures that clicking on any of the search suggestion items doesn't close the search bar and goes directly to the search results page as intended.

### Changelog

**Changed**

- quick check to ensure the blur event doesn't occur if clicking a masthead search result

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
