### PR TITLE
docs(cdn): updated to point to the new cdn urls

### DIFF
--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -171,7 +171,7 @@ Here is an example of implementing the `dotcom-shell`:
 <html>
   <head>
     <script type="module">
-      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/dotcom-shell.min.js';
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/dotcom-shell.min.js';
 
       // The minimum prerequisite to use our service for translation data, etc.
       window.digitalData = {
@@ -212,7 +212,7 @@ application does not already take these steps:
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     ...
   </head>
 </html>
@@ -233,14 +233,14 @@ application does not already take these steps:
 The CDN packages are available by NPM tags `latest` (full releases), `next` (latest release candidate), and `beta` (bi-weekly releases), as well as specific versions. The URL pattern for import would be:
 
 ```html
-<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/[VERSION]/dotcom-shell.min.js"></script>
+<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version/[VERSION]/dotcom-shell.min.js"></script>
 ```
 
 or
 
 ```html
 <script type="module">
-  import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/[VERSION]/dotcom-shell.min.js';
+  import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version/[VERSION]/dotcom-shell.min.js';
 </script>
 ```
 
@@ -248,21 +248,25 @@ A tag release would be called as:
 
 ```html
 <!-- LATEST -->
-<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/dotcom-shell.min.js"></script>
+<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/dotcom-shell.min.js"></script>
 
 <!-- NEXT -->
-<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/next/dotcom-shell.min.js"></script>
+<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/next/dotcom-shell.min.js"></script>
 
 <!-- BETA -->
-<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/dotcom-shell.min.js"></script>
+<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/beta/dotcom-shell.min.js"></script>
 ```
 
 A specific release would be called as:
 
 ```html
 <!-- SPECIFIC VERSION (available starting v1.6.0) -->
-<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/v1.6.0/dotcom-shell.min.js"></script>
+<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version/v1.x.y/dotcom-shell.min.js"></script>
 ```
+
+> NOTE: The latest/next/beta tags are moving versions. While beneficial to
+> always stay on the most recent version, it is recommended to choose a specific
+> version and properly test your application when upgrading to a newer version.
 
 #### Using RTL
 
@@ -285,9 +289,7 @@ For applications that are currently running on other design systems like [legacy
 <link rel="stylesheet" href="https://1.www.s81c.com/common/v18/css/www.css" />
 <script src="https://1.www.s81c.com/common/v18/js/www.js"></script>
 <!-- Loads Carbon for IBM.com Web Components masthead -->
-<script type="module" src="">
-  import '@carbon/ibmdotcom-web-components/es/components/masthead/masthead-container.js';
-</script>
+<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/masthead.min.js"></script>
 
 ...
 

--- a/packages/web-components/examples/codesandbox/components/back-to-top/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/back-to-top/cdn.html
@@ -11,14 +11,14 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     #app {
       width: 300px;
       height: 6000px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/back-to-top.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/back-to-top.min.js"></script>
 </head>
 <body>
 <h1>Scroll down! 👋</h1>

--- a/packages/web-components/examples/codesandbox/components/back-to-top/index.html
+++ b/packages/web-components/examples/codesandbox/components/back-to-top/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       #app {
         width: 300px;

--- a/packages/web-components/examples/codesandbox/components/button-group/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/button-group/cdn.html
@@ -11,14 +11,14 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-button-group:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/button-group.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button-group.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/button-group/index.html
+++ b/packages/web-components/examples/codesandbox/components/button-group/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-button-group:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/callout-data/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/callout-data/cdn.html
@@ -11,14 +11,14 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-callout-data:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/callout-data.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/callout-data.min.js"></script>
 </head>
 <body>
 <dds-callout-data>

--- a/packages/web-components/examples/codesandbox/components/callout-data/index.html
+++ b/packages/web-components/examples/codesandbox/components/callout-data/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <script src="src/index.js"></script>
   </head>
   <body>

--- a/packages/web-components/examples/codesandbox/components/callout-quote/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/callout-quote/cdn.html
@@ -11,14 +11,14 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-callout-quote:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/callout-quote.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/callout-quote.min.js"></script>
 </head>
 <body>
 <dds-callout-quote

--- a/packages/web-components/examples/codesandbox/components/callout-quote/index.html
+++ b/packages/web-components/examples/codesandbox/components/callout-quote/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-callout-quote:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/callout-with-media/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/callout-with-media/cdn.html
@@ -11,14 +11,14 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-callout-with-media:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/callout-with-media.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/callout-with-media.min.js"></script>
 </head>
 <body>
 <dds-callout-with-media>

--- a/packages/web-components/examples/codesandbox/components/callout-with-media/index.html
+++ b/packages/web-components/examples/codesandbox/components/callout-with-media/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-callout-with-media:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/card-group/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-group/cdn.html
@@ -11,14 +11,14 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-card-group:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/card-group.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-group.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/card-group/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-group/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-card-group:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/card-in-card/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-in-card/cdn.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-card-in-card:not(:defined) {
@@ -22,7 +22,7 @@ LICENSE file in the root directory of this source tree.
       width: 300px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/card-in-card.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-in-card.min.js"></script>
 </head>
 <body>
 <h1>Hello World! 👋</h1>

--- a/packages/web-components/examples/codesandbox/components/card-in-card/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-in-card/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-card-in-card:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/card-link/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-link/cdn.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-card-link:not(:defined) {
@@ -22,7 +22,7 @@ LICENSE file in the root directory of this source tree.
       width: 300px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/card-link.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-link.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/card-link/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-link/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-card-link:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/card-section-images/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-images/cdn.html
@@ -11,14 +11,14 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-card-section-images:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/card-section-images.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-section-images.min.js"></script>
 </head>
 <body>
 <dds-card-section-images>

--- a/packages/web-components/examples/codesandbox/components/card-section-images/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-images/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-card-section-images:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/card-section-simple/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-simple/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-card-section-simple:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/card-section-simple.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-section-simple.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/card-section-simple/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-simple/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-card-section-simple:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/card/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card/cdn.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-card:not(:defined) {
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
       width: 450px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/card.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/card/index.html
+++ b/packages/web-components/examples/codesandbox/components/card/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-card:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/carousel/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/carousel/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-carousel:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/carousel.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/card.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/carousel.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card.min.js"></script>
 </head>
 <body>
 <dds-carousel>

--- a/packages/web-components/examples/codesandbox/components/carousel/index.html
+++ b/packages/web-components/examples/codesandbox/components/carousel/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-carousel:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/content-block-card-static/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-card-static/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-block-card-static:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-block-card-static.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-card-static.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-block-card-static/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-card-static/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <script src="src/index.js"></script>
     <style type="text/css">
       /* Suppress custom element until styles are loaded */

--- a/packages/web-components/examples/codesandbox/components/content-block-cards/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-cards/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-block-cards:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-block-cards.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-cards.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-block-cards/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-cards/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-content-block-cards:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/content-block-headlines/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-headlines/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-block-headlines:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-block-headlines.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-headlines.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-block-headlines/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-headlines/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-content-block-headlines:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/content-block-media/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-media/cdn.html
@@ -11,16 +11,16 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-block-media:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-block-media.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/image-with-caption.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-media.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/image-with-caption.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-block-media/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-media/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <script type="module" src="src/index.js"></script>
     <style type="text/css">
       /* Suppress custom element until styles are loaded */

--- a/packages/web-components/examples/codesandbox/components/content-block-mixed/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-mixed/cdn.html
@@ -11,18 +11,18 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-block-mixed:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-block-mixed.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-group-cards.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-group-pictograms.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-group-simple.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-mixed.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-cards.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-pictograms.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-simple.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-block-mixed/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-mixed/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <script type="module" src="src/index.js"></script>
     <style type="text/css">
       /* Suppress custom element until styles are loaded */

--- a/packages/web-components/examples/codesandbox/components/content-block-segmented/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-segmented/cdn.html
@@ -11,17 +11,17 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-block-segmented:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-block-segmented.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/link-list.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/video-player.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-segmented.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-list.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/video-player.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-block-segmented/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-segmented/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-content-block-segmented:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/content-block-simple/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-simple/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-block-simple:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-block-simple.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-simple.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-block-simple/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-simple/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-content-block-simple:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/content-group-cards/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-cards/cdn.html
@@ -9,15 +9,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-group-cards:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-group-cards.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-cards.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-group-cards/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-cards/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <script type="module" src="src/index.js"></script>
     <style type="text/css">
       /* Suppress custom element until styles are loaded */

--- a/packages/web-components/examples/codesandbox/components/content-group-horizontal/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-horizontal/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-group-horizontal:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-group-horizontal.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-horizontal.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-group-horizontal/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-horizontal/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-content-group-horizontal:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/content-group-pictograms/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-pictograms/cdn.html
@@ -9,15 +9,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-group-pictograms:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-group-pictograms.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-pictograms.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-group-pictograms/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-pictograms/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-content-group-pictograms:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/content-group-simple/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-simple/cdn.html
@@ -9,15 +9,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-group-simple:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-group-simple.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-simple.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/content-group-simple/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-simple/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-content-group-simple:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/content-item-horizontal/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-item-horizontal/cdn.html
@@ -9,15 +9,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-content-item-horizontal:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/content-item-horizontal.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-item-horizontal.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/content-item-horizontal/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-item-horizontal/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-content-item-horizontal:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/cta-block/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-block/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     dds-cta-block:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/cta-block.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/cta-block.min.js"></script>
 </head>
 
 <body>

--- a/packages/web-components/examples/codesandbox/components/cta-block/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-block/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       dds-cta-block:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/cta-card/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-card/cdn.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-card-cta:not(:defined) {
@@ -27,7 +27,7 @@ LICENSE file in the root directory of this source tree.
       width: 450px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/card-cta.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-cta.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/cta-card/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-card/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-card-cta:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/cta-feature/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-feature/cdn.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-feature-cta:not(:defined) {
@@ -27,7 +27,7 @@ LICENSE file in the root directory of this source tree.
       width: 450px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/feature-cta.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/feature-cta.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/cta-feature/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-feature/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-feature-cta:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/cta-section/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-section/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-cta-section:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/cta-section.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/cta-section.min.js"></script>
 </head>
 
 <body>

--- a/packages/web-components/examples/codesandbox/components/cta-section/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-section/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-cta-section:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/cta-text/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-text/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-video-cta-container:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/text-cta.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/video-cta-container.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/text-cta.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/video-cta-container.min.js"></script>
 </head>
 <body>
 <dds-video-cta-container>

--- a/packages/web-components/examples/codesandbox/components/cta-text/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-text/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-video-cta-container:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/dotcom-shell/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/dotcom-shell/cdn.html
@@ -145,15 +145,15 @@ LICENSE file in the root directory of this source tree.
   <link rel="alternate" hreflang="en-vn" href="https://www.ibm.com/vn-en" />
   <link rel="alternate" hreflang="en-zm" href="https://www.ibm.com/zm-en" />
   <link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-dotcom-shell-container:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/dotcom-shell.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/dotcom-shell.min.js"></script>
 </head>
 <body>
 <dds-dotcom-shell-container>

--- a/packages/web-components/examples/codesandbox/components/dotcom-shell/index.html
+++ b/packages/web-components/examples/codesandbox/components/dotcom-shell/index.html
@@ -145,7 +145,7 @@ LICENSE file in the root directory of this source tree.
     <link rel="alternate" hreflang="en-vn" href="https://www.ibm.com/vn-en" />
     <link rel="alternate" hreflang="en-zm" href="https://www.ibm.com/zm-en" />
     <link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-dotcom-shell-container:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/expressive-modal/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/expressive-modal/cdn.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-expressive-modal:not(:defined), dds-button-expressive:not(:defined) {
@@ -22,8 +22,8 @@ LICENSE file in the root directory of this source tree.
       width: 300px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/button.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/expressive-modal.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/expressive-modal.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/expressive-modal/index.html
+++ b/packages/web-components/examples/codesandbox/components/expressive-modal/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       #app {
         width: 300px;

--- a/packages/web-components/examples/codesandbox/components/feature-card-block-large/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/feature-card-block-large/cdn.html
@@ -9,15 +9,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-feature-card-block-large:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/feature-card-block-large.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/feature-card-block-large.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/feature-card-block-large/index.html
+++ b/packages/web-components/examples/codesandbox/components/feature-card-block-large/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-feature-card-block-large:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/feature-card/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/feature-card/cdn.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-feature-card:not(:defined) {
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
       width: 450px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/feature-card.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/feature-card.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/feature-card/index.html
+++ b/packages/web-components/examples/codesandbox/components/feature-card/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-feature-card:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/footer/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/footer/cdn.html
@@ -145,14 +145,14 @@ LICENSE file in the root directory of this source tree.
   <link rel="alternate" hreflang="en-vn" href="https://www.ibm.com/vn-en" />
   <link rel="alternate" hreflang="en-zm" href="https://www.ibm.com/zm-en" />
   <link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-footer-container:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/footer.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/footer.min.js"></script>
 </head>
 <body>
 <dds-footer-container></dds-footer-container>

--- a/packages/web-components/examples/codesandbox/components/footer/index.html
+++ b/packages/web-components/examples/codesandbox/components/footer/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <script src="src/index.js"></script>
   </head>
   <body>

--- a/packages/web-components/examples/codesandbox/components/horizontal-rule/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/horizontal-rule/cdn.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-horizontal-rule:not(:defined) {
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
       width: 300px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/horizontal-rule.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/horizontal-rule.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/horizontal-rule/index.html
+++ b/packages/web-components/examples/codesandbox/components/horizontal-rule/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-horizontal-rule:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/image/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/image/cdn.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-image:not(:defined) {
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
       width: 700px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/image.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/image.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/image/index.html
+++ b/packages/web-components/examples/codesandbox/components/image/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-image:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/leadspace-block/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/leadspace-block/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-leadspace-block:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/leadspace-block.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/leadspace-block.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/leadspace-block/index.html
+++ b/packages/web-components/examples/codesandbox/components/leadspace-block/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-leadspace-block:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/leadspace/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/leadspace/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-leadspace:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/leadspace.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/leadspace.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/leadspace/index.html
+++ b/packages/web-components/examples/codesandbox/components/leadspace/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-leadspace:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/leaving-ibm/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/leaving-ibm/cdn.html
@@ -11,14 +11,14 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-leaving-ibm-container:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/leaving-ibm.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/leaving-ibm.min.js"></script>
 </head>
 <body>
 <dds-leaving-ibm-container open="true" href="https://www.example.com/"></dds-leaving-ibm-container>

--- a/packages/web-components/examples/codesandbox/components/leaving-ibm/index.html
+++ b/packages/web-components/examples/codesandbox/components/leaving-ibm/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-leaving-ibm-container:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/lightbox-media-viewer/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/lightbox-media-viewer/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-button-expressive:not(:defined), dds-lightbox-video-player-container:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/button.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/lightbox-video-player.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/lightbox-video-player.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/lightbox-media-viewer/index.html
+++ b/packages/web-components/examples/codesandbox/components/lightbox-media-viewer/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-button-expressive:not(:defined), dds-lightbox-video-player-container:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/link-list-section/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/link-list-section/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-link-list-section:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/link-list-section.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-list-section.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/link-list-section/index.html
+++ b/packages/web-components/examples/codesandbox/components/link-list-section/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-link-list-section:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/link-list/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/link-list/cdn.html
@@ -11,16 +11,16 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-link-list:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/link-list.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/card.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-list.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/link-list/index.html
+++ b/packages/web-components/examples/codesandbox/components/link-list/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-link-list:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/link-with-icon/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/link-with-icon/cdn.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-link-with-icon:not(:defined) {
@@ -22,7 +22,7 @@ LICENSE file in the root directory of this source tree.
       width: 300px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/link-with-icon.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-with-icon.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/link-with-icon/index.html
+++ b/packages/web-components/examples/codesandbox/components/link-with-icon/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-link-with-icon:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/locale-modal/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/cdn.html
@@ -145,7 +145,7 @@ LICENSE file in the root directory of this source tree.
   <link rel="alternate" hreflang="en-vn" href="https://www.ibm.com/vn-en" />
   <link rel="alternate" hreflang="en-zm" href="https://www.ibm.com/zm-en" />
   <link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-button-expressive:not(:defined), dds-locale-modal-container:not(:defined) {
@@ -156,8 +156,8 @@ LICENSE file in the root directory of this source tree.
       width: 300px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/locale-modal.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/button.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/locale-modal.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/locale-modal/index.html
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/index.html
@@ -145,7 +145,7 @@ LICENSE file in the root directory of this source tree.
     <link rel="alternate" hreflang="en-vn" href="https://www.ibm.com/vn-en" />
     <link rel="alternate" hreflang="en-zm" href="https://www.ibm.com/zm-en" />
     <link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-button-expressive:not(:defined), dds-locale-modal-container:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/logo-grid/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/logo-grid/cdn.html
@@ -11,14 +11,14 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-logo-grid:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/logo-grid.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/logo-grid.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/logo-grid/index.html
+++ b/packages/web-components/examples/codesandbox/components/logo-grid/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-logo-grid:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/masthead/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/masthead/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-masthead-container:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/masthead.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/masthead.min.js"></script>
   <script src="src/index-cdn.js"></script>
 </head>
 <body>

--- a/packages/web-components/examples/codesandbox/components/masthead/index.html
+++ b/packages/web-components/examples/codesandbox/components/masthead/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-masthead-container:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/pictogram-item/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/pictogram-item/cdn.html
@@ -9,15 +9,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-pictogram-item:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/pictogram-item.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/pictogram-item.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/pictogram-item/index.html
+++ b/packages/web-components/examples/codesandbox/components/pictogram-item/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-pictogram-item:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/quote/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/quote/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-quote:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/quote.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/quote.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/quote/index.html
+++ b/packages/web-components/examples/codesandbox/components/quote/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-quote:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/scroll-animations/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/scroll-animations/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/scroll-animations.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/scroll-animations.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-scroll-animations:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/scroll-animations.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/scroll-animations.min.js"></script>
 </head>
 <body>
 <dds-scroll-animations animation="fade" selector-targets="h1" keep-animation="true">

--- a/packages/web-components/examples/codesandbox/components/scroll-animations/index.html
+++ b/packages/web-components/examples/codesandbox/components/scroll-animations/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-scroll-animations:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/table-of-contents/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/table-of-contents/cdn.html
@@ -11,8 +11,8 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/table-of-contents.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/table-of-contents.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-table-of-contents:not(:defined) {
@@ -28,7 +28,7 @@ LICENSE file in the root directory of this source tree.
       padding-bottom: 2rem;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/table-of-contents.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/table-of-contents.min.js"></script>
 </head>
 <body>
 <dds-table-of-contents>

--- a/packages/web-components/examples/codesandbox/components/table-of-contents/index.html
+++ b/packages/web-components/examples/codesandbox/components/table-of-contents/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-table-of-contents:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/tabs-extended/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/tabs-extended/cdn.html
@@ -11,14 +11,14 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-tabs-extended:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/tabs-extended.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/tabs-extended.min.js"></script>
 </head>
 <body>
 <h1>Hello World! 👋</h1>

--- a/packages/web-components/examples/codesandbox/components/tabs-extended/index.html
+++ b/packages/web-components/examples/codesandbox/components/tabs-extended/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-tabs-extended:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/tag-group/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/tag-group/cdn.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-tag-group:not(:defined) {
@@ -20,8 +20,8 @@ LICENSE file in the root directory of this source tree.
       width: 600px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/tag-group.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/tag-link.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/tag-group.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/tag-link.min.js"></script>
 </head>
 <body>
 <h1>Hello World! 👋</h1>

--- a/packages/web-components/examples/codesandbox/components/tag-group/index.html
+++ b/packages/web-components/examples/codesandbox/components/tag-group/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-tag-group:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/tag-link/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/tag-link/cdn.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-tag-link:not(:defined) {
@@ -24,7 +24,7 @@ LICENSE file in the root directory of this source tree.
       width: 600px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/tag-link.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/tag-link.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/codesandbox/components/tag-link/index.html
+++ b/packages/web-components/examples/codesandbox/components/tag-link/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-tag-link:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/video-player/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/video-player/cdn.html
@@ -11,15 +11,15 @@ LICENSE file in the root directory of this source tree.
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-video-player-container:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/video-player.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/video-player.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">

--- a/packages/web-components/examples/codesandbox/components/video-player/index.html
+++ b/packages/web-components/examples/codesandbox/components/video-player/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       dds-video-player-container:not(:defined) {

--- a/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-handlebars/app.js
+++ b/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-handlebars/app.js
@@ -32,7 +32,7 @@ global.sessionStorage = {
 };
 
 app.get('/', async function topRoute(req, res) {
-  // Determins user's preferred language
+  // Determines user's preferred language
   const { code = 'en', region = 'US' } = acceptLanguageParser.parse(req.headers['accept-language'])[0] || {};
   // Loads translation, etc. data from IBM.com services
   const [langDisplay, localeList, translation] = await Promise.all([

--- a/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-handlebars/index.hbs
+++ b/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-handlebars/index.hbs
@@ -16,7 +16,7 @@ LICENSE file in the root directory of this source tree.
       <link rel="alternate" hreflang="{{locale}}" href="{{href}}">
     {{/each}}
     <script type="module">
-      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/dotcom-shell.min.js';
 
       document.addEventListener('click', event => {
         if (event.target.matches('dds-locale-button')) {

--- a/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl/index.hbs
+++ b/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl/index.hbs
@@ -27,7 +27,7 @@ LICENSE file in the root directory of this source tree.
     <meta charset="UTF-8" />
     <script type="module">
       // Loads the LTR or RTL version of the bundle
-      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell{{dirSuffix}}.min.js';
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/dotcom-shell{{dirSuffix}}.min.js';
     </script>
     <style type="text/css">
       html, body {

--- a/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn/index.html
+++ b/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn/index.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
     <script type="module">
-      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/dotcom-shell.min.js';
     </script>
     <style type="text/css">
       html,

--- a/packages/web-components/src/globals/internal/storybook-cdn.ts
+++ b/packages/web-components/src/globals/internal/storybook-cdn.ts
@@ -50,16 +50,16 @@ export const cdnJs = ({ components }) => {
 
 \`\`\`html
 // SPECIFIC VERSION (available starting v1.6.0)
-${_renderScript(components, `v${packageJson.version}`)}
+${_renderScript(components, `version/v${packageJson.version}`)}
 
 // LATEST tag
-${_renderScript(components, 'latest')}
+${_renderScript(components, 'tag/v1/latest')}
 
 // NEXT tag
-${_renderScript(components, 'next')}
+${_renderScript(components, 'tag/v1/next')}
 
 // BETA tag
-${_renderScript(components, 'beta')}
+${_renderScript(components, 'tag/v1/beta')}
 \`\`\`
 
 > NOTE: The latest/next/beta tags are moving versions. While beneficial to
@@ -83,16 +83,16 @@ in your application's style bundle, this can be included via CDN:
 
 \`\`\`html
 // SPECIFIC VERSION (available starting v1.6.0)
-${_renderStyle(components, `v${packageJson.version}`)}
+${_renderStyle(components, `version/v${packageJson.version}`)}
 
 // LATEST tag
-${_renderStyle(components, 'latest')}
+${_renderStyle(components, 'tag/v1/latest')}
 
 // NEXT tag
-${_renderStyle(components, 'next')}
+${_renderStyle(components, 'tag/v1/next')}
 
 // BETA tag
-${_renderStyle(components, 'beta')}
+${_renderStyle(components, 'tag/v1/beta')}
 \`\`\`
   `;
 };
@@ -110,16 +110,16 @@ application does not already take these steps:
 
 \`\`\`html
 // SPECIFIC VERSION (available starting v1.6.0)
-<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/v${packageJson.version}/plex.css" />
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version/v${packageJson.version}/plex.css" />
 
 // LATEST tag
-<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/plex.css" />
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
 
 // NEXT tag
-<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/next/plex.css" />
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/next/plex.css" />
 
 // BETA tag
-<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/beta/plex.css" />
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/beta/plex.css" />
 \`\`\`
   `;
 };


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

After consideration, have decided to add more specificity to the CDN urls for tag releases. This is in anticipation of any future major releases of `Carbon for IBM.com`. URLs are now:

tag version:
```https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/[tag name]/[component name].min.js```

specific version:
```https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version/[version number]/[component name].min.js```

Note, I already kicked off devops jobs to fill in the tag releases with at least the latest version on master, but should be populated with the proper tag releases once those are scheduled to auto-run.

### Changelog

**Changed**

- Multiple documentation for CDN urls