### PR TITLE
fix(locale-modal): set region item to be tabbable for voiceover

### DIFF
--- a/packages/web-components/src/components/locale-modal/locale-modal.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal.ts
@@ -182,6 +182,7 @@ class DDSLocaleModal extends DDSExpressiveModal {
       const { selectorPrimaryFocus } = this.constructor as typeof DDSLocaleModal;
       const activeRegion = this.querySelector(selectorPrimaryFocus);
       if (activeRegion) {
+        (activeRegion as HTMLElement).tabIndex = 0;
         (activeRegion as HTMLElement).focus();
       }
     }


### PR DESCRIPTION
### Related Ticket(s)

Web component: Dotcom shell - Locale modal- when we activate "Select geographic area" link, the First modal is not displayed #6077

### Description

When using voiceover on iphone, the user isn't taken back to the first modal with all the geographic regions (Americas, Asia Pacific, etc) after selecting the "Select geographic area" link to go back. The "Americas" region card is briefly focused before voiceover announces the `select` component. 

Solution is the set the `tabIndex` of the first `<dds-region-item>` component in the first modal. This way voiceover recognizes the component as tabbable and will then focus properly on it.

### Changelog

**Changed**

- set `tabIndex` of the first region item to 0 to ensure voiceover focuses on it

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
