### PR TITLE
fix(card-section-offset): update to use card-cta-footer

### DIFF
--- a/packages/web-components/examples/codesandbox/components/card-section-offset/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-offset/cdn.html
@@ -50,7 +50,7 @@ LICENSE file in the root directory of this source tree.
             <p>
               Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis democritum ex. Illud ullum graecis
             </p>
-            <dds-card-footer slot="footer">
+            <dds-card-cta-footer slot="footer">
               <svg
                 slot="icon"
                 focusable="false"
@@ -63,7 +63,7 @@ LICENSE file in the root directory of this source tree.
               >
                 <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
               </svg>
-            </dds-card-footer>
+            </dds-card-cta-footer>
           </dds-card-group-item>
           <dds-card-group-item href="https://example.com">
             <dds-card-eyebrow>Label</dds-card-eyebrow>
@@ -71,7 +71,7 @@ LICENSE file in the root directory of this source tree.
             <p>
               Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis democritum ex. Illud ullum graecis
             </p>
-            <dds-card-footer slot="footer">
+            <dds-card-cta-footer slot="footer">
               <svg
                 slot="icon"
                 focusable="false"
@@ -84,7 +84,7 @@ LICENSE file in the root directory of this source tree.
               >
                 <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
               </svg>
-            </dds-card-footer>
+            </dds-card-cta-footer>
           </dds-card-group-item>
           <dds-card-group-item href="https://example.com">
             <dds-card-eyebrow>Label</dds-card-eyebrow>
@@ -92,7 +92,7 @@ LICENSE file in the root directory of this source tree.
             <p>
               Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis democritum ex. Illud ullum graecis
             </p>
-            <dds-card-footer slot="footer">
+            <dds-card-cta-footer slot="footer">
               <svg
                 slot="icon"
                 focusable="false"
@@ -105,7 +105,7 @@ LICENSE file in the root directory of this source tree.
               >
                 <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
               </svg>
-            </dds-card-footer>
+            </dds-card-cta-footer>
           </dds-card-group-item>
         </dds-card-group>
       </dds-card-section-offset>

--- a/packages/web-components/examples/codesandbox/components/card-section-offset/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-offset/index.html
@@ -50,7 +50,7 @@ LICENSE file in the root directory of this source tree.
               <p>
                 Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis democritum ex. Illud ullum graecis
               </p>
-              <dds-card-footer slot="footer">
+              <dds-card-cta-footer slot="footer">
                 <svg
                   slot="icon"
                   focusable="false"
@@ -63,7 +63,7 @@ LICENSE file in the root directory of this source tree.
                 >
                   <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
                 </svg>
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-group-item>
             <dds-card-group-item href="https://example.com">
               <dds-card-eyebrow>Label</dds-card-eyebrow>
@@ -71,7 +71,7 @@ LICENSE file in the root directory of this source tree.
               <p>
                 Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis democritum ex. Illud ullum graecis
               </p>
-              <dds-card-footer slot="footer">
+              <dds-card-cta-footer slot="footer">
                 <svg
                   slot="icon"
                   focusable="false"
@@ -84,7 +84,7 @@ LICENSE file in the root directory of this source tree.
                 >
                   <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
                 </svg>
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-group-item>
             <dds-card-group-item href="https://example.com">
               <dds-card-eyebrow>Label</dds-card-eyebrow>
@@ -92,7 +92,7 @@ LICENSE file in the root directory of this source tree.
               <p>
                 Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis democritum ex. Illud ullum graecis
               </p>
-              <dds-card-footer slot="footer">
+              <dds-card-cta-footer slot="footer">
                 <svg
                   slot="icon"
                   focusable="false"
@@ -105,7 +105,7 @@ LICENSE file in the root directory of this source tree.
                 >
                   <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
                 </svg>
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-group-item>
           </dds-card-group>
         </dds-card-section-offset>

