### PR TITLE
fix(masthead): set platform name z-index and background color

### DIFF
--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -74,12 +74,14 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
   return (
     <>
       {topNavProps.platform && (
-        <HeaderName
-          prefix=""
-          href={topNavProps.platform.url}
-          data-autoid={`${stablePrefix}--masthead-${topNavProps.navType}__l0-ecosystemname`}>
-          {topNavProps.platform.name}
-        </HeaderName>
+        <div className={`${prefix}--masthead__platform-name`}>
+          <HeaderName
+            prefix=""
+            href={topNavProps.platform.url}
+            data-autoid={`${stablePrefix}--masthead-${topNavProps.navType}__l0-ecosystemname`}>
+            {topNavProps.platform.name}
+          </HeaderName>
+        </div>
       )}
       <HeaderNavContainer>
         <HeaderNavigation

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -69,6 +69,12 @@
           display: none;
         }
       }
+
+      .#{$prefix}--masthead__platform-name {
+        z-index: 1;
+        height: 100%;
+        background: $ui-background;
+      }
     }
 
     .#{$prefix}--header__nav {

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -74,6 +74,8 @@
 
 :host(#{$dds-prefix}-top-nav-name) {
   outline: none;
+  z-index: 1;
+  background: $ui-background;
 
   a.#{$prefix}--header__name {
     @include masthead-top-nav-name;


### PR DESCRIPTION
### Related Ticket(s)

Masthead with Platform - Divider activates hover state on platform #5484

### Description

There was work (PR: fix(Masthead): remove pseudo element from platform name #5835) to address the ticket by removing the pseudo element from the platform name, but in web components that led to the overflow menu options to show behind the platform name.

This PR addresses the overflow menu items by setting the `z-index` and `background` of the platform name.

BEFORE:
<img width="547" alt="Screen Shot 2021-04-22 at 4 01 25 PM" src="https://user-images.githubusercontent.com/54281166/115778915-4f384e00-a385-11eb-84c0-a9918db92ed5.png">


AFTER:
<img width="490" alt="Screen Shot 2021-04-22 at 3 59 49 PM" src="https://user-images.githubusercontent.com/54281166/115778888-48114000-a385-11eb-9bae-6019de2f93f0.png">


### Changelog

**Changed**

- set the `z-index` and `background` of `top-nav-name` component

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
