### PR TITLE
feat(background media): Create background-media component

### DIFF
--- a/packages/styles/scss/components/background-media/background-media.scss
+++ b/packages/styles/scss/components/background-media/background-media.scss
@@ -1,0 +1,58 @@
+@mixin background-media {
+  :host(#{$dds-prefix}-background-media) {
+    .#{$prefix}--background-media-container {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+
+    .#{$prefix}--background-media-gradient {
+        position: relative;
+        width: 100%;
+        height: 100%;
+
+        &:after {
+            content:'';
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            display: inline-block;
+            z-index: 2;
+
+            @include carbon--breakpoint-down('md') {
+                position: relative;
+                height: aspect-ratio(4, 3);
+
+            }
+        }
+    }
+
+    .#{$prefix}--background-media-image {
+      object-fit: cover;
+      height: 100%;
+      width: 100%;  
+    }
+
+
+    &[gradient-direction='left'] .#{$prefix}--background-media-gradient:after {
+        background: linear-gradient(0deg, rgba(#ffffff, 1) 0%, rgba(#ffffff, .4) 50%, rgba(#ffffff, 0) 75%);
+        @include carbon--breakpoint(md) {
+            background: linear-gradient(90deg, rgba(#ffffff, 1) 0%, rgba(#ffffff, .4) 50%, rgba(#ffffff, 0) 75%);           
+        }
+    }
+
+    &[gradient-direction='top'] .#{$prefix}--background-media-gradient:after {
+        background: linear-gradient(0deg, rgba(#ffffff, 1) 0%, rgba(#ffffff, .4) 50%, rgba(#ffffff, 0) 75%);
+    }
+  }
+
+    
+}
+
+@include exports('background-media ') {
+    @include background-media;
+  }

--- a/packages/styles/scss/components/background-media/background-media.scss
+++ b/packages/styles/scss/components/background-media/background-media.scss
@@ -1,17 +1,38 @@
+//
+// Copyright IBM Corp. 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../globals/utils/aspect-ratio';
+
 @mixin background-media {
   :host(#{$dds-prefix}-background-media) {
+
+    .#{$prefix}--background-media {
+        width: 100%;
+        height: 100%;
+    }
+      
     .#{$prefix}--background-media-container {
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      top: 0;
-      left: 0;
+        position:relative;
+        height: 100%;
+        width: 100%;
+
+        @include carbon--breakpoint-down('md') {
+            position: flex;
+            flex-direction: column;
+        }
     }
 
     .#{$prefix}--background-media-gradient {
-        position: relative;
+        position: absolute;
         width: 100%;
         height: 100%;
+        top: 0;
+        left: 0;
+        z-index: -1;
 
         &:after {
             content:'';
@@ -20,13 +41,14 @@
             top: 0;
             width: 100%;
             height: 100%;
-            display: inline-block;
-            z-index: 2;
+        }
 
+        .#{$prefix}--background-media-item {
             @include carbon--breakpoint-down('md') {
                 position: relative;
-                height: aspect-ratio(4, 3);
-
+                padding-top: aspect-ratio(4, 3);
+                width: 100%;
+                order: 2;
             }
         }
     }
@@ -35,13 +57,21 @@
       object-fit: cover;
       height: 100%;
       width: 100%;  
+
+      
     }
 
 
     &[gradient-direction='left'] .#{$prefix}--background-media-gradient:after {
