### PR TITLE
fix(CTA): allow onClick for buttonCTA to be passed

### DIFF
--- a/packages/react/src/components/CTA/ButtonCTA.js
+++ b/packages/react/src/components/CTA/ButtonCTA.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -76,7 +76,9 @@ const _renderButtons = ({
         : formatCTAcopy({ title: title[0].title, duration: title[0].duration });
       button.href = '#';
     } else {
-      button.onClick = e => CTALogic.jump(e, button.type);
+      button.onClick = button.onClick
+        ? button.onClick
+        : e => CTALogic.jump(e, button.type);
       button.target = CTALogic.external(button.type);
     }
     button.renderIcon = CTALogic.iconSelector(button.type);

--- a/packages/react/src/components/CTA/ButtonCTA.js
+++ b/packages/react/src/components/CTA/ButtonCTA.js
@@ -76,7 +76,7 @@ const _renderButtons = ({
         : formatCTAcopy({ title: title[0].title, duration: title[0].duration });
       button.href = '#';
     } else {
-      button.onClick = button.onClick || e => CTALogic.jump(e, button.type);
+      button.onClick = button.onClick || (e => CTALogic.jump(e, button.type));
       button.target = CTALogic.external(button.type);
     }
     button.renderIcon = CTALogic.iconSelector(button.type);

--- a/packages/react/src/components/CTA/ButtonCTA.js
+++ b/packages/react/src/components/CTA/ButtonCTA.js
@@ -76,9 +76,7 @@ const _renderButtons = ({
         : formatCTAcopy({ title: title[0].title, duration: title[0].duration });
       button.href = '#';
     } else {
-      button.onClick = button.onClick
-        ? button.onClick
-        : e => CTALogic.jump(e, button.type);
+      button.onClick = button.onClick || e => CTALogic.jump(e, button.type);
       button.target = CTALogic.external(button.type);
     }
     button.renderIcon = CTALogic.iconSelector(button.type);


### PR DESCRIPTION
### Related Ticket(s)

[CTASection]: passing Onclick to the cta does not work #6844

### Description

The `button.onClick` was being overwritten, so adopters trying to pass in an onClick function were not able to. Solution is to check if an `onClick` function was passed in before setting it.

### Changelog

**Changed**

- check if `onClick` function has been passed before setting the jump function

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
