### PR TITLE
fix(leadspace): overlapping bug

### DIFF
--- a/packages/react/src/components/LeadSpace/LeadSpace.js
+++ b/packages/react/src/components/LeadSpace/LeadSpace.js
@@ -82,15 +82,13 @@ const LeadSpace = ({
   return (
     <div
       data-autoid={`${stablePrefix}--leadspace`}
-      className={`${prefix}--leadspace`}>
-      <section className={classNames(type, image, theme)}>
-        <div
-          style={background}
-          className={classnames({
-            [`${prefix}--leadspace__container`]: size === 'tall',
-            [`${prefix}--leadspace__container--medium`]: size === 'medium',
-            [`${prefix}--leadspace__container--super`]: size === 'super',
-          })}>
+      className={classnames(`${prefix}--leadspace`, {
+        [`${prefix}--leadspace--medium`]: size === 'medium',
+        [`${prefix}--leadspace--tall`]: size === 'tall',
+        [`${prefix}--leadspace--super`]: size === 'super',
+      })}>
+      <section style={background} className={classNames(type, image, theme)}>
+        <div className={`${prefix}--leadspace__container`}>
           <div
             className={classnames(`${prefix}--leadspace__overlay`, {
               [`${prefix}--leadspace--gradient`]: gradient,

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -106,20 +106,6 @@ $btn-min-width: 26;
       height: 100%;
     }
 
-    .#{$prefix}--leadspace__section {
-      .#{$prefix}--leadspace__container--medium {
-        height: carbon--mini-units(60);
-      }
-
-      .#{$prefix}--leadspace__container {
-        height: carbon--mini-units(70);
-      }
-
-      .#{$prefix}--leadspace__container--super {
-        height: carbon--mini-units(80);
-      }
-    }
-
     ::slotted(#{$dds-prefix}-image),
     .#{$prefix}--image {
       position: absolute;
@@ -444,6 +430,24 @@ $btn-min-width: 26;
     }
   }
 
+  .#{$prefix}--leadspace--medium {
+    .#{$prefix}--leadspace__section {
+      height: carbon--mini-units(60);
+    }
+  }
+
+  .#{$prefix}--leadspace--tall {
+    .#{$prefix}--leadspace__section {
+      height: carbon--mini-units(70);
+    }
+  }
+
+  .#{$prefix}--leadspace--super {
+    .#{$prefix}--leadspace__section {
+      height: carbon--mini-units(80);
+    }
+  }
+
   :host(#{$dds-prefix}-leadspace) ::slotted([slot='navigation']) {
     z-index: 1;
     padding-left: $spacing-05;
@@ -472,6 +476,17 @@ $btn-min-width: 26;
     width: 95%;
     z-index: 1;
     @include carbon--type-style(expressive-heading-06, true);
+  }
+
+  :host(#{$dds-prefix}-leadspace)[size='tall'],
+  :host(#{$dds-prefix}-leadspace)[size] {
+    ::slotted(#{$dds-prefix}-leadspace-heading) {
+      margin-bottom: $spacing-06;
+      @include carbon--type-style(expressive-heading-06, true);
+    }
+    .#{$prefix}--leadspace__section {
+      height: carbon--mini-units(70);
+    }
   }
 
   :host(#{$dds-prefix}-leadspace)[size='medium'] {

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -480,10 +480,6 @@ $btn-min-width: 26;
 
   :host(#{$dds-prefix}-leadspace)[size='tall'],
   :host(#{$dds-prefix}-leadspace)[size] {
-    ::slotted(#{$dds-prefix}-leadspace-heading) {
-      margin-bottom: $spacing-06;
-      @include carbon--type-style(expressive-heading-06, true);
-    }
     .#{$prefix}--leadspace__section {
       height: carbon--mini-units(70);
     }

--- a/packages/web-components/src/components/leadspace/defs.ts
+++ b/packages/web-components/src/components/leadspace/defs.ts
@@ -52,6 +52,11 @@ export enum LEADSPACE_SIZE {
   NONE = '',
 
   /**
+   * Tall - tall size of the leadspace
+   */
+  TALL = 'tall',
+
+  /**
    * Medium - medium size of the leadspace
    */
   MEDIUM = 'medium',

--- a/packages/web-components/src/components/leadspace/leadspace.scss
+++ b/packages/web-components/src/components/leadspace/leadspace.scss
@@ -7,8 +7,6 @@
 
 @import '@carbon/ibmdotcom-styles/scss/globals/vars';
 @import '@carbon/ibmdotcom-styles/scss/components/leadspace/leadspace';
-@import '../../../../styles/scss/components/leadspace/leadspace';
-
 @import 'carbon-web-components/scss/components/breadcrumb/breadcrumb';
 
 :host(#{$dds-prefix}-leadspace) {

--- a/packages/web-components/src/components/leadspace/leadspace.scss
+++ b/packages/web-components/src/components/leadspace/leadspace.scss
@@ -7,6 +7,8 @@
 
 @import '@carbon/ibmdotcom-styles/scss/globals/vars';
 @import '@carbon/ibmdotcom-styles/scss/components/leadspace/leadspace';
+@import '../../../../styles/scss/components/leadspace/leadspace';
+
 @import 'carbon-web-components/scss/components/breadcrumb/breadcrumb';
 
 :host(#{$dds-prefix}-leadspace) {

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -82,7 +82,7 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
     return classMap({
       [`${prefix}--leadspace__container--super`]: this.size === LEADSPACE_SIZE.SUPER,
       [`${prefix}--leadspace__container--medium`]: this.size === LEADSPACE_SIZE.MEDIUM,
-      [`${prefix}--leadspace__container`]: this.size === LEADSPACE_SIZE.NONE,
+      [`${prefix}--leadspace__container`]: this.size === LEADSPACE_SIZE.NONE || this.size === LEADSPACE_SIZE.TALL,
     });
   }
 
@@ -107,7 +107,7 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
     return classMap({
       [`${prefix}--leadspace__desc--super`]: this.size === LEADSPACE_SIZE.SUPER,
       [`${prefix}--leadspace__desc--medium`]: this.size === LEADSPACE_SIZE.MEDIUM,
-      [`${prefix}--leadspace__desc`]: this.size === LEADSPACE_SIZE.NONE,
+      [`${prefix}--leadspace__desc`]: this.size === LEADSPACE_SIZE.NONE || this.size === LEADSPACE_SIZE.TALL,
     });
   }
 
@@ -116,7 +116,7 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
    */
   protected _getContentType() {
     return classMap({
-      [`${prefix}--leadspace--content__container`]: this.size === LEADSPACE_SIZE.NONE,
+      [`${prefix}--leadspace--content__container`]: this.size === LEADSPACE_SIZE.NONE || this.size === LEADSPACE_SIZE.TALL,
       [`${prefix}--leadspace--content__container--medium`]: this.size === LEADSPACE_SIZE.MEDIUM,
       [`${prefix}--leadspace--content__container--super`]: this.size === LEADSPACE_SIZE.SUPER,
     });


### PR DESCRIPTION
### Related Ticket(s)

React & Web component Service Page: Table of contents and Leadspace are overlapping #6323

### Description

fix styles and classes

### Changelog

**New**

- add tall def to leadspace

**Changed**

- update react heights 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