--- a/packages/web-components/src/components/back-to-top/__stories__/data/content.ts
+++ b/packages/web-components/src/components/back-to-top/__stories__/data/content.ts
@@ -170,9 +170,9 @@ const StoryContent = () =>
                   <dds-card-heading>Linux OS on mainframes</dds-card-heading>
                   Linux on IBM mainframes lets you transform your application and data portfolio with data privacy, security, and
                   cyber resiliency.
-                  <dds-card-footer slot="footer">
+                  <dds-card-cta-footer slot="footer">
                     ${ArrowRight20({ slot: 'icon' })}
-                  </dds-card-footer>
+                  </dds-card-cta-footer>
                 </dds-card-group-item>
                 <dds-card-group-item href="https://example.com">
                   <dds-card-heading>Linux OS on LinuxONE</dds-card-heading>
@@ -180,9 +180,9 @@ const StoryContent = () =>
                     Transform your application and data portfolio with innovative data privacy, security and cyber resiliency
                     capabilities, plus minimal downtime.
                   </p>
-                  <dds-card-footer slot="footer">
+                  <dds-card-cta-footer slot="footer">
                     ${ArrowRight20({ slot: 'icon' })}
-                  </dds-card-footer>
+                  </dds-card-cta-footer>
                 </dds-card-group-item>
                 <dds-card-group-item href="https://example.com">
                   <dds-card-heading>Linux OS on Power Systems</dds-card-heading>
@@ -190,9 +190,9 @@ const StoryContent = () =>
                     Process massive amounts of data quickly, efficiently and cost-effectively on an open, scalable infrastructure
                     with built-in acceleration.
                   </p>
-                  <dds-card-footer slot="footer">
+                  <dds-card-cta-footer slot="footer">
                     ${ArrowRight20({ slot: 'icon' })}
-                  </dds-card-footer>
+                  </dds-card-cta-footer>
                 </dds-card-group-item>
               </dds-card-group>
             </dds-card-section-simple>

