### PR TITLE
chore(feature-card): update sandbox to include css custom props flag

### DIFF
--- a/packages/react/examples/codesandbox/components/FeatureCard/src/styles.scss
+++ b/packages/react/examples/codesandbox/components/FeatureCard/src/styles.scss
@@ -1,9 +1,15 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+
+$feature-flags: (
+  enable-css-custom-properties: true,
+);
+
 
 .bx--grid {
   padding-top: 1rem;

--- a/packages/react/src/components/FeatureCard/README.stories.mdx
+++ b/packages/react/src/components/FeatureCard/README.stories.mdx
@@ -65,6 +65,7 @@ const largeCard = {
   },
   eyebrow: "This is an eyebrow",
   heading: "Explore AI use cases in all industries",
+  copy: "This is a copy",
   image: {
     defaultSrc:
       'https://fpoimg.com/672x672?text=1:1&bg_color=ee5396&text_color=161616',
@@ -85,7 +86,7 @@ Add the following line in your `.env` file at the root of your project.
   SASS_PATH=node_modules:src
 ```
 
-> 💡 Don't forget to import the FeatureCard styles from
+> 💡 Don't forget to import the FeatureCard styles *and* add the CSS custom properties flag from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles).
 
 ##### OPTIONAL 💡


### PR DESCRIPTION
### Related Ticket(s)
None

### Description
Codebox Example wasn't styling properly due to not having the CSS custom properties flag set, this PR ensures its on.

### Changelog

**New**

- added CSS Custom property flag within FeatureCard Sandbox Example

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
