### PR TITLE
fix(content-group-horizontal): adding back deprecated scss file

### DIFF
--- a/packages/styles/scss/components/content-group-horizontal/_content-group-horizontal.scss
+++ b/packages/styles/scss/components/content-group-horizontal/_content-group-horizontal.scss
@@ -1,0 +1,36 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/content-block-horizontal/content-block-horizontal"
+@warn 'Deprecated scss import for `content-group-horizontal`, remap to `@carbon/ibmdotcom-styles/scss/components/content-block-horizontal/content-block-horizontal`';
+@import '../content-block-horizontal/content-block-horizontal';
+
+@mixin content-group-horizontal {
+  .#{$prefix}--content-group-horizontal {
+    .#{$prefix}--content-item-horizontal__item:last-child {
+      @include carbon--breakpoint('max') {
+        padding-bottom: $layout-07;
+      }
+      @include carbon--breakpoint('lg') {
+        padding-bottom: $layout-07;
+      }
+      @include carbon--breakpoint('md') {
+        padding-bottom: $layout-06;
+      }
+      @include carbon--breakpoint('sm') {
+        padding-bottom: $layout-05;
+      }
+    }
+    .#{$prefix}--content-block {
+      padding-bottom: 0;
+    }
+  }
+}
+
+@include exports('content-group-horizontal') {
+  @include content-group-horizontal;
+}


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The scss file for `content-group-horizontal` still will need to exist for applications that have not yet moved to `content-block-horizontal`. This adds in the file so that applications won't break when building.

### Changelog

**New**

- Deprecated `_content-group-horizontal.scss` file
