### PR TITLE
fix(e2e): fixing content-block-card-static e2e build test

### DIFF
--- a/packages/web-components/examples/codesandbox/components/content-block-card-static/.sassrc
+++ b/packages/web-components/examples/codesandbox/components/content-block-card-static/.sassrc
@@ -1,3 +1,3 @@
 {
-  "includePaths": ["node_modules"],
+  "includePaths": ["node_modules", "../../node_modules"],
 }

--- a/packages/web-components/examples/codesandbox/components/content-block-card-static/package.json
+++ b/packages/web-components/examples/codesandbox/components/content-block-card-static/package.json
@@ -6,8 +6,9 @@
   "license": "Apache-2",
   "main": "index.html",
   "scripts": {
+    "clean": "rimraf node_modules dist .cache",
     "start": "NODE_ENV=* parcel index.html --port=9000 --no-hmr",
-    "build": "parcel build index.html --no-minify"
+    "build": "parcel build index.html --no-minify --public-url ./"
   },
   "dependencies": {
     "@carbon/ibmdotcom-web-components": "canary",
@@ -16,7 +17,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",
+    "carbon-components": "^10.36.0",
     "parcel-bundler": "1.12.3",
+    "rimraf": "^3.0.2",
     "sass": "^1.32.13"
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The content-block-card-static example was using the older format for the examples code, this fixes it so that the e2e build can run properly.

### Changelog

**Changed**

- content-block-card-static example application setup