### PR TITLE
fix(CardLink): fix disabled behavior

### DIFF
--- a/packages/react/src/components/Card/Card.js
+++ b/packages/react/src/components/Card/Card.js
@@ -84,7 +84,7 @@ export const Card = ({
           {eyebrow && <p className={`${prefix}--card__eyebrow`}>{eyebrow}</p>}
           {heading && <h3 className={`${prefix}--card__heading`}>{heading}</h3>}
           {optionalContent(copy)}
-          {renderFooter(cta, copy, heading, pictogram)}
+          {renderFooter(cta, copy, props.disabled, heading, pictogram)}
         </div>
       </div>
     </Tile>
@@ -113,10 +113,12 @@ function optionalContent(copy) {
  * @param {object} cta cta object
  * @returns {object} JSX object
  */
-function renderFooter(cta, copy, heading, pictogram) {
+function renderFooter(cta, copy, disabled, heading, pictogram) {
+  const CardFooter = disabled ? 'p' : Link;
+
   return (
     cta && (
-      <Link
+      <CardFooter
         className={classNames(`${prefix}--card__footer`, {
           [`${prefix}--card__footer__icon-left`]: cta?.iconPlacement === 'left',
           [`${prefix}--card__footer__copy`]: cta?.copy,
@@ -135,7 +137,7 @@ function renderFooter(cta, copy, heading, pictogram) {
           <cta.icon.src className={`${prefix}--card__cta`} {...cta?.icon} />
         )}
         {pictogram && pictogram}
-      </Link>
+      </CardFooter>
     )
   );
 }


### PR DESCRIPTION
### Related Ticket(s)

#6513 

### Description

Adds conditional rendering of `CardLink` footer based on `disabled` state.

### Changelog

**Changed**

- conditionally render footer based on `disabled`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
