### PR TITLE
fix(MastheadSearch): set focus on search suggestion to false

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -576,6 +576,7 @@ const MastheadSearch = ({
             renderSuggestion={renderSuggestion} // How to display a suggestion
             renderSuggestionsContainer={renderSuggestionsContainer}
             onSuggestionSelected={onSuggestionSelected} // When a suggestion is selected
+            focusInputOnSuggestionClick={false}
             inputProps={inputProps}
             containerProps={containerProps}
             renderInputComponent={renderInputComponent}


### PR DESCRIPTION
### Related Ticket(s)

[Masthead] React component: Autosuggest in the searchbox causes runtime error #6505

### Description

sets the `focusInputOnSuggestionClick` prop for the `Autosuggest` component to false so error doesn't appear when user clicks on search suggestion.

### Changelog

**Changed**

- set `focusInputOnSuggestionClick={false}` for `Autosuggest` component

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
