### PR TITLE
fix(leadspace): width and theme fix

### DIFF
--- a/packages/react/src/components/LeadSpace/LeadSpace.js
+++ b/packages/react/src/components/LeadSpace/LeadSpace.js
@@ -182,9 +182,11 @@ LeadSpace.propTypes = {
    * | Name    | Data Type | Description           |
    * | ------- | --------- | --------------------- |
    * | `white` | String    | Carbon White theme    |
+   * | `g10`   | String    | Carbon Gray 10 theme  |
+   * | `g90`   | String    | Carbon Gray 90 theme  |
    * | `g100`  | String    | Carbon Gray 100 theme |
    */
-  theme: PropTypes.oneOf(['white', 'g100']),
+  theme: PropTypes.oneOf(['white', 'g10', 'g90', 'g100']),
 
   /**
    * Title of LeadSpace.

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -71,6 +71,7 @@ $btn-min-width: 26;
     .#{$prefix}--image {
       picture {
         width: 100%;
+        max-width: rem(1584px);
       }
     }
 

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -25,6 +25,10 @@ $btn-min-width: 26;
     background-color: $ui-background;
   }
 
+  .#{$prefix}--leadspace__gradient__stops stop {
+    stop-color: $ui-background;
+  }
+
   .#{$prefix}--leadspace--centered .#{$prefix}--leadspace__overlay {
     background-color: $ui-background;
   }
@@ -64,6 +68,12 @@ $btn-min-width: 26;
 
   :host(#{$dds-prefix}-leadspace),
   .#{$prefix}--leadspace {
+    .#{$prefix}--image {
+      picture {
+        width: 100%;
+      }
+    }
+
     .#{$prefix}--leadspace--content__container--super,
     .#{$prefix}--leadspace--content__container--medium,
     .#{$prefix}--leadspace--content__container {
@@ -346,8 +356,6 @@ $btn-min-width: 26;
     }
 
     .#{$prefix}--leadspace__gradient__stops stop {
-      stop-color: $ui-background;
-
       &:nth-of-type(1) {
         stop-opacity: 1;
       }


### PR DESCRIPTION
### Changelog

- Added 100% width to `<picture>` for larger screens
- Moved the gradient stop color rule to `themed-items` mixin (how did this ever work before?)
- Added `g10` and `g90` to theme prop types to avoid console log error

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
