### PR TITLE
docs(akamai): switching url for artifacts to akamai domain

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -330,7 +330,7 @@ Masthead.propTypes = {
    * | none               | null      | No navigation                               | `<Masthead />`                      |
    *
    * `Custom` navigation data must follow the same structure and key names as `default`.
-   * See [this](https://www.ibm.com/common/carbon-for-ibm-dotcom/translations/masthead-footer/usen.json) for an example.
+   * See [this](https://1.www.s81c.com/common/carbon-for-ibm-dotcom/translations/masthead-footer/usen.json) for an example.
    */
   navigation: PropTypes.oneOfType([
     PropTypes.string,
@@ -433,7 +433,7 @@ Masthead.propTypes = {
      * | none               | null      | No navigation                               | `<MastheadL1 />`                      |
      *
      * `Custom` navigation data must follow the same structure and key names as `default`.
-     * See [this](https://www.ibm.com/common/carbon-for-ibm-dotcom/translations/masthead-footer/usen.json) for an example.
+     * See [this](https://1.www.s81c.com/common/carbon-for-ibm-dotcom/translations/masthead-footer/usen.json) for an example.
      */
     navigationL1: PropTypes.oneOfType([
       PropTypes.string,

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -159,7 +159,7 @@ For quick start, you can use our pre-built CDN bundle that contains the dotcom s
 <html>
   <head>
     <script type="module">
-      import 'https://www.ibm.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
 
       // The minimum prerequisite to use our service for translation data, etc.
       window.digitalData = {
@@ -208,7 +208,7 @@ The CDN packages are available by NPM tags `latest` (full releases), `next` (lat
 
 ```html
 <script type="module">
-  import 'https://www.ibm.com/common/carbon-for-ibm-dotcom/[VERSION]/ibmdotcom-web-components-dotcom-shell.min.js';
+  import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/[VERSION]/ibmdotcom-web-components-dotcom-shell.min.js';
 </script>
 ```
 
@@ -217,17 +217,17 @@ A tag release would be called as:
 ```html
 <script type="module">
   // latest
-  import 'https://www.ibm.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
+  import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
 </script>
 
 <script type="module">
   // next
-  import 'https://www.ibm.com/common/carbon-for-ibm-dotcom/next/ibmdotcom-web-components-dotcom-shell.min.js';
+  import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/next/ibmdotcom-web-components-dotcom-shell.min.js';
 </script>
 
 <script type="module">
   // beta
-  import 'https://www.ibm.com/common/carbon-for-ibm-dotcom/beta/ibmdotcom-web-components-dotcom-shell.min.js';
+  import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/ibmdotcom-web-components-dotcom-shell.min.js';
 </script>
 ```
 
@@ -236,7 +236,7 @@ A specific release would be called as:
 ```html
 <script type="module">
   // v0.6.0
-  import 'https://www.ibm.com/common/carbon-for-ibm-dotcom/v0.6.0/ibmdotcom-web-components-dotcom-shell.min.js';
+  import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/v0.6.0/ibmdotcom-web-components-dotcom-shell.min.js';
 </script>
 ```
 

--- a/packages/web-components/docs/enable-rtl.md
+++ b/packages/web-components/docs/enable-rtl.md
@@ -37,7 +37,7 @@ module.exports = {
 While we recommend using a module bundler for creating a fully optimized RTL version 
 for your application (as shown in the example above), 
 you can use our pre-built CDN version for evaluation purposes (which comes with the dotcom shell). The pre-built 
-version can be found at `https://www.ibm.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.rtl.min.js`.
+version can be found at `https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.rtl.min.js`.
 
 > 💡 Check our
 > [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl)

--- a/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-handlebars/index.hbs
+++ b/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-handlebars/index.hbs
@@ -16,7 +16,7 @@ LICENSE file in the root directory of this source tree.
       <link rel="alternate" hreflang="{{locale}}" href="{{href}}">
     {{/each}}
     <script type="module">
-      import 'https://www.ibm.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
 
       document.addEventListener('click', event => {
         if (event.target.matches('dds-locale-button')) {

--- a/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl/index.hbs
+++ b/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl/index.hbs
@@ -27,7 +27,7 @@ LICENSE file in the root directory of this source tree.
     <meta charset="UTF-8" />
     <script type="module">
       // Loads the LTR or RTL version of the bundle
-      import 'https://www.ibm.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell{{dirSuffix}}.min.js';
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell{{dirSuffix}}.min.js';
     </script>
     <style type="text/css">
       html, body {

--- a/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn/index.html
+++ b/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn/index.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
     <script type="module">
-      import 'https://www.ibm.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
     </script>
     <style type="text/css">
       html, body {


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

For the CDN artifacts, we should be pointing to the Akamai domain and not ibm.com.

### Changelog

**Changed**

- Various documentation 
