### PR TITLE
fix(rtl): fix to not have rtlcss styles get parsed out

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -110,7 +110,8 @@
     top: 0;
     right: 0;
 
-    /* rtl:raw:
+    /* stylelint-disable-next-line comment-whitespace-inside */
+    /*!rtl:raw:
     left: 0;
     */
 

--- a/packages/web-components/examples/codesandbox/components/masthead/cdn-rtl.html
+++ b/packages/web-components/examples/codesandbox/components/masthead/cdn-rtl.html
@@ -1,0 +1,73 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html dir="rtl">
+<head>
+  <title>@carbon/ibmdotcom-web-components example</title>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/plex.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/grid.css" />
+  <style type="text/css">
+    /* Suppress custom element until styles are loaded */
+    dds-masthead-container:not(:defined) {
+      display: none;
+    }
+  </style>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/canary/masthead.rtl.min.js"></script>
+  <script src="src/index-cdn.js"></script>
+</head>
+<body>
+<dds-masthead-container id="masthead-container"></dds-masthead-container>
+<main class="bx--content dds-ce-demo--ui-shell-content">
+  <div class="bx--grid">
+    <div class="bx--row">
+      <div class="bx--offset-lg-3 bx--col-lg-13">
+        <h2>
+          Purpose and function
+        </h2>
+        <p>
+          The shell is perhaps the most crucial piece of any UI built with Carbon. It contains the shared navigation framework
+          for the entire design system and ties the products in IBM’s portfolio together in a cohesive and elegant way. The
+          shell is the home of the topmost navigation, where users can quickly and dependably gain their bearings and move
+          between pages.
+          <br />
+          <br />
+          The shell was designed with maximum flexibility built in, to serve the needs of a broad range of products and users.
+          Adopting the shell ensures compliance with IBM design standards, simplifies development efforts, and provides great
+          user experiences. All IBM products built with Carbon are required to use the shell’s header.
+          <br />
+          <br />
+          To better understand the purpose and function of the UI shell, consider the “shell” of MacOS, which contains the
+          Apple menu, top-level navigation, and universal, OS-level controls at the top of the screen, as well as a universal
+          dock along the bottom or side of the screen. The Carbon UI shell is roughly analogous in function to these parts of
+          the Mac UI. For example, the app switcher portion of the shell can be compared to the dock in MacOS.
+        </p>
+        <h2>
+          Header responsive behavior
+        </h2>
+        <p>
+          As a header scales down to fit smaller screen sizes, headers with persistent side nav menus should have the side nav
+          collapse into “hamburger” menu. See the example to better understand responsive behavior of the header.
+        </p>
+        <h2>
+          Secondary navigation
+        </h2>
+        <p>
+          The side-nav contains secondary navigation and fits below the header. It can be configured to be either fixed-width
+          or flexible, with only one level of nested items allowed. Both links and category lists can be used in the side-nav
+          and may be mixed together. There are several configurations of the side-nav, but only one configuration should be
+          used per product section. If tabs are needed on a page when using a side-nav, then the tabs are secondary in
+          hierarchy to the side-nav.
+        </p>
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -162,14 +162,16 @@
 
   .#{$prefix}--header__nav-caret-right-container {
     right: 0;
-    /* rtl:raw:
+    /* stylelint-disable-next-line comment-whitespace-inside */
+    /*!rtl:raw:
     position: absolute !important;
     */
   }
 
   .#{$prefix}--header__nav-caret-left-container {
     left: 0;
-    /* rtl:raw:
+    /* stylelint-disable-next-line comment-whitespace-inside */
+    /*!rtl:raw:
     position: absolute !important;
     */
   }
@@ -414,15 +416,8 @@
       0 calc(#{mini-units(6)} + 1px),
       mini-units(6) calc(#{mini-units(6)} + 1px)
     )
-    #{'/*rtl:polygon(
-    0 0,
-    calc(100% - ' + mini-units(6) + ') 0,
-    calc(100% - ' + mini-units(6) + ') calc(' +
-    mini-units(6) + ' + 1px),
-    100% calc(' + mini-units(6) + ' + 1px),
-    100% 100%,
-    0 100%
-  )*/'};
+    #{'/*!rtl:polygon(0 0, calc(100% - ' + mini-units(6) + ') 0, calc(100% - ' + mini-units(6) + ') calc(' + mini-units(6) +
+    ' + 1px), 100% calc(' + mini-units(6) + ' + 1px), 100% 100%, 0 100%)*/'};
 }
 
 :host(#{$dds-prefix}-left-nav-overlay) {


### PR DESCRIPTION
### Related Ticket(s)

Refs #6697 

### Description

This adds some updates to change the declaration for rtl in scss files so they don't get parsed out.

### Changelog

**Changed**

- Various RTL style declaration changes
