### PR TITLE
docs(carousel): fix carousel imports in React-wrapper README instance

### DIFF
--- a/packages/web-components/src/components/carousel/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/carousel/__stories__/README.stories.react.mdx
@@ -18,12 +18,10 @@ Here's a quick example to get you started.
 
 ```javascript
 import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20.js';
-import DDSCard from '@carbon/ibmdotcom-web-components/es/components-react/card/card.js';
-import DDSCardHeading from '@carbon/ibmdotcom-web-components/es/components-react/card/card-heading.js';
-import DDSCarousel from '@carbon/ibmdotcom-web-components/es/components-react/carousel/carousel.js';
-import DDSContentSection from '@carbon/ibmdotcom-web-components/es/components-react/content-section/content-section-leading.js';
-import DDSContentSectionHeading from '@carbon/ibmdotcom-web-components/es/components-react/content-section/content-section-heading.js';
-import DDSContentSectionCopy from '@carbon/ibmdotcom-web-components/es/components-react/content-section/content-section-copy.js';
+import DDSCard from '@carbon/ibmdotcom-web-components/es/components-react/card/card';
+import DDSCardFooter from '@carbon/ibmdotcom-web-components/es/components-react/card/card-footer';
+import DDSCardHeading from '@carbon/ibmdotcom-web-components/es/components-react/card/card-heading';
+import DDSCarousel from '@carbon/ibmdotcom-web-components/es/components-react/carousel/carousel';
 
 function App() {
   return (


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

The carousel react-wrapper documentation includes unnecessary imports that aren't used in the example JS portion and is missing the card footer important needed.

### Changelog

**Removed**

- unnecessary imports and added card-footer import to documentation

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
