### PR TITLE
fix(styles): temporarily hard-code breakpoint values

### DIFF
--- a/packages/styles/scss/components/footer/_footer-nav.scss
+++ b/packages/styles/scss/components/footer/_footer-nav.scss
@@ -30,7 +30,10 @@
         padding: 0 $carbon--grid-gutter / 2;
       }
 
-      @include carbon--breakpoint-between('md', $TEMP--breakpoint-down--lg) {
+      @include carbon--breakpoint-between(
+        42.02rem,
+        $TEMP--breakpoint-down--lg
+      ) {
         padding-top: carbon--mini-units(2);
         border-top: 1px solid $ui-03;
       }

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -67,7 +67,7 @@
       }
     }
 
-    @include carbon--breakpoint-between('md', 'lg') {
+    @include carbon--breakpoint-between(42.02rem, 65.98rem) {
       + .#{$prefix}--header__logo {
         a {
           padding: 0 $carbon--spacing-05;


### PR DESCRIPTION
### Related Ticket(s)

#6554 

### Description

Temporarily use numerical breakpoint values for the `carbon--breakpoint-between` mixin. Currently there is an error in this mixin that prevents the usage of breakpoint keywords, i.e. `md`, `lg`, etc.

A [PR](https://github.com/carbon-design-system/carbon/pull/9102) for this fix is currently open. Once merged these changes can be reverted to use keywords.

### To-do
Revert these changes when the changes are available in the next `carbon-components` release. [#6558]

### Changelog

**Changed**

- use numerical values instead of keywords for `carbon--breakpoint-between` mixin

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
