### PR TITLE
feat(loadPlex): introduce loadPlex utility

### DIFF
--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -1,141 +1,177 @@
-<link rel="alternate" hreflang="en-us" href="https://www.ibm.com/us-en/" />
-<link rel="alternate" hreflang="x-default" href="https://www.ibm.com" />
-<link rel="alternate" hreflang="en-af" href="https://www.ibm.com/af-en" />
-<link rel="alternate" hreflang="fr-dz" href="https://www.ibm.com/dz-fr" />
-<link rel="alternate" hreflang="pt-ao" href="https://www.ibm.com/ao-pt" />
-<link rel="alternate" hreflang="en-ai" href="https://www.ibm.com/ai-en" />
-<link rel="alternate" hreflang="en-ag" href="https://www.ibm.com/ag-en" />
-<link rel="alternate" hreflang="es-ar" href="https://www.ibm.com/ar-es" />
-<link rel="alternate" hreflang="en-aw" href="https://www.ibm.com/aw-en" />
-<link rel="alternate" hreflang="en-au" href="https://www.ibm.com/au-en" />
-<link rel="alternate" hreflang="de-at" href="https://www.ibm.com/at-de" />
-<link rel="alternate" hreflang="en-bs" href="https://www.ibm.com/bs-en" />
-<link rel="alternate" hreflang="en-bh" href="https://www.ibm.com/bh-en" />
-<link rel="alternate" hreflang="en-bd" href="https://www.ibm.com/bd-en" />
-<link rel="alternate" hreflang="en-bb" href="https://www.ibm.com/bb-en" />
-<link rel="alternate" hreflang="en-be" href="https://www.ibm.com/be-en" />
-<link rel="alternate" hreflang="en-bm" href="https://www.ibm.com/bm-en" />
-<link rel="alternate" hreflang="es-bo" href="https://www.ibm.com/bo-es" />
-<link rel="alternate" hreflang="en-bw" href="https://www.ibm.com/bw-en" />
-<link rel="alternate" hreflang="pt-br" href="https://www.ibm.com/br-pt" />
-<link rel="alternate" hreflang="en-vg" href="https://www.ibm.com/vg-en" />
-<link rel="alternate" hreflang="en-bn" href="https://www.ibm.com/bn-en" />
-<link rel="alternate" hreflang="en-bg" href="https://www.ibm.com/bg-en" />
-<link rel="alternate" hreflang="fr-bf" href="https://www.ibm.com/bf-fr" />
-<link rel="alternate" hreflang="en-kh" href="https://www.ibm.com/kh-en" />
-<link rel="alternate" hreflang="fr-cm" href="https://www.ibm.com/cm-fr" />
-<link rel="alternate" hreflang="en-ca" href="https://www.ibm.com/ca-en" />
-<link rel="alternate" hreflang="fr-ca" href="https://www.ibm.com/ca-fr" />
-<link rel="alternate" hreflang="en-ky" href="https://www.ibm.com/ky-en" />
-<link rel="alternate" hreflang="fr-td" href="https://www.ibm.com/td-fr" />
-<link rel="alternate" hreflang="es-cl" href="https://www.ibm.com/cl-es" />
-<link rel="alternate" hreflang="zh-cn" href="https://www.ibm.com/cn-zh" />
-<link rel="alternate" hreflang="es-co" href="https://www.ibm.com/co-es" />
-<link rel="alternate" hreflang="fr-cd" href="https://www.ibm.com/cd-fr" />
-<link rel="alternate" hreflang="fr-cg" href="https://www.ibm.com/cg-fr" />
-<link rel="alternate" hreflang="es-cr" href="https://www.ibm.com/cr-es" />
-<link rel="alternate" hreflang="en-hr" href="https://www.ibm.com/hr-en" />
-<link rel="alternate" hreflang="en-cw" href="https://www.ibm.com/cw-en" />
-<link rel="alternate" hreflang="en-cy" href="https://www.ibm.com/cy-en" />
-<link rel="alternate" hreflang="en-cz" href="https://www.ibm.com/cz-en" />
-<link rel="alternate" hreflang="en-dm" href="https://www.ibm.com/dm-en" />
-<link rel="alternate" hreflang="en-dk" href="https://www.ibm.com/dk-en" />
-<link rel="alternate" hreflang="es-ec" href="https://www.ibm.com/ec-es" />
-<link rel="alternate" hreflang="en-eg" href="https://www.ibm.com/eg-en" />
-<link rel="alternate" hreflang="en-ee" href="https://www.ibm.com/ee-en" />
-<link rel="alternate" hreflang="en-et" href="https://www.ibm.com/et-en" />
-<link rel="alternate" hreflang="en-fi" href="https://www.ibm.com/fi-en" />
-<link rel="alternate" hreflang="fr-fr" href="https://www.ibm.com/fr-fr" />
-<link rel="alternate" hreflang="fr-ga" href="https://www.ibm.com/ga-fr" />
-<link rel="alternate" hreflang="de-de" href="https://www.ibm.com/de-de" />
-<link rel="alternate" hreflang="en-gh" href="https://www.ibm.com/gh-en" />
-<link rel="alternate" hreflang="en-gr" href="https://www.ibm.com/gr-en" />
-<link rel="alternate" hreflang="en-gd" href="https://www.ibm.com/gd-en" />
-<link rel="alternate" hreflang="en-gy" href="https://www.ibm.com/gy-en" />
-<link rel="alternate" hreflang="en-hk" href="https://www.ibm.com/hk-en" />
-<link rel="alternate" hreflang="en-hu" href="https://www.ibm.com/hu-en" />
-<link rel="alternate" hreflang="en-in" href="https://www.ibm.com/in-en" />
-<link rel="alternate" hreflang="en-id" href="https://www.ibm.com/id-en" />
-<link rel="alternate" hreflang="en-iq" href="https://www.ibm.com/iq-en" />
-<link rel="alternate" hreflang="en-ie" href="https://www.ibm.com/ie-en" />
-<link rel="alternate" hreflang="en-il" href="https://www.ibm.com/il-en" />
-<link rel="alternate" hreflang="it-it" href="https://www.ibm.com/it-it" />
-<link rel="alternate" hreflang="fr-ci" href="https://www.ibm.com/ci-fr" />
-<link rel="alternate" hreflang="en-jm" href="https://www.ibm.com/jm-en" />
-<link rel="alternate" hreflang="ja-jp" href="https://www.ibm.com/jp-ja" />
-<link rel="alternate" hreflang="en-jo" href="https://www.ibm.com/jo-en" />
-<link rel="alternate" hreflang="en-kz" href="https://www.ibm.com/kz-en" />
-<link rel="alternate" hreflang="en-ke" href="https://www.ibm.com/ke-en" />
-<link rel="alternate" hreflang="ko-kr" href="https://www.ibm.com/kr-ko" />
-<link rel="alternate" hreflang="en-kw" href="https://www.ibm.com/kw-en" />
-<link rel="alternate" hreflang="en-lv" href="https://www.ibm.com/lv-en" />
-<link rel="alternate" hreflang="en-lb" href="https://www.ibm.com/lb-en" />
-<link rel="alternate" hreflang="en-ly" href="https://www.ibm.com/ly-en" />
-<link rel="alternate" hreflang="fr-mg" href="https://www.ibm.com/mg-fr" />
-<link rel="alternate" hreflang="en-lt" href="https://www.ibm.com/lt-en" />
-<link rel="alternate" hreflang="en-mw" href="https://www.ibm.com/mw-en" />
-<link rel="alternate" hreflang="en-my" href="https://www.ibm.com/my-en" />
-<link rel="alternate" hreflang="fr-mu" href="https://www.ibm.com/mu-fr" />
-<link rel="alternate" hreflang="es-mx" href="https://www.ibm.com/mx-es" />
-<link rel="alternate" hreflang="en-ms" href="https://www.ibm.com/ms-en" />
-<link rel="alternate" hreflang="fr-ma" href="https://www.ibm.com/ma-fr" />
-<link rel="alternate" hreflang="pt-mz" href="https://www.ibm.com/mz-pt" />
-<link rel="alternate" hreflang="en-na" href="https://www.ibm.com/na-en" />
-<link rel="alternate" hreflang="en-np" href="https://www.ibm.com/np-en" />
-<link rel="alternate" hreflang="en-nl" href="https://www.ibm.com/nl-en" />
-<link rel="alternate" hreflang="en-nz" href="https://www.ibm.com/nz-en" />
-<link rel="alternate" hreflang="fr-ne" href="https://www.ibm.com/ne-fr" />
-<link rel="alternate" hreflang="en-ng" href="https://www.ibm.com/ng-en" />
-<link rel="alternate" hreflang="en-no" href="https://www.ibm.com/no-en" />
-<link rel="alternate" hreflang="en-om" href="https://www.ibm.com/om-en" />
-<link rel="alternate" hreflang="en-pk" href="https://www.ibm.com/pk-en" />
-<link rel="alternate" hreflang="es-py" href="https://www.ibm.com/py-es" />
-<link rel="alternate" hreflang="es-pe" href="https://www.ibm.com/pe-es" />
-<link rel="alternate" hreflang="en-ph" href="https://www.ibm.com/ph-en" />
-<link rel="alternate" hreflang="pl-pl" href="https://www.ibm.com/pl-pl" />
-<link rel="alternate" hreflang="pt-pt" href="https://www.ibm.com/pt-pt" />
-<link rel="alternate" hreflang="en-pt" href="https://www.ibm.com/pt-en" />
-<link rel="alternate" hreflang="en-qa" href="https://www.ibm.com/qa-en" />
-<link rel="alternate" hreflang="en-ro" href="https://www.ibm.com/ro-en" />
-<link rel="alternate" hreflang="ru-ru" href="https://www.ibm.com/ru-ru" />
-<link rel="alternate" hreflang="en-kn" href="https://www.ibm.com/kn-en" />
-<link rel="alternate" hreflang="en-lc" href="https://www.ibm.com/lc-en" />
-<link rel="alternate" hreflang="en-vc" href="https://www.ibm.com/vc-en" />
-<link rel="alternate" hreflang="en-sa" href="https://www.ibm.com/sa-en" />
-<link rel="alternate" hreflang="ar-sa" href="https://www.ibm.com/sa-ar" />
-<link rel="alternate" hreflang="fr-sn" href="https://www.ibm.com/sn-fr" />
-<link rel="alternate" hreflang="en-rs" href="https://www.ibm.com/rs-en" />
-<link rel="alternate" hreflang="fr-sc" href="https://www.ibm.com/sc-fr" />
-<link rel="alternate" hreflang="en-sl" href="https://www.ibm.com/sl-en" />
-<link rel="alternate" hreflang="en-sg" href="https://www.ibm.com/sg-en" />
-<link rel="alternate" hreflang="en-sk" href="https://www.ibm.com/sk-en" />
-<link rel="alternate" hreflang="en-si" href="https://www.ibm.com/si-en" />
-<link rel="alternate" hreflang="en-za" href="https://www.ibm.com/za-en" />
-<link rel="alternate" hreflang="es-es" href="https://www.ibm.com/es-es" />
-<link rel="alternate" hreflang="en-lk" href="https://www.ibm.com/lk-en" />
-<link rel="alternate" hreflang="en-sr" href="https://www.ibm.com/sr-en" />
-<link rel="alternate" hreflang="en-se" href="https://www.ibm.com/se-en" />
-<link rel="alternate" hreflang="fr-ch" href="https://www.ibm.com/ch-fr" />
-<link rel="alternate" hreflang="de-ch" href="https://www.ibm.com/ch-de" />
-<link rel="alternate" hreflang="zh-tw" href="https://www.ibm.com/tw-zh" />
-<link rel="alternate" hreflang="en-tz" href="https://www.ibm.com/tz-en" />
-<link rel="alternate" hreflang="en-th" href="https://www.ibm.com/th-en" />
-<link rel="alternate" hreflang="en-tt" href="https://www.ibm.com/tt-en" />
-<link rel="alternate" hreflang="fr-tn" href="https://www.ibm.com/tn-fr" />
-<link rel="alternate" hreflang="tr-tr" href="https://www.ibm.com/tr-tr" />
-<link rel="alternate" hreflang="en-ye" href="https://www.ibm.com/ye-en" />
-<link rel="alternate" hreflang="en-tc" href="https://www.ibm.com/tc-en" />
-<link rel="alternate" hreflang="en-ua" href="https://www.ibm.com/ua-en" />
-<link rel="alternate" hreflang="en-ug" href="https://www.ibm.com/ug-en" />
-<link rel="alternate" hreflang="en-ae" href="https://www.ibm.com/ae-en" />
-<link rel="alternate" hreflang="ar-ae" href="https://www.ibm.com/ae-ar" />
-<link rel="alternate" hreflang="en-gb" href="https://www.ibm.com/uk-en" />
-<link rel="alternate" hreflang="es-uy" href="https://www.ibm.com/uy-es" />
-<link rel="alternate" hreflang="en-uz" href="https://www.ibm.com/uz-en" />
-<link rel="alternate" hreflang="es-ve" href="https://www.ibm.com/ve-es" />
-<link rel="alternate" hreflang="en-vn" href="https://www.ibm.com/vn-en" />
-<link rel="alternate" hreflang="en-zm" href="https://www.ibm.com/zm-en" />
-<link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en" />
+<link rel="alternate" hreflang="en-us" href="iframe.html?id=components-dotcom-shell--default&cc=us&lc=en" />
+<link rel="alternate" hreflang="x-default" href="iframe.html?id=components-dotcom-shell--default&cc=us&lc=en" />
+<link rel="alternate" hreflang="en-af" href="iframe.html?id=components-dotcom-shell--default&cc=af&lc=en" />
+<link rel="alternate" hreflang="fr-dz" href="iframe.html?id=components-dotcom-shell--default&cc=dz&lc=fr" />
+<link rel="alternate" hreflang="pt-ao" href="iframe.html?id=components-dotcom-shell--default&cc=ao&lc=pt" />
+<link rel="alternate" hreflang="en-ai" href="iframe.html?id=components-dotcom-shell--default&cc=ai&lc=en" />
+<link rel="alternate" hreflang="en-ag" href="iframe.html?id=components-dotcom-shell--default&cc=ag&lc=en" />
+<link rel="alternate" hreflang="es-ar" href="iframe.html?id=components-dotcom-shell--default&cc=ar&lc=es" />
+<link rel="alternate" hreflang="en-aw" href="iframe.html?id=components-dotcom-shell--default&cc=aw&lc=en" />
+<link rel="alternate" hreflang="en-au" href="iframe.html?id=components-dotcom-shell--default&cc=au&lc=en" />
+<link rel="alternate" hreflang="de-at" href="iframe.html?id=components-dotcom-shell--default&cc=at&lc=de" />
+<link rel="alternate" hreflang="en-bs" href="iframe.html?id=components-dotcom-shell--default&cc=bs&lc=en" />
+<link rel="alternate" hreflang="en-bh" href="iframe.html?id=components-dotcom-shell--default&cc=bh&lc=en" />
+<link rel="alternate" hreflang="en-bd" href="iframe.html?id=components-dotcom-shell--default&cc=bd&lc=en" />
+<link rel="alternate" hreflang="en-bb" href="iframe.html?id=components-dotcom-shell--default&cc=bb&lc=en" />
+<link rel="alternate" hreflang="en-be" href="iframe.html?id=components-dotcom-shell--default&cc=be&lc=en" />
+<link rel="alternate" hreflang="en-bm" href="iframe.html?id=components-dotcom-shell--default&cc=bm&lc=en" />
+<link rel="alternate" hreflang="es-bo" href="iframe.html?id=components-dotcom-shell--default&cc=bo&lc=es" />
+<link rel="alternate" hreflang="en-bw" href="iframe.html?id=components-dotcom-shell--default&cc=bw&lc=en" />
+<link rel="alternate" hreflang="pt-br" href="iframe.html?id=components-dotcom-shell--default&cc=br&lc=pt" />
+<link rel="alternate" hreflang="en-vg" href="iframe.html?id=components-dotcom-shell--default&cc=vg&lc=en" />
+<link rel="alternate" hreflang="en-bn" href="iframe.html?id=components-dotcom-shell--default&cc=bn&lc=en" />
+<link rel="alternate" hreflang="en-bg" href="iframe.html?id=components-dotcom-shell--default&cc=bg&lc=en" />
+<link rel="alternate" hreflang="fr-bf" href="iframe.html?id=components-dotcom-shell--default&cc=bf&lc=fr" />
+<link rel="alternate" hreflang="en-kh" href="iframe.html?id=components-dotcom-shell--default&cc=kh&lc=en" />
+<link rel="alternate" hreflang="fr-cm" href="iframe.html?id=components-dotcom-shell--default&cc=cm&lc=fr" />
+<link rel="alternate" hreflang="en-ca" href="iframe.html?id=components-dotcom-shell--default&cc=ca&lc=en" />
+<link rel="alternate" hreflang="fr-ca" href="iframe.html?id=components-dotcom-shell--default&cc=ca&lc=fr" />
+<link rel="alternate" hreflang="en-ky" href="iframe.html?id=components-dotcom-shell--default&cc=ky&lc=en" />
+<link rel="alternate" hreflang="fr-td" href="iframe.html?id=components-dotcom-shell--default&cc=td&lc=fr" />
+<link rel="alternate" hreflang="es-cl" href="iframe.html?id=components-dotcom-shell--default&cc=cl&lc=es" />
+<link rel="alternate" hreflang="zh-cn" href="iframe.html?id=components-dotcom-shell--default&cc=cn&lc=zh" />
+<link rel="alternate" hreflang="es-co" href="iframe.html?id=components-dotcom-shell--default&cc=co&lc=es" />
+<link rel="alternate" hreflang="fr-cd" href="iframe.html?id=components-dotcom-shell--default&cc=cd&lc=fr" />
+<link rel="alternate" hreflang="fr-cg" href="iframe.html?id=components-dotcom-shell--default&cc=cg&lc=fr" />
+<link rel="alternate" hreflang="es-cr" href="iframe.html?id=components-dotcom-shell--default&cc=cr&lc=es" />
+<link rel="alternate" hreflang="en-hr" href="iframe.html?id=components-dotcom-shell--default&cc=hr&lc=en" />
+<link rel="alternate" hreflang="en-cw" href="iframe.html?id=components-dotcom-shell--default&cc=cw&lc=en" />
+<link rel="alternate" hreflang="en-cy" href="iframe.html?id=components-dotcom-shell--default&cc=cy&lc=en" />
+<link rel="alternate" hreflang="en-cz" href="iframe.html?id=components-dotcom-shell--default&cc=cz&lc=en" />
+<link rel="alternate" hreflang="en-dm" href="iframe.html?id=components-dotcom-shell--default&cc=dm&lc=en" />
+<link rel="alternate" hreflang="en-dk" href="iframe.html?id=components-dotcom-shell--default&cc=dk&lc=en" />
+<link rel="alternate" hreflang="es-ec" href="iframe.html?id=components-dotcom-shell--default&cc=ec&lc=es" />
+<link rel="alternate" hreflang="en-eg" href="iframe.html?id=components-dotcom-shell--default&cc=eg&lc=en" />
+<link rel="alternate" hreflang="en-ee" href="iframe.html?id=components-dotcom-shell--default&cc=ee&lc=en" />
+<link rel="alternate" hreflang="en-et" href="iframe.html?id=components-dotcom-shell--default&cc=et&lc=en" />
+<link rel="alternate" hreflang="en-fi" href="iframe.html?id=components-dotcom-shell--default&cc=fi&lc=en" />
+<link rel="alternate" hreflang="fr-fr" href="iframe.html?id=components-dotcom-shell--default&cc=fr&lc=fr" />
+<link rel="alternate" hreflang="fr-ga" href="iframe.html?id=components-dotcom-shell--default&cc=ga&lc=fr" />
+<link rel="alternate" hreflang="de-de" href="iframe.html?id=components-dotcom-shell--default&cc=de&lc=de" />
+<link rel="alternate" hreflang="en-gh" href="iframe.html?id=components-dotcom-shell--default&cc=gh&lc=en" />
+<link rel="alternate" hreflang="en-gr" href="iframe.html?id=components-dotcom-shell--default&cc=gr&lc=en" />
+<link rel="alternate" hreflang="en-gd" href="iframe.html?id=components-dotcom-shell--default&cc=gd&lc=en" />
+<link rel="alternate" hreflang="en-gy" href="iframe.html?id=components-dotcom-shell--default&cc=gy&lc=en" />
+<link rel="alternate" hreflang="en-hk" href="iframe.html?id=components-dotcom-shell--default&cc=hk&lc=en" />
+<link rel="alternate" hreflang="en-hu" href="iframe.html?id=components-dotcom-shell--default&cc=hu&lc=en" />
+<link rel="alternate" hreflang="en-in" href="iframe.html?id=components-dotcom-shell--default&cc=in&lc=en" />
+<link rel="alternate" hreflang="en-id" href="iframe.html?id=components-dotcom-shell--default&cc=id&lc=en" />
+<link rel="alternate" hreflang="en-iq" href="iframe.html?id=components-dotcom-shell--default&cc=iq&lc=en" />
+<link rel="alternate" hreflang="en-ie" href="iframe.html?id=components-dotcom-shell--default&cc=ie&lc=en" />
+<link rel="alternate" hreflang="en-il" href="iframe.html?id=components-dotcom-shell--default&cc=il&lc=en" />
+<link rel="alternate" hreflang="it-it" href="iframe.html?id=components-dotcom-shell--default&cc=it&lc=it" />
+<link rel="alternate" hreflang="fr-ci" href="iframe.html?id=components-dotcom-shell--default&cc=ci&lc=fr" />
+<link rel="alternate" hreflang="en-jm" href="iframe.html?id=components-dotcom-shell--default&cc=jm&lc=en" />
+<link rel="alternate" hreflang="ja-jp" href="iframe.html?id=components-dotcom-shell--default&cc=jp&lc=ja" />
+<link rel="alternate" hreflang="en-jo" href="iframe.html?id=components-dotcom-shell--default&cc=jo&lc=en" />
+<link rel="alternate" hreflang="en-kz" href="iframe.html?id=components-dotcom-shell--default&cc=kz&lc=en" />
+<link rel="alternate" hreflang="en-ke" href="iframe.html?id=components-dotcom-shell--default&cc=ke&lc=en" />
+<link rel="alternate" hreflang="ko-kr" href="iframe.html?id=components-dotcom-shell--default&cc=kr&lc=ko" />
+<link rel="alternate" hreflang="en-kw" href="iframe.html?id=components-dotcom-shell--default&cc=kw&lc=en" />
+<link rel="alternate" hreflang="en-lv" href="iframe.html?id=components-dotcom-shell--default&cc=lv&lc=en" />
+<link rel="alternate" hreflang="en-lb" href="iframe.html?id=components-dotcom-shell--default&cc=lb&lc=en" />
+<link rel="alternate" hreflang="en-ly" href="iframe.html?id=components-dotcom-shell--default&cc=ly&lc=en" />
+<link rel="alternate" hreflang="fr-mg" href="iframe.html?id=components-dotcom-shell--default&cc=mg&lc=fr" />
+<link rel="alternate" hreflang="en-lt" href="iframe.html?id=components-dotcom-shell--default&cc=lt&lc=en" />
+<link rel="alternate" hreflang="en-mw" href="iframe.html?id=components-dotcom-shell--default&cc=mw&lc=en" />
+<link rel="alternate" hreflang="en-my" href="iframe.html?id=components-dotcom-shell--default&cc=my&lc=en" />
+<link rel="alternate" hreflang="fr-mu" href="iframe.html?id=components-dotcom-shell--default&cc=mu&lc=fr" />
+<link rel="alternate" hreflang="es-mx" href="iframe.html?id=components-dotcom-shell--default&cc=mx&lc=es" />
+<link rel="alternate" hreflang="en-ms" href="iframe.html?id=components-dotcom-shell--default&cc=ms&lc=en" />
+<link rel="alternate" hreflang="fr-ma" href="iframe.html?id=components-dotcom-shell--default&cc=ma&lc=fr" />
+<link rel="alternate" hreflang="pt-mz" href="iframe.html?id=components-dotcom-shell--default&cc=mz&lc=pt" />
+<link rel="alternate" hreflang="en-na" href="iframe.html?id=components-dotcom-shell--default&cc=na&lc=en" />
+<link rel="alternate" hreflang="en-np" href="iframe.html?id=components-dotcom-shell--default&cc=np&lc=en" />
+<link rel="alternate" hreflang="en-nl" href="iframe.html?id=components-dotcom-shell--default&cc=nl&lc=en" />
+<link rel="alternate" hreflang="en-nz" href="iframe.html?id=components-dotcom-shell--default&cc=nz&lc=en" />
+<link rel="alternate" hreflang="fr-ne" href="iframe.html?id=components-dotcom-shell--default&cc=ne&lc=fr" />
+<link rel="alternate" hreflang="en-ng" href="iframe.html?id=components-dotcom-shell--default&cc=ng&lc=en" />
+<link rel="alternate" hreflang="en-no" href="iframe.html?id=components-dotcom-shell--default&cc=no&lc=en" />
+<link rel="alternate" hreflang="en-om" href="iframe.html?id=components-dotcom-shell--default&cc=om&lc=en" />
+<link rel="alternate" hreflang="en-pk" href="iframe.html?id=components-dotcom-shell--default&cc=pk&lc=en" />
+<link rel="alternate" hreflang="es-py" href="iframe.html?id=components-dotcom-shell--default&cc=py&lc=es" />
+<link rel="alternate" hreflang="es-pe" href="iframe.html?id=components-dotcom-shell--default&cc=pe&lc=es" />
+<link rel="alternate" hreflang="en-ph" href="iframe.html?id=components-dotcom-shell--default&cc=ph&lc=en" />
+<link rel="alternate" hreflang="pl-pl" href="iframe.html?id=components-dotcom-shell--default&cc=pl&lc=pl" />
+<link rel="alternate" hreflang="pt-pt" href="iframe.html?id=components-dotcom-shell--default&cc=pt&lc=pt" />
+<link rel="alternate" hreflang="en-pt" href="iframe.html?id=components-dotcom-shell--default&cc=pt&lc=en" />
+<link rel="alternate" hreflang="en-qa" href="iframe.html?id=components-dotcom-shell--default&cc=qa&lc=en" />
+<link rel="alternate" hreflang="en-ro" href="iframe.html?id=components-dotcom-shell--default&cc=ro&lc=en" />
+<link rel="alternate" hreflang="ru-ru" href="iframe.html?id=components-dotcom-shell--default&cc=ru&lc=ru" />
+<link rel="alternate" hreflang="en-kn" href="iframe.html?id=components-dotcom-shell--default&cc=kn&lc=en" />
+<link rel="alternate" hreflang="en-lc" href="iframe.html?id=components-dotcom-shell--default&cc=lc&lc=en" />
+<link rel="alternate" hreflang="en-vc" href="iframe.html?id=components-dotcom-shell--default&cc=vc&lc=en" />
+<link rel="alternate" hreflang="en-sa" href="iframe.html?id=components-dotcom-shell--default&cc=sa&lc=en" />
+<link rel="alternate" hreflang="ar-sa" href="iframe.html?id=components-dotcom-shell--default&cc=sa&lc=ar" />
+<link rel="alternate" hreflang="fr-sn" href="iframe.html?id=components-dotcom-shell--default&cc=sn&lc=fr" />
+<link rel="alternate" hreflang="en-rs" href="iframe.html?id=components-dotcom-shell--default&cc=rs&lc=en" />
+<link rel="alternate" hreflang="fr-sc" href="iframe.html?id=components-dotcom-shell--default&cc=sc&lc=fr" />
+<link rel="alternate" hreflang="en-sl" href="iframe.html?id=components-dotcom-shell--default&cc=sl&lc=en" />
+<link rel="alternate" hreflang="en-sg" href="iframe.html?id=components-dotcom-shell--default&cc=sg&lc=en" />
+<link rel="alternate" hreflang="en-sk" href="iframe.html?id=components-dotcom-shell--default&cc=sk&lc=en" />
+<link rel="alternate" hreflang="en-si" href="iframe.html?id=components-dotcom-shell--default&cc=si&lc=en" />
+<link rel="alternate" hreflang="en-za" href="iframe.html?id=components-dotcom-shell--default&cc=za&lc=en" />
+<link rel="alternate" hreflang="es-es" href="iframe.html?id=components-dotcom-shell--default&cc=es&lc=es" />
+<link rel="alternate" hreflang="en-lk" href="iframe.html?id=components-dotcom-shell--default&cc=lk&lc=en" />
+<link rel="alternate" hreflang="en-sr" href="iframe.html?id=components-dotcom-shell--default&cc=sr&lc=en" />
+<link rel="alternate" hreflang="en-se" href="iframe.html?id=components-dotcom-shell--default&cc=se&lc=en" />
+<link rel="alternate" hreflang="fr-ch" href="iframe.html?id=components-dotcom-shell--default&cc=ch&lc=fr" />
+<link rel="alternate" hreflang="de-ch" href="iframe.html?id=components-dotcom-shell--default&cc=ch&lc=de" />
+<link rel="alternate" hreflang="zh-tw" href="iframe.html?id=components-dotcom-shell--default&cc=tw&lc=zh" />
+<link rel="alternate" hreflang="en-tz" href="iframe.html?id=components-dotcom-shell--default&cc=tz&lc=en" />
+<link rel="alternate" hreflang="en-th" href="iframe.html?id=components-dotcom-shell--default&cc=th&lc=en" />
+<link rel="alternate" hreflang="en-tt" href="iframe.html?id=components-dotcom-shell--default&cc=tt&lc=en" />
+<link rel="alternate" hreflang="fr-tn" href="iframe.html?id=components-dotcom-shell--default&cc=tn&lc=fr" />
+<link rel="alternate" hreflang="tr-tr" href="iframe.html?id=components-dotcom-shell--default&cc=tr&lc=tr" />
+<link rel="alternate" hreflang="en-ye" href="iframe.html?id=components-dotcom-shell--default&cc=ye&lc=en" />
+<link rel="alternate" hreflang="en-tc" href="iframe.html?id=components-dotcom-shell--default&cc=tc&lc=en" />
+<link rel="alternate" hreflang="en-ua" href="iframe.html?id=components-dotcom-shell--default&cc=ua&lc=en" />
+<link rel="alternate" hreflang="en-ug" href="iframe.html?id=components-dotcom-shell--default&cc=ug&lc=en" />
+<link rel="alternate" hreflang="en-ae" href="iframe.html?id=components-dotcom-shell--default&cc=ae&lc=en" />
+<link rel="alternate" hreflang="ar-ae" href="iframe.html?id=components-dotcom-shell--default&cc=ae&lc=ar" />
+<link rel="alternate" hreflang="en-gb" href="iframe.html?id=components-dotcom-shell--default&cc=uk&lc=en" />
+<link rel="alternate" hreflang="es-uy" href="iframe.html?id=components-dotcom-shell--default&cc=uy&lc=es" />
+<link rel="alternate" hreflang="en-uz" href="iframe.html?id=components-dotcom-shell--default&cc=uz&lc=en" />
+<link rel="alternate" hreflang="es-ve" href="iframe.html?id=components-dotcom-shell--default&cc=ve&lc=es" />
+<link rel="alternate" hreflang="en-vn" href="iframe.html?id=components-dotcom-shell--default&cc=vn&lc=en" />
+<link rel="alternate" hreflang="en-zm" href="iframe.html?id=components-dotcom-shell--default&cc=zm&lc=en" />
+<link rel="alternate" hreflang="en-zw" href="iframe.html?id=components-dotcom-shell--default&cc=zw&lc=en" />
+<script>
+  window.digitalData = {
+    "page": {
+      "category": {
+        "primaryCategory": ""
+      },
+      "pageInfo": {
+        "effectiveDate": "",
+        "expiryDate": "",
+        "language": "en-US",
+        "publishDate": "",
+        "publisher": "",
+        "version": "Carbon for IBM.com",
+        "ibm": {
+          "contentDelivery": "",
+          "contentProducer": "",
+          "country": "US",
+          "industry": "",
+          "owner": "",
+          "siteID": "",
+          "subject": "",
+          "type": ""
+        }
+      }
+    }
+  };
+
+  var params = new URLSearchParams(window.location.search);
+
+  if(params.has('lc') && params.has('cc')) {
+    var currentLang = params.get('lc') + '-' + params.get('cc').toUpperCase();
+    document.getElementsByTagName("html")[0].setAttribute("lang", currentLang);
+    digitalData.page.pageInfo.language = currentLang;
+    digitalData.page.pageInfo.ibm.country = params.get('cc').toUpperCase();
+  }
+</script>
 
 <!-- IBM Tag Management and Site Analytics -->
 <script src="//1.www.s81c.com/common/stats/ibm-common.js" defer></script>

