### PR TITLE
fix(back-to-top): fix button right padding

### DIFF
--- a/packages/styles/scss/components/back-to-top/_back-to-top.scss
+++ b/packages/styles/scss/components/back-to-top/_back-to-top.scss
@@ -15,6 +15,7 @@
     bottom: 0;
     display: flex;
     padding-bottom: $carbon--spacing-05;
+    padding-right: $carbon--spacing-05;
     outline: none;
 
     .#{$prefix}--back-to-top__btn {


### PR DESCRIPTION
### Related Ticket(s)

#6303

### Description

Fixes incorrect spacing in `back-to-top` button.

### Changelog

**New**

- adds 16px to `padding-right`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
