### PR TITLE
fix(cloud-masthead): set position of masthead to fixed when expanded

### DIFF
--- a/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
+++ b/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
@@ -101,6 +101,11 @@ class DDSMegaMenuTopNavMenu extends DDSTopNavMenu {
         .querySelector('dds-masthead')
         ?.shadowRoot?.querySelector('.bx--masthead__l0');
 
+      // set position of masthead when megamenu is expanded specifically for cloud
+      const cloudMasthead: HTMLElement | null | undefined = doc
+        .querySelector('dds-cloud-masthead-container')
+        ?.querySelector('dds-masthead');
+
       if (this.expanded) {
         doc.body.style.marginRight = `${this._scrollBarWidth}px`;
         doc.body.style.overflow = `hidden`;
@@ -109,12 +114,18 @@ class DDSMegaMenuTopNavMenu extends DDSTopNavMenu {
         });
         if (masthead) {
           masthead.style.marginRight = `${this._scrollBarWidth}px`;
+          if (cloudMasthead) {
+            cloudMasthead.style.position = 'fixed';
+          }
         }
       } else {
         doc.body.style.marginRight = '0px';
         doc.body.style.overflow = ``;
         if (masthead) {
           masthead.style.marginRight = '0px';
+          if (cloudMasthead) {
+            cloudMasthead.style.position = '';
+          }
         }
       }
     }


### PR DESCRIPTION
### Related Ticket(s)

[Cloud Masthead] Slight page shift when the Mega Menu is opened on machines where scrollbar is set to visible + Adjust minor icon RTL issue #6831

### Description

Cloud masthead shifts when megamenu is expanded. This is due to the combination of styles implemented from the cloud side to set the masthead `position: static` to accommodate the L1 and the `margin-right` added when the scrollbar is locked on megamenu expand. This PR sets the masthead - scoped to cloud - to `position: fixed` when megamenu is expanded. 

### Changelog

**Changed**

- set `position:fixed` to the cloud-mastead on megamenu expand

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
