### PR TITLE
fix(cloud-masthead): hc-2086 properly form request return object

### DIFF
--- a/packages/services/src/services/CloudAccountAuth/CloudAccountAuth.js
+++ b/packages/services/src/services/CloudAccountAuth/CloudAccountAuth.js
@@ -29,7 +29,7 @@ class CloudAccountAuthAPI {
   static checkCookie() {
     const cloudLogin = Cookies.get(_cookieName);
 
-    return cloudLogin === '1' ? 'authenticated' : 'anonymous';
+    return { user: cloudLogin === '1' ? 'authenticated' : 'anonymous' };
   }
 
   /**
@@ -57,7 +57,7 @@ class CloudAccountAuthAPI {
         return 'anonymous';
       });
 
-    return cloudLogin;
+    return { user: cloudLogin };
   }
 }
 

--- a/packages/services/src/services/CloudAccountAuth/__tests__/CloudAccountAuth.test.js
+++ b/packages/services/src/services/CloudAccountAuth/__tests__/CloudAccountAuth.test.js
@@ -15,7 +15,7 @@ describe('CloudAccountAuth cookie utility', () => {
     });
 
     const loginStatus = CloudAccountAuthAPI.checkCookie();
-    expect(loginStatus).toStrictEqual('authenticated');
+    expect(loginStatus).toStrictEqual({ user: 'authenticated' });
   });
 
   it('should fetch the CloudAccountAuth cookie and return the anonymous string', () => {
@@ -25,6 +25,6 @@ describe('CloudAccountAuth cookie utility', () => {
     });
 
     const loginStatus = CloudAccountAuthAPI.checkCookie();
-    expect(loginStatus).toStrictEqual('anonymous');
+    expect(loginStatus).toStrictEqual({ user: 'anonymous' });
   });
 });

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -28,6 +28,7 @@ import {
   MastheadMenuItem,
   MastheadProfileItem,
 } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI.d';
+import { UNAUTHENTICATED_STATUS } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/cloudAccountAuthAPI';
 import styles from './cloud-masthead.scss';
 import DDSMastheadComposite, { NAV_ITEMS_RENDER_TARGET } from '../masthead-composite';
 
@@ -77,6 +78,12 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
    */
   @property({ attribute: 'auth-method' })
   authMethod = 'cookie';
+
+  /**
+   * The user authentication status.
+   */
+  @property({ attribute: 'user-status' })
+  userStatus = UNAUTHENTICATED_STATUS;
 
   /**
    *  Render MegaMenu content


### PR DESCRIPTION
### Related Ticket(s)

[HC-2086](https://jsw.ibm.com/browse/HC-2086)

Resolves #6703 

### Description

We weren't seeing the user's auth status reflected based on the cookie we're checking as expected. The issues were:

1. the cloud masthead was using the unauthenticated status const defined in the profile API, which uses a different string
2. the cloud account login API was returning a bare string, but the cloud masthead expects an object with a property called user

### Changelog

**New**

- n/a

**Changed**

- `packages/services/src/services/CloudAccountAuth/CloudAccountAuth.js` - add a definition for user status in cloud masthead composite which points to the correct unauthenticated status string defined in the cloud account login API
- `packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts` -  update the API to output a properly formatted result

**Removed**

- n/a

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
