### PR TITLE
fix(masthead): remove cloud masthead position fixing code

### DIFF
--- a/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
+++ b/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
@@ -101,11 +101,6 @@ class DDSMegaMenuTopNavMenu extends DDSTopNavMenu {
         .querySelector('dds-masthead')
         ?.shadowRoot?.querySelector('.bx--masthead__l0');
 
-      // set position of masthead when megamenu is expanded specifically for cloud
-      const cloudMasthead: HTMLElement | null | undefined = doc
-        .querySelector('dds-cloud-masthead-container')
-        ?.querySelector('dds-masthead');
-
       if (this.expanded) {
         doc.body.style.marginRight = `${this._scrollBarWidth}px`;
         doc.body.style.overflow = `hidden`;
@@ -114,18 +109,12 @@ class DDSMegaMenuTopNavMenu extends DDSTopNavMenu {
         });
         if (masthead) {
           masthead.style.marginRight = `${this._scrollBarWidth}px`;
-          if (cloudMasthead) {
-            cloudMasthead.style.position = 'fixed';
-          }
         }
       } else {
         doc.body.style.marginRight = '0px';
         doc.body.style.overflow = ``;
         if (masthead) {
           masthead.style.marginRight = '0px';
-          if (cloudMasthead) {
-            cloudMasthead.style.position = '';
-          }
         }
       }
     }


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Reverting changes made in: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/6836

Setting the position to fix solves part of the issue, but when there is a banner above the masthead, the masthead is hidden underneath the banner. Reverting the changes for no until there is a more solid fix.

### Changelog

**Removed**

- cloud-masthead position fixing code

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
