### PR TITLE
fix(leadspace): ensure leadspace image takes up entire width in lg bp

### DIFF
--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -521,6 +521,7 @@ $btn-min-width: 26;
       width: 100%;
       height: 100%;
       padding: 0;
+      display: block;
 
       .bx--image__img {
         height: 100%;


### PR DESCRIPTION
### Related Ticket(s)

CDN Web Component Leadspace with error #6807

### Description

The leadspace-image was not fitting the entire width of the component. Setting the `display: block` in the large breakpoint fixes this issue.

**BEFORE:**
<img width="1608" alt="Screen Shot 2021-08-04 at 12 31 31 PM" src="https://user-images.githubusercontent.com/54281166/128222897-e2131500-337e-491d-bd47-e72614373ae3.png">

AFTER:
<img width="1606" alt="Screen Shot 2021-08-04 at 12 31 57 PM" src="https://user-images.githubusercontent.com/54281166/128222838-a1243391-020d-4101-84df-8276ac063afb.png">


### Changelog

**Changed**

- set `display` to `block` on large breakpoint for leadspace-image

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
