### PR TITLE
chore(cta): fixed style imports in README

### DIFF
--- a/packages/react/src/components/CTA/README.stories.mdx
+++ b/packages/react/src/components/CTA/README.stories.mdx
@@ -26,12 +26,14 @@ Here's a quick example to get you started.
 @import '@carbon/type/scss/font-face/sans';
 @include carbon--font-face-mono();
 @include carbon--font-face-sans();
-@import '@carbon/ibmdotcom-styles/scss/components/imagecomponent/imagecomponent';
+
+@import "@carbon/ibmdotcom-styles/scss/components/buttongroup/buttongroup";
+@import "@carbon/ibmdotcom-styles/scss/components/card-link/card-link";
+@import "@carbon/ibmdotcom-styles/scss/components/feature-card/feature-card";
+@import "@carbon/ibmdotcom-styles/scss/components/link-with-icon/link-with-icon";
 ```
 
-> 💡 Only import fonts once per usage. Don't forget to import the CTA styles
-> from
-> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
+> 💡 Only import fonts once per usage. 
 
 ##### JS
 


### PR DESCRIPTION
### Related Ticket(s)
None.

### Description
Previous CTA README contained an outdated component, this PR adds the proper styles for CTA to work.

### Changelog
**Changed**

- added proper imports to the README

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
