### PR TITLE
fix(masthead): ensure only search bar displays on load upon search open

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -190,12 +190,16 @@ class DDSMastheadComposite extends LitElement {
   protected _renderLogo() {
     if (!this.logoData)
       return html`
-        <dds-masthead-logo></dds-masthead-logo>
+        <dds-masthead-logo ?hide-logo="${this.activateSearch}"></dds-masthead-logo>
       `;
     const useAlternateLogo = MastheadLogoAPI.setMastheadLogo(this.logoData);
     const { tooltip, svg } = this.logoData;
     return html`
-      <dds-masthead-logo ?hasTooltip="${tooltip}" aria-label="${ifNonNull(tooltip)}" tabIndex="0"
+      <dds-masthead-logo
+        ?hide-logo="${this.activateSearch}"
+        ?hasTooltip="${tooltip}"
+        aria-label="${ifNonNull(tooltip)}"
+        tabIndex="0"
         >${useAlternateLogo ? unsafeSVG(svg) : nothing}</dds-masthead-logo
       >
     `;
@@ -682,6 +686,7 @@ class DDSMastheadComposite extends LitElement {
         <dds-masthead-menu-button
           button-label-active="${ifNonNull(menuButtonAssistiveTextActive)}"
           button-label-inactive="${ifNonNull(menuButtonAssistiveTextInactive)}"
+          ?hide-menu-button="${activateSearch}"
         >
         </dds-masthead-menu-button>
 

--- a/packages/web-components/src/components/masthead/masthead-logo.ts
+++ b/packages/web-components/src/components/masthead/masthead-logo.ts
@@ -47,6 +47,12 @@ class DDSMastheadLogo extends FocusMixin(HostListenerMixin(BXLink)) {
   };
 
   /**
+   * `true` to hide the logo at render
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'hide-logo' })
+  hideLogo = false;
+
+  /**
    * Link `href`.
    */
   @property()
@@ -65,12 +71,16 @@ class DDSMastheadLogo extends FocusMixin(HostListenerMixin(BXLink)) {
     `;
   }
 
-  updated() {
-    const { _linkNode: linkNode, _hasSearchActive: hasSearchActive } = this;
+  updated(changedProperties) {
+    const { _linkNode: linkNode } = this;
+
+    if (changedProperties.has('hideLogo')) {
+      this._hasSearchActive = this.hideLogo;
+    }
     if (linkNode) {
       linkNode.setAttribute('aria-label', 'IBM logo');
       linkNode.classList.remove(`${prefix}--link`);
-      linkNode.classList.toggle(`${ddsPrefix}-ce--header__logo--has-search-active`, hasSearchActive);
+      linkNode.classList.toggle(`${ddsPrefix}-ce--header__logo--has-search-active`, this._hasSearchActive);
     }
   }
 

--- a/packages/web-components/src/components/masthead/masthead-menu-button.ts
+++ b/packages/web-components/src/components/masthead/masthead-menu-button.ts
@@ -76,6 +76,12 @@ class DDSMastheadMenuButton extends HostListenerMixin(BXHeaderMenuButton) {
   @property({ reflect: true })
   slot = 'brand';
 
+  /**
+   * `true` to hide the logo at render
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'hide-menu-button' })
+  hideMenuButton = false;
+
   focus() {
     const { _buttonNode: buttonNode } = this;
     if (buttonNode) {
@@ -91,6 +97,10 @@ class DDSMastheadMenuButton extends HostListenerMixin(BXHeaderMenuButton) {
       } else if (this._hFocusWrap) {
         this._hFocusWrap = this._hFocusWrap.release();
       }
+    }
+
+    if (changedProperties.has('hideMenuButton')) {
+      this._hasSearchActive = this.hideMenuButton;
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)
Mentioned in the QA meeting this morning, couldn't find an open issue for this

### Description
The Masthead Menu button and IBM logo still showed up on load on the Masthead - Search Open by Default story. The previous fix which ensures toggling the search bar still works only, though only after closing it once.This fix ensures these two components hide upon load. 

### Changelog

**New**

- hide booleans for `<masthead-logo>` and `<masthead-menu-button>` to ensure they are hidden upon load the same way `<masthead-top-nav>` does it

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
