### PR TITLE
fix(cdn): enable CSS custom properties in CDN artifacts

### DIFF
--- a/packages/web-components/.storybook/config.ts
+++ b/packages/web-components/.storybook/config.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -33,6 +33,7 @@ addParameters({
     storySort: getSimpleStorySort([
       'overview-getting-started--page',
       'overview-building-for-ibm-dotcom--page',
+      'overview-carbon-cdn-style-helpers--page',
       'overview-stable-selectors--page',
       'overview-using-server-side-template--page',
       'overview-enable-right-to-left-rtl--page',

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -7,7 +7,7 @@ A `Carbon for IBM.com` variant that is as easy to use as native HTML elements, w
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-## Table of Contents
+## Table of contents
 
 - [Getting started](#getting-started)
 - [Usage Examples](#usage-examples)
@@ -15,7 +15,8 @@ A `Carbon for IBM.com` variant that is as easy to use as native HTML elements, w
     - [Basic Setup](#basic-setup)
     - [Using Sass](#using-sass)
     - [Enabling RTL](#enabling-rtl)
-  - [Dotcom Shell CDN Bundle](#dotcom-shell-cdn-bundle)
+    - [Process.env Error](#processenv-error)
+  - [CDN Bundles](#cdn-bundles)
     - [Versioned Bundles](#versioned-bundles)
     - [Using RTL](#using-rtl)
   - [Using with other design systems (e.g Northstar v18)](#using-with-other-design-systems-eg-northstar-v18)
@@ -204,9 +205,12 @@ Here is an example of implementing the `dotcom-shell`:
 </html>
 ```
 
-There is aslo an optional CDN artifact available that will run the Carbon reset
-as well as import Plex fonts necessary for the page. This can be included if your
-application does not already take these steps:
+#### Carbon CDN style helpers (optional)
+
+There are optional CDN artifacts available that can assist with global Carbon
+styles in lieu of including into your specific application bundle.
+
+For example, the following adds Carbon reset and necessary Plex fonts to the page:
 
 ```html
 <!DOCTYPE html>
@@ -218,8 +222,10 @@ application does not already take these steps:
 </html>
 ```
 
+[Learn more about Carbon CDN style helpers here](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/web-components/docs/carbon-cdn-style-helpers.md)
+
 > 💡 Refer to
-> ["Building for IBM.com'](http://ibmdotcom-web-components.mybluemix.net/?path=/docs/overview-building-for-ibm-dotcom--page) page
+> ["Building for IBM.com'](https://ibmdotcom-web-components.mybluemix.net/?path=/docs/overview-building-for-ibm-dotcom--page) page
 > for `window.digitalData` and `<link rel="alternate" ...>`.
 
 > 💡 Check our

--- a/packages/web-components/docs/carbon-cdn-style-helpers.md
+++ b/packages/web-components/docs/carbon-cdn-style-helpers.md
@@ -1,0 +1,142 @@
+# Carbon CDN Style Helpers
+<!-- prettier-ignore-start -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of contents
+
+- [Overview](#overview)
+- [Plex fonts and Carbon reset](#plex-fonts-and-carbon-reset)
+- [Carbon grid](#carbon-grid)
+- [Carbon theme zoning classes](#carbon-theme-zoning-classes)
+  - [Available classes](#available-classes)
+  - [Example usage](#example-usage)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- prettier-ignore-end -->
+
+## Overview
+
+In order to minimize the necessity of using front-end bundlers with the Carbon 
+for IBM.com Web Components CDN artifacts, page level styles artifacts are also
+available to use.
+
+If your application is not already compiling its own version of the below 
+artifacts, these can be included as part of your project.
+
+> NOTE: The latest/next/beta tags are moving versions. While beneficial to
+> always stay on the most recent version, it is recommended to choose a specific
+> version and properly test your application when upgrading to a newer version.
+> Check for latest version number on [npm](https://www.npmjs.com/package/@carbon/ibmdotcom-web-components).
+
+## Plex fonts and Carbon reset
+
+The following includes Carbon reset, as well as imports Plex fonts necessary for 
+the page. 
+
+```html
+// SPECIFIC VERSION
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version/[v1.x.y]/plex.css" />
+
+// LATEST tag
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+
+// NEXT tag
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/next/plex.css" />
+
+// BETA tag
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/beta/plex.css" />
+```
+
+## Carbon grid
+
+The following includes Carbon grid and all corresponding grid classes.
+
+```html
+// SPECIFIC VERSION
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version/[v1.x.y]/grid.css" />
+
+// LATEST tag
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+
+// NEXT tag
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/next/grid.css" />
+
+// BETA tag
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/beta/grid.css" />
+```
+
+[Learn more about the Carbon 2x Grid](https://carbondesignsystem.com/guidelines/2x-grid/overview)
+
+## Carbon theme zoning classes
+
+The following includes classes for creating Carbon theme zones (white, g10, g90, 
+g100). Note that these classes take advantage of using CSS Custom Properties enabled
+in Carbon.
+
+```html
+// SPECIFIC VERSION
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version/[v1.x.y]/themes.css" />
+
+// LATEST tag
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/themes.css" />
+
+// NEXT tag
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/next/themes.css" />
+
+// BETA tag
+<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/beta/themes.css" />
+```
+
+### Available classes
+
+| Theme  | Class name              |
+| ------ | ----------------------- |
+| white  | `.dds-theme-zone-white` |
+| g10    | `.dds-theme-zone-g10`   |
+| g90    | `.dds-theme-zone-g90`   |
+| g100   | `.dds-theme-zone-g100`  |
+
+### Example usage
+
+```html
+<html>
+<head>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/themes.css" />
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/dotcom-shell.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/leadspace.min.js"></script>
+  ...
+</head>
+<body>
+<dds-dotcom-shell-container>
+<main>
+    <dds-leadspace size="medium" class="dds-theme-zone-g90">
+      <dds-leadspace-heading>LeadSpace title</dds-leadspace-heading>
+      LeadSpace copy
+      <dds-button-group slot="action">
+        <dds-button-group-item href="www.example.com">
+          Button 1
+          <svg 
+            focusable="false" 
+            preserveAspectRatio="xMidYMid meet" 
+            xmlns="http://www.w3.org/2000/svg" 
+            fill="currentColor" 
+            aria-hidden="true" 
+            width="20" 
+            height="20" 
+            viewBox="0 0 20 20" 
+            slot="icon"
+          >
+            <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+          </svg>
+        </dds-button-group-item>
+      </dds-button-group>
+      <dds-leadspace-image slot="image" class="bx--image" alt="alt text" default-src="https://picsum.photos/id/1076/1056/480">
+        <dds-image-item media="(min-width: 672px)" srcset="https://picsum.photos/id/1076/672/400"></dds-image-item>
+        <dds-image-item media="(min-width: 0)" srcset="https://picsum.photos/id/1076/320/370"></dds-image-item>
+      </dds-leadspace-image>
+    </dds-leadspace>  
+</main>
+</dds-dotcom-shell-container>
+</body>
+</html>
+```

--- a/packages/web-components/docs/carbon-cdn-style-helpers.stories.mdx
+++ b/packages/web-components/docs/carbon-cdn-style-helpers.stories.mdx
@@ -1,0 +1,6 @@
+import { Description, Meta } from '@storybook/addon-docs/blocks';
+import readme from './carbon-cdn-style-helpers.md';
+
+<Meta title="Overview/Carbon CDN style helpers" />
+
+<Description markdown={readme} />

--- a/packages/web-components/docs/coding-conventions.md
+++ b/packages/web-components/docs/coding-conventions.md
@@ -2,7 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-## Table of Contents
+## Table of contents
 
 - [Linters/formatters](#lintersformatters)
 - [TSDoc comments](#tsdoc-comments)

--- a/packages/web-components/docs/contributing-to-web-components.md
+++ b/packages/web-components/docs/contributing-to-web-components.md
@@ -1,6 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-## Table of Contents
+## Table of contents
 
 - [Contributing to Carbon for IBM.com Web Components package](#contributing-to-carbon-for-ibmcom-web-components-package)
   - [Overview](#overview)

--- a/packages/web-components/docs/enable-rtl.md
+++ b/packages/web-components/docs/enable-rtl.md
@@ -1,3 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of contents
+
+- [Using RTL version of CSS](#using-rtl-version-of-css)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Using RTL version of CSS
 
 `@carbon/ibmdotcom-web-components` ships both LTR/RTL versions of CSS modules in 

--- a/packages/web-components/docs/feature-flags.md
+++ b/packages/web-components/docs/feature-flags.md
@@ -1,6 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-## Table of Contents
+## Table of contents
 
 - [Feature Flags](#feature-flags)
   - [Overview](#overview)

--- a/packages/web-components/docs/markdown-contents.md
+++ b/packages/web-components/docs/markdown-contents.md
@@ -1,7 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-## Table of Contents
+## Table of contents
 
 - [Markdown contents](#markdown-contents)
   - [Using `<dds-content-*-copy>`](#using-dds-content--copy)

--- a/packages/web-components/docs/stable-selectors.md
+++ b/packages/web-components/docs/stable-selectors.md
@@ -1,6 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-## Table of Contents
+## Table of contents
 
 - [Stable selectors (for analytics and integration/E2E testing) in Web Components](#stable-selectors-for-analytics-and-integratione2e-testing-in-web-components)
   - [`data-autoid` support for partial backward compatibility](#data-autoid-support-for-partial-backward-compatibility)

--- a/packages/web-components/gulp-tasks/build/sass-cdn.js
+++ b/packages/web-components/gulp-tasks/build/sass-cdn.js
@@ -51,6 +51,23 @@ function _buildGrid() {
 }
 
 /**
+ * Builds the sass file for the theme zone classes
+ *
+ * @returns {*} gulp stream
+ */
+function _buildThemes() {
+  return gulp
+    .src([`${config.srcDir}/globals/scss/themes.scss`])
+    .pipe(
+      sass({
+        includePaths: ['node_modules', '../../node_modules'],
+        outputStyle: 'compressed',
+      }).on('error', sass.logError)
+    )
+    .pipe(gulp.dest(config.bundleDestDir));
+}
+
+/**
  * Builds the sass file for scroll animation
  *
  * @returns {*} gulp stream
@@ -88,9 +105,16 @@ function _buildTOC() {
 
 gulp.task('build:sass:cdn:plex', _buildPlex);
 gulp.task('build:sass:cdn:grid', _buildGrid);
+gulp.task('build:sass:cdn:themes', _buildThemes);
 gulp.task('build:sass:cdn:scroll', _buildScroll);
 gulp.task('build:sass:cdn:toc', _buildTOC);
 gulp.task(
   'build:sass:cdn',
-  gulp.parallel('build:sass:cdn:plex', 'build:sass:cdn:grid', 'build:sass:cdn:scroll', 'build:sass:cdn:toc')
+  gulp.parallel(
+    'build:sass:cdn:plex',
+    'build:sass:cdn:grid',
+    'build:sass:cdn:themes',
+    'build:sass:cdn:scroll',
+    'build:sass:cdn:toc'
+  )
 );

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -55,7 +55,7 @@
     "ci-check": "yarn wca && yarn format:diff && yarn lint:src && yarn typecheck && yarn build && yarn test:unit",
     "clean": "gulp clean",
     "clean:dist": "rimraf dist",
-    "doctoc": "doctoc --title '## Table of Contents' docs && doctoc --title '## Table of Contents' README.md",
+    "doctoc": "doctoc --title '## Table of contents' docs && doctoc --title '## Table of contents' README.md",
     "format": "prettier --write \"**/*.{css,js,ts,md,scss}\"",
     "format:diff": "prettier --check \"**/*.{css,js,ts,md,scss}\"",
     "format:staged": "prettier --write",

--- a/packages/web-components/src/globals/internal/storybook-cdn.ts
+++ b/packages/web-components/src/globals/internal/storybook-cdn.ts
@@ -102,24 +102,11 @@ ${_renderStyle(components, 'tag/v1/beta')}
  */
 export const cdnCss = () => {
   return `
-### CSS (optional)
+### Carbon CDN style helpers (optional)
 
-There is an optional CDN artifact available that will run the Carbon reset as
-well as import Plex fonts necessary for the page. This can be included if your
-application does not already take these steps:
+There are optional CDN artifacts available that can assist with global Carbon
+styles in lieu of including into your specific application bundle.
 
-\`\`\`html
-// SPECIFIC VERSION (available starting v1.6.0)
-<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version/v${packageJson.version}/plex.css" />
-
-// LATEST tag
-<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-
-// NEXT tag
-<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/next/plex.css" />
-
-// BETA tag
-<link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/beta/plex.css" />
-\`\`\`
+[Click here to learn more](/docs/overview-carbon-cdn-style-helpers--page)\n\n
   `;
 };

--- a/packages/web-components/src/globals/scss/themes.scss
+++ b/packages/web-components/src/globals/scss/themes.scss
@@ -1,0 +1,30 @@
+//
+// Copyright IBM Corp. 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '@carbon/ibmdotcom-styles/scss/globals/vars';
+@import 'carbon-components/scss/globals/scss/css--helpers';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/mixins';
+
+:host(.#{$dds-prefix}-theme-zone-white),
+.#{$dds-prefix}-theme-zone-white {
+  @include carbon--theme($carbon--theme--white, true);
+}
+
+:host(.#{$dds-prefix}-theme-zone-g10),
+.#{$dds-prefix}-theme-zone-g10 {
+  @include carbon--theme($carbon--theme--g10, true);
+}
+
+:host(.#{$dds-prefix}-theme-zone-g90),
+.#{$dds-prefix}-theme-zone-g90 {
+  @include carbon--theme($carbon--theme--g90, true);
+}
+
+:host(.#{$dds-prefix}-theme-zone-g100),
+.#{$dds-prefix}-theme-zone-g100 {
+  @include carbon--theme($carbon--theme--g100, true);
+}

--- a/packages/web-components/tools/rollup-plugin-lit-scss.js
+++ b/packages/web-components/tools/rollup-plugin-lit-scss.js
@@ -61,10 +61,16 @@ function rollupPluginLitSCSS({ include = /\.scss$/i, exclude, preprocessor = noo
         return null;
       }
 
+      const finalContent = `
+        $feature-flags: (
+          enable-css-custom-properties: true,
+        );
+       ${contents}`;
+
       const { css } = await renderSass({
         ...options,
         file: id,
-        data: contents,
+        data: finalContent,
       });
 
       return {


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

A bug that came up is that the CDN artifacts did not have Carbon's CSS custom properties flag enabled. This PR enables so that CSS custom properties can be taken advantage of. In addition, there are new theme classes being introduced
as a CDN style helper. This enables the ability of creating theming zones using the theme classes. Documentation has also been added for this.

### Changelog

**New**

- `themes.css` CDN artifact with theme zone classes
- Documentation on `Carbon CDN style helpers`

**Changed**

- Updated rollup config to include css custom properties flag