### PR TITLE
fix(leadspace): breadcrumb style import

### DIFF
--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -438,31 +438,8 @@ $btn-min-width: 26;
     max-width: rem(640px);
   }
 
-  :host(#{$dds-prefix}-leadspace)
-    ::slotted([slot='navigation']:not(#{$dds-prefix}-tag-group)) {
-    padding-bottom: $spacing-05;
-  }
-
   :host(#{$dds-prefix}-leadspace) ::slotted(#{$dds-prefix}-tag-group) {
     padding-bottom: $spacing-03;
-  }
-
-  :host(#{$dds-prefix}-breadcrumb) {
-    @extend :host(#{$prefix}-breadcrumb);
-  }
-
-  :host(#{$dds-prefix}-breadcrumb-item) {
-    @extend :host(#{$prefix}-breadcrumb-item);
-
-    display: inline;
-  }
-
-  :host(#{$dds-prefix}-breadcrumb-item:last-of-type)::after {
-    @extend :host(#{$prefix}-breadcrumb-item:last-of-type)::after;
-  }
-
-  :host(#{$dds-prefix}-breadcrumb-link) {
-    @extend :host(#{$prefix}-breadcrumb-link);
   }
 
   :host(#{$dds-prefix}-breadcrumb-link[aria-current='page']) .#{$prefix}--link {

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -10,7 +10,6 @@
 @import '../buttongroup/_buttongroup';
 @import '../image/image';
 @import '../tag-group/tag-group';
-@import 'carbon-web-components/scss/components/breadcrumb/breadcrumb';
 
 $btn-min-width: 26;
 
@@ -439,14 +438,17 @@ $btn-min-width: 26;
     max-width: rem(640px);
   }
 
+  :host(#{$dds-prefix}-leadspace)
+    ::slotted([slot='navigation']:not(#{$dds-prefix}-tag-group)) {
+    padding-bottom: $spacing-05;
+  }
+
   :host(#{$dds-prefix}-leadspace) ::slotted(#{$dds-prefix}-tag-group) {
     padding-bottom: $spacing-03;
   }
 
   :host(#{$dds-prefix}-breadcrumb) {
     @extend :host(#{$prefix}-breadcrumb);
-
-    padding-bottom: $spacing-05;
   }
 
   :host(#{$dds-prefix}-breadcrumb-item) {

--- a/packages/web-components/src/components/leadspace/leadspace.scss
+++ b/packages/web-components/src/components/leadspace/leadspace.scss
@@ -7,6 +7,7 @@
 
 @import '@carbon/ibmdotcom-styles/scss/globals/vars';
 @import '@carbon/ibmdotcom-styles/scss/components/leadspace/leadspace';
+@import 'carbon-web-components/scss/components/breadcrumb/breadcrumb';
 
 :host(#{$dds-prefix}-leadspace) {
   display: block;

--- a/packages/web-components/src/components/leadspace/leadspace.scss
+++ b/packages/web-components/src/components/leadspace/leadspace.scss
@@ -32,3 +32,23 @@
     }
   }
 }
+
+:host(#{$dds-prefix}-breadcrumb) {
+  @extend :host(#{$prefix}-breadcrumb);
+
+  padding-bottom: $spacing-05;
+}
+
+:host(#{$dds-prefix}-breadcrumb-item) {
+  @extend :host(#{$prefix}-breadcrumb-item);
+
+  display: inline;
+}
+
+:host(#{$dds-prefix}-breadcrumb-item:last-of-type)::after {
+  @extend :host(#{$prefix}-breadcrumb-item:last-of-type)::after;
+}
+
+:host(#{$dds-prefix}-breadcrumb-link) {
+  @extend :host(#{$prefix}-breadcrumb-link);
+}


### PR DESCRIPTION
### Related Ticket(s)

#6237

### Description

moved carbon's breadcrumb web component import to web component styles. breaking nextjs template

### Changelog

**Changed**

- moved breadcrumb import


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
