### PR TITLE
feat(Footer): add specific link title to legal link data-autoids

### DIFF
--- a/packages/react/src/components/Footer/LegalNav.js
+++ b/packages/react/src/components/Footer/LegalNav.js
@@ -34,14 +34,22 @@ const LegalNav = ({ links, type, button }) => {
       <nav className={`${prefix}--legal-nav`}>
         <div className={`${prefix}--legal-nav__list ${listStyle}`}>
           <ul className={`${prefix}--legal-nav__holder`}>
-            {links.map(({ title, url }, index) => {
+            {links.map(({ title, titleEnglish, url }, index) => {
               if (!title || !url) {
                 return null;
               }
+
+              const dataTitle = titleEnglish
+                ? titleEnglish
+                    .replace(/[^-a-zA-Z0-9_ ]/g, '')
+                    .replace(/ +/g, '-')
+                    .toLowerCase()
+                : null;
+
               return (
                 <li className={`${prefix}--legal-nav__list-item`} key={index}>
                   <Link
-                    data-autoid={`${stablePrefix}--footer-legal-nav__link`}
+                    data-autoid={`${stablePrefix}--footer-legal-nav__link-${dataTitle}`}
                     className={`${prefix}--footer__link`}
                     href={url}>
                     {title}

--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -299,8 +299,8 @@ class DDSFooterComposite extends ModalRenderMixin(HybridRenderMixin(HostListener
           : ``}
         <dds-legal-nav size="${ifNonNull(size)}">
           ${legalLinks?.map(
-            ({ title, url }) => html`
-              <dds-legal-nav-item href="${ifNonNull(url)}">${title}</dds-legal-nav-item>
+            ({ title, url, titleEnglish }) => html`
+              <dds-legal-nav-item autoid="${ifNonNull(titleEnglish)}" href="${ifNonNull(url)}">${title}</dds-legal-nav-item>
             `
           )}
           <dds-legal-nav-cookie-preferences-placeholder></dds-legal-nav-cookie-preferences-placeholder>

--- a/packages/web-components/src/components/footer/legal-nav-item.ts
+++ b/packages/web-components/src/components/footer/legal-nav-item.ts
@@ -1,16 +1,18 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { customElement } from 'lit-element';
+import { customElement, property } from 'lit-element';
+import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import DDSFooterNavItem from './footer-nav-item';
 
+const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;
 
 /**
@@ -19,6 +21,24 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * @element dds-legal-nav-item
  */
 @customElement(`${ddsPrefix}-legal-nav-item`)
-class DDSLegalNavItem extends DDSFooterNavItem {}
+class DDSLegalNavItem extends DDSFooterNavItem {
+  /**
+   * autoid text.
+   */
+  @property()
+  autoid = '';
+
+  updated() {
+    const { _linkNode: linkNode } = this;
+    if (linkNode) {
+      const dataTitle = this.autoid
+        ?.replace(/[^-a-zA-Z0-9_ ]/g, '')
+        .replace(/ +/g, '-')
+        .toLowerCase();
+      linkNode.classList.add(`${prefix}--footer__link`);
+      linkNode.setAttribute('data-autoid', `${ddsPrefix}--footer-legal-nav__link-${dataTitle}`);
+    }
+  }
+}
 
 export default DDSLegalNavItem;


### PR DESCRIPTION
### Related Ticket(s)

[Beacon for IBM.com] Create audits for the bucket "Legal" in Beacon #5939

### Description

Incorporate the legal link's name into the `data-autoid` so beacon can differentiate between the links and check if they are on the page.

### Changelog

**New**

- add the legal link's name to `data-autoid` based from the `titleEnglish` field in the footer data

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