--- a/packages/web-components/src/components/card-section-images/__tests__/card-section-images.test.ts
+++ b/packages/web-components/src/components/card-section-images/__tests__/card-section-images.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -45,9 +45,9 @@ describe('dds-card-section-images', function() {
               </dds-image>
               <dds-card-eyebrow>Topic</dds-card-eyebrow>
               <dds-card-heading>Natural Language Processing.</dds-card-heading>
-              <dds-card-footer slot="footer">
+              <dds-card-cta-footer slot="footer">
                 ${ArrowRight20({ slot: 'icon' })}
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-group-item>
           `,
         }),

--- a/packages/web-components/src/components/card-section-images/index.ts
+++ b/packages/web-components/src/components/card-section-images/index.ts
@@ -10,7 +10,7 @@
 import './card-section-images';
 import '../card/card-eyebrow';
 import '../card/card-heading';
-import '../card/card-footer';
+import '../cta/card-cta-footer';
 import '../card-group/card-group';
 import '../card-group/card-group-item';
 import '../content-section/content-section';

--- a/packages/web-components/src/components/card-section-offset/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-section-offset/__stories__/README.stories.mdx
@@ -60,7 +60,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-offset/index
       <p>
         Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis democritum ex. Illud ullum graecis
       </p>
-      <dds-card-footer slot="footer">
+      <dds-card-cta-footer slot="footer">
         <svg
           slot="icon"
           focusable="false"
@@ -73,7 +73,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-offset/index
         >
           <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
-      </dds-card-footer>
+      </dds-card-cta-footer>
     </dds-card-group-item>
     <dds-card-group-item href="https://example.com">
       <dds-card-eyebrow>Label</dds-card-eyebrow>
@@ -81,7 +81,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-offset/index
       <p>
         Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis democritum ex. Illud ullum graecis
       </p>
-      <dds-card-footer slot="footer">
+      <dds-card-cta-footer slot="footer">
         <svg
           slot="icon"
           focusable="false"
@@ -94,7 +94,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-offset/index
         >
           <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
-      </dds-card-footer>
+      </dds-card-cta-footer>
     </dds-card-group-item>
     <dds-card-group-item href="https://example.com">
       <dds-card-eyebrow>Label</dds-card-eyebrow>
@@ -102,7 +102,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-offset/index
       <p>
         Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis democritum ex. Illud ullum graecis
       </p>
-      <dds-card-footer slot="footer">
+      <dds-card-cta-footer slot="footer">
         <svg
           slot="icon"
           focusable="false"
@@ -115,7 +115,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-offset/index
         >
           <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
-      </dds-card-footer>
+      </dds-card-cta-footer>
     </dds-card-group-item>
   </dds-card-group>
 </dds-card-section-offset>

--- a/packages/web-components/src/components/card-section-offset/__stories__/card-section-offset.stories.ts
+++ b/packages/web-components/src/components/card-section-offset/__stories__/card-section-offset.stories.ts
@@ -45,9 +45,9 @@ const defaultCardGroupItem = html`
     <p>
       Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis democritum ex. Illud ullum graecis
     </p>
-    <dds-card-footer slot="footer">
+    <dds-card-cta-footer slot="footer">
       ${ArrowRight20({ slot: 'icon' })}
-    </dds-card-footer>
+    </dds-card-cta-footer>
   </dds-card-group-item>
 `;
 

--- a/packages/web-components/src/components/card-section-offset/__tests__/card-section-offset.test.ts
+++ b/packages/web-components/src/components/card-section-offset/__tests__/card-section-offset.test.ts
@@ -45,9 +45,9 @@ describe('dds-card-section-offset', function() {
             <dds-card-group-item href="https://example.com">
               <dds-card-eyebrow>Topic</dds-card-eyebrow>
               <dds-card-heading>Natural Language Processing.</dds-card-heading>
-              <dds-card-footer slot="footer">
+              <dds-card-cta-footer slot="footer">
                 ${ArrowRight20({ slot: 'icon' })}
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-group-item>
             <dds-card-group-item href="https://example.com">
               <dds-card-eyebrow>Topic</dds-card-eyebrow>
@@ -59,9 +59,9 @@ describe('dds-card-section-offset', function() {
             <dds-card-group-item href="https://example.com">
               <dds-card-eyebrow>Topic</dds-card-eyebrow>
               <dds-card-heading>Natural Language Processing.</dds-card-heading>
-              <dds-card-footer slot="footer">
+              <dds-card-cta-footer slot="footer">
                 ${ArrowRight20({ slot: 'icon' })}
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-group-item>
           `,
         }),

