### PR TITLE
fix(cta-card): updating `video-cta-composite` to match new API

### DIFF
--- a/packages/web-components/src/components/cta/video-cta-composite.ts
+++ b/packages/web-components/src/components/cta/video-cta-composite.ts
@@ -13,7 +13,7 @@ import on from 'carbon-components/es/globals/js/misc/on.js';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
 import HostListener from 'carbon-web-components/es/globals/decorators/host-listener.js';
 import HostListenerMixin from 'carbon-web-components/es/globals/mixins/host-listener.js';
-import VideoPlayerAPI from '@carbon/ibmdotcom-services/es/services/VideoPlayer/VideoPlayer.js';
+import KalturaPlayerAPI from '@carbon/ibmdotcom-services/es/services/KalturaPlayer/KalturaPlayer.js';
 import ModalRenderMixin from '../../globals/mixins/modal-render';
 import { VideoData } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/videoPlayerAPI.d';
 import Handle from '../../globals/internal/handle';
@@ -77,7 +77,7 @@ class DDSVideoCTAComposite extends ModalRenderMixin(HostListenerMixin(LitElement
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private async _handleRequestVideoData(event: CustomEvent) {
     const { href } = event.detail;
-    (event.target as VideoCTAMixinImpl).videoThumbnailUrl = VideoPlayerAPI.getThumbnailUrl({
+    (event.target as VideoCTAMixinImpl).videoThumbnailUrl = KalturaPlayerAPI.getThumbnailUrl({
       mediaId: href,
       width: '320',
     });

--- a/packages/web-components/src/components/cta/video-cta-composite.ts
+++ b/packages/web-components/src/components/cta/video-cta-composite.ts
@@ -36,12 +36,12 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 @customElement(`${ddsPrefix}-video-cta-composite`)
 class DDSVideoCTAComposite extends ModalRenderMixin(HostListenerMixin(LitElement)) {
   /**
-   * The placeholder for `_embedVideo()` action that may be mixed in.
+   * The placeholder for `_embedMedia()` action that may be mixed in.
    *
    * @internal
    */
   @internalProperty()
-  _embedVideo?: (videoId: string) => Promise<any>;
+  _embedMedia?: (videoId: string) => Promise<any>;
 
   /**
    * The placeholder for `_loadVideoData()` Redux action that may be mixed in.
@@ -78,7 +78,7 @@ class DDSVideoCTAComposite extends ModalRenderMixin(HostListenerMixin(LitElement
   private async _handleRequestVideoData(event: CustomEvent) {
     const { href } = event.detail;
     (event.target as VideoCTAMixinImpl).videoThumbnailUrl = VideoPlayerAPI.getThumbnailUrl({
-      videoId: href,
+      mediaId: href,
       width: '320',
     });
     const videoData = await this._loadVideoData?.(href);
@@ -151,7 +151,7 @@ class DDSVideoCTAComposite extends ModalRenderMixin(HostListenerMixin(LitElement
    * @returns The media viewer lightbox for `type="video"`.
    */
   renderModal() {
-    const { embeddedVideos, videoData, _activeVideoId: activeVideoId, _embedVideo: embedVideo } = this;
+    const { embeddedVideos, videoData, _activeVideoId: activeVideoId, _embedMedia: embedMedia } = this;
     return html`
       <dds-lightbox-video-player-composite
         ?open="${Boolean(activeVideoId)}"
@@ -159,7 +159,7 @@ class DDSVideoCTAComposite extends ModalRenderMixin(HostListenerMixin(LitElement
         video-id="${ifNonNull(activeVideoId)}"
         .embeddedVideos="${ifNonNull(embeddedVideos)}"
         .videoData="${ifNonNull(videoData)}"
-        ._embedVideo="${ifNonNull(embedVideo)}"
+        ._embedMedia="${ifNonNull(embedMedia)}"
       >
       </dds-lightbox-video-player-composite>
     `;


### PR DESCRIPTION
### Related Ticket(s)

Web component: Card group - Video links are broken and do not open on lightbox media view. #6674

### Description

{{Add a human-readable description / detail summary of what the PR is changing and any details around how and why}}

{{If applicable, include a screenshot indicating an example or examples of what the PR is changing in the application}}

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
