### PR TITLE
fix(lightbox-media): check for kaltura onClose

### DIFF
--- a/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
+++ b/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
@@ -142,13 +142,11 @@ const LightboxMediaViewer = ({ media, onClose, ...modalProps }) => {
    * Stop video on modal close
    */
   function closeModal() {
-    if (onClose?.() !== false) {
-      if (root.kWidget) {
-        root.kWidget.addReadyCallback(videoId => {
-          const kdp = document.getElementById(videoId);
-          kdp.sendNotification('doStop');
-        });
-      }
+    if (onClose?.() !== false && root.kWidget) {
+      root.kWidget.addReadyCallback(videoId => {
+        const kdp = document.getElementById(videoId);
+        kdp.sendNotification('doStop');
+      });
     }
   }
 };

--- a/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
+++ b/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
@@ -143,10 +143,12 @@ const LightboxMediaViewer = ({ media, onClose, ...modalProps }) => {
    */
   function closeModal() {
     if (onClose?.() !== false) {
-      root.kWidget.addReadyCallback(videoId => {
-        const kdp = document.getElementById(videoId);
-        kdp.sendNotification('doStop');
-      });
+      if (root.kWidget) {
+        root.kWidget.addReadyCallback(videoId => {
+          const kdp = document.getElementById(videoId);
+          kdp.sendNotification('doStop');
+        });
+      }
     }
   }
 };


### PR DESCRIPTION
### Related Ticket(s)

#6884 

### Description

Fixes an issue when Kaltura callback is called every time `onClose`, even when video isn't being used.

### Changelog

**Changed**

- send Kaltura notifications only when widget is detected


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
