### PR TITLE
fix(custom-events): onloadend type defined

### DIFF
--- a/packages/web-components/src/typings/resources.d.ts
+++ b/packages/web-components/src/typings/resources.d.ts
@@ -19,6 +19,12 @@ declare module '*.mdx' {
   };
 }
 
+declare global {
+  interface ElementEventMap {
+    loadend: Event;
+  }
+}
+
 declare module '*.scss';
 declare module '*.svg';
 declare module '*.jpg';


### PR DESCRIPTION
Related Ticket(s)
#5852

Description
I've added a type definition for loadend on the global ElementEventMap, so we fix the error that was blocking Angular 10 development.