### PR TITLE
fix(cloud-megamenu): modify regex to only remove punctuation special characters

### DIFF
--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -80,7 +80,7 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
         return viewAllLink;
       }
       const title = item.title
-        .replace(/[^-a-zA-Z0-9_ ]/g, '')
+        .replace(/[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]/g, '')
         .replace(/ +/g, '-')
         .toLowerCase();
 


### PR DESCRIPTION
### Related Ticket(s)

[Cloud Megamenu]: Non-alphabetical titles being selected in the cloud megamenu when using special character languages #6340

### Description

Regex was removing characters from non latin languages (ie. chinese) which caused issues with the tab component of the cloud megamenu (not knowing which tab was selected, setting all special character items as "selected" state, etc). Solution is to only remove punctuation characters.

BEFORE:
<img width="1596" alt="Screen Shot 2021-06-23 at 8 53 34 AM" src="https://user-images.githubusercontent.com/54281166/123110175-d77cb300-d409-11eb-858a-b77203c336da.png">


AFTER:
<img width="1546" alt="Screen Shot 2021-06-23 at 9 29 42 AM" src="https://user-images.githubusercontent.com/54281166/123110202-dc416700-d409-11eb-89d5-8219eeff4119.png">


### Changelog

**Changed**

- edit regex to only target punctuation characters

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
