### PR TITLE
fix(card-static): cta link not working in safari

### DIFF
--- a/packages/web-components/src/components/card/card.scss
+++ b/packages/web-components/src/components/card/card.scss
@@ -115,3 +115,7 @@
     color: $inverse-link;
   }
 }
+
+:host(#{$dds-prefix}-card-footer[href])::after {
+  position: relative;
+}


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6490

### Description

CTA link is now operable on mobile and desktop safari browsers.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
