### PR TITLE
feat(videoPlayer): introducing `playingMode` feature (pairing with wc version)

### DIFF
--- a/packages/react/src/components/VideoPlayer/VideoImageOverlay.js
+++ b/packages/react/src/components/VideoPlayer/VideoImageOverlay.js
@@ -18,12 +18,12 @@ const { prefix } = settings;
 /**
  * VideoPlayer Image Overlay component
  */
-const VideoImageOverlay = ({ videoId, videoData, embedVideo }) => {
+const VideoImageOverlay = ({ videoId, videoData, embedVideo, playingMode }) => {
   return (
     <button
       className={`${prefix}--video-player__image-overlay`}
       data-autoid={`${stablePrefix}--video-player__image-overlay`}
-      onClick={() => _embedPlayer(event, embedVideo)}>
+      onClick={() => _embedPlayer(event, embedVideo, playingMode)}>
       <Image
         defaultSrc={KalturaPlayerAPI.getThumbnailUrl({
           mediaId: videoId,
@@ -36,9 +36,11 @@ const VideoImageOverlay = ({ videoId, videoData, embedVideo }) => {
   );
 };
 
-const _embedPlayer = (e, embedVideo) => {
-  const element = e.target;
-  element.remove();
+const _embedPlayer = (e, embedVideo, playingMode) => {
+  if (playingMode === 'inline') {
+    const element = e.target;
+    element.remove();
+  }
   embedVideo(true);
 };
 
@@ -57,6 +59,11 @@ VideoImageOverlay.propTypes = {
    * Func to set state to trigger embedding of video
    */
   embedVideo: PropTypes.func,
+
+  /**
+   * Choose whether the video will be rendered inline or using the `LightboxMediaViewer`.
+   */
+  playingMode: PropTypes.oneOf(['inline', 'lightbox']),
 };
 
 export default VideoImageOverlay;

--- a/packages/react/src/components/VideoPlayer/VideoPlayer.js
+++ b/packages/react/src/components/VideoPlayer/VideoPlayer.js
@@ -9,6 +9,7 @@ import React, { useEffect, useState } from 'react';
 import cx from 'classnames';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import KalturaPlayerAPI from '@carbon/ibmdotcom-services/es/services/KalturaPlayer/KalturaPlayer';
+import LightboxMediaViewer from '../LightboxMediaViewer/LightboxMediaViewer';
 import PropTypes from 'prop-types';
 import settings from 'carbon-components/es/globals/js/settings';
 import uniqueid from '@carbon/ibmdotcom-utilities/es/utilities/uniqueid/uniqueid';
@@ -26,6 +27,7 @@ const VideoPlayer = ({
   customClassName,
   autoPlay,
   aspectRatio,
+  playingMode,
 }) => {
   const [videoData, setVideoData] = useState({ description: '', name: '' });
 
@@ -66,6 +68,42 @@ const VideoPlayer = ({
     [`${prefix}--video-player__aspect-ratio--${aspectRatio}`]: aspectRatio,
   });
 
+  const renderInLightbox = (
+    <>
+      <div className={`${prefix}--video-player__video`}>
+        <VideoImageOverlay
+          videoId={videoId}
+          videoData={videoData}
+          embedVideo={setEmbedVideo}
+          playingMode={playingMode}
+        />
+      </div>
+      <LightboxMediaViewer
+        open={embedVideo}
+        media={{
+          type: 'video',
+          src: videoId,
+        }}
+        onClose={() => setEmbedVideo(false)}
+      />
+    </>
+  );
+
+  const renderInline = (
+    <div
+      className={`${prefix}--video-player__video`}
+      id={`${prefix}--${videoPlayerId}`}>
+      {!autoPlay && (
+        <VideoImageOverlay
+          videoId={videoId}
+          videoData={videoData}
+          embedVideo={setEmbedVideo}
+          playingMode={playingMode}
+        />
+      )}
+    </div>
+  );
+
   return (
     <div
       aria-label={`${videoData.name} ${videoDuration}`}
@@ -73,17 +111,7 @@ const VideoPlayer = ({
       <div
         className={`${prefix}--video-player__video-container ${aspectRatioClass}`}
         data-autoid={`${stablePrefix}--video-player__video-${videoId}`}>
-        <div
-          className={`${prefix}--video-player__video`}
-          id={`${prefix}--${videoPlayerId}`}>
-          {!autoPlay && (
-            <VideoImageOverlay
-              videoId={videoId}
-              videoData={videoData}
-              embedVideo={setEmbedVideo}
-            />
-          )}
-        </div>
+        {playingMode === 'lightbox' ? renderInLightbox : renderInline}
       </div>
       {showCaption && (
         <div className={`${prefix}--video-player__video-caption`}>
@@ -120,10 +148,16 @@ VideoPlayer.propTypes = {
    * `true` to show the description.
    */
   showCaption: PropTypes.bool,
+
+  /**
+   * Choose whether the video will be rendered inline or using the `LightboxMediaViewer`.
+   */
+  playingMode: PropTypes.oneOf(['inline', 'lightbox']),
 };
 
 VideoPlayer.defaultProps = {
   autoPlay: false,
+  playingMode: 'inline',
 };
 
 export default VideoPlayer;

--- a/packages/react/src/components/VideoPlayer/__stories__/VideoPlayer.stories.js
+++ b/packages/react/src/components/VideoPlayer/__stories__/VideoPlayer.stories.js
@@ -21,7 +21,7 @@ export default {
 };
 
 export const Default = ({ parameters }) => {
-  const { showCaption, aspectRatio, videoId } =
+  const { showCaption, aspectRatio, videoId, playingMode } =
     parameters?.props?.VideoPlayer ?? {};
 
   return (
@@ -32,6 +32,7 @@ export const Default = ({ parameters }) => {
             videoId={videoId}
             showCaption={showCaption}
             aspectRatio={aspectRatio}
+            playingMode={playingMode}
           />
         </div>
       </div>
@@ -46,6 +47,7 @@ Default.story = {
         showCaption: boolean('Show caption (showCaption):', true, groupId),
         aspectRatio: 'default',
         videoId: '1_9h94wo6b',
+        playingMode: 'inline',
       }),
     },
   },
@@ -64,6 +66,7 @@ aspectRatio1x1.story = {
           showCaption: boolean('Show caption (showCaption):', true, groupId),
           aspectRatio: '1x1',
           videoId: '1_9h94wo6b',
+          playingMode: 'inline',
         };
       },
     },
@@ -83,8 +86,27 @@ aspectRatio4x3.story = {
           showCaption: boolean('Show caption (showCaption):', true, groupId),
           aspectRatio: '4x3',
           videoId: '1_p2osmd1z',
+          playingMode: 'inline',
         };
       },
+    },
+  },
+};
+
+export const withLightboxMediaViewer = ({ parameters }) => (
+  <Default parameters={parameters} />
+);
+
+withLightboxMediaViewer.story = {
+  name: 'With lightbox media viewer',
+  parameters: {
+    knobs: {
+      VideoPlayer: ({ groupId }) => ({
+        showCaption: boolean('Show caption (showCaption):', true, groupId),
+        aspectRatio: 'default',
+        videoId: '1_p2osmd1z',
+        playingMode: 'lightbox',
+      }),
     },
   },
 };


### PR DESCRIPTION
### Related Ticket(s)

React: [Video Player] Include onClick enhancement to open in lightbox media viewer #5266

### Description

{{Add a human-readable description / detail summary of what the PR is changing and any details around how and why}}

{{If applicable, include a screenshot indicating an example or examples of what the PR is changing in the application}}

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
