### PR TITLE
fix(tabs-extended): display tooltip on truncated tab focus

### DIFF
--- a/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
+++ b/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
@@ -63,16 +63,17 @@
         overflow: visible;
         white-space: normal;
 
+        &[hasTooltip] {
+          @include tooltip--trigger('definition', top);
+          @include tooltip--placement('definition', 'bottom', 'start');
+
+          &:focus {
+            @include focus-outline('outline');
+          }
+        }
+
         div {
           align-self: flex-start;
-          &[hasTooltip] {
-            @include tooltip--trigger('definition', top);
-            @include tooltip--placement('definition', 'bottom', 'start');
-
-            &:focus {
-              outline: none;
-            }
-          }
         }
 
         /* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix */

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -66,12 +66,13 @@ class DDSTabsExtended extends StableSelectorMixin(LitElement) {
     this._tabItems.map((tab, index) => {
       (tab as DDSTab).selected = index === this._activeTab;
       (tab as DDSTab).setIndex(index);
-      const navLink = this.shadowRoot!.querySelectorAll('.bx--tabs__nav-link div p')[index];
-      if (navLink.scrollHeight > 70) {
+      const navLink = this.shadowRoot!.querySelectorAll(`.${prefix}--tabs__nav-link`)[index];
+      const navText = navLink!.querySelector('div p');
+      if (navText!.scrollHeight > 70) {
         const label = (tab as DDSTab).getAttribute('label');
         if (label) {
-          navLink.parentElement!.setAttribute('aria-label', label);
-          navLink.parentElement!.setAttribute('hasToolTip', label);
+          navLink!.setAttribute('aria-label', label);
+          navLink!.setAttribute('hasTooltip', label);
         }
       }
       return tab;


### PR DESCRIPTION
### Related Ticket(s)

#6233

### Description

This PR updates the extended tabs so that tooltips for truncated tab labels appear on tab focus in addition to hover (existing behavior from #6155)

on focus:

![image](https://user-images.githubusercontent.com/8265238/127205781-d968481e-27ae-43ae-851a-14f4dc20a370.png)

on hover:

![image](https://user-images.githubusercontent.com/8265238/127206859-1455ef4b-24a8-4fc6-a4ce-ca9e918bd546.png)



### Changelog

**Changed**

- move tooltip mixins from tab label text to tab label anchor

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
