### PR TITLE
fix(code-snippet): expressive code snippet carbon 10.31.0 update adjustments

### DIFF
--- a/packages/styles/scss/themes/expressive/components/_code-snippet.scss
+++ b/packages/styles/scss/themes/expressive/components/_code-snippet.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,16 +18,23 @@
   // Single Line Snippet
   .#{$prefix}--snippet--single {
     height: $carbon--spacing-09;
+
+    #{$prefix}--snippet-container {
+      height: 100%;
+      padding-left: $spacing-05;
+    }
+
+    .bx--snippet__overflow-indicator--right {
+      right: $spacing-09;
+    }
   }
-  .#{$prefix}--snippet--single .#{$prefix}--snippet-container {
-    height: 100%;
-    padding: 0;
-  }
+
   button.#{$prefix}--btn.#{$prefix}--snippet-btn--expand {
     padding: 0.375rem 0.8125rem;
   }
+
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-button {
-    height: $carbon--spacing-09;
-    width: $carbon--spacing-09;
+    height: $spacing-09;
+    width: $spacing-09;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

[Carbon expressive] Code snippet single line off #5611

### Description

Adjustment to left padding and hover state

## Left padding
![Screen Shot 2021-03-24 at 6 00 04 PM](https://user-images.githubusercontent.com/45692622/112389327-f3699f00-8cca-11eb-8b81-c1f1244e7930.png)
**Carbon reference** 
![Screen Shot 2021-03-25 at 9 40 18 AM](https://user-images.githubusercontent.com/45692622/112482198-2b65f600-8d4e-11eb-8d09-06015bb9c909.png)

## Hover state
![Screen Shot 2021-03-24 at 6 00 10 PM](https://user-images.githubusercontent.com/45692622/112482024-01accf00-8d4e-11eb-977c-13037bb46831.png)
**Carbon reference**
![Screen Shot 2021-03-25 at 9 40 53 AM](https://user-images.githubusercontent.com/45692622/112482254-3d479900-8d4e-11eb-8b0e-917ef4c6ece1.png)

### Changelog

**Changed**

- adjust `padding-left` of single code snippet
- adjust overflow-right-indicator positioning

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
