### PR TITLE
fix(markdown): use large link and expressive lists

### DIFF
--- a/packages/utilities/src/utilities/markdownToHtml/__tests__/markdownToHtml.test.js
+++ b/packages/utilities/src/utilities/markdownToHtml/__tests__/markdownToHtml.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -33,7 +33,7 @@ describe('Markdown converter utility', () => {
 
   it('returns the converted string with link', () => {
     const output = markdownToHtml(link);
-    const expected = `<p><a href="https://www.ibm.com" class="${prefix}--link">This</a> is an anchor link.</p>`;
+    const expected = `<p><a href="https://www.ibm.com" class="${prefix}--link ${prefix}--link--lg">This</a> is an anchor link.</p>`;
     expect(output.trim()).toBe(expected);
   });
 

--- a/packages/utilities/src/utilities/markdownToHtml/markdownToHtml.js
+++ b/packages/utilities/src/utilities/markdownToHtml/markdownToHtml.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -60,7 +60,7 @@ function markdownToHtml(
   const defaultRenderer = {
     link(href, title, text) {
       const linkTitle = title ? `title="${title}"` : null;
-      return `<a class="${prefix}--link" href="${href}" ${linkTitle}>${text}</a>`;
+      return `<a class="${prefix}--link ${prefix}--link--lg" href="${href}" ${linkTitle}>${text}</a>`;
     },
     list(body, ordered) {
       const listType = ordered ? 'ol' : 'ul';

--- a/packages/web-components/src/components/markdown/markdown.ts
+++ b/packages/web-components/src/components/markdown/markdown.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -49,10 +49,10 @@ class DDSMarkdown extends LitElement {
   protected get _renderer() {
     return {
       link(href, title, text) {
-        return `<${prefix}-link href="${href}"${title ? `title="${title}"` : ''}>${text}</${prefix}-link>`;
+        return `<${prefix}-link href="${href}" size="lg" ${title ? `title="${title}"` : ''}>${text}</${prefix}-link>`;
       },
       list(body, ordered) {
-        const tag = `${prefix}-${ordered ? 'ordered' : 'unordered'}-list`;
+        const tag = `${prefix}-${ordered ? 'ordered' : 'unordered'}-list isexpressive="true"`;
         return `<${tag}>${body}</${tag}>`;
       },
       listitem(text) {
@@ -77,6 +77,12 @@ class DDSMarkdown extends LitElement {
       this._hasRendered = true;
       render(lightDOMTemplateResult, this, { eventContext: this });
     }
+    this.querySelectorAll('bx-unordered-list').forEach(e => {
+      e.setAttribute('isexpressive', '');
+    });
+    this.querySelectorAll('bx-ordered-list').forEach(e => {
+      e.setAttribute('isexpressive', '');
+    });
   }
 
   render() {

--- a/packages/web-components/src/components/markdown/markdown.ts
+++ b/packages/web-components/src/components/markdown/markdown.ts
@@ -77,11 +77,8 @@ class DDSMarkdown extends LitElement {
       this._hasRendered = true;
       render(lightDOMTemplateResult, this, { eventContext: this });
     }
-    this.querySelectorAll('bx-unordered-list').forEach(e => {
-      e.setAttribute('isexpressive', '');
-    });
-    this.querySelectorAll('bx-ordered-list').forEach(e => {
-      e.setAttribute('isexpressive', '');
+    this.querySelectorAll('bx-ordered-list, bx-unordered-list').forEach(e => {
+      e.setAttribute('isExpressive', '');
     });
   }
 

--- a/packages/web-components/src/components/markdown/markdown.ts
+++ b/packages/web-components/src/components/markdown/markdown.ts
@@ -52,7 +52,7 @@ class DDSMarkdown extends LitElement {
         return `<${prefix}-link href="${href}" size="lg" ${title ? `title="${title}"` : ''}>${text}</${prefix}-link>`;
       },
       list(body, ordered) {
-        const tag = `${prefix}-${ordered ? 'ordered' : 'unordered'}-list isexpressive="true"`;
+        const tag = `${prefix}-${ordered ? 'ordered' : 'unordered'}-list`;
         return `<${tag}>${body}</${tag}>`;
       },
       listitem(text) {


### PR DESCRIPTION
### Related Ticket(s)

#6185 

### Description

Update markdown to use large or expressive variations for links and unordered/ordered lists 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
