### PR TITLE
fix(stripHTML): add check if there are no surrounding elements

### DIFF
--- a/packages/utilities/src/utilities/stripHTML/__tests__/index.test.js
+++ b/packages/utilities/src/utilities/stripHTML/__tests__/index.test.js
@@ -8,9 +8,14 @@
 import { stripHTML } from '../';
 
 describe('StripHTML utility', () => {
-  const content = '<h1>Lorem ipsum dolor sit amet.</h1>';
-
   it('should return a string without HTML tags', () => {
+    const content = '<h1>Lorem ipsum dolor sit amet.</h1>';
+    const output = stripHTML(content);
+    expect(output).toBe('Lorem ipsum dolor sit amet.');
+  });
+
+  it('should return the original string if there are no tags', () => {
+    const content = 'Lorem ipsum dolor sit amet.';
     const output = stripHTML(content);
     expect(output).toBe('Lorem ipsum dolor sit amet.');
   });

--- a/packages/utilities/src/utilities/stripHTML/stripHTML.js
+++ b/packages/utilities/src/utilities/stripHTML/stripHTML.js
@@ -20,7 +20,9 @@ const stripHTML = content => {
   const component = document.createElement('textarea');
   component.innerHTML = content;
 
-  return component.childNodes[0].nodeValue.replace(/(<([^>]+)>)/gi, '');
+  return component.childNodes[0]
+    ? component.childNodes[0].nodeValue.replace(/(<([^>]+)>)/gi, '')
+    : content;
 };
 
 export default stripHTML;


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The stripHTML utility always assumes that there is a wrapping tag. However, in the cases when only a string is passed, it should just pass through without doing anything, rather than throwing an error.

### Changelog

**Changed**

- Add additional string check in `stripHTML`
