### PR TITLE
fix(locale): return locale with the fetch list call

### DIFF
--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -182,10 +182,10 @@ class LocaleAPI {
   static async getLocale() {
     const cookie = ipcinfoCookie.get();
     const lang = await this.getLang();
-    // grab locale from the html lang attribute
+
     if (lang) {
-      await this.getList(lang);
-      return lang;
+      const list = await this.getList(lang);
+      return list.locale;
     }
     // grab the locale from the cookie
     else if (cookie && cookie.cc && cookie.lc) {
@@ -277,7 +277,7 @@ class LocaleAPI {
 
   /**
    * Get the country list of all supported countries and their languages
-   * if not set in session storage
+   * if it is not already stored in session storage
    *
    * @param {object} params params object
    * @param {string} params.cc country code
@@ -321,6 +321,7 @@ class LocaleAPI {
         _requestsList[key] = axios.get(url, _axiosConfig).then(response => {
           const { data } = response;
           data['timestamp'] = Date.now();
+          data.locale = { lc, cc };
           sessionStorage.setItem(
             `${_sessionListKey}-${cc}-${lc}`,
             JSON.stringify(data)

--- a/packages/services/src/services/Locale/__tests__/Locale.test.js
+++ b/packages/services/src/services/Locale/__tests__/Locale.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -420,7 +420,9 @@ describe('LocaleAPI', () => {
       .mockReturnValue(Promise.resolve('testLang'));
     jest
       .spyOn(LocaleAPI, 'getList')
-      .mockReturnValue(Promise.resolve('testList'));
+      .mockReturnValue(
+        Promise.resolve({ list: 'list data', locale: 'testLang' })
+      );
     jest.spyOn(LocaleAPI, 'verifyLocale').mockReturnValue('testVerified');
     const locale = await LocaleAPI.getLocale();
 


### PR DESCRIPTION
### Related Ticket(s)

Masthead and Footer components not supporting locales like en-cn or en-gb #5890

### Description
For pages with DDO set to a locale that we do not support (ie. cn-en), the masthead and footer is returning blank.

When fetching the locale from the DDO to use in the translation service, we make a call to fetch the countrylist with the retrieved locale. If the countrylist call fails, we make another call with our default locale. However this change to the default locale is not communicated to the translation service and so the translation call is made with the non-existent locale.

Solution is to set the locale in the data returned from the successful countrylist call and use that locale.

### Changelog

**Changed**

- set locale in the returned countrylist data in `fetchList()`
- use the locale from the returned data

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
