### PR TITLE
fix(feature-section): add missing 16px spacing under eyebrow

### DIFF
--- a/packages/styles/scss/components/feature-section/_feature-section.scss
+++ b/packages/styles/scss/components/feature-section/_feature-section.scss
@@ -18,31 +18,6 @@
     padding-right: $carbon--spacing-05;
   }
 
-  // Reverse row direction if media-alignment="left".
-  // .#{$prefix}--feature-section__align-left {
-  //   .#{$prefix}--feature-section__container {
-  //     @include carbon--breakpoint('md') {
-  //       flex-direction: row-reverse;
-  //     }
-  //   }
-
-  //   .#{$prefix}--feature-section__image {
-  //     .#{$prefix}--card-link,
-  //     ::slotted(#{$dds-prefix}-card-link) {
-  //       right: inherit;
-  //       left: 0;
-
-  //       @include carbon--breakpoint('md') {
-  //         left: $carbon--spacing-05;
-  //       }
-
-  //       @include carbon--breakpoint('max') {
-  //         left: $carbon--spacing-06;
-  //       }
-  //     }
-  //   }
-  // }
-
   .#{$prefix}--feature-section__container {
     background-color: $hover-ui;
     display: block;
@@ -110,6 +85,12 @@
         height: aspect-ratio(1, 1);
       }
     }
+  }
+
+  .#{$prefix}--card__eyebrow,
+  ::slotted(#{$dds-prefix}-card-eyebrow) {
+    display: inline-block;
+    margin-bottom: $carbon--spacing-05;
   }
 
   .#{$prefix}--card-link,


### PR DESCRIPTION
### Related Ticket(s)
https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6470


### Description
- This PR adds missing 16px spacer under eyebrow that was missed during the design QA review of this PR (https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/6344).

### Expected

![expected-design](https://user-images.githubusercontent.com/1815714/123308521-c5763f80-d4f1-11eb-93db-b9aa51382b10.png)


**Testing Instructions**
- Visit the `Feature section` - `/?path=/story/components-feature-section--default`
- Ensure that there a `16px` or `$carbon--spacing-05` spacing between the eyebrow and heading.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
