### PR TITLE
fix(card-group): card grid alignment

### DIFF
--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -120,6 +120,13 @@
   // Add Grid Mode Narrow (16px gutter) style.
   :host(#{$dds-prefix}-card-group)[grid-mode='narrow'],
   .#{$prefix}--card-group--narrow {
+    @include carbon--breakpoint('lg') {
+      grid-template-columns: repeat(
+        3,
+        calc((66.66% - 2rem) / 2) calc((66.66% - 2rem) / 2) 33.33%
+      );
+    }
+
     @include carbon--breakpoint('sm') {
       column-gap: $carbon--spacing-05;
     }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5730

### Description

@shixiedesign I can fix the alignment perfectly when the card only includes text. 

The problem happens when the card includes an image. 

From my tests, it's mathematically impossible to make it work unless we add a javascript fix that makes all images inside the card same height. To make the last card's content align with the grid, it needs to be the same width as the top card, which takes 33.333...% of the width. If you substract that width plus the two 16px gutters from 100%, we don't have enough space left to make the other two cards in the same row the same width as the last card, which causes their images to be shorter than the last card. 

I can fix that problem by making them all the same width, but the last card wouldn't hang like the top card and image.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