--- a/packages/web-components/src/components/card-section-simple/__tests__/card-section-simple.test.ts
+++ b/packages/web-components/src/components/card-section-simple/__tests__/card-section-simple.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -41,9 +41,9 @@ describe('dds-card-section-simple', function() {
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec
                 hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
               </p>
-              <dds-card-footer slot="footer">
+              <dds-card-cta-footer slot="footer">
                 ${ArrowRight20({ slot: 'icon' })}
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-group-item>
           `,
         }),

--- a/packages/web-components/src/components/card-section-simple/index.ts
+++ b/packages/web-components/src/components/card-section-simple/index.ts
@@ -9,7 +9,7 @@
 
 import './card-section-simple';
 import '../card/card-heading';
-import '../card/card-footer';
+import '../cta/card-cta-footer';
 import '../card-group/card-group';
 import '../card-group/card-group-item';
 import '../content-section/content-section';

--- a/packages/web-components/src/components/content-block-card-static/__tests__/content-block-card-static.test.ts
+++ b/packages/web-components/src/components/content-block-card-static/__tests__/content-block-card-static.test.ts
@@ -48,9 +48,9 @@ describe('dds-content-block-card-static', function() {
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec
                 hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
               </p>
-              <dds-card-footer slot="footer">
+              <dds-card-cta-footer slot="footer">
                 ${ArrowRight20({ slot: 'icon' })}
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-group-item>
           `,
           contentItemHeading: 'Lorem ipsum',

--- a/packages/web-components/src/components/content-block-cards/__tests__/content-block-cards.test.ts
+++ b/packages/web-components/src/components/content-block-cards/__tests__/content-block-cards.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -46,9 +46,9 @@ describe('dds-content-block-cards', function() {
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec
                 hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
               </p>
-              <dds-card-footer slot="footer">
+              <dds-card-cta-footer slot="footer">
                 ${ArrowRight20({ slot: 'icon' })}
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-group-item>
           `,
         }),

--- a/packages/web-components/src/components/content-block-simple/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-simple/__stories__/README.stories.mdx
@@ -90,7 +90,7 @@ import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20.js';
   </dds-image>
     <dds-card-cta slot="footer" cta-type="local" href="https://www.ibm.com/">
       Lorem ipsum dolor sit amet
-      <dds-card-footer>
+      <dds-card-cta-footer>
         <svg
           slot="icon"
           focusable="false"
@@ -104,7 +104,7 @@ import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20.js';
         >
           <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
-      </dds-card-footer>
+      </dds-card-cta-footer>
     </dds-card-cta>
 </dds-content-block-simple>
 ```

--- a/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.ts
+++ b/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.ts
@@ -84,11 +84,11 @@ export const Default = ({ parameters }) => {
         ? html`
             <dds-card-cta slot="footer" cta-type="${ifNonNull(ctaType)}" href="${ifNonNull(href)}">
               ${ctaCopy}
-              <dds-card-footer>
+              <dds-card-cta-footer>
                 ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
                 ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
                 ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-cta>
           `
         : html`
@@ -119,11 +119,11 @@ export const WithImage = ({ parameters }) => {
         ? html`
             <dds-card-cta slot="footer" cta-type="${ifNonNull(ctaType)}" href="${ifNonNull(href)}">
               ${ctaCopy}
-              <dds-card-footer>
+              <dds-card-cta-footer>
                 ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
                 ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
                 ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-cta>
           `
         : html`
@@ -158,11 +158,11 @@ export const WithVideo = ({ parameters }) => {
         ? html`
             <dds-card-cta slot="footer" cta-type="${ifNonNull(ctaType)}" href="${ifNonNull(href)}">
               ${ctaCopy}
-              <dds-card-footer>
+              <dds-card-cta-footer>
                 ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
                 ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
                 ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-cta>
           `
         : html`
@@ -211,11 +211,11 @@ export const WithLinkList = ({ parameters }) => {
         ? html`
             <dds-card-cta slot="footer" cta-type="${ifNonNull(ctaType)}" href="${ifNonNull(href)}">
               ${ctaCopy}
-              <dds-card-footer>
+              <dds-card-cta-footer>
                 ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
                 ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
                 ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </dds-card-footer>
+              </dds-card-cta-footer>
             </dds-card-cta>
           `
         : html`

--- a/packages/web-components/tests/snapshots/dds-content-block-card-static.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-card-static.md
@@ -94,14 +94,17 @@
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec
                 hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
-      <dds-card-footer
+      <dds-card-cta-footer
         color-scheme=""
-        data-autoid="dds--card-footer"
+        cta-type=""
+        data-autoid="dds--card-cta-footer"
+        href="https://example.com"
         icon-placement="right"
+        parent-href="https://example.com"
         size=""
         slot="footer"
       >
-      </dds-card-footer>
+      </dds-card-cta-footer>
     </dds-card-group-item>
   </dds-card-group>
   <dds-content-item data-autoid="dds--content-item">


### PR DESCRIPTION
### Related Ticket(s)

#6733 
### Description

update components to use `card-cta-footer` instead of just `card-footer` when applicable. 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
