### PR TITLE
fix(masthead): flip megamenu link arrow icons in rtl

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -192,6 +192,14 @@
     span {
       flex: inherit;
     }
+
+    ::slotted([slot='icon']) {
+      transform: none;
+      /* stylelint-disable-next-line comment-whitespace-inside */
+      /*!rtl:raw:
+      transform: scaleX(-1);
+      */
+    }
   }
 
   :host(#{$dds-prefix}-megamenu-link-with-icon)[style-scheme='category-headline'],

--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -322,6 +322,14 @@
       background-color: $hover-ui;
       text-decoration: none;
     }
+
+    svg {
+      transform: none;
+      /* stylelint-disable-next-line comment-whitespace-inside */
+      /*!rtl:raw:
+      transform: scaleX(-1);
+      */
+    }
   }
 
   :host(#{$dds-prefix}-megamenu-left-navigation),

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
@@ -249,6 +249,11 @@
         margin: 0 $spacing-03;
         padding-top: $spacing-02;
         fill: $link-01;
+
+        /* stylelint-disable-next-line comment-whitespace-inside */
+        /*!rtl:raw:
+        transform: scaleX(-1);
+        */
       }
 
       &:hover {

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -185,6 +185,7 @@
     left: 0;
     /* stylelint-disable-next-line comment-whitespace-inside */
     /*!rtl:raw:
+    right: initial;
     position: absolute !important;
     */
   }


### PR DESCRIPTION
### Related Ticket(s)

[Cloud Masthead] Slight page shift when the Mega Menu is opened on machines where scrollbar is set to visible + Adjust minor icon RTL issue#6831

### Description

In RTL, the arrow icons in the megamenu are not flipping. This PR adds `rtlcss` styles to flip the megamenu arrow icons.

**BEFORE:**
<img width="1254" alt="Screen Shot 2021-08-09 at 1 31 10 PM" src="https://user-images.githubusercontent.com/54281166/128754476-19bafc23-562e-4b21-80e5-2ca071d451ea.png">

<img width="1252" alt="Screen Shot 2021-08-09 at 1 30 41 PM" src="https://user-images.githubusercontent.com/54281166/128754428-c481d7dc-64ac-4a12-9d44-596f7606921f.png">

**AFTER:**
<img width="1261" alt="Screen Shot 2021-08-09 at 2 10 04 PM" src="https://user-images.githubusercontent.com/54281166/128754517-ed80b11b-fd3e-4878-a7b8-a3e187097bbf.png">
<img width="1261" alt="Screen Shot 2021-08-09 at 2 10 51 PM" src="https://user-images.githubusercontent.com/54281166/128754526-e508c30f-7fff-4927-a16c-0ba1b7926d81.png">


### Changelog

**New**

- add `rtlcss` styles to `:host(#{$dds-prefix}-megamenu-link-with-icon)` and `:host(#{$dds-prefix}-cloud-megamenu-category-heading)`
- also set the `right` styling for `.#{$prefix}--header__nav-caret-left-container` in rtl to position caret correctly for overflow in masthead-l1

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
