### PR TITLE
fix(cta-card): cta-type updating icon in storybook knob

### DIFF
--- a/packages/web-components/src/components/cta/__stories__/cta.stories.ts
+++ b/packages/web-components/src/components/cta/__stories__/cta.stories.ts
@@ -16,7 +16,11 @@ import '../feature-cta-footer';
 import '../text-cta';
 import { classMap } from 'lit-html/directives/class-map';
 import { html } from 'lit-element';
+import ArrowDown20 from 'carbon-web-components/es/icons/arrow--down/20.js';
 import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20.js';
+import Download20 from 'carbon-web-components/es/icons/download/20.js';
+import Launch20 from 'carbon-web-components/es/icons/launch/20.js';
+import PlayOutline20 from 'carbon-web-components/es/icons/play--outline/20.js';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
 import { select } from '@storybook/addon-knobs';
 // eslint-disable-next-line sort-imports
@@ -139,7 +143,11 @@ export const Card = ({ parameters }) => {
         download="${ifNonNull(footerDownload)}"
         href="${ifNonNull(footerHref)}"
       >
-        ${footerCopy || ArrowRight20({ slot: 'icon' })}
+        ${ctaType === 'local' ? footerCopy || ArrowRight20({ slot: 'icon' }) : ''}
+        ${ctaType === 'jump' ? footerCopy || ArrowDown20({ slot: 'icon' }) : ''}
+        ${ctaType === 'external' ? footerCopy || Launch20({ slot: 'icon' }) : ''}
+        ${ctaType === 'download' ? footerCopy || Download20({ slot: 'icon' }) : ''}
+        ${ctaType === 'video' ? footerCopy || PlayOutline20({ slot: 'icon' }) : ''}
       </dds-card-cta-footer>
     </dds-card-cta>
   `;


### PR DESCRIPTION
### Related Ticket(s)

#6010 

### Description

Update CTA-Card story to reflect icon changes when changing storybook cta-type knob

### Changelog

**New**

- added conditions so each type's icon is updated appropriately and card-footer copy still gets rendered. 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
