### PR TITLE
fix(card-group): updated border color

### DIFF
--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -119,10 +119,10 @@
   :host(#{$dds-prefix}-card-group-item),
   .#{$prefix}--card-group__cards__col {
     padding: 0;
-    background: $ui-04;
+    background: $decorative-01;
 
-    border-right: 1px solid $ui-04;
-    border-top: 1px solid $ui-04;
+    border-right: 1px solid $decorative-01;
+    border-top: 1px solid $decorative-01;
 
     &:last-of-type {
       border-right: 0;
@@ -170,13 +170,13 @@
     ::slotted(#{$dds-prefix}-card-group-item),
     .#{$prefix}--card-group__cards__col {
       padding: 0;
-      border: 1px solid $ui-04;
+      border: 1px solid $decorative-01;
       border-bottom: 0;
     }
 
     ::slotted(#{$dds-prefix}-card-group-item:last-of-type),
     .#{$prefix}--card-group__cards__col:last-of-type {
-      border-bottom: 1px solid $ui-04;
+      border-bottom: 1px solid $decorative-01;
       padding-right: 0;
     }
 
@@ -191,7 +191,7 @@
       ::slotted(#{$dds-prefix}-card-group-item:last-of-type),
       .#{$prefix}--card-group__cards__col:nth-child(2n),
       .#{$prefix}--card-group__cards__col:last-of-type {
-        border-right: 1px solid $ui-04;
+        border-right: 1px solid $decorative-01;
       }
 
       ::slotted(#{$dds-prefix}-card-group-item:last-of-type:not(:nth-child(2n))),
@@ -201,7 +201,7 @@
 
       ::slotted(#{$dds-prefix}-card-group-item:nth-last-of-type(-n + 2)),
       .#{$prefix}--card-group__cards__col:nth-last-of-type(-n + 2) {
-        border-bottom: 1px solid $ui-04;
+        border-bottom: 1px solid $decorative-01;
         height: calc(100% + 1px);
       }
     }
@@ -220,13 +220,13 @@
       ::slotted(#{$dds-prefix}-card-group-item:last-of-type),
       .#{$prefix}--card-group__cards__col:nth-child(3n),
       .#{$prefix}--card-group__cards__col:last-of-type {
-        border-right: 1px solid $ui-04;
+        border-right: 1px solid $decorative-01;
         width: calc(100% + 1px);
       }
 
       ::slotted(#{$dds-prefix}-card-group-item:nth-last-of-type(-n + 3)),
       .#{$prefix}--card-group__cards__col:nth-last-of-type(-n + 3) {
-        border-bottom: 1px solid $ui-04;
+        border-bottom: 1px solid $decorative-01;
         height: calc(100% + 1px);
       }
 


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6312

### Description

Changed border color from `ui-04` to `decorative-01`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
