### PR TITLE
fix(storybook): adjust dotcomshell and masthead knobs for platform

### DIFF
--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -895,6 +895,7 @@ export default {
     knobs: {
       escapeHTML: false,
       DotcomShell: ({ groupId }) => ({
+        platform: select('Platform (platform)', { none: null, platform: platformData.name }, null, groupId),
         hasProfile: boolean('Show profile in masthead (profile)', true, groupId),
         hasSearch: boolean('Show search in masthead (search)', true, groupId),
         searchPlaceholder: textNullable('Search placeholder (searchPlaceholder)', inPercy() ? ' ' : 'Search all of IBM', groupId),

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -67,14 +67,6 @@ const platformData = {
   url: 'https://www.ibm.com/cloud',
 };
 
-/**
- * l1 platform data
- */
-const l1PlatformData = {
-  name: 'Stock Charts',
-  url: 'https://www.example.com',
-};
-
 const footerSizes = {
   Default: FOOTER_SIZE.REGULAR,
   [`Short (${FOOTER_SIZE.SHORT})`]: FOOTER_SIZE.SHORT,
@@ -712,7 +704,6 @@ withMicroFooterLanguageOnly.story = {
 
 export const withL1 = ({ parameters }) => {
   const {
-    platform,
     hasProfile,
     userStatus,
     navLinks,
@@ -734,8 +725,6 @@ export const withL1 = ({ parameters }) => {
     ${useMock
       ? html`
           <dds-dotcom-shell-composite
-            platform="${ifNonNull(platform.name)}"
-            platform-url="${ifNonNull(platform.url)}"
             language="${ifNonNull(language)}"
             lang-display="${ifNonNull(langDisplay)}"
             user-status="${ifNonNull(userStatus)}"
@@ -757,8 +746,6 @@ export const withL1 = ({ parameters }) => {
         `
       : html`
           <dds-dotcom-shell-container
-            platform="${ifNonNull(platform.name)}"
-            platform-url="${ifNonNull(platform.url)}"
             language="${ifNonNull(language)}"
             lang-display="${ifNonNull(langDisplay)}"
             user-status="${ifNonNull(userStatus)}"
@@ -783,7 +770,6 @@ withL1.story = {
   parameters: {
     knobs: {
       DotcomShell: ({ groupId }) => ({
-        platform: l1PlatformData,
         hasProfile: boolean('show the profile functionality (has-profile)', true, groupId),
         hasSearch: boolean('show the search functionality (has-search)', true, groupId),
         searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', inPercy() ? ' ' : 'Search all of IBM', groupId),

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -35,14 +35,6 @@ const platformData = {
   url: 'https://www.ibm.com/cloud',
 };
 
-/**
- * l1 platform data
- */
-const l1PlatformData = {
-  name: 'Stock Charts',
-  url: 'https://www.example.com',
-};
-
 export const Default = ({ parameters }) => {
   const { platform, hasProfile, hasSearch, selectedMenuItem, searchPlaceholder, userStatus, navLinks } =
     parameters?.props?.MastheadComposite ?? {};
@@ -196,7 +188,7 @@ withPlatform.story = {
 };
 
 export const withL1 = ({ parameters }) => {
-  const { platform, selectedMenuItem, userStatus, navLinks, hasProfile, hasSearch, searchPlaceholder } =
+  const { selectedMenuItem, userStatus, navLinks, hasProfile, hasSearch, searchPlaceholder } =
     parameters?.props?.MastheadComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
@@ -206,8 +198,6 @@ export const withL1 = ({ parameters }) => {
     ${useMock
       ? html`
           <dds-masthead-composite
-            platform="${ifNonNull(platform.name)}"
-            platform-url="${ifNonNull(platform.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             user-status="${ifNonNull(userStatus)}"
@@ -221,8 +211,6 @@ export const withL1 = ({ parameters }) => {
         `
       : html`
           <dds-masthead-container
-            platform="${ifNonNull(platform.name)}"
-            platform-url="${ifNonNull(platform.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             ?has-profile="${hasProfile}"
@@ -238,7 +226,6 @@ withL1.story = {
   parameters: {
     knobs: {
       MastheadComposite: ({ groupId }) => ({
-        platform: l1PlatformData,
         hasProfile: boolean('show the profile functionality (has-profile)', true, groupId),
         hasSearch: boolean('show the search functionality (has-search)', true, groupId),
         searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', inPercy() ? '' : 'Search all of IBM', groupId),


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Add `platform` knob to DotcomShell story - this will prevent us from seeing the `[Object Object]` bug observed when going from L1 story to default. 

Removed the `L1PlatfromData` from the Masthead/DotcomShell L1 story as it is already pulling that data from the data file. There is no need to pass in `platform` and `platform-url` attributes to that particular story as those attributes will not be used. 

### Changelog

**New**

- `platform` knob in DotcomShell WC story, to toggle showing platform name

**Removed**

- unnecessarily passing in the `platform` attributes from Masthead/DotcomShell L1 story as it is already rendering the L1 platform from data file.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
