### PR TITLE
fix(left-nav): add body scroll lock logic to left nav

### DIFF
--- a/packages/web-components/src/components/masthead/left-nav.ts
+++ b/packages/web-components/src/components/masthead/left-nav.ts
@@ -117,8 +117,10 @@ class DDSLeftNav extends StableSelectorMixin(BXSideNav) {
       const { expanded, _startSentinelNode: startSentinelNode, _endSentinelNode: endSentinelNode } = this;
       if (expanded) {
         this._hFocusWrap = focuswrap(this.shadowRoot!, [startSentinelNode, endSentinelNode]);
+        doc?.body?.classList.add(`${prefix}--body__lock-scroll`);
       } else {
         const { selectorNavItemsExpanded } = this.constructor as typeof DDSLeftNav;
+        doc?.body?.classList.remove(`${prefix}--body__lock-scroll`);
 
         this.querySelectorAll(selectorNavItemsExpanded).forEach(ddsLeftNavMenu => {
           (ddsLeftNavMenu as DDSLeftNavMenu).expanded = false;


### PR DESCRIPTION
### Related Ticket(s)

Web component: Dotcom Shell - Hamburger menu open, while user scrolls menu options, close icon not seen for the user. #6026

### Description

Add the `${prefix}--body__lock-scroll` class to the `body` when the `left-nav` is expanded to prevent scrolling on mobile.

### Changelog

**New**

- add body scroll lock logic when the `left-nav` is expanded

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
