### PR TITLE
fix(masthead): L1 platform not showing in hamburger menu

### DIFF
--- a/packages/react/src/components/CardGroup/CardGroup.js
+++ b/packages/react/src/components/CardGroup/CardGroup.js
@@ -67,7 +67,6 @@ const CardGroup = ({ cards, cta }) => {
         );
 
         splitItemEyebrows.forEach(row => {
-          console.log(row);
           sameHeight(
             row.filter(e => {
               return e;

--- a/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
+++ b/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
@@ -293,6 +293,7 @@ WithL1.story = {
       DotcomShell: () => {
         const { Masthead: mastheadKnobs } = l1Story.story.parameters.knobs;
         return {
+          platform: mastheadKnobs.l1Platform,
           mastheadProps: {
             ...mastheadKnobs({ groupId: 'Masthead' }),
           },

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -305,6 +305,7 @@ const Masthead = ({
               <div ref={mastheadL1Ref}>
                 <MastheadL1
                   {...mastheadL1Data}
+                  platform={platform}
                   isShort={isMastheadSticky}
                   navType={navType}
                   selectedMenuItem={selectedMenuItem}
@@ -403,14 +404,16 @@ Masthead.propTypes = {
    */
   mastheadL1Data: PropTypes.shape({
     /**
-     * Title for the masthead L1 (experimental).
+     * Platform name that appears on L1.
+     * Includes platform name
+     * Object requires `name` and `url`.
+     * See [docs](http://ibmdotcom-react.mybluemix.net/?path=/docs/components-masthead--default#platform) for more details.
      */
-    title: PropTypes.string,
+    platform: PropTypes.shape({
+      name: PropTypes.string,
+      url: PropTypes.string,
+    }),
 
-    /**
-     * Title optional link for the masthead L1 (experimental).
-     */
-    titleLink: PropTypes.string,
     /**
      * Text for the eyebrow link in masthead L1 (experimental).
      */

--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -22,7 +22,7 @@ const { prefix } = settings;
 /**
  * MastHead L1 component.
  */
-const MastheadL1 = ({ title, titleLink, navigationL1, ...rest }) => {
+const MastheadL1 = ({ navigationL1, ...rest }) => {
   const className = cx({
     [`${prefix}--masthead__l1`]: true,
   });
@@ -65,7 +65,7 @@ const MastheadL1 = ({ title, titleLink, navigationL1, ...rest }) => {
             className={`${prefix}--masthead__l1-name`}
             aria-selected={!rest.selectedMenuItem}>
             <span className={`${prefix}--masthead__l1-name-title`}>
-              <a href={titleLink}>{title}</a>
+              <a href={rest.platform.url}>{rest.platform.name}</a>
             </span>
           </div>
           <HeaderNavContainer>

--- a/packages/react/src/components/Masthead/README.stories.mdx
+++ b/packages/react/src/components/Masthead/README.stories.mdx
@@ -74,8 +74,10 @@ object that contains the navigation data of L1 nav:
 
 ```javascipt
 const mastheadL1Data = {
-  title: 'Stock Charts',
-  titleLink: 'https://example.com/',
+  platform: {
+    name: 'Stock Charts',
+    url: 'https://example.com/',
+  },
   navigationL1: (The nav links),
 }
 

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -213,6 +213,7 @@ WithL1.story = {
       escapeHTML: false,
       Masthead: ({ groupId }) => {
         return {
+          platform: mastheadKnobs.l1Platform,
           hasProfile: boolean(
             'show the profile functionality (hasProfile)',
             true,
@@ -229,12 +230,6 @@ WithL1.story = {
             groupId
           ),
           mastheadL1Data: {
-            title: text('L1 title (title)', 'Stock Charts', groupId),
-            titleLink: text(
-              'L1 title link (titleLink)',
-              'https://example.com/',
-              groupId
-            ),
             navigationL1: mastheadKnobs.navigation.custom,
           },
           selectedMenuItem: text(

--- a/packages/react/src/components/Masthead/__stories__/data/Masthead.stories.knobs.js
+++ b/packages/react/src/components/Masthead/__stories__/data/Masthead.stories.knobs.js
@@ -25,6 +25,10 @@ const mastheadKnobs = {
       url: 'https://www.ibm.com/cloud',
     },
   },
+  l1Platform: {
+    name: 'Stock Charts',
+    url: 'https://www.example.com',
+  },
   mastheadLogo: {
     defaultNoTooltip: {
       denylist: [],

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -372,11 +372,13 @@
     }
 
     &[aria-haspopup='true'] {
-      height: carbon--mini-units(6);
+      height: $container-04;
       &.bx--side-nav__submenu-platform {
+        border-top: 1px solid $ui-03;
         border-bottom: 1px solid $ui-04;
         text-decoration: none;
         color: $text-01;
+        height: $container-04;
 
         @include carbon--type-style(expressive-heading-02);
       }

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -64,6 +64,14 @@ const platformData = {
   url: 'https://www.ibm.com/cloud',
 };
 
+/**
+ * l1 platform data
+ */
+const l1PlatformData = {
+  name: 'Stock Charts',
+  url: 'https://www.example.com',
+};
+
 const footerSizes = {
   Default: FOOTER_SIZE.REGULAR,
   [`Short (${FOOTER_SIZE.SHORT})`]: FOOTER_SIZE.SHORT,
@@ -629,8 +637,8 @@ export const withL1 = ({ parameters }) => {
     ${useMock
       ? html`
           <dds-dotcom-shell-composite
-            platform="${ifNonNull(platform)}"
-            platform-url="${ifNonNull(platformData.url)}"
+            platform="${ifNonNull(platform.name)}"
+            platform-url="${ifNonNull(platform.url)}"
             language="${ifNonNull(language)}"
             lang-display="${ifNonNull(langDisplay)}"
             user-status="${ifNonNull(userStatus)}"
@@ -652,8 +660,8 @@ export const withL1 = ({ parameters }) => {
         `
       : html`
           <dds-dotcom-shell-container
-            platform="${ifNonNull(platform)}"
-            platform-url="${ifNonNull(platformData.url)}"
+            platform="${ifNonNull(platform.name)}"
+            platform-url="${ifNonNull(platform.url)}"
             language="${ifNonNull(language)}"
             lang-display="${ifNonNull(langDisplay)}"
             user-status="${ifNonNull(userStatus)}"
@@ -672,6 +680,21 @@ export const withL1 = ({ parameters }) => {
           </dds-dotcom-shell-container>
         `}
   `;
+};
+
+withL1.story = {
+  parameters: {
+    knobs: {
+      MastheadComposite: ({ groupId }) => ({
+        platform: l1PlatformData,
+        hasProfile: boolean('show the profile functionality (has-profile)', true, groupId),
+        hasSearch: boolean('show the search functionality (has-search)', true, groupId),
+        searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', inPercy() ? '' : 'Search all of IBM', groupId),
+        selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
+        userStatus: select('The user authenticated status (user-status)', userStatuses, userStatuses.unauthenticated, groupId),
+      }),
+    },
+  },
 };
 
 export default {

--- a/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
@@ -48,8 +48,10 @@ object that contains the navigation data of L1 nav:
 
 ```javascipt
 const l1Data = {
-  title: 'Stock Charts',
-  url: 'https://example.com',
+  platform: {
+    name: 'Stock Charts',
+    url: 'https://example.com/',
+  },
   menuItems: (The nav links),
 }
 ```

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -35,6 +35,14 @@ const platformData = {
   url: 'https://www.ibm.com/cloud',
 };
 
+/**
+ * l1 platform data
+ */
+const l1PlatformData = {
+  name: 'Stock Charts',
+  url: 'https://www.example.com',
+};
+
 export const Default = ({ parameters }) => {
   const { platform, hasProfile, hasSearch, selectedMenuItem, searchPlaceholder, userStatus, navLinks } =
     parameters?.props?.MastheadComposite ?? {};
@@ -198,8 +206,8 @@ export const withL1 = ({ parameters }) => {
     ${useMock
       ? html`
           <dds-masthead-composite
-            platform="${ifNonNull(platform)}"
-            platform-url="${ifNonNull(platformData.url)}"
+            platform="${ifNonNull(platform.name)}"
+            platform-url="${ifNonNull(platform.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             user-status="${ifNonNull(userStatus)}"
@@ -213,8 +221,8 @@ export const withL1 = ({ parameters }) => {
         `
       : html`
           <dds-masthead-container
-            platform="${ifNonNull(platform)}"
-            platform-url="${ifNonNull(platformData.url)}"
+            platform="${ifNonNull(platform.name)}"
+            platform-url="${ifNonNull(platform.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             ?has-profile="${hasProfile}"
@@ -224,6 +232,21 @@ export const withL1 = ({ parameters }) => {
           ></dds-masthead-container>
         `}
   `;
+};
+
+withL1.story = {
+  parameters: {
+    knobs: {
+      MastheadComposite: ({ groupId }) => ({
+        platform: l1PlatformData,
+        hasProfile: boolean('show the profile functionality (has-profile)', true, groupId),
+        hasSearch: boolean('show the search functionality (has-search)', true, groupId),
+        searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', inPercy() ? '' : 'Search all of IBM', groupId),
+        selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Services & Consulting', groupId),
+        userStatus: select('The user authenticated status (user-status)', userStatuses, userStatuses.unauthenticated, groupId),
+      }),
+    },
+  },
 };
 
 export const withAlternateLogoAndTooltip = ({ parameters }) => {

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -692,7 +692,7 @@ class DDSMastheadComposite extends LitElement {
         </dds-masthead-menu-button>
 
         ${this._renderLogo()}
-        ${!platform
+        ${!platform || l1Data
           ? undefined
           : html`
               <dds-top-nav-name href="${ifNonNull(platformUrl)}">${platform}</dds-top-nav-name>

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -53,13 +53,6 @@
     @include tooltip--placement('definition', 'bottom', 'start');
   }
 
-  // Ensures that IBM logo gets the padding of "wider screen" mode if we use nav pager
-  a {
-    @include carbon--breakpoint(800px) {
-      padding: 0 $carbon--spacing-07;
-    }
-  }
-
   a ::slotted(svg) {
     width: 58px;
     height: 23px;
@@ -284,7 +277,7 @@
     align-items: center;
     height: carbon--mini-units(6);
     padding: 0 mini-units(2);
-    border-bottom: 1px solid $ui-03;
+    border-bottom: 1px solid $ui-04;
     text-decoration: none;
     color: $text-01;
     flex-direction: row;


### PR DESCRIPTION
### Related Ticket(s)

#5896 
### Description

Current `L1` platform implementations in React and web components are inconsistent, and in React simply do not work. This makes both implementations consistent in their naming and data structures. Also fixes some styling inconsistencies in the web components version.

### Changelog

**Changed**

- `title` for L1 is now `platform` (same as `L0`)
- update Storybook stories for React and web components
- update web components masthead styles

**Removed**

- `title` and `titleUrl` from web components `L1`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
