### PR TITLE
fix(masthead-l1): match data structure to react and reuse general `renderNavItems` function

### DIFF
--- a/packages/services-store/src/types/translateAPI.ts
+++ b/packages/services-store/src/types/translateAPI.ts
@@ -87,17 +87,7 @@ export interface MastheadLink {
 export interface MastheadL1 {
   title: string;
   url?: string;
-  menuItems?: MastheadL1Item[];
-}
-/**
- * An item for MastheadL1
- */
-
-export interface MastheadL1Item {
-  title: string;
-  titleEnglish?: string;
-  url?: string;
-  menuItems?: MastheadL1Item[];
+  menuItems?: MastheadLink[];
 }
 
 /**

--- a/packages/web-components/src/components/masthead/__stories__/links.ts
+++ b/packages/web-components/src/components/masthead/__stories__/links.ts
@@ -53,31 +53,312 @@ const l1Data: MastheadL1 = {
   url: 'https://example.com',
   menuItems: [
     {
-      title: 'Products & Solutions',
-      titleEnglish: 'Products & Solutions',
-      url: 'https://example.com',
-    },
-    {
-      title: 'Services & Consulting',
-      titleEnglish: 'Services & Consulting',
-      url: 'https://example.com',
-      menuItems: [
+      title: 'Lorem ipsum dolor sit amet',
+      titleEnglish: 'Lorem ipsum dolor sit amet',
+      url: '',
+      hasMenu: true,
+      hasMegapanel: false,
+      menuSections: [
         {
-          title: 'About IBM',
-          titleEnglish: 'About IBM',
-          url: 'https://example.com',
-        },
-        {
-          title: 'Partners',
-          titleEnglish: 'Partners',
-          url: 'https://example.com',
-        },
-        {
-          title: 'IBM Research',
-          titleEnglish: 'IBM Research',
-          url: 'https://example.com',
+          heading: 'Explore',
+          menuItems: [
+            {
+              title: 'Link 1',
+              url: '',
+              megapanelContent: {
+                headingTitle: '',
+                headingUrl: '',
+                description: '',
+                quickLinks: {
+                  title: 'Title',
+                  links: [
+                    {
+                      title: 'Subnav 1',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 2',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 3',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 4',
+                      url: '',
+                    },
+                  ],
+                },
+                feature: {
+                  heading: '',
+                  imageUrl: '',
+                  linkTitle: '',
+                  linkUrl: '',
+                },
+              },
+            },
+          ],
         },
       ],
+    },
+    {
+      title: 'Consectetur adipiscing elit',
+      titleEnglish: 'Consectetur adipiscing elit',
+      url: '',
+      hasMenu: true,
+      menuSections: [
+        {
+          heading: '',
+          menuItems: [
+            {
+              title: 'Link 2',
+              url: '',
+              megapanelContent: {
+                headingTitle: 'Services',
+                headingUrl: 'https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn',
+                description: 'Reimagine your business, designing and building the platforms necessary for growth',
+                quickLinks: {
+                  title: 'Quicklinks',
+                  links: [
+                    {
+                      title: 'Subnav 1',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 2',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 3',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 4',
+                      url: '',
+                    },
+                  ],
+                },
+                feature: {
+                  heading: 'IBM Services, your Digital Reinvention â„¢ partner',
+                  imageUrl: 'https://www.ibm.com/images/portal/U609055Q90660U49/windmills.jpg',
+                  linkTitle: 'Explore all our business consulting and technology services',
+                  linkUrl: 'https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn',
+                },
+              },
+            },
+            {
+              title: 'Financing',
+              url: 'https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn',
+              megapanelContent: {
+                headingTitle: 'Financing',
+                headingUrl: 'https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn',
+                description: 'Funding options that fit your business',
+                quickLinks: {
+                  title: 'Quicklinks',
+                  links: [
+                    {
+                      title: 'Subnav 1',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 2',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 3',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 4',
+                      url: '',
+                    },
+                  ],
+                },
+                feature: {
+                  heading: 'Cloud financing strategies that work for your business',
+                  imageUrl: 'https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1',
+                  linkTitle: 'Committed to cloud? Make the most of your cash flow.',
+                  linkUrl: 'https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Nulla quis sem at nibh elementum imperdiet',
+      titleEnglish: 'Nulla quis sem at nibh elementum imperdiet',
+      url: 'https://www.ibm.com/industries?lnk=min',
+      hasMenu: false,
+      hasMegapanel: false,
+      menuSections: [],
+    },
+    {
+      title: 'Fusce nec tellus sed augue semper porta',
+      titleEnglish: 'Fusce nec tellus sed augue semper porta',
+      url: '',
+      hasMenu: true,
+      hasMegapanel: false,
+      menuSections: [
+        {
+          heading: '',
+          menuItems: [
+            {
+              title: 'IBM Developer',
+              url: 'https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn',
+              megapanelContent: {
+                headingTitle: 'IBM Developer',
+                headingUrl: 'https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn',
+                description: '',
+                quickLinks: {
+                  title: 'Quicklinks',
+                  links: [
+                    {
+                      title: 'Subnav 1',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 2',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 3',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 4',
+                      url: '',
+                    },
+                  ],
+                },
+                feature: {
+                  heading: 'IBM Developer newsletters',
+                  imageUrl: 'https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg',
+                  linkTitle: 'Technical info on popular software development topics, including AI, Blockchain, Java and more',
+                  linkUrl: 'https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn',
+                },
+              },
+            },
+            {
+              title: 'Blockchain',
+              url: 'https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn',
+              megapanelContent: {
+                headingTitle: 'Blockchain',
+                headingUrl: 'https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn',
+                description: '',
+                quickLinks: {
+                  title: 'Quicklinks',
+                  links: [
+                    {
+                      title: 'Subnav 1',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 2',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 3',
+                      url: '',
+                    },
+                    {
+                      title: 'Subnav 4',
+                      url: '',
+                    },
+                  ],
+                },
+                feature: {
+                  heading: 'Blockchain 101',
+                  imageUrl: 'https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3',
+                  linkTitle:
+                    'Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan',
+                  linkUrl:
+                    'https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn',
+                },
+              },
+            },
+            {
+              title: 'Containers',
+              url: 'https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn',
+              megapanelContent: {
+                headingTitle: 'Containers',
+                headingUrl: 'https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn',
+                description: '',
+                quickLinks: {
+                  title: 'Quicklinks',
+                  links: [
+                    {
+                      title: 'Code patterns',
+                      url: 'https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn',
+                    },
+                    {
+                      title: 'Tutorials',
+                      url: 'https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn',
+                    },
+                    {
+                      title: 'Events',
+                      url: 'https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn',
+                    },
+                  ],
+                },
+                feature: {
+                  heading: 'Make sense of Kubernetes',
+                  imageUrl: 'https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2',
+                  linkTitle: 'Deploy a simple Python application with Kubernetes',
+                  linkUrl: 'https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn',
+                },
+              },
+            },
+            {
+              title: 'Analytics',
+              url: 'https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn',
+              megapanelContent: {
+                headingTitle: 'Analytics',
+                headingUrl: 'https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn',
+                description: '',
+                quickLinks: {
+                  title: 'Quicklinks',
+                  links: [
+                    {
+                      title: 'Code patterns',
+                      url: 'https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn',
+                    },
+                    {
+                      title: 'Tutorials',
+                      url: 'https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn',
+                    },
+                    {
+                      title: 'Events',
+                      url: 'https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn',
+                    },
+                    {
+                      title: 'Developer community',
+                      url: 'https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn',
+                    },
+                  ],
+                },
+                feature: {
+                  heading: 'Train your data no matter where it lives',
+                  imageUrl: 'https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg',
+                  linkTitle: 'Easily and securely connect to your data source for initial model training and continuous learning',
+                  linkUrl:
+                    'https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Sed cursus ante dapibus diam',
+      titleEnglish: 'Sed cursus ante dapibus diam',
+      url: 'https://www.ibm.com/support/home/?lnk=msu_usen',
+      hasMenu: false,
+      hasMegapanel: false,
+      menuSections: [],
     },
   ],
 };

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -166,8 +166,7 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
           : html`
               <dds-left-nav-name href="${ifNonNull(platformUrl)}">${platform}</dds-left-nav-name>
             `}
-        ${l1Data ? undefined : this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV })}
-        ${l1Data ? this._renderL1Items({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV }) : undefined}
+        ${this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV, hasL1: !!l1Data })}
         ${authenticated
           ? null
           : html`
@@ -200,7 +199,7 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
           ? undefined
           : html`
               <dds-top-nav menu-bar-label="${ifNonNull(menuBarAssistiveText)}">
-                ${this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.TOP_NAV })}
+                ${this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.TOP_NAV, hasL1: false })}
               </dds-top-nav>
             `}
         <dds-masthead-search-composite

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -98,7 +98,9 @@ class DDSMastheadComposite extends LitElement {
           : html`
               <dds-masthead-l1-name title="${title}" aria-selected="${!selectedMenuItem}" url="${url}"></dds-masthead-l1-name>
             `}
-        ${this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.TOP_NAV, hasL1: true })}
+        <dds-top-nav-l1
+          >${this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.TOP_NAV, hasL1: true })}</dds-top-nav-l1
+        >
       </dds-masthead-l1>
     `;
   }

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -82,86 +82,6 @@ export enum NAV_ITEMS_RENDER_TARGET {
 @customElement(`${ddsPrefix}-masthead-composite`)
 class DDSMastheadComposite extends LitElement {
   /**
-   * Renders the L1 Items
-   *
-   * @param options The options.
-   * @param [options.selectedMenuItem] The selected nav item.
-   * @param options.target The target of rendering navigation items.
-   */
-  protected _renderL1Items({ selectedMenuItem, target }: { selectedMenuItem?: string; target: NAV_ITEMS_RENDER_TARGET }) {
-    if (!this.l1Data) return undefined;
-    const { menuItems } = this.l1Data;
-    if (menuItems) {
-      return target === NAV_ITEMS_RENDER_TARGET.TOP_NAV
-        ? html`
-            <dds-top-nav-l1>
-              ${menuItems.map((elem, i) => {
-                const selected = selectedMenuItem && elem.titleEnglish === selectedMenuItem;
-                return elem.menuItems
-                  ? html`
-                      <dds-top-nav-menu
-                        ?active="${selected}"
-                        menu-label="${elem.title}"
-                        trigger-content="${elem.title}"
-                        data-autoid="${ddsPrefix}--masthead__l1-nav--nav${i}"
-                      >
-                        ${elem.menuItems.map(
-                          (item, j) => html`
-                            <dds-top-nav-menu-item
-                              href="${item.url}"
-                              title="${item.title}"
-                              data-autoid="${ddsPrefix}--masthead__l1-nav--subnav-col${i}-item${j}"
-                            ></dds-top-nav-menu-item>
-                          `
-                        )}
-                      </dds-top-nav-menu>
-                    `
-                  : html`
-                      <dds-top-nav-item
-                        ?active="${selected}"
-                        href="${elem.url}"
-                        title="${elem.title}"
-                        data-autoid="${ddsPrefix}--masthead__l1-nav--nav${i}"
-                      ></dds-top-nav-item>
-                    `;
-              })}
-            </dds-top-nav-l1>
-          `
-        : menuItems.map((elem, i) => {
-            const selected = selectedMenuItem && elem.titleEnglish === selectedMenuItem;
-            return elem.menuItems
-              ? html`
-                  <dds-left-nav-menu
-                    ?active="${selected}"
-                    title="${elem.title}"
-                    data-autoid="${ddsPrefix}--masthead__l1-sidenav--nav${i}"
-                  >
-                    ${elem.menuItems.map(
-                      (item, j) => html`
-                        <dds-left-nav-menu-item
-                          href="${item.url}"
-                          title="${item.title}"
-                          data-autoid="${ddsPrefix}--masthead__l1-sidenav--subnav-col${i}-item${j}"
-                        ></dds-left-nav-menu-item>
-                      `
-                    )}
-                  </dds-left-nav-menu>
-                `
-              : html`
-                  <dds-left-nav-item
-                    ?active="${selected}"
-                    href="${elem.url}"
-                    title="${elem.title}"
-                    data-autoid="${ddsPrefix}--masthead__l1-sidenav--nav${i}"
-                  ></dds-left-nav-item>
-                `;
-          });
-    }
-
-    return undefined;
-  }
-
-  /**
    * Renders L1 menu based on l1Data
    *
    * @param [options] The options.
@@ -178,7 +98,7 @@ class DDSMastheadComposite extends LitElement {
           : html`
               <dds-masthead-l1-name title="${title}" aria-selected="${!selectedMenuItem}" url="${url}"></dds-masthead-l1-name>
             `}
-        ${this._renderL1Items({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.TOP_NAV })}
+        ${this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.TOP_NAV, hasL1: true })}
       </dds-masthead-l1>
     `;
   }
@@ -359,11 +279,24 @@ class DDSMastheadComposite extends LitElement {
    * @param options.target The target of rendering navigation items.
    * @returns The nav items.
    */
-  protected _renderNavItems({ selectedMenuItem, target }: { selectedMenuItem?: string; target: NAV_ITEMS_RENDER_TARGET }) {
-    const { navLinks } = this;
-    return !navLinks
+  protected _renderNavItems({
+    selectedMenuItem,
+    target,
+    hasL1,
+  }: {
+    selectedMenuItem?: string;
+    target: NAV_ITEMS_RENDER_TARGET;
+    hasL1: boolean;
+  }) {
+    const { navLinks, l1Data } = this;
+    let menu: MastheadLink[] | undefined = navLinks;
+    const autoid = `${ddsPrefix}--masthead__${l1Data?.menuItems ? 'l1' : 'l0'}`;
+    if (hasL1) {
+      menu = l1Data?.menuItems;
+    }
+    return !menu
       ? undefined
-      : navLinks.map((link, i) => {
+      : menu.map((link, i) => {
           const { menuSections = [], title, titleEnglish, url } = link;
           const selected = selectedMenuItem && titleEnglish === selectedMenuItem;
           let sections;
@@ -382,18 +315,19 @@ class DDSMastheadComposite extends LitElement {
                       <dds-top-nav-menu-item
                         href="${menuItemUrl}"
                         title="${menuItemTitle}"
-                        data-autoid="${ddsPrefix}--masthead__l0-nav--subnav-col${i}-item${j}"
+                        data-autoid="${autoid}-nav--subnav-col${i}-item${j}"
                       ></dds-top-nav-menu-item>
                     `
                   : html`
                       <dds-left-nav-menu-item
                         href="${menuItemUrl}"
                         title="${menuItemTitle}"
-                        data-autoid="${ddsPrefix}--masthead__l0-sidenav--subnav-col${i}-item${j}"
+                        data-autoid="${autoid}-sidenav--subnav-col${i}-item${j}"
                       ></dds-left-nav-menu-item>
                     `
               );
           }
+          console.log('sections', sections);
           if (target === NAV_ITEMS_RENDER_TARGET.TOP_NAV) {
             if (sections.length === 0) {
               return html`
@@ -401,7 +335,7 @@ class DDSMastheadComposite extends LitElement {
                   ?active="${selected}"
                   href="${url}"
                   title="${title}"
-                  data-autoid="${ddsPrefix}--masthead__l0-nav--nav${i}"
+                  data-autoid="${autoid}-nav--nav${i}"
                 ></dds-top-nav-item>
               `;
             }
@@ -411,7 +345,7 @@ class DDSMastheadComposite extends LitElement {
                   ?active="${selected}"
                   menu-label="${title}"
                   trigger-content="${title}"
-                  data-autoid="${ddsPrefix}--masthead__l0-nav--nav${i}"
+                  data-autoid="${autoid}-nav--nav${i}"
                 >
                   ${sections}
                 </dds-megamenu-top-nav-menu>
@@ -422,7 +356,7 @@ class DDSMastheadComposite extends LitElement {
                 ?active="${selected}"
                 menu-label="${title}"
                 trigger-content="${title}"
-                data-autoid="${ddsPrefix}--masthead__l0-nav--nav${i}"
+                data-autoid="${autoid}-nav--nav${i}"
               >
                 ${sections}
               </dds-top-nav-menu>
@@ -434,15 +368,11 @@ class DDSMastheadComposite extends LitElement {
                   ?active="${selected}"
                   href="${url}"
                   title="${title}"
-                  data-autoid="${ddsPrefix}--masthead__l0-sidenav--nav${i}"
+                  data-autoid="${autoid}-sidenav--nav${i}"
                 ></dds-left-nav-item>
               `
             : html`
-                <dds-left-nav-menu
-                  ?active="${selected}"
-                  title="${title}"
-                  data-autoid="${ddsPrefix}--masthead__l0-sidenav--nav${i}"
-                >
+                <dds-left-nav-menu ?active="${selected}" title="${title}" data-autoid="${autoid}-sidenav--nav${i}">
                   ${sections}
                 </dds-left-nav-menu>
               `;
@@ -686,8 +616,7 @@ class DDSMastheadComposite extends LitElement {
           : html`
               <dds-left-nav-name href="${ifNonNull(platformUrl)}">${platform}</dds-left-nav-name>
             `}
-        ${l1Data ? undefined : this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV })}
-        ${l1Data ? this._renderL1Items({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV }) : undefined}
+        ${this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV, hasL1: !!l1Data })}
       </dds-left-nav>
       <dds-masthead aria-label="${ifNonNull(mastheadAssistiveText)}">
         <dds-masthead-menu-button
@@ -707,7 +636,7 @@ class DDSMastheadComposite extends LitElement {
           ? undefined
           : html`
               <dds-top-nav menu-bar-label="${ifNonNull(menuBarAssistiveText)}" ?hideNav="${activateSearch}">
-                ${this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.TOP_NAV })}
+                ${this._renderNavItems({ selectedMenuItem, target: NAV_ITEMS_RENDER_TARGET.TOP_NAV, hasL1: false })}
               </dds-top-nav>
             `}
         ${!hasSearch

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -327,7 +327,6 @@ class DDSMastheadComposite extends LitElement {
                     `
               );
           }
-          console.log('sections', sections);
           if (target === NAV_ITEMS_RENDER_TARGET.TOP_NAV) {
             if (sections.length === 0) {
               return html`

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -156,6 +156,7 @@
   .#{$prefix}--header__nav-caret-right-container {
     bottom: 0;
     z-index: 1;
+    position: relative;
   }
 
   .#{$prefix}--header__nav-caret-right-container {


### PR DESCRIPTION
### Related Ticket(s)

Web Component: Change Mega Menu to include animation (back button & forward motion) #4831

### Description

React version data structure for L1 menu items is the same as L0 menu items from translation API. This should match expected structure of L1 in web-components.

Use the same structure and remove the L1 specific left nav item function, instead use the same function used to render the L0 top nav and left nav items.

Use same custom data as React storybook example

### Changelog

**Changed**

- use custom data from React example.
- edit `MastheadL1` type in the services-store translateAPI to use `MastheadLink[]` as the data structure shouldn't differ

**Removed**

- `renderL1Items()` and ulitize `renderNavItems()` instead as the structure of the L1 data and L0 data is the same

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
