### PR TITLE
fix(masthead): multi-section search headline

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -494,7 +494,7 @@ const MastheadSearch = ({
    * @returns {string} Section title
    */
   function renderSectionTitle(section) {
-    return section.items.length > 1 && section.title ? (
+    return section.items.length > 0 && section.title ? (
       <span>{section.title}</span>
     ) : null;
   }


### PR DESCRIPTION
### Related Ticket(s)

#5942 

### Description

Fixes an issue where search result section title would not show unless more than one item is in the section. The title should show when there is one or more items in the section.

### Changelog

**Changed**

- updated section title to show when one or more results are present


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