--- a/packages/services/src/services/global/global.js
+++ b/packages/services/src/services/global/global.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,6 +7,8 @@
 
 import { AnalyticsAPI } from '../Analytics';
 import { DDOAPI } from '../DDO';
+import { loadPlex } from '@carbon/ibmdotcom-utilities/src/utilities/loadPlex';
+import { LocaleAPI } from '../Locale';
 
 /**
  * Flag to determine if the global init has been fired
@@ -32,6 +34,11 @@ export function globalInit() {
       'Error setting the version of the library in the DDO:',
       error
     );
+  });
+
+  // Sets the Plex font for non-Latin fonts
+  LocaleAPI.getLang().then(lang => {
+    loadPlex(lang.lc);
   });
 
   // analytics tracking

--- a/packages/utilities/src/utilities/index.js
+++ b/packages/utilities/src/utilities/index.js
@@ -14,6 +14,7 @@ export * from './featureflag';
 export * from './formatVideoCaption';
 export * from './geolocation';
 export * from './ipcinfoCookie';
+export * from './loadPlex';
 export * from './markdownToHtml';
 export * from './removeHtmlTagEntities';
 export * from './sameHeight';

--- a/packages/utilities/src/utilities/loadPlex/__tests__/loadPlex.test.js
+++ b/packages/utilities/src/utilities/loadPlex/__tests__/loadPlex.test.js
@@ -43,7 +43,7 @@ describe('Load plex utility | Arabic', () => {
 
 describe('Load plex utility | Japanese', () => {
   beforeAll(() => {
-    loadPlex('jp');
+    loadPlex('ja');
   });
 
   afterAll(() => {
@@ -67,7 +67,7 @@ describe('Load plex utility | Japanese', () => {
 
 describe('Load plex utility | Korean', () => {
   beforeAll(() => {
-    loadPlex('kr');
+    loadPlex('ko');
   });
 
   afterAll(() => {

--- a/packages/utilities/src/utilities/loadPlex/__tests__/loadPlex.test.js
+++ b/packages/utilities/src/utilities/loadPlex/__tests__/loadPlex.test.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { loadPlex } from '../';
+
+/**
+ * Cleans the page after testing
+ *
+ * @private
+ */
+function _cleanPage() {
+  document.body.style.fontFamily = '';
+  document.getElementsByTagName('head')[0].innerHTML = '';
+}
+
+describe('Load plex utility | Arabic', () => {
+  beforeAll(() => {
+    loadPlex('ar');
+  });
+
+  afterAll(() => {
+    _cleanPage();
+  });
+
+  it('should set Plex Arabic font-family on the page', () => {
+    expect(document.body.style.fontFamily).toBe(
+      'IBM Plex Sans Arabic,IBM Plex Sans,Helvetica Neue,Arial,sans-serif'
+    );
+  });
+
+  it('should load Plex Arabic font css on the page', () => {
+    const headContent = document.getElementsByTagName('head')[0].innerHTML;
+    const fontLink =
+      'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/plex/sans-arabic.css';
+
+    expect(headContent.indexOf(fontLink)).not.toEqual(-1);
+  });
+});
+
+describe('Load plex utility | Japanese', () => {
+  beforeAll(() => {
+    loadPlex('jp');
+  });
+
+  afterAll(() => {
+    _cleanPage();
+  });
+
+  it('should set Plex Japanese font-family on the page', () => {
+    expect(document.body.style.fontFamily).toBe(
+      'IBM Plex Sans JP,IBM Plex Sans,Helvetica Neue,Arial,sans-serif'
+    );
+  });
+
+  it('should load Plex Japanese font css on the page', () => {
+    const headContent = document.getElementsByTagName('head')[0].innerHTML;
+    const fontLink =
+      'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/plex/sans-jp.css';
+
+    expect(headContent.indexOf(fontLink)).not.toEqual(-1);
+  });
+});
+
+describe('Load plex utility | Korean', () => {
+  beforeAll(() => {
+    loadPlex('kr');
+  });
+
+  afterAll(() => {
+    _cleanPage();
+  });
+
+  it('should set Plex Korean font-family on the page', () => {
+    expect(document.body.style.fontFamily).toBe(
+      'IBM Plex Sans KR,IBM Plex Sans,Helvetica Neue,Arial,sans-serif'
+    );
+  });
+
+  it('should load Plex Korean font css on the page', () => {
+    const headContent = document.getElementsByTagName('head')[0].innerHTML;
+    const fontLink =
+      'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/plex/sans-kr.css';
+
+    expect(headContent.indexOf(fontLink)).not.toEqual(-1);
+  });
+});
+
+describe('Load plex utility | English', () => {
+  beforeAll(() => {
+    loadPlex('en');
+  });
+
+  it('should not set anything if passing `en`', () => {
+    const links = document.getElementsByTagName('link').length;
+    const family = document.body.style.fontFamily;
+
+    expect(links).toEqual(0);
+    expect(family).toBe('');
+  });
+});

