### PR TITLE
chore(content-block-mixed): update import paths in docs

### DIFF
--- a/packages/web-components/src/components/content-block-mixed/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-mixed/__stories__/README.stories.mdx
@@ -22,12 +22,12 @@ Here's a quick example to get you started.
 ### JS (via import)
 
 ```javascript
-import '@carbon/ibmdotcom-web-components/content-block-mixed/index.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-mixed/index.js';
 
 // add optional content blocks/groups
-import '@carbon/ibmdotcom-web-components/content-group-cards/index.js';
-import '@carbon/ibmdotcom-web-components/content-group-pictograms/index.js';
-import '@carbon/ibmdotcom-web-components/content-group-simple/index.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-group-cards/index.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-group-pictograms/index.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-group-simple/index.js';
 ```
 
 <Description markdown={`${cdnJs({ components: ['content-block-mixed'] })}`} />


### PR DESCRIPTION
### Description

Update import paths in README.

### Changelog

**Changed**

- update import paths to use `es` modules


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
