### PR TITLE
fix(utilities): use util package for deprecate instead of relative path

### DIFF
--- a/packages/web-components/src/components/feature-card-block-large/feature-card-block-large.ts
+++ b/packages/web-components/src/components/feature-card-block-large/feature-card-block-large.ts
@@ -10,7 +10,7 @@
 import { customElement, html } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import deprecate from '../../../../utilities/src/utilities/deprecate/deprecate';
+import deprecate from '@carbon/ibmdotcom-utilities/es/utilities/deprecate/deprecate.js';
 import DDSFeatureCard from '../feature-card/feature-card';
 import '../image/image';
 import styles from './feature-card-block-large.scss';

--- a/packages/web-components/src/components/feature-card-block-medium/feature-card-block-medium.ts
+++ b/packages/web-components/src/components/feature-card-block-medium/feature-card-block-medium.ts
@@ -10,7 +10,7 @@
 import { customElement, html } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import deprecate from '../../../../utilities/src/utilities/deprecate/deprecate';
+import deprecate from '@carbon/ibmdotcom-utilities/es/utilities/deprecate/deprecate.js';
 import DDSFeatureCard from '../feature-card/feature-card';
 import styles from './feature-card-block-medium.scss';
 


### PR DESCRIPTION
### Related Ticket(s)

Refs https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6236

### Description

use the utilities package instead of relative path

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
