### PR TITLE
chore(masthead): udpate L1 codesandbox example

### DIFF
--- a/packages/react/examples/codesandbox/components/MastheadL1/package.json
+++ b/packages/react/examples/codesandbox/components/MastheadL1/package.json
@@ -1,20 +1,29 @@
 {
+  "name": "ibmdotcom-react-masthead-example",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.html",
   "scripts": {
-    "start": "snowpack dev",
-    "build": "snowpack build"
+    "start": "parcel serve -p 9000 index.html --no-hmr",
+    "build": "parcel build index.html"
   },
   "dependencies": {
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
     "@carbon/icons-react": "latest",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0"
+    "react": "16.13.0",
+    "react-dom": "16.13.0"
   },
   "devDependencies": {
-    "@babel/preset-react": "^7.10.0",
-    "@snowpack/plugin-babel": "^2.1.0",
-    "@snowpack/plugin-react-refresh": "^2.2.0",
-    "snowpack": "2.10.1",
-    "snowpack-plugin-sass": "^1.0.0"
+    "@babel/core": "^7.0.0-0",
+    "@babel/plugin-transform-runtime": "^7.14.5",
+    "@babel/preset-env": "^7.14.8",
+    "parcel-bundler": "1.12.3",
+    "sass": "^1.26.9"
+  },
+  "sass": {
+    "includePaths": [
+      "./node_modules"
+    ]
   }
 }

--- a/packages/react/examples/codesandbox/components/MastheadL1/snowpack.config.json
+++ b/packages/react/examples/codesandbox/components/MastheadL1/snowpack.config.json
@@ -1,7 +1,0 @@
-{
-  "plugins": [
-    "@snowpack/plugin-react-refresh",
-    "@snowpack/plugin-babel",
-    "snowpack-plugin-sass"
-  ]
-}

--- a/packages/react/examples/codesandbox/components/MastheadL1/src/App.js
+++ b/packages/react/examples/codesandbox/components/MastheadL1/src/App.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,8 +14,8 @@ export default function App() {
   const mastheadProps = {
     navigation: 'default',
     platform: {
-      name: 'IBM Cloud',
-      url: 'https://www.ibm.com/cloud',
+      name: 'Stock Charts',
+      url: 'https://www.example.com',
     },
     hasNavigation: true,
     hasProfile: true,
@@ -25,8 +25,6 @@ export default function App() {
       searchOpenOnload: false,
     },
     mastheadL1Data: {
-      title: 'Stock Charts',
-      titleLink: 'https://example.com/',
       navigationL1: links,
     },
   };

--- a/packages/react/examples/codesandbox/components/MastheadL1/src/links.js
+++ b/packages/react/examples/codesandbox/components/MastheadL1/src/links.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,10 +13,11 @@
 
 const mastheadLinks = [
   {
-    title: 'Link 1',
+    title: 'Lorem ipsum dolor sit amet',
+    titleEnglish: 'Lorem ipsum dolor sit amet',
     url: '',
     hasMenu: true,
-    hasMegapanel: true,
+    hasMegapanel: false,
     menuSections: [
       {
         heading: 'Explore',
@@ -57,15 +58,19 @@ const mastheadLinks = [
               },
             },
           },
+          {
+            title: 'Menu dropdown item with extra long text',
+            url: '',
+          },
         ],
       },
     ],
   },
   {
-    title: 'Link 2',
+    title: 'Consectetur adipiscing elit',
+    titleEnglish: 'Consectetur adipiscing elit',
     url: '',
     hasMenu: true,
-    hasMegapanel: true,
     menuSections: [
       {
         heading: '',
@@ -156,17 +161,19 @@ const mastheadLinks = [
     ],
   },
   {
-    title: 'Industries',
+    title: 'Nulla quis sem at nibh elementum imperdiet',
+    titleEnglish: 'Nulla quis sem at nibh elementum imperdiet',
     url: 'https://www.ibm.com/industries?lnk=min',
     hasMenu: false,
     hasMegapanel: false,
     menuSections: [],
   },
   {
-    title: 'Link 3',
+    title: 'Fusce nec tellus sed augue semper porta',
+    titleEnglish: 'Fusce nec tellus sed augue semper porta',
     url: '',
     hasMenu: true,
-    hasMegapanel: true,
+    hasMegapanel: false,
     menuSections: [
       {
         heading: '',
@@ -340,7 +347,8 @@ const mastheadLinks = [
     ],
   },
   {
-    title: 'Support',
+    title: 'Sed cursus ante dapibus diam',
+    titleEnglish: 'Sed cursus ante dapibus diam',
     url: 'https://www.ibm.com/support/home/?lnk=msu_usen',
     hasMenu: false,
     hasMegapanel: false,
@@ -348,4 +356,4 @@ const mastheadLinks = [
   },
 ];
 
-export default mastheadLinks;
+module.exports = mastheadLinks;


### PR DESCRIPTION
### Description

Fixes `Masthead - L1` Codesandbox example and update data structure to reflect latest changes.

### Changelog

**Changed**

- update `package.json`
- update `L1` links

**Removed**

- `snowpack`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
