### PR TITLE
chore(cloud-foundry): updating manifest configs to force https

### DIFF
--- a/packages/react/manifest-canary.yml
+++ b/packages/react/manifest-canary.yml
@@ -4,6 +4,7 @@ applications:
     path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-react-canary.mybluemix.net
 

--- a/packages/react/manifest-experimental.yml
+++ b/packages/react/manifest-experimental.yml
@@ -4,6 +4,7 @@ applications:
     path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-react-experimental.mybluemix.net
 

--- a/packages/react/manifest-expressive.yml
+++ b/packages/react/manifest-expressive.yml
@@ -4,6 +4,7 @@ applications:
     path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-react-expressive.mybluemix.net
 

--- a/packages/react/manifest-rtl.yml
+++ b/packages/react/manifest-rtl.yml
@@ -4,6 +4,7 @@ applications:
     path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-react-rtl.mybluemix.net
 

--- a/packages/react/manifest-staging.yml
+++ b/packages/react/manifest-staging.yml
@@ -4,6 +4,7 @@ applications:
     path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-react-staging.mybluemix.net
 

--- a/packages/react/manifest.yml
+++ b/packages/react/manifest.yml
@@ -4,6 +4,7 @@ applications:
     path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-react.mybluemix.net
 

--- a/packages/services/manifest.yml
+++ b/packages/services/manifest.yml
@@ -4,6 +4,7 @@ applications:
     path: ./docs
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-services.mybluemix.net
 

--- a/packages/styles/manifest.yml
+++ b/packages/styles/manifest.yml
@@ -4,6 +4,7 @@ applications:
     path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: carbon-expressive.mybluemix.net
 

--- a/packages/utilities/manifest.yml
+++ b/packages/utilities/manifest.yml
@@ -4,6 +4,7 @@ applications:
     path: ./docs
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-utilities.mybluemix.net
 

--- a/packages/web-components/manifest-canary.yml
+++ b/packages/web-components/manifest-canary.yml
@@ -4,5 +4,6 @@ applications:
   path: ./storybook-static
   memory: 64M
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  force_https: true
   routes:
     - route: ibmdotcom-web-components-canary.mybluemix.net

--- a/packages/web-components/manifest-experimental.yml
+++ b/packages/web-components/manifest-experimental.yml
@@ -4,5 +4,6 @@ applications:
   path: ./storybook-static
   memory: 64M
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  force_https: true
   routes:
     - route: ibmdotcom-web-components-experimental.mybluemix.net

--- a/packages/web-components/manifest-react.yml
+++ b/packages/web-components/manifest-react.yml
@@ -4,5 +4,6 @@ applications:
   path: ./storybook-static-react
   memory: 64M
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  force_https: true
   routes:
     - route: ibmdotcom-web-components-react.mybluemix.net

--- a/packages/web-components/manifest-rtl.yml
+++ b/packages/web-components/manifest-rtl.yml
@@ -4,5 +4,6 @@ applications:
   path: ./storybook-static
   memory: 64M
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  force_https: true
   routes:
     - route: ibmdotcom-web-components-rtl.mybluemix.net

--- a/packages/web-components/manifest-staging.yml
+++ b/packages/web-components/manifest-staging.yml
@@ -4,5 +4,6 @@ applications:
   path: ./storybook-static
   memory: 64M
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  force_https: true
   routes:
     - route: ibmdotcom-web-components-staging.mybluemix.net

--- a/packages/web-components/manifest.yml
+++ b/packages/web-components/manifest.yml
@@ -4,5 +4,6 @@ applications:
   path: ./storybook-static
   memory: 64M
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  force_https: true
   routes:
     - route: ibmdotcom-web-components.mybluemix.net


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This will force https for all of our cloud foundry apps for `Carbon for IBM.com`.

### Changelog

**Changed**

- various manifest files for cloud foundry
