### PR TITLE
fix(expressive-modal): remove dialog role

### DIFF
--- a/packages/web-components/src/components/expressive-modal/expressive-modal.ts
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal.ts
@@ -341,13 +341,7 @@ class DDSExpressiveModal extends StableSelectorMixin(HostListenerMixin(LitElemen
     });
     return html`
       <a id="start-sentinel" class="${prefix}--visually-hidden" href="javascript:void 0" role="navigation"></a>
-      <div
-        role="dialog"
-        class="${containerClasses}"
-        tabindex="-1"
-        @click="${handleClickContainer}"
-        @slotchange="${handleSlotChange}"
-      >
+      <div class="${containerClasses}" tabindex="-1" @click="${handleClickContainer}" @slotchange="${handleSlotChange}">
         <div class="bx--modal-content">
           ${this._renderHeader()}${this._renderBody()}${this._renderFooter()}
         </div>

--- a/packages/web-components/tests/snapshots/dds-expressive-modal.md
+++ b/packages/web-components/tests/snapshots/dds-expressive-modal.md
@@ -14,7 +14,6 @@
 </a>
 <div
   class="bx--modal-container"
-  role="dialog"
   tabindex="-1"
 >
   <div class="bx--modal-content">
@@ -54,7 +53,6 @@
 </a>
 <div
   class="bx--modal-container"
-  role="dialog"
   tabindex="-1"
 >
   <div class="bx--modal-content">
@@ -96,7 +94,6 @@
 </a>
 <div
   class="bx--modal-container"
-  role="dialog"
   tabindex="-1"
 >
   <div class="bx--modal-content">
@@ -136,7 +133,6 @@
 </a>
 <div
   class="bx--modal-container"
-  role="dialog"
   tabindex="-1"
 >
   <div class="bx--modal-content">
@@ -176,7 +172,6 @@
 </a>
 <div
   class="bx--modal-container"
-  role="dialog"
   tabindex="-1"
 >
   <div class="bx--modal-content">

--- a/packages/web-components/tests/snapshots/dds-locale-modal.md
+++ b/packages/web-components/tests/snapshots/dds-locale-modal.md
@@ -14,7 +14,6 @@
 </a>
 <div
   class="bx--modal-container"
-  role="dialog"
   tabindex="-1"
 >
   <div class="bx--modal-content">
@@ -56,7 +55,6 @@
 </a>
 <div
   class="bx--modal-container"
-  role="dialog"
   tabindex="-1"
 >
   <div class="bx--modal-content">
@@ -104,7 +102,6 @@
 </a>
 <div
   class="bx--modal-container"
-  role="dialog"
   tabindex="-1"
 >
   <div class="bx--modal-content">


### PR DESCRIPTION
### Related Ticket(s)

#5669 

### Description

removed unnessary dialog role. The dialog role is already being set in carbon-web-components modal

### Changelog

**Removed**

- dialog role from expressive modal

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
