### PR TITLE
chore(support): updating support roster for sprint 15

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report 🐛
 about: Something isn't working as expected? Here is the right place to report.
 labels: bug
-assignees: jeffchew, ljcarot, shixiedesign, RobertaJHahn, DragosRistici, kennylam, andysherman2121
+assignees: jeffchew, ljcarot, shixiedesign, RobertaJHahn, RichKummer, ariellalgilmore, IgnacioBecerra
 ---
 
 <!-- Feel free to remove sections that aren't relevant.

--- a/.github/ISSUE_TEMPLATE/contribution_request.md
+++ b/.github/ISSUE_TEMPLATE/contribution_request.md
@@ -3,7 +3,7 @@ name: Contribution Request 💓
 about: Contribute things large and small—of code, design, ideas, and guidance.
 title: ''
 labels: contribution
-assignees: jeffchew, ljcarot, shixiedesign, RobertaJHahn, DragosRistici, kennylam, andysherman2121
+assignees: jeffchew, ljcarot, shixiedesign, RobertaJHahn, RichKummer, ariellalgilmore, IgnacioBecerra
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature Request 💡
 about: Suggest a new idea for the project.
 title: ''
 labels: Feature request
-assignees: jeffchew, ljcarot, shixiedesign, RobertaJHahn, DragosRistici, kennylam, andysherman2121
+assignees: jeffchew, ljcarot, shixiedesign, RobertaJHahn, RichKummer, ariellalgilmore, IgnacioBecerra
 ---
 
 <!-- replace _{{...}}_ with your own words -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question 🤔
 about: Usage question or discussion about Carbon for IBM.com.
 labels: question
-assignees: jeffchew, ljcarot, shixiedesign, RobertaJHahn, DragosRistici, kennylam, andysherman2121
+assignees: jeffchew, ljcarot, shixiedesign, RobertaJHahn, RichKummer, ariellalgilmore, IgnacioBecerra
 ---
 
 <!--


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This updates the fireline support roster for sprint 15.

### Changelog

**Changed**

- Github issue templates