### PR TITLE
fix(masthead): menu options blocking items when active

### DIFF
--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -195,6 +195,7 @@
 
   .#{$prefix}--header__menu-title[role='menuitem'][aria-expanded='true'] {
     background-color: $ui-01;
+    z-index: 0;
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

#5949 

### Description

when masthead menu items open they cover the logo and other masthead iteams outside of the 

<img width="921" alt="Screen Shot 2021-05-24 at 1 16 56 PM" src="https://user-images.githubusercontent.com/20210594/119402832-59a27c00-bc92-11eb-933b-20da9827a6f7.png">

### Changelog

**New**

- z-index: 0 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
