### PR TITLE
fix(locale-modal): re-focus on region item when navigating within modal

### DIFF
--- a/packages/web-components/src/components/locale-modal/locale-modal.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal.ts
@@ -177,6 +177,13 @@ class DDSLocaleModal extends DDSExpressiveModal {
         (localeSearch as DDSLocaleSearch).reset();
         (localeSearch as HTMLElement).focus();
       }
+
+      // re-focus on first region-item when navigating back to the first modal pane
+      const { selectorPrimaryFocus } = this.constructor as typeof DDSLocaleModal;
+      const activeRegion = this.querySelector(selectorPrimaryFocus);
+      if (activeRegion) {
+        (activeRegion as HTMLElement).focus();
+      }
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

#5847

### Description

This fixes a bug where the current `locale-modal` does not re-focus on the first `region-item` button when a user navigates back to the first pane from the country filter.

https://user-images.githubusercontent.com/909118/117159277-23a66200-ad8e-11eb-82e5-acb18af403d5.mp4



### Changelog

**New**

- add focus state to first geographic `region-item` when navigating back to the first modal pane from search pane


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
