### PR TITLE
fix(dependencies): changed @carbon/telemetry to be a dependency

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -80,6 +80,7 @@
     "@carbon/ibmdotcom-styles": "1.18.1-rc.0",
     "@carbon/ibmdotcom-utilities": "1.18.1-rc.0",
     "@carbon/layout": "10.22.0",
+    "@carbon/telemetry": "0.0.0-alpha.6",
     "carbon-components": "10.32.1",
     "carbon-web-components": "1.13.0",
     "lodash-es": "^4.17.0",
@@ -90,7 +91,6 @@
   },
   "optionalDependencies": {
     "@carbon/icons-react": "10.29.0",
-    "@carbon/telemetry": "0.0.0-alpha.6",
     "lodash.pickby": "^4.6.0",
     "prop-types": "^15.7.0",
     "react": "^16.10.0 || ^17.0.0",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -90,6 +90,7 @@
   },
   "optionalDependencies": {
     "@carbon/icons-react": "10.29.0",
+    "@carbon/telemetry": "0.0.0-alpha.6",
     "lodash.pickby": "^4.6.0",
     "prop-types": "^15.7.0",
     "react": "^16.10.0 || ^17.0.0",
@@ -115,7 +116,6 @@
     "@carbon/ibmdotcom-services-store": "1.18.1-rc.0",
     "@carbon/icon-helpers": "10.15.0",
     "@carbon/icons": "10.29.0",
-    "@carbon/telemetry": "0.0.0-alpha.6",
     "@open-wc/semantic-dom-diff": "^0.15.0",
     "@percy-io/in-percy": "^0.1.11",
     "@percy/storybook": "^3.3.0",


### PR DESCRIPTION
### Related Ticket(s)

#5867

### Description

The web components package was missed when moving Carbon telemetry as a
dependency. This is getting this fix in before the patch is released.

### Changelog

**Changed**

- `@carbon/telemetry` changed as a dependency

