### PR TITLE
fix(rtl): add codesandbox example for cloud masthead

### DIFF
--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/.babelrc
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/.babelrc
@@ -1,0 +1,22 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "modules": false,
+        "targets": [
+          "last 1 version",
+          "Firefox ESR",
+          "not opera > 0",
+          "not op_mini > 0",
+          "not op_mob > 0",
+          "not android > 0",
+          "not edge > 0",
+          "not ie > 0",
+          "not ie_mob > 0"
+        ]
+      }
+    ]
+  ],
+  "plugins": [["@babel/plugin-transform-runtime", { "version": "7.3.0" }]]
+}

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/.env.local
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/.env.local
@@ -1,0 +1,1 @@
+DDS_CLOUD_MASTHEAD=true

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/.gitignore
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/.gitignore
@@ -1,0 +1,22 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.cache
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/.sassrc
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/.sassrc
@@ -1,0 +1,5 @@
+{
+  "includePaths": [
+    "node_modules", "../../node_modules"
+  ],
+}

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
@@ -1,0 +1,73 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+<head>
+  <title>@carbon/ibmdotcom-web-components example</title>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/grid.css" />
+  <style type="text/css">
+    /* Suppress custom element until styles are loaded */
+    dds-cloud-masthead-container:not(:defined) {
+      display: none;
+    }
+  </style>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/cloud-masthead.rtl.min.js"></script>
+  <script src="src/index-cdn.js"></script>
+</head>
+<body>
+<dds-cloud-masthead-composite data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></dds-cloud-masthead-composite>
+<main class="bx--content dds-ce-demo--ui-shell-content">
+  <div class="bx--grid">
+    <div class="bx--row">
+      <div class="bx--offset-lg-3 bx--col-lg-13">
+        <h2>
+          Purpose and function
+        </h2>
+        <p>
+          The shell is perhaps the most crucial piece of any UI built with Carbon. It contains the shared navigation framework
+          for the entire design system and ties the products in IBM’s portfolio together in a cohesive and elegant way. The
+          shell is the home of the topmost navigation, where users can quickly and dependably gain their bearings and move
+          between pages.
+          <br />
+          <br />
+          The shell was designed with maximum flexibility built in, to serve the needs of a broad range of products and users.
+          Adopting the shell ensures compliance with IBM design standards, simplifies development efforts, and provides great
+          user experiences. All IBM products built with Carbon are required to use the shell’s header.
+          <br />
+          <br />
+          To better understand the purpose and function of the UI shell, consider the “shell” of MacOS, which contains the
+          Apple menu, top-level navigation, and universal, OS-level controls at the top of the screen, as well as a universal
+          dock along the bottom or side of the screen. The Carbon UI shell is roughly analogous in function to these parts of
+          the Mac UI. For example, the app switcher portion of the shell can be compared to the dock in MacOS.
+        </p>
+        <h2>
+          Header responsive behavior
+        </h2>
+        <p>
+          As a header scales down to fit smaller screen sizes, headers with persistent side nav menus should have the side nav
+          collapse into “hamburger” menu. See the example to better understand responsive behavior of the header.
+        </p>
+        <h2>
+          Secondary navigation
+        </h2>
+        <p>
+          The side-nav contains secondary navigation and fits below the header. It can be configured to be either fixed-width
+          or flexible, with only one level of nested items allowed. Both links and category lists can be used in the side-nav
+          and may be mixed together. There are several configurations of the side-nav, but only one configuration should be
+          used per product section. If tabs are needed on a page when using a side-nav, then the tabs are secondary in
+          hierarchy to the side-nav.
+        </p>
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
@@ -12,7 +12,6 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-cloud-masthead-container:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
@@ -23,7 +23,7 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index-cdn.js"></script>
 </head>
 <body>
-<dds-cloud-masthead-composite data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></dds-cloud-masthead-composite>
+<dds-cloud-masthead-container data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></dds-cloud-masthead-container>
 <main class="bx--content dds-ce-demo--ui-shell-content">
   <div class="bx--grid">
     <div class="bx--row">

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
@@ -7,7 +7,7 @@ This source code is licensed under the Apache-2.0 license found in the
 LICENSE file in the root directory of this source tree.
 -->
 
