### PR TITLE
fix(e2e): change baseline target to master branch

### DIFF
--- a/.github/workflows/percy-update-base-wc-e2e-codesandbox.yml
+++ b/.github/workflows/percy-update-base-wc-e2e-codesandbox.yml
@@ -3,7 +3,7 @@ name: percy-update-base-wc-e2e-codesandbox
 on:
   push:
     branches:
-      - test/e2e-percy-baseline
+      - master
 
 jobs:
   web-components:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This is making the adjustment to have the e2e code sandbox tests happen on `master` instead of the moving baseline test branch.

### Changelog

**Changed**

- Github workflow file