--- a/packages/utilities/src/utilities/loadPlex/index.js
+++ b/packages/utilities/src/utilities/loadPlex/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { default as loadPlex } from './loadPlex';

--- a/packages/utilities/src/utilities/loadPlex/loadPlex.js
+++ b/packages/utilities/src/utilities/loadPlex/loadPlex.js
@@ -24,11 +24,11 @@ const _fonts = {
     entry: 'sans-arabic',
     family: 'IBM Plex Sans Arabic',
   },
-  jp: {
+  ja: {
     entry: 'sans-jp',
     family: 'IBM Plex Sans JP',
   },
-  kr: {
+  ko: {
     entry: 'sans-kr',
     family: 'IBM Plex Sans KR',
   },

--- a/packages/utilities/src/utilities/loadPlex/loadPlex.js
+++ b/packages/utilities/src/utilities/loadPlex/loadPlex.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * CDN host for plex fonts
+ *
+ * @type {string}
+ * @private
+ */
+const _host = 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/plex';
+
+/**
+ * Non-Latin font keys and corresponding entry file/font-family
+ *
+ * @type {{ar: {entry: string, family: string}, jp: {entry: string, family: string}, kr: {entry: string, family: string}}}
+ * @private
+ */
+const _fonts = {
+  ar: {
+    entry: 'sans-arabic',
+    family: 'IBM Plex Sans Arabic',
+  },
+  jp: {
+    entry: 'sans-jp',
+    family: 'IBM Plex Sans JP',
+  },
+  kr: {
+    entry: 'sans-kr',
+    family: 'IBM Plex Sans KR',
+  },
+};
+
+/**
+ * Injects the corresponding CSS entry point to the page
+ *
+ * @param {string} language two-character language code
+ * @private
+ */
+function _injectCSS(language) {
+  const link = document.createElement('link');
+  link.href = `${_host}/${_fonts[language].entry}.css`;
+  link.type = 'text/css';
+  link.rel = 'stylesheet';
+  link.media = 'screen,print';
+
+  document.getElementsByTagName('head')[0].appendChild(link);
+}
+
+/**
+ * Sets the language's font-family to the page
+ *
+ * @param {string} language two-character language code
+ * @private
+ */
+function _setFontFamily(language) {
+  document.body.style.fontFamily = `${_fonts[language].family},IBM Plex Sans,Helvetica Neue,Arial,sans-serif`;
+}
+
+/**
+ * Utility to load in the corresponding non-Latin Plex font if necessary
+ *
+ * @example
+ * import {loadPlex} from '@carbon/ibmdotcom-utilities';
+ *
+ * loadPlex('ar');
+ *
+ * @param {string} language two-character language code
+ */
+function loadPlex(language) {
+  if (_fonts[language]) {
+    _injectCSS(language);
+    _setFontFamily(language);
+  }
+}
+
+export default loadPlex;

--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -1,139 +1,176 @@
-<link rel="alternate" hreflang="en-us" href="https://www.ibm.com/us-en/" />
-<link rel="alternate" hreflang="x-default" href="https://www.ibm.com" />
-<link rel="alternate" hreflang="en-af" href="https://www.ibm.com/af-en" />
-<link rel="alternate" hreflang="fr-dz" href="https://www.ibm.com/dz-fr" />
-<link rel="alternate" hreflang="pt-ao" href="https://www.ibm.com/ao-pt" />
-<link rel="alternate" hreflang="en-ai" href="https://www.ibm.com/ai-en" />
-<link rel="alternate" hreflang="en-ag" href="https://www.ibm.com/ag-en" />
-<link rel="alternate" hreflang="es-ar" href="https://www.ibm.com/ar-es" />
-<link rel="alternate" hreflang="en-aw" href="https://www.ibm.com/aw-en" />
-<link rel="alternate" hreflang="en-au" href="https://www.ibm.com/au-en" />
-<link rel="alternate" hreflang="de-at" href="https://www.ibm.com/at-de" />
-<link rel="alternate" hreflang="en-bs" href="https://www.ibm.com/bs-en" />
-<link rel="alternate" hreflang="en-bh" href="https://www.ibm.com/bh-en" />
-<link rel="alternate" hreflang="en-bd" href="https://www.ibm.com/bd-en" />
-<link rel="alternate" hreflang="en-bb" href="https://www.ibm.com/bb-en" />
-<link rel="alternate" hreflang="en-be" href="https://www.ibm.com/be-en" />
-<link rel="alternate" hreflang="en-bm" href="https://www.ibm.com/bm-en" />
-<link rel="alternate" hreflang="es-bo" href="https://www.ibm.com/bo-es" />
-<link rel="alternate" hreflang="en-bw" href="https://www.ibm.com/bw-en" />
-<link rel="alternate" hreflang="pt-br" href="https://www.ibm.com/br-pt" />
-<link rel="alternate" hreflang="en-vg" href="https://www.ibm.com/vg-en" />
-<link rel="alternate" hreflang="en-bn" href="https://www.ibm.com/bn-en" />
-<link rel="alternate" hreflang="en-bg" href="https://www.ibm.com/bg-en" />
-<link rel="alternate" hreflang="fr-bf" href="https://www.ibm.com/bf-fr" />
-<link rel="alternate" hreflang="en-kh" href="https://www.ibm.com/kh-en" />
-<link rel="alternate" hreflang="fr-cm" href="https://www.ibm.com/cm-fr" />
-<link rel="alternate" hreflang="en-ca" href="https://www.ibm.com/ca-en" />
-<link rel="alternate" hreflang="fr-ca" href="https://www.ibm.com/ca-fr" />
-<link rel="alternate" hreflang="en-ky" href="https://www.ibm.com/ky-en" />
-<link rel="alternate" hreflang="fr-td" href="https://www.ibm.com/td-fr" />
-<link rel="alternate" hreflang="es-cl" href="https://www.ibm.com/cl-es" />
-<link rel="alternate" hreflang="zh-cn" href="https://www.ibm.com/cn-zh" />
-<link rel="alternate" hreflang="es-co" href="https://www.ibm.com/co-es" />
-<link rel="alternate" hreflang="fr-cd" href="https://www.ibm.com/cd-fr" />
-<link rel="alternate" hreflang="fr-cg" href="https://www.ibm.com/cg-fr" />
-<link rel="alternate" hreflang="es-cr" href="https://www.ibm.com/cr-es" />
-<link rel="alternate" hreflang="en-hr" href="https://www.ibm.com/hr-en" />
-<link rel="alternate" hreflang="en-cw" href="https://www.ibm.com/cw-en" />
-<link rel="alternate" hreflang="en-cy" href="https://www.ibm.com/cy-en" />
-<link rel="alternate" hreflang="en-cz" href="https://www.ibm.com/cz-en" />
-<link rel="alternate" hreflang="en-dm" href="https://www.ibm.com/dm-en" />
-<link rel="alternate" hreflang="en-dk" href="https://www.ibm.com/dk-en" />
-<link rel="alternate" hreflang="es-ec" href="https://www.ibm.com/ec-es" />
-<link rel="alternate" hreflang="en-eg" href="https://www.ibm.com/eg-en" />
-<link rel="alternate" hreflang="en-ee" href="https://www.ibm.com/ee-en" />
-<link rel="alternate" hreflang="en-et" href="https://www.ibm.com/et-en" />
-<link rel="alternate" hreflang="en-fi" href="https://www.ibm.com/fi-en" />
-<link rel="alternate" hreflang="fr-fr" href="https://www.ibm.com/fr-fr" />
-<link rel="alternate" hreflang="fr-ga" href="https://www.ibm.com/ga-fr" />
-<link rel="alternate" hreflang="de-de" href="https://www.ibm.com/de-de" />
-<link rel="alternate" hreflang="en-gh" href="https://www.ibm.com/gh-en" />
-<link rel="alternate" hreflang="en-gr" href="https://www.ibm.com/gr-en" />
-<link rel="alternate" hreflang="en-gd" href="https://www.ibm.com/gd-en" />
-<link rel="alternate" hreflang="en-gy" href="https://www.ibm.com/gy-en" />
-<link rel="alternate" hreflang="en-hk" href="https://www.ibm.com/hk-en" />
-<link rel="alternate" hreflang="en-hu" href="https://www.ibm.com/hu-en" />
-<link rel="alternate" hreflang="en-in" href="https://www.ibm.com/in-en" />
-<link rel="alternate" hreflang="en-id" href="https://www.ibm.com/id-en" />
-<link rel="alternate" hreflang="en-iq" href="https://www.ibm.com/iq-en" />
-<link rel="alternate" hreflang="en-ie" href="https://www.ibm.com/ie-en" />
-<link rel="alternate" hreflang="en-il" href="https://www.ibm.com/il-en" />
-<link rel="alternate" hreflang="it-it" href="https://www.ibm.com/it-it" />
-<link rel="alternate" hreflang="fr-ci" href="https://www.ibm.com/ci-fr" />
-<link rel="alternate" hreflang="en-jm" href="https://www.ibm.com/jm-en" />
-<link rel="alternate" hreflang="ja-jp" href="https://www.ibm.com/jp-ja" />
-<link rel="alternate" hreflang="en-jo" href="https://www.ibm.com/jo-en" />
-<link rel="alternate" hreflang="en-kz" href="https://www.ibm.com/kz-en" />
-<link rel="alternate" hreflang="en-ke" href="https://www.ibm.com/ke-en" />
-<link rel="alternate" hreflang="ko-kr" href="https://www.ibm.com/kr-ko" />
-<link rel="alternate" hreflang="en-kw" href="https://www.ibm.com/kw-en" />
-<link rel="alternate" hreflang="en-lv" href="https://www.ibm.com/lv-en" />
-<link rel="alternate" hreflang="en-lb" href="https://www.ibm.com/lb-en" />
-<link rel="alternate" hreflang="en-ly" href="https://www.ibm.com/ly-en" />
-<link rel="alternate" hreflang="en-lt" href="https://www.ibm.com/lt-en" />
-<link rel="alternate" hreflang="en-mw" href="https://www.ibm.com/mw-en" />
-<link rel="alternate" hreflang="en-my" href="https://www.ibm.com/my-en" />
-<link rel="alternate" hreflang="fr-mu" href="https://www.ibm.com/mu-fr" />
-<link rel="alternate" hreflang="es-mx" href="https://www.ibm.com/mx-es" />
-<link rel="alternate" hreflang="en-ms" href="https://www.ibm.com/ms-en" />
-<link rel="alternate" hreflang="fr-ma" href="https://www.ibm.com/ma-fr" />
-<link rel="alternate" hreflang="pt-mz" href="https://www.ibm.com/mz-pt" />
-<link rel="alternate" hreflang="en-na" href="https://www.ibm.com/na-en" />
-<link rel="alternate" hreflang="en-np" href="https://www.ibm.com/np-en" />
-<link rel="alternate" hreflang="en-nl" href="https://www.ibm.com/nl-en" />
-<link rel="alternate" hreflang="en-nz" href="https://www.ibm.com/nz-en" />
-<link rel="alternate" hreflang="fr-ne" href="https://www.ibm.com/ne-fr" />
-<link rel="alternate" hreflang="en-ng" href="https://www.ibm.com/ng-en" />
-<link rel="alternate" hreflang="en-no" href="https://www.ibm.com/no-en" />
-<link rel="alternate" hreflang="en-om" href="https://www.ibm.com/om-en" />
-<link rel="alternate" hreflang="en-pk" href="https://www.ibm.com/pk-en" />
-<link rel="alternate" hreflang="es-py" href="https://www.ibm.com/py-es" />
-<link rel="alternate" hreflang="es-pe" href="https://www.ibm.com/pe-es" />
-<link rel="alternate" hreflang="en-ph" href="https://www.ibm.com/ph-en" />
-<link rel="alternate" hreflang="pl-pl" href="https://www.ibm.com/pl-pl" />
-<link rel="alternate" hreflang="en-pt" href="https://www.ibm.com/pt-en" />
-<link rel="alternate" hreflang="en-qa" href="https://www.ibm.com/qa-en" />
-<link rel="alternate" hreflang="en-ro" href="https://www.ibm.com/ro-en" />
-<link rel="alternate" hreflang="ru-ru" href="https://www.ibm.com/ru-ru" />
-<link rel="alternate" hreflang="en-kn" href="https://www.ibm.com/kn-en" />
-<link rel="alternate" hreflang="en-lc" href="https://www.ibm.com/lc-en" />
-<link rel="alternate" hreflang="en-vc" href="https://www.ibm.com/vc-en" />
-<link rel="alternate" hreflang="en-sa" href="https://www.ibm.com/sa-en" />
-<link rel="alternate" hreflang="fr-sn" href="https://www.ibm.com/sn-fr" />
-<link rel="alternate" hreflang="en-rs" href="https://www.ibm.com/rs-en" />
-<link rel="alternate" hreflang="fr-sc" href="https://www.ibm.com/sc-fr" />
-<link rel="alternate" hreflang="en-sl" href="https://www.ibm.com/sl-en" />
-<link rel="alternate" hreflang="en-sg" href="https://www.ibm.com/sg-en" />
-<link rel="alternate" hreflang="en-sk" href="https://www.ibm.com/sk-en" />
-<link rel="alternate" hreflang="en-si" href="https://www.ibm.com/si-en" />
-<link rel="alternate" hreflang="en-za" href="https://www.ibm.com/za-en" />
-<link rel="alternate" hreflang="es-es" href="https://www.ibm.com/es-es" />
-<link rel="alternate" hreflang="en-lk" href="https://www.ibm.com/lk-en" />
-<link rel="alternate" hreflang="en-sr" href="https://www.ibm.com/sr-en" />
-<link rel="alternate" hreflang="en-se" href="https://www.ibm.com/se-en" />
-<link rel="alternate" hreflang="fr-ch" href="https://www.ibm.com/ch-fr" />
-<link rel="alternate" hreflang="de-ch" href="https://www.ibm.com/ch-de" />
-<link rel="alternate" hreflang="zh-tw" href="https://www.ibm.com/tw-zh" />
-<link rel="alternate" hreflang="en-tz" href="https://www.ibm.com/tz-en" />
-<link rel="alternate" hreflang="en-th" href="https://www.ibm.com/th-en" />
-<link rel="alternate" hreflang="en-tt" href="https://www.ibm.com/tt-en" />
-<link rel="alternate" hreflang="fr-tn" href="https://www.ibm.com/tn-fr" />
-<link rel="alternate" hreflang="tr-tr" href="https://www.ibm.com/tr-tr" />
-<link rel="alternate" hreflang="en-ye" href="https://www.ibm.com/ye-en" />
-<link rel="alternate" hreflang="en-tc" href="https://www.ibm.com/tc-en" />
-<link rel="alternate" hreflang="en-ua" href="https://www.ibm.com/ua-en" />
-<link rel="alternate" hreflang="en-ug" href="https://www.ibm.com/ug-en" />
-<link rel="alternate" hreflang="en-ae" href="https://www.ibm.com/ae-en" />
-<link rel="alternate" hreflang="en-gb" href="https://www.ibm.com/uk-en" />
-<link rel="alternate" hreflang="es-uy" href="https://www.ibm.com/uy-es" />
-<link rel="alternate" hreflang="en-uz" href="https://www.ibm.com/uz-en" />
-<link rel="alternate" hreflang="es-ve" href="https://www.ibm.com/ve-es" />
-<link rel="alternate" hreflang="en-vn" href="https://www.ibm.com/vn-en" />
-<link rel="alternate" hreflang="en-zm" href="https://www.ibm.com/zm-en" />
-<link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en" />
-<script type="text/javascript">
-  document.documentElement.setAttribute('lang', 'en');
+<link rel="alternate" hreflang="en-us" href="iframe.html?id=components-dotcom-shell--default&cc=us&lc=en" />
+<link rel="alternate" hreflang="x-default" href="iframe.html?id=components-dotcom-shell--default&cc=us&lc=en" />
+<link rel="alternate" hreflang="en-af" href="iframe.html?id=components-dotcom-shell--default&cc=af&lc=en" />
+<link rel="alternate" hreflang="fr-dz" href="iframe.html?id=components-dotcom-shell--default&cc=dz&lc=fr" />
+<link rel="alternate" hreflang="pt-ao" href="iframe.html?id=components-dotcom-shell--default&cc=ao&lc=pt" />
+<link rel="alternate" hreflang="en-ai" href="iframe.html?id=components-dotcom-shell--default&cc=ai&lc=en" />
+<link rel="alternate" hreflang="en-ag" href="iframe.html?id=components-dotcom-shell--default&cc=ag&lc=en" />
+<link rel="alternate" hreflang="es-ar" href="iframe.html?id=components-dotcom-shell--default&cc=ar&lc=es" />
+<link rel="alternate" hreflang="en-aw" href="iframe.html?id=components-dotcom-shell--default&cc=aw&lc=en" />
+<link rel="alternate" hreflang="en-au" href="iframe.html?id=components-dotcom-shell--default&cc=au&lc=en" />
+<link rel="alternate" hreflang="de-at" href="iframe.html?id=components-dotcom-shell--default&cc=at&lc=de" />
+<link rel="alternate" hreflang="en-bs" href="iframe.html?id=components-dotcom-shell--default&cc=bs&lc=en" />
+<link rel="alternate" hreflang="en-bh" href="iframe.html?id=components-dotcom-shell--default&cc=bh&lc=en" />
+<link rel="alternate" hreflang="en-bd" href="iframe.html?id=components-dotcom-shell--default&cc=bd&lc=en" />
+<link rel="alternate" hreflang="en-bb" href="iframe.html?id=components-dotcom-shell--default&cc=bb&lc=en" />
+<link rel="alternate" hreflang="en-be" href="iframe.html?id=components-dotcom-shell--default&cc=be&lc=en" />
+<link rel="alternate" hreflang="en-bm" href="iframe.html?id=components-dotcom-shell--default&cc=bm&lc=en" />
+<link rel="alternate" hreflang="es-bo" href="iframe.html?id=components-dotcom-shell--default&cc=bo&lc=es" />
+<link rel="alternate" hreflang="en-bw" href="iframe.html?id=components-dotcom-shell--default&cc=bw&lc=en" />
+<link rel="alternate" hreflang="pt-br" href="iframe.html?id=components-dotcom-shell--default&cc=br&lc=pt" />
+<link rel="alternate" hreflang="en-vg" href="iframe.html?id=components-dotcom-shell--default&cc=vg&lc=en" />
+<link rel="alternate" hreflang="en-bn" href="iframe.html?id=components-dotcom-shell--default&cc=bn&lc=en" />
+<link rel="alternate" hreflang="en-bg" href="iframe.html?id=components-dotcom-shell--default&cc=bg&lc=en" />
+<link rel="alternate" hreflang="fr-bf" href="iframe.html?id=components-dotcom-shell--default&cc=bf&lc=fr" />
+<link rel="alternate" hreflang="en-kh" href="iframe.html?id=components-dotcom-shell--default&cc=kh&lc=en" />
+<link rel="alternate" hreflang="fr-cm" href="iframe.html?id=components-dotcom-shell--default&cc=cm&lc=fr" />
+<link rel="alternate" hreflang="en-ca" href="iframe.html?id=components-dotcom-shell--default&cc=ca&lc=en" />
+<link rel="alternate" hreflang="fr-ca" href="iframe.html?id=components-dotcom-shell--default&cc=ca&lc=fr" />
+<link rel="alternate" hreflang="en-ky" href="iframe.html?id=components-dotcom-shell--default&cc=ky&lc=en" />
+<link rel="alternate" hreflang="fr-td" href="iframe.html?id=components-dotcom-shell--default&cc=td&lc=fr" />
+<link rel="alternate" hreflang="es-cl" href="iframe.html?id=components-dotcom-shell--default&cc=cl&lc=es" />
+<link rel="alternate" hreflang="zh-cn" href="iframe.html?id=components-dotcom-shell--default&cc=cn&lc=zh" />
+<link rel="alternate" hreflang="es-co" href="iframe.html?id=components-dotcom-shell--default&cc=co&lc=es" />
+<link rel="alternate" hreflang="fr-cd" href="iframe.html?id=components-dotcom-shell--default&cc=cd&lc=fr" />
+<link rel="alternate" hreflang="fr-cg" href="iframe.html?id=components-dotcom-shell--default&cc=cg&lc=fr" />
+<link rel="alternate" hreflang="es-cr" href="iframe.html?id=components-dotcom-shell--default&cc=cr&lc=es" />
+<link rel="alternate" hreflang="en-hr" href="iframe.html?id=components-dotcom-shell--default&cc=hr&lc=en" />
+<link rel="alternate" hreflang="en-cw" href="iframe.html?id=components-dotcom-shell--default&cc=cw&lc=en" />
+<link rel="alternate" hreflang="en-cy" href="iframe.html?id=components-dotcom-shell--default&cc=cy&lc=en" />
+<link rel="alternate" hreflang="en-cz" href="iframe.html?id=components-dotcom-shell--default&cc=cz&lc=en" />
+<link rel="alternate" hreflang="en-dm" href="iframe.html?id=components-dotcom-shell--default&cc=dm&lc=en" />
+<link rel="alternate" hreflang="en-dk" href="iframe.html?id=components-dotcom-shell--default&cc=dk&lc=en" />
+<link rel="alternate" hreflang="es-ec" href="iframe.html?id=components-dotcom-shell--default&cc=ec&lc=es" />
+<link rel="alternate" hreflang="en-eg" href="iframe.html?id=components-dotcom-shell--default&cc=eg&lc=en" />
+<link rel="alternate" hreflang="en-ee" href="iframe.html?id=components-dotcom-shell--default&cc=ee&lc=en" />
+<link rel="alternate" hreflang="en-et" href="iframe.html?id=components-dotcom-shell--default&cc=et&lc=en" />
+<link rel="alternate" hreflang="en-fi" href="iframe.html?id=components-dotcom-shell--default&cc=fi&lc=en" />
+<link rel="alternate" hreflang="fr-fr" href="iframe.html?id=components-dotcom-shell--default&cc=fr&lc=fr" />
+<link rel="alternate" hreflang="fr-ga" href="iframe.html?id=components-dotcom-shell--default&cc=ga&lc=fr" />
+<link rel="alternate" hreflang="de-de" href="iframe.html?id=components-dotcom-shell--default&cc=de&lc=de" />
+<link rel="alternate" hreflang="en-gh" href="iframe.html?id=components-dotcom-shell--default&cc=gh&lc=en" />
+<link rel="alternate" hreflang="en-gr" href="iframe.html?id=components-dotcom-shell--default&cc=gr&lc=en" />
+<link rel="alternate" hreflang="en-gd" href="iframe.html?id=components-dotcom-shell--default&cc=gd&lc=en" />
+<link rel="alternate" hreflang="en-gy" href="iframe.html?id=components-dotcom-shell--default&cc=gy&lc=en" />
+<link rel="alternate" hreflang="en-hk" href="iframe.html?id=components-dotcom-shell--default&cc=hk&lc=en" />
+<link rel="alternate" hreflang="en-hu" href="iframe.html?id=components-dotcom-shell--default&cc=hu&lc=en" />
+<link rel="alternate" hreflang="en-in" href="iframe.html?id=components-dotcom-shell--default&cc=in&lc=en" />
+<link rel="alternate" hreflang="en-id" href="iframe.html?id=components-dotcom-shell--default&cc=id&lc=en" />
+<link rel="alternate" hreflang="en-iq" href="iframe.html?id=components-dotcom-shell--default&cc=iq&lc=en" />
+<link rel="alternate" hreflang="en-ie" href="iframe.html?id=components-dotcom-shell--default&cc=ie&lc=en" />
+<link rel="alternate" hreflang="en-il" href="iframe.html?id=components-dotcom-shell--default&cc=il&lc=en" />
+<link rel="alternate" hreflang="it-it" href="iframe.html?id=components-dotcom-shell--default&cc=it&lc=it" />
+<link rel="alternate" hreflang="fr-ci" href="iframe.html?id=components-dotcom-shell--default&cc=ci&lc=fr" />
+<link rel="alternate" hreflang="en-jm" href="iframe.html?id=components-dotcom-shell--default&cc=jm&lc=en" />
+<link rel="alternate" hreflang="ja-jp" href="iframe.html?id=components-dotcom-shell--default&cc=jp&lc=ja" />
+<link rel="alternate" hreflang="en-jo" href="iframe.html?id=components-dotcom-shell--default&cc=jo&lc=en" />
+<link rel="alternate" hreflang="en-kz" href="iframe.html?id=components-dotcom-shell--default&cc=kz&lc=en" />
+<link rel="alternate" hreflang="en-ke" href="iframe.html?id=components-dotcom-shell--default&cc=ke&lc=en" />
+<link rel="alternate" hreflang="ko-kr" href="iframe.html?id=components-dotcom-shell--default&cc=kr&lc=ko" />
+<link rel="alternate" hreflang="en-kw" href="iframe.html?id=components-dotcom-shell--default&cc=kw&lc=en" />
+<link rel="alternate" hreflang="en-lv" href="iframe.html?id=components-dotcom-shell--default&cc=lv&lc=en" />
+<link rel="alternate" hreflang="en-lb" href="iframe.html?id=components-dotcom-shell--default&cc=lb&lc=en" />
+<link rel="alternate" hreflang="en-ly" href="iframe.html?id=components-dotcom-shell--default&cc=ly&lc=en" />
+<link rel="alternate" hreflang="fr-mg" href="iframe.html?id=components-dotcom-shell--default&cc=mg&lc=fr" />
+<link rel="alternate" hreflang="en-lt" href="iframe.html?id=components-dotcom-shell--default&cc=lt&lc=en" />
+<link rel="alternate" hreflang="en-mw" href="iframe.html?id=components-dotcom-shell--default&cc=mw&lc=en" />
+<link rel="alternate" hreflang="en-my" href="iframe.html?id=components-dotcom-shell--default&cc=my&lc=en" />
+<link rel="alternate" hreflang="fr-mu" href="iframe.html?id=components-dotcom-shell--default&cc=mu&lc=fr" />
+<link rel="alternate" hreflang="es-mx" href="iframe.html?id=components-dotcom-shell--default&cc=mx&lc=es" />
+<link rel="alternate" hreflang="en-ms" href="iframe.html?id=components-dotcom-shell--default&cc=ms&lc=en" />
+<link rel="alternate" hreflang="fr-ma" href="iframe.html?id=components-dotcom-shell--default&cc=ma&lc=fr" />
+<link rel="alternate" hreflang="pt-mz" href="iframe.html?id=components-dotcom-shell--default&cc=mz&lc=pt" />
+<link rel="alternate" hreflang="en-na" href="iframe.html?id=components-dotcom-shell--default&cc=na&lc=en" />
+<link rel="alternate" hreflang="en-np" href="iframe.html?id=components-dotcom-shell--default&cc=np&lc=en" />
+<link rel="alternate" hreflang="en-nl" href="iframe.html?id=components-dotcom-shell--default&cc=nl&lc=en" />
+<link rel="alternate" hreflang="en-nz" href="iframe.html?id=components-dotcom-shell--default&cc=nz&lc=en" />
+<link rel="alternate" hreflang="fr-ne" href="iframe.html?id=components-dotcom-shell--default&cc=ne&lc=fr" />
+<link rel="alternate" hreflang="en-ng" href="iframe.html?id=components-dotcom-shell--default&cc=ng&lc=en" />
+<link rel="alternate" hreflang="en-no" href="iframe.html?id=components-dotcom-shell--default&cc=no&lc=en" />
+<link rel="alternate" hreflang="en-om" href="iframe.html?id=components-dotcom-shell--default&cc=om&lc=en" />
+<link rel="alternate" hreflang="en-pk" href="iframe.html?id=components-dotcom-shell--default&cc=pk&lc=en" />
+<link rel="alternate" hreflang="es-py" href="iframe.html?id=components-dotcom-shell--default&cc=py&lc=es" />
+<link rel="alternate" hreflang="es-pe" href="iframe.html?id=components-dotcom-shell--default&cc=pe&lc=es" />
+<link rel="alternate" hreflang="en-ph" href="iframe.html?id=components-dotcom-shell--default&cc=ph&lc=en" />
+<link rel="alternate" hreflang="pl-pl" href="iframe.html?id=components-dotcom-shell--default&cc=pl&lc=pl" />
+<link rel="alternate" hreflang="pt-pt" href="iframe.html?id=components-dotcom-shell--default&cc=pt&lc=pt" />
+<link rel="alternate" hreflang="en-pt" href="iframe.html?id=components-dotcom-shell--default&cc=pt&lc=en" />
+<link rel="alternate" hreflang="en-qa" href="iframe.html?id=components-dotcom-shell--default&cc=qa&lc=en" />
+<link rel="alternate" hreflang="en-ro" href="iframe.html?id=components-dotcom-shell--default&cc=ro&lc=en" />
+<link rel="alternate" hreflang="ru-ru" href="iframe.html?id=components-dotcom-shell--default&cc=ru&lc=ru" />
+<link rel="alternate" hreflang="en-kn" href="iframe.html?id=components-dotcom-shell--default&cc=kn&lc=en" />
+<link rel="alternate" hreflang="en-lc" href="iframe.html?id=components-dotcom-shell--default&cc=lc&lc=en" />
+<link rel="alternate" hreflang="en-vc" href="iframe.html?id=components-dotcom-shell--default&cc=vc&lc=en" />
+<link rel="alternate" hreflang="en-sa" href="iframe.html?id=components-dotcom-shell--default&cc=sa&lc=en" />
+<link rel="alternate" hreflang="ar-sa" href="iframe.html?id=components-dotcom-shell--default&cc=sa&lc=ar" />
+<link rel="alternate" hreflang="fr-sn" href="iframe.html?id=components-dotcom-shell--default&cc=sn&lc=fr" />
+<link rel="alternate" hreflang="en-rs" href="iframe.html?id=components-dotcom-shell--default&cc=rs&lc=en" />
+<link rel="alternate" hreflang="fr-sc" href="iframe.html?id=components-dotcom-shell--default&cc=sc&lc=fr" />
+<link rel="alternate" hreflang="en-sl" href="iframe.html?id=components-dotcom-shell--default&cc=sl&lc=en" />
+<link rel="alternate" hreflang="en-sg" href="iframe.html?id=components-dotcom-shell--default&cc=sg&lc=en" />
+<link rel="alternate" hreflang="en-sk" href="iframe.html?id=components-dotcom-shell--default&cc=sk&lc=en" />
+<link rel="alternate" hreflang="en-si" href="iframe.html?id=components-dotcom-shell--default&cc=si&lc=en" />
+<link rel="alternate" hreflang="en-za" href="iframe.html?id=components-dotcom-shell--default&cc=za&lc=en" />
+<link rel="alternate" hreflang="es-es" href="iframe.html?id=components-dotcom-shell--default&cc=es&lc=es" />
+<link rel="alternate" hreflang="en-lk" href="iframe.html?id=components-dotcom-shell--default&cc=lk&lc=en" />
+<link rel="alternate" hreflang="en-sr" href="iframe.html?id=components-dotcom-shell--default&cc=sr&lc=en" />
+<link rel="alternate" hreflang="en-se" href="iframe.html?id=components-dotcom-shell--default&cc=se&lc=en" />
+<link rel="alternate" hreflang="fr-ch" href="iframe.html?id=components-dotcom-shell--default&cc=ch&lc=fr" />
+<link rel="alternate" hreflang="de-ch" href="iframe.html?id=components-dotcom-shell--default&cc=ch&lc=de" />
+<link rel="alternate" hreflang="zh-tw" href="iframe.html?id=components-dotcom-shell--default&cc=tw&lc=zh" />
+<link rel="alternate" hreflang="en-tz" href="iframe.html?id=components-dotcom-shell--default&cc=tz&lc=en" />
+<link rel="alternate" hreflang="en-th" href="iframe.html?id=components-dotcom-shell--default&cc=th&lc=en" />
+<link rel="alternate" hreflang="en-tt" href="iframe.html?id=components-dotcom-shell--default&cc=tt&lc=en" />
+<link rel="alternate" hreflang="fr-tn" href="iframe.html?id=components-dotcom-shell--default&cc=tn&lc=fr" />
+<link rel="alternate" hreflang="tr-tr" href="iframe.html?id=components-dotcom-shell--default&cc=tr&lc=tr" />
+<link rel="alternate" hreflang="en-ye" href="iframe.html?id=components-dotcom-shell--default&cc=ye&lc=en" />
+<link rel="alternate" hreflang="en-tc" href="iframe.html?id=components-dotcom-shell--default&cc=tc&lc=en" />
+<link rel="alternate" hreflang="en-ua" href="iframe.html?id=components-dotcom-shell--default&cc=ua&lc=en" />
+<link rel="alternate" hreflang="en-ug" href="iframe.html?id=components-dotcom-shell--default&cc=ug&lc=en" />
+<link rel="alternate" hreflang="en-ae" href="iframe.html?id=components-dotcom-shell--default&cc=ae&lc=en" />
+<link rel="alternate" hreflang="ar-ae" href="iframe.html?id=components-dotcom-shell--default&cc=ae&lc=ar" />
+<link rel="alternate" hreflang="en-gb" href="iframe.html?id=components-dotcom-shell--default&cc=uk&lc=en" />
+<link rel="alternate" hreflang="es-uy" href="iframe.html?id=components-dotcom-shell--default&cc=uy&lc=es" />
+<link rel="alternate" hreflang="en-uz" href="iframe.html?id=components-dotcom-shell--default&cc=uz&lc=en" />
+<link rel="alternate" hreflang="es-ve" href="iframe.html?id=components-dotcom-shell--default&cc=ve&lc=es" />
+<link rel="alternate" hreflang="en-vn" href="iframe.html?id=components-dotcom-shell--default&cc=vn&lc=en" />
+<link rel="alternate" hreflang="en-zm" href="iframe.html?id=components-dotcom-shell--default&cc=zm&lc=en" />
+<link rel="alternate" hreflang="en-zw" href="iframe.html?id=components-dotcom-shell--default&cc=zw&lc=en" />
+<script>
+  window.digitalData = {
+    "page": {
+      "category": {
+        "primaryCategory": ""
+      },
+      "pageInfo": {
+        "effectiveDate": "",
+        "expiryDate": "",
+        "language": "en-US",
+        "publishDate": "",
+        "publisher": "",
+        "version": "Carbon for IBM.com",
+        "ibm": {
+          "contentDelivery": "",
+          "contentProducer": "",
+          "country": "US",
+          "industry": "",
+          "owner": "",
+          "siteID": "",
+          "subject": "",
+          "type": ""
+        }
+      }
+    }
+  };
+
+  var params = new URLSearchParams(window.location.search);
+
+  if(params.has('lc') && params.has('cc')) {
+    var currentLang = params.get('lc') + '-' + params.get('cc').toUpperCase();
+    document.getElementsByTagName("html")[0].setAttribute("lang", currentLang);
+    digitalData.page.pageInfo.language = currentLang;
+    digitalData.page.pageInfo.ibm.country = params.get('cc').toUpperCase();
+  }
 </script>
 
 <!-- IBM Tag Management and Site Analytics -->


### PR DESCRIPTION
### Related Ticket(s)

Refs https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5025

### Description

This utility will dynamically load in non-Latin fonts, as well as
setting the font-family to the page accordingly. This leverages the
existing Plex CDN fonts.

In addition, the globalInit introduced the execution of this code, so
this ensures that any page that loads in the Masthead or Footer will do
this check and load in the fonts accordingly.

The `react` and `web-components` storybooks have been updated to 
properly set the language/locale codes so that testing of the language 
selector can be done in Storybook.

### Changelog

**New**

- `loadPlex` utility

**Changed**

- Added `loadPlex` logic to `globalInit`
- Added proper language/locale setting in storybooks
