### PR TITLE
fix(language-selector): added missing label to select

### DIFF
--- a/packages/react/src/components/Footer/LanguageSelector.js
+++ b/packages/react/src/components/Footer/LanguageSelector.js
@@ -95,7 +95,8 @@ const LanguageSelector = ({
         className={`${prefix}--language-selector`}
         onChange={evt => _setSelectedItem(evt)}
         text={selectedItem.text}
-        labelText={labelText}>
+        labelText={labelText}
+        aria-label={labelText}>
         {renderSelectItems(items)}
       </Select>
     </div>


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6022

### Description

Added missing `aria-label` to `select` in React.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
