### PR TITLE
fix(masthead): switching protocol for ibm logo to https

### DIFF
--- a/packages/react/src/components/Icon/IbmLogo.js
+++ b/packages/react/src/components/Icon/IbmLogo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -39,7 +39,7 @@ const IbmLogo = ({ autoid, logoData, isSearchActive }) => {
           <a // eslint-disable-line
             aria-label="IBM®"
             data-autoid={autoid}
-            href={`http://www.ibm.com${logoData.path}`}
+            href={`https://www.ibm.com${logoData.path}`}
             dangerouslySetInnerHTML={{ __html: logoData.svg }}
           />
         ) : (


### PR DESCRIPTION
### Related Ticket(s)

Refs https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6031

### Description

This switched the protocol for the alternative IBM logo to use the https protocol.

### Changelog

**Changed**

- `IbmLogo`