-        background: linear-gradient(0deg, rgba(#ffffff, 1) 0%, rgba(#ffffff, .4) 50%, rgba(#ffffff, 0) 75%);
-        @include carbon--breakpoint(md) {
-            background: linear-gradient(90deg, rgba(#ffffff, 1) 0%, rgba(#ffffff, .4) 50%, rgba(#ffffff, 0) 75%);           
+        // TODO : Figure out how to use the ui-background color variable in these rules
+        background: linear-gradient(90deg, rgba(#ffffff, 1) 0%, rgba(#ffffff, .4) 50%, rgba(#ffffff, 0) 75%);     
+
+        @include carbon--breakpoint-down(md) {
+            background: linear-gradient(0deg, rgba(#ffffff, 1) 0%, rgba(#ffffff, .4) 50%, rgba(#ffffff, 0) 75%);           
+        }
+
+        @include carbon--breakpoint-down(sm) {
+            background: none;           
         }
     }
 

--- a/packages/web-components/src/components/background-media/__stories__/background-media.stories.ts
+++ b/packages/web-components/src/components/background-media/__stories__/background-media.stories.ts
@@ -38,9 +38,12 @@ export const Default = ({ parameters }) => {
   const { source, gradient_direction, mobile_position } = parameters?.props?.['dds-background-media'] ?? {};
 
   return html`
+  
     <dds-background-media source="${ifNonNull(source)}" gradient-direction="${ifNonNull(gradient_direction)}" mobile-position="${ifNonNull(mobile_position)}">
-     
+      <div style="width:1200px; height:500px"></div>
+       
     </dds-background-media>
+    
   `;
 };
 
@@ -49,13 +52,9 @@ export default {
   decorators: [
     story =>
       html`
-        <div class="bx--grid">
-          <div class="bx--row">
-            <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+        
               ${story()}
-            </div>
-          </div>
-        </div>
+
       `,
   ],
   parameters: {

--- a/packages/web-components/src/components/background-media/__stories__/background-media.stories.ts
+++ b/packages/web-components/src/components/background-media/__stories__/background-media.stories.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '../background-media';
+import { html } from 'lit-element';
+import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
+import { select } from '@storybook/addon-knobs';
+import '../background-media';
+import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--005.jpg';
+import imgLg2x1 from '../../../../../storybook-images/assets/720/fpo--2x1--720x360--005.jpg';
+
+import readme from './README.stories.mdx';
+
+
+
+const images = {
+  '2:1': imgLg2x1,
+  '16:9': imgLg16x9,
+};
+
+const gradient_directions = {
+  'left': 'left',
+  'top': 'top',
+};
+
+const mobile_positions = {
+  'top': 'top',
+  'bottom': 'bottom',
+};
+
+export const Default = ({ parameters }) => {
+  const { source, gradient_direction, mobile_position } = parameters?.props?.['dds-background-media'] ?? {};
+
+  return html`
+    <dds-background-media source="${ifNonNull(source)}" gradient-direction="${ifNonNull(gradient_direction)}" mobile-position="${ifNonNull(mobile_position)}">
+     
+    </dds-background-media>
+  `;
+};
+
+export default {
+  title: 'Components/Background Media',
+  decorators: [
+    story =>
+      html`
+        <div class="bx--grid">
+          <div class="bx--row">
+            <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+              ${story()}
+            </div>
+          </div>
+        </div>
+      `,
+  ],
+  parameters: {
+    ...readme.parameters,
+    knobs: {
+      'dds-background-media': ({ groupId }) => ({
+        source: select('Default image (default-src)', images, imgLg2x1, groupId),
+        gradient_direction: select('Gradient Direction (gradient-direction):', gradient_directions, gradient_directions.left, groupId),
+        mobile_position: select('Mobile Position (mobile-position):', mobile_positions, mobile_positions.top, groupId),
+      }),
+    },
+  },
+};

--- a/packages/web-components/src/components/background-media/background-media.scss
+++ b/packages/web-components/src/components/background-media/background-media.scss
@@ -8,4 +8,4 @@
 @import '@carbon/ibmdotcom-styles/scss/globals/vars';
 @import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/mixins';
 @import '@carbon/ibmdotcom-styles/scss/components/image/image';
-@import '@carbon/ibmdotcom-styles/scss/components/background-media/background-media';
+@import '@carbon/ibmdotcom-styles/scss/components/background-media/background-media'; 

--- a/packages/web-components/src/components/background-media/background-media.scss
+++ b/packages/web-components/src/components/background-media/background-media.scss
@@ -1,0 +1,11 @@
+//
+// Copyright IBM Corp. 2020, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '@carbon/ibmdotcom-styles/scss/globals/vars';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/mixins';
+@import '@carbon/ibmdotcom-styles/scss/components/image/image';
+@import '@carbon/ibmdotcom-styles/scss/components/background-media/background-media';

--- a/packages/web-components/src/components/background-media/background-media.ts
+++ b/packages/web-components/src/components/background-media/background-media.ts
@@ -39,12 +39,17 @@ class DDSBackgroundMedia extends DDSImage {
   render() {
     
     return html`
-      <div class="${prefix}--background-media-container">
-      <slot></slot>
-        <div class="${prefix}--background-media-gradient">
-          <img class="${prefix}--background-media-image" src="${this.source}">
+      <div class="${prefix}--background-media">
+        <div class="${prefix}--background-media-container">
+          <div class="${prefix}--background-media-content">
+            <slot></slot>
+          </div>
+          <div class="${prefix}--background-media-item">
+            <div class="${prefix}--background-media-gradient">
+              <img class="${prefix}--background-media-image" src="${this.source}">
+            </div>
+          </div>
         </div>
-
       </div>
     `;
   }

--- a/packages/web-components/src/components/background-media/background-media.ts
+++ b/packages/web-components/src/components/background-media/background-media.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp.  2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html, property, customElement, LitElement, css } from 'lit-element';
+import settings from 'carbon-components/es/globals/js/settings';
+import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
+import DDSImage from '../image/image';
+import styles from './background-media.scss';
+import { GRADIENT_DIRECTION, MOBILE_POSITION } from './defs';
+
+const { prefix } = settings;
+const { stablePrefix: ddsPrefix } = ddsSettings;
+
+/**
+ * Background Media.
+ *
+ * @element dds-background-media
+ * @slot long-description - The long description content.
+ * @slot icon - The icon content.
+ */
+@customElement(`${ddsPrefix}-background-media`)
+class DDSBackgroundMedia extends DDSImage {
+
+  @property({ attribute: 'source' })
+  source = ''; 
+
+  @property({ attribute: 'gradient-direction', reflect: true })
+  gradient_direction = GRADIENT_DIRECTION.RIGHT;
+
+  @property({ attribute: 'mobile-position', reflect: true })
+  mobile_position = MOBILE_POSITION.TOP;
+
+  render() {
+    
+    return html`
+      <div class="${prefix}--background-media-container">
+      <slot></slot>
+        <div class="${prefix}--background-media-gradient">
+          <img class="${prefix}--background-media-image" src="${this.source}">
+        </div>
+
+      </div>
+    `;
+  }
+
+  static get stableSelector() {
+    return `${ddsPrefix}--background-media`;
+  }
+
+  static get styles() {
+    return css`${super.styles}${styles}`;
+  }
+}
+
+export default DDSBackgroundMedia;

--- a/packages/web-components/src/components/background-media/defs.ts
+++ b/packages/web-components/src/components/background-media/defs.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Gradient Direction
+ */
+ export enum GRADIENT_DIRECTION {
+
+     LEFT = 'left',
+
+     RIGHT = 'right',
+ }
+
+ /**
+ * Mobile Position
+ */
+  export enum MOBILE_POSITION {
+     
+    TOP = 'top',
+
+    BOTTOM = 'bottom',
+}


### PR DESCRIPTION
### Related Ticket(s)
DDS ticket: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6394
HC Jira ticket: https://jsw.ibm.com/browse/HC-2014


### Description
**This is a work in progress and should not be merged yet**

This adds the initial work on the background-media component (https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/wiki/Background-media).


### Changelog

**New**

- Adds background-media component.

**Changed**



**Removed**


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
