### PR TITLE
fix(cloud-masthead): Megamenu height is not displaying correctly within the Drupal integration

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -53,7 +53,6 @@
       position: fixed;
       display: block;
       visibility: hidden;
-      min-height: carbon--mini-units(40);
       margin-bottom: $layout-05;
       left: 0;
       width: 100vw;
@@ -79,6 +78,7 @@
       // `100vw` in Shadow DOM causes delayed rendering bug in Safari
       // https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/4493
       width: var(--#{$dds-prefix}-ce--viewport-width, 100vw);
+      min-height: carbon--mini-units(40);
 
       ::slotted(#{$dds-prefix}-megamenu),
       ::slotted(#{$dds-prefix}-cloud-megamenu),

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -190,6 +190,7 @@ $search-transition-timing: 95ms;
     background-color: $overlay-01;
     visibility: visible;
     opacity: 1;
+    height: 100vh;
   }
 
   :host(#{$dds-prefix}-megamenu-link-with-icon) {


### PR DESCRIPTION
### Related Ticket(s)

GH Issue: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6704
JIRA ticket: https://jsw.ibm.com/browse/HC-2087

### Description

- While testing the new `<dds-cloud-masthead-container>` Web Components in Drupal, I noticed that the megamenu height is inheriting `min-height: 20rem;` instead of the height shown within the Storybook preview.
- Also, this PR addresses the `dds-megamenu-overlay` height issue where the overlay is not taking up `100%` of the viewport height.

### Steps to reproduce the issue

1. Visit this Drupal preview page (VPN requires) - https://wc-masthead-jfbm8ry4yxvz0jplleccg7urlffpem5u.w3-origin-007522.intranet.ibm.com/cloud/watson-assistant
2. Click on the "Products" mega menu item
3. The height is not the same as what is being shown here - (see - http://ibmdotcom-web-components-experimental.mybluemix.net/?path=/story/components-cloud-masthead--default)

![Screen Recording 2021-07-21 at 2 07 40 PM](https://user-images.githubusercontent.com/1815714/126538969-76e16c4d-ba42-40dd-b66c-3e705c9d66a7.gif)


### Changelog

**Changed**

- Set min-height to when `.#{$prefix}--header__menu` is `active`
- Add `100vh` to `dds-megamenu-overlay`

**Note**

- We'll need to test these changes to ensure we're not breaking anything inadvertently on the Global Masthead side.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
