### PR TITLE
chore(cloud-masthead): update styles flex value

### DIFF
--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
@@ -180,7 +180,7 @@
 :host(#{$dds-prefix}-cloud-megamenu-category-link-group) {
   display: flex;
   flex-flow: wrap;
-  justify-content: start;
+  justify-content: flex-start;
 }
 
 :host(#{$dds-prefix}-cloud-megamenu-category-link) {


### PR DESCRIPTION
### Description

Removes shorthand flex value causing build warnings.

![image](https://user-images.githubusercontent.com/909118/121060018-1961f400-c790-11eb-83d6-8a3323bf2d1d.png)


### Changelog


**Changed**

- `start` to `flex-start`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