-<html>
+<html dir="rtl">
 <head>
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
@@ -12,10 +12,29 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/plex.css" />
-  <style type="text/css">
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/grid.css" />
+  <style>
     /* Suppress custom element until styles are loaded */
     dds-cloud-masthead-container:not(:defined) {
       display: none;
+    }
+
+    body {
+      padding: 3rem;
+    }
+
+    @media (min-width: 66rem) {
+      .bx--offset-lg-3 {
+        margin-left: 0;
+      }
+    }
+
+    .bx--content.dds-ce-demo--ui-shell-content h2 {
+      margin: 30px 0;
+    }
+
+    .bx--content.dds-ce-demo--ui-shell-content h2:first-of-type {
+      margin-top: 0;
     }
   </style>
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/cloud-masthead.rtl.min.js"></script>

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
     }
 
     body {
-      padding: 3rem;
+      padding: 6rem 3rem;
     }
 
     @media (min-width: 66rem) {

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
@@ -12,7 +12,6 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     dds-cloud-masthead-container:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
@@ -23,7 +23,7 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index-cdn.js"></script>
 </head>
 <body>
-<dds-cloud-masthead-composite data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></dds-cloud-masthead-composite>
+<dds-cloud-masthead-container data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></dds-cloud-masthead-container>
 <main class="bx--content dds-ce-demo--ui-shell-content">
   <div class="bx--grid">
     <div class="bx--row">

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
@@ -1,0 +1,73 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+<head>
+  <title>@carbon/ibmdotcom-web-components example</title>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/grid.css" />
+  <style type="text/css">
+    /* Suppress custom element until styles are loaded */
+    dds-cloud-masthead-container:not(:defined) {
+      display: none;
+    }
+  </style>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/cloud-masthead.min.js"></script>
+  <script src="src/index-cdn.js"></script>
+</head>
+<body>
+<dds-cloud-masthead-composite data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></dds-cloud-masthead-composite>
+<main class="bx--content dds-ce-demo--ui-shell-content">
+  <div class="bx--grid">
+    <div class="bx--row">
+      <div class="bx--offset-lg-3 bx--col-lg-13">
+        <h2>
+          Purpose and function
+        </h2>
+        <p>
+          The shell is perhaps the most crucial piece of any UI built with Carbon. It contains the shared navigation framework
+          for the entire design system and ties the products in IBM’s portfolio together in a cohesive and elegant way. The
+          shell is the home of the topmost navigation, where users can quickly and dependably gain their bearings and move
+          between pages.
+          <br />
+          <br />
+          The shell was designed with maximum flexibility built in, to serve the needs of a broad range of products and users.
+          Adopting the shell ensures compliance with IBM design standards, simplifies development efforts, and provides great
+          user experiences. All IBM products built with Carbon are required to use the shell’s header.
+          <br />
+          <br />
+          To better understand the purpose and function of the UI shell, consider the “shell” of MacOS, which contains the
+          Apple menu, top-level navigation, and universal, OS-level controls at the top of the screen, as well as a universal
+          dock along the bottom or side of the screen. The Carbon UI shell is roughly analogous in function to these parts of
+          the Mac UI. For example, the app switcher portion of the shell can be compared to the dock in MacOS.
+        </p>
+        <h2>
+          Header responsive behavior
+        </h2>
+        <p>
+          As a header scales down to fit smaller screen sizes, headers with persistent side nav menus should have the side nav
+          collapse into “hamburger” menu. See the example to better understand responsive behavior of the header.
+        </p>
+        <h2>
+          Secondary navigation
+        </h2>
+        <p>
+          The side-nav contains secondary navigation and fits below the header. It can be configured to be either fixed-width
+          or flexible, with only one level of nested items allowed. Both links and category lists can be used in the side-nav
+          and may be mixed together. There are several configurations of the side-nav, but only one configuration should be
+          used per product section. If tabs are needed on a page when using a side-nav, then the tabs are secondary in
+          hierarchy to the side-nav.
+        </p>
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
@@ -12,10 +12,29 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/plex.css" />
-  <style type="text/css">
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/grid.css" />
+  <style>
     /* Suppress custom element until styles are loaded */
     dds-cloud-masthead-container:not(:defined) {
       display: none;
+    }
+
+    body {
+      padding: 3rem;
+    }
+
+    @media (min-width: 66rem) {
+      .bx--offset-lg-3 {
+        margin-left: 0;
+      }
+    }
+
+    .bx--content.dds-ce-demo--ui-shell-content h2 {
+      margin: 30px 0;
+    }
+
+    .bx--content.dds-ce-demo--ui-shell-content h2:first-of-type {
+      margin-top: 0;
     }
   </style>
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/cloud-masthead.min.js"></script>

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
     }
 
     body {
-      padding: 3rem;
+      padding: 6rem 3rem;
     }
 
     @media (min-width: 66rem) {

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/index.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/index.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-    <style type="text/css">
+    <style>
       /* Suppress custom element until styles are loaded */
       dds-cloud-masthead-container:not(:defined) {
         display: none;

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/index.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/index.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-  <dds-cloud-masthead-composite data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></dds-cloud-masthead-composite>
+  <dds-cloud-masthead-container data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></dds-cloud-masthead-container>
   <main class="bx--content dds-ce-demo--ui-shell-content">
       <div class="bx--grid">
         <div class="bx--row">

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/index.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/index.html
@@ -1,0 +1,71 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+  <head>
+    <title>@carbon/ibmdotcom-web-components example</title>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+    <style type="text/css">
+      /* Suppress custom element until styles are loaded */
+      dds-cloud-masthead-container:not(:defined) {
+        display: none;
+      }
+    </style>
+    <script src="src/index.js"></script>
+  </head>
+  <body>
+  <dds-cloud-masthead-composite data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></dds-cloud-masthead-composite>
+  <main class="bx--content dds-ce-demo--ui-shell-content">
+      <div class="bx--grid">
+        <div class="bx--row">
+          <div class="bx--offset-lg-3 bx--col-lg-13">
+            <h2>
+              Purpose and function
+            </h2>
+            <p>
+              The shell is perhaps the most crucial piece of any UI built with Carbon. It contains the shared navigation framework
+              for the entire design system and ties the products in IBM’s portfolio together in a cohesive and elegant way. The
+              shell is the home of the topmost navigation, where users can quickly and dependably gain their bearings and move
+              between pages.
+              <br />
+              <br />
+              The shell was designed with maximum flexibility built in, to serve the needs of a broad range of products and users.
+              Adopting the shell ensures compliance with IBM design standards, simplifies development efforts, and provides great
+              user experiences. All IBM products built with Carbon are required to use the shell’s header.
+              <br />
+              <br />
+              To better understand the purpose and function of the UI shell, consider the “shell” of MacOS, which contains the
+              Apple menu, top-level navigation, and universal, OS-level controls at the top of the screen, as well as a universal
+              dock along the bottom or side of the screen. The Carbon UI shell is roughly analogous in function to these parts of
+              the Mac UI. For example, the app switcher portion of the shell can be compared to the dock in MacOS.
+            </p>
+            <h2>
+              Header responsive behavior
+            </h2>
+            <p>
+              As a header scales down to fit smaller screen sizes, headers with persistent side nav menus should have the side nav
+              collapse into “hamburger” menu. See the example to better understand responsive behavior of the header.
+            </p>
+            <h2>
+              Secondary navigation
+            </h2>
+            <p>
+              The side-nav contains secondary navigation and fits below the header. It can be configured to be either fixed-width
+              or flexible, with only one level of nested items allowed. Both links and category lists can be used in the side-nav
+              and may be mixed together. There are several configurations of the side-nav, but only one configuration should be
+              used per product section. If tabs are needed on a page when using a side-nav, then the tabs are secondary in
+              hierarchy to the side-nav.
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/package.json
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ibmdotcom-web-components-cloud-masthead-example",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sample project for getting started with the Web Components from Carbon for IBM.com.",
+  "license": "Apache-2",
+  "main": "index.html",
+  "scripts": {
+    "clean": "rimraf node_modules dist .cache",
+    "start": "parcel index.html --port=9000 --no-hmr",
+    "build": "parcel build *.html --no-minify --public-url ./"
+  },
+  "dependencies": {
+    "@carbon/ibmdotcom-web-components": "canary",
+    "lit-element": "^2.3.0",
+    "lit-html": "^1.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0-0",
+    "carbon-components": "^10.36.0",
+    "parcel-bundler": "1.12.3",
+    "rimraf": "^3.0.2",
+    "sass": "^1.32.13"
+  }
+}

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/sandbox.config.json
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/src/index-cdn.js
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/src/index-cdn.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './index.scss';
+
+window.digitalData = {
+  page: {
+    pageInfo: {
+      language: 'en-US',
+      ibm: {
+        country: 'US',
+        siteID: 'IBMTESTWWW',
+      },
+    },
+    isDataLayerReady: true,
+  },
+};

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/src/index-cdn.js
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/src/index-cdn.js
@@ -7,8 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import './index.scss';
-
 window.digitalData = {
   page: {
     pageInfo: {

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/src/index.js
@@ -1,0 +1,24 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '@carbon/ibmdotcom-web-components/es/components/masthead/cloud/index.js';
+import './index.scss';
+
+window.digitalData = {
+  page: {
+    pageInfo: {
+      language: 'en-US',
+      ibm: {
+        country: 'US',
+        siteID: 'IBMTESTWWW',
+      },
+    },
+    isDataLayerReady: true,
+  },
+};

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/src/index.scss
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/src/index.scss
@@ -1,0 +1,37 @@
+//
+// @license
+//
+// Copyright IBM Corp. 2020, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// `enable-css-custom-properties` and `grid-columns-16` feature flags are requirements for Carbon for IBM.com styles
+$feature-flags: (
+  enable-css-custom-properties: true,
+  grid-columns-16: true,
+);
+
+@import 'carbon-components/scss/globals/grid/grid';
+@import 'carbon-components/scss/components/ui-shell/content';
+
+body {
+  padding: calc(#{$spacing-09} + #{mini-units(6)} + 1px) $spacing-09 $spacing-09 $spacing-09;
+}
+
+@media (min-width: 66rem) {
+  .bx--offset-lg-3 {
+    margin-left: 0;
+  }
+}
+
+.bx--content.dds-ce-demo--ui-shell-content {
+  h2 {
+    margin: 30px 0;
+
+    &:first-of-type {
+      margin-top: 0;
+    }
+  }
+}

--- a/packages/web-components/tests/e2e/build/build-examples.js
+++ b/packages/web-components/tests/e2e/build/build-examples.js
@@ -18,6 +18,7 @@ const { mkdirSync, track } = require('temp');
 program
   .option('-C, --skip-clean', 'Skips cleaning build folders')
   .option('-P, --skip-packages', 'Skips the local package setup')
+  .option('-D, --skip-dist', 'Skips the local dist components build')
   .option('-E, --skip-examples', 'Skips the local examples setup');
 program.parse();
 
@@ -149,6 +150,38 @@ function _setupPackages() {
 }
 
 /**
+ * Copies the CDN folder to the web test folder
+ *
+ * @private
+ */
+function _copyCDN() {
+  log(chalk.yellow('Copying CDN packages to the web folder...'));
+  execSync(`mkdir "${_distFolder}/cdn"`);
+  execSync(`cp -a "${_projectRoot}/dist/." "${_distFolder}/cdn"`);
+}
+
+/**
+ * Builds the CDN artifacts
+ *
+ * @private
+ */
+function _buildDist() {
+  if (!_opts.skipDist) {
+    log(chalk.yellow('Building CDN artifacts...'));
+
+    execSync('yarn build:components', {
+      cwd: _projectRoot,
+      stdio: 'inherit',
+    });
+
+    execSync('yarn build:sass:cdn', {
+      cwd: _projectRoot,
+      stdio: 'inherit',
+    });
+  }
+}
+
+/**
  * Builds then copies the dist folder to the final location
  *
  * @private
@@ -156,12 +189,12 @@ function _setupPackages() {
 function _buildExamples() {
   log(chalk.yellow('Installing all examples...'));
   // need to install twice for some reason, need to look into this
-  execSync('yarn install', {
+  execSync('yarn install --network-timeout 100000', {
     cwd: _exampleBuild,
     stdio: 'inherit',
   });
 
-  execSync('yarn cache clean && yarn install', {
+  execSync('yarn cache clean && yarn install --network-timeout 100000', {
     cwd: _exampleBuild,
     stdio: 'inherit',
   });
@@ -173,6 +206,14 @@ function _buildExamples() {
       cwd: `${_exampleBuild}/components/${example}`,
       stdio: 'inherit',
     });
+
+    // replace the CDN artifact before it's moved
+    const contents = fs.readFileSync(`${_exampleBuild}/components/${example}/dist/cdn.html`, 'utf8');
+    const contentsFinal = contents.replace(
+      /https?:.\/1.www.s81c.com\/common\/carbon-for-ibm-dotcom\/tag\/v1\/canary\//g,
+      '../cdn/'
+    );
+    fs.writeFileSync(`${_exampleBuild}/components/${example}/dist/cdn.html`, contentsFinal);
 
     // Copying dist output
     log(chalk.green(`Copying ${example} to dist...`));
@@ -252,7 +293,14 @@ function build() {
   log(chalk.yellow(`Temporary examples directory created: ${_exampleBuild}`));
   _copyExamples();
 
+  // Create the dynamic index root file
   _createIndex();
+
+  // Builds the CDN artifacts
+  _buildDist();
+
+  // Copies the local CDN packages to the web test folder
+  _copyCDN();
 
   _examples.forEach(example => {
     log(chalk.green(`Replacing dependencies for ${example} and installing`));

--- a/packages/web-components/tests/e2e/build/build-examples.js
+++ b/packages/web-components/tests/e2e/build/build-examples.js
@@ -208,12 +208,24 @@ function _buildExamples() {
     });
 
     // replace the CDN artifact before it's moved
-    const contents = fs.readFileSync(`${_exampleBuild}/components/${example}/dist/cdn.html`, 'utf8');
+    const cdnFile = `${_exampleBuild}/components/${example}/dist/cdn.html`;
+    const contents = fs.readFileSync(cdnFile, 'utf8');
     const contentsFinal = contents.replace(
       /https?:.\/1.www.s81c.com\/common\/carbon-for-ibm-dotcom\/tag\/v1\/canary\//g,
       '../cdn/'
     );
-    fs.writeFileSync(`${_exampleBuild}/components/${example}/dist/cdn.html`, contentsFinal);
+    fs.writeFileSync(cdnFile, contentsFinal);
+
+    // replace the CDN RTL version if it exists
+    const cdnRtlFile = `${_exampleBuild}/components/${example}/dist/cdn-rtl.html`;
+    if (fs.existsSync(cdnRtlFile)) {
+      const contentsRTL = fs.readFileSync(cdnRtlFile, 'utf8');
+      const contentsRTLFinal = contentsRTL.replace(
+        /https?:.\/1.www.s81c.com\/common\/carbon-for-ibm-dotcom\/tag\/v1\/canary\//g,
+        '../cdn/'
+      );
+      fs.writeFileSync(cdnRtlFile, contentsRTLFinal);
+    }
 
     // Copying dist output
     log(chalk.green(`Copying ${example} to dist...`));


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This adds a codesandbox example for Cloud Masthead. In addition, this cherrypicks the local CDN testing for codesandbox deploy preview from the `master` branch.

### Changelog

**New**

- Cloud Masthead codesandbox example

**Changed**

- Cherry-pick test:e2e:build script changes for CDN testing
