### PR TITLE
test(e2e): adding percy base update for e2e tests on staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -48,13 +48,13 @@ jobs:
         env:
           SELENIUM_HOST: https://ibmdotcom-react-staging.mybluemix.net
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_REACT_E2E }}
-          - name: Create e2e percy snapshots
-            run: yarn test:e2e
-            working-directory: packages/tests-e2e
-          - uses: act10ns/slack@v1
-            with:
-              status: ${{ job.status }}
-            if: failure()
+      - name: Create e2e percy snapshots
+        run: yarn test:e2e
+        working-directory: packages/tests-e2e
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+        if: failure()
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -55,10 +55,6 @@ jobs:
         with:
           status: ${{ job.status }}
         if: failure()
-      - uses: act10ns/slack@v1
-        with:
-          status: ${{ job.status }}
-        if: failure()
   web-components:
     runs-on: ubuntu-16.04
     env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,6 +41,20 @@ jobs:
           cf-app: ibmdotcom-react-staging
           cf-manifest: manifest-staging.yml
           deploy-dir: packages/react
+      - name: Set env vars for e2e percy snapshots
+        uses: ./.github/actions/set-dotenv
+        with:
+          env-file: packages/tests-e2e/.env
+        env:
+          SELENIUM_HOST: https://ibmdotcom-react-staging.mybluemix.net
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_REACT_E2E }}
+          - name: Create e2e percy snapshots
+            run: yarn test:e2e
+            working-directory: packages/tests-e2e
+          - uses: act10ns/slack@v1
+            with:
+              status: ${{ job.status }}
+            if: failure()
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/tasks/get-changelog.js
+++ b/tasks/get-changelog.js
@@ -141,7 +141,7 @@ function getChangelog(pkgName, folder) {
       const choreSubject = _getCommitSubject(commitParse);
 
       chores[choreName] = chores[choreName] || [];
-      if (choreSubject !== 'publish') {
+      if (choreSubject !== 'publish' && choreSubject !== 'release') {
         chores[choreName].push(choreSubject);
       }
     }


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This was missed in order to set up the baseline snapshots for the React
e2e tests on staging.

### Changelog

**Changed**

- `deploy-staging.yml`
