### PR TITLE
chore(github-actions): upgrading ubuntu to 20.04

### DIFF
--- a/.github/workflows/automerge-feat.yml
+++ b/.github/workflows/automerge-feat.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   automerge-feat:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   automerge:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   check-packages:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14.x']
@@ -23,7 +23,7 @@ jobs:
           yarn ci-check
           yarn lerna run --stream --ignore=@carbon/ibmdotcom-web-components ci-check
   web-components:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14.x']
@@ -42,7 +42,7 @@ jobs:
       - name: Run basic checks
         run: xvfb-run --auto-servernum yarn lerna run --stream --prefix --scope=@carbon/ibmdotcom-web-components ci-check
   a11y:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14.x']

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   update-offline-mirror:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14.x']

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   react:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -56,7 +56,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   react-experimental:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -96,7 +96,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   react-rtl:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -136,7 +136,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -175,7 +175,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components-rtl:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -215,7 +215,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components-experimental:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -255,7 +255,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components-react:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -294,7 +294,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   services:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -333,7 +333,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   utilities:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -371,7 +371,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   carbon-expressive:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   react:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -56,7 +56,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/percy-update-base-wc-e2e-codesandbox.yml
+++ b/.github/workflows/percy-update-base-wc-e2e-codesandbox.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   web-components:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14.x']

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   react:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14.x']
@@ -36,7 +36,7 @@ jobs:
         run: yarn visual-snapshot
         working-directory: packages/react
   web-components:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14.x']
@@ -64,7 +64,7 @@ jobs:
         run: yarn build-storybook && yarn percy-storybook --widths=320,1280
         working-directory: packages/web-components
   carbon-expressive:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14.x']

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   react:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Per documentation from Github, Ubuntu 16.04 is deprecated. This is upgrading our workflows to 20.04.

https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/

### Changelog

**Changed**

- Github actions workflow files
