### PR TITLE
fix(filter-panel): use correct element name

### DIFF
--- a/packages/web-components/src/components/filter-panel/filter-modal-footer.ts
+++ b/packages/web-components/src/components/filter-panel/filter-modal-footer.ts
@@ -19,7 +19,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 /**
  * extends the BXModalFooter
  *
- * @element filter modal footer
+ * @element dds-filter-modal-footer
  */
 @customElement(`${ddsPrefix}-filter-modal-footer`)
 class DDSFilterModalFooter extends StableSelectorMixin(BXModalFooter) {

--- a/packages/web-components/src/components/filter-panel/filter-panel-composite.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-composite.ts
@@ -27,7 +27,7 @@ const gridBreakpoint = parseFloat(breakpoints.md.width) * baseFontSize;
 /**
  * Filter panel composite
  *
- * @element Filter panel composite
+ * @element dds-filter-panel-composite
  */
 @customElement(`${ddsPrefix}-filter-panel-composite`)
 class DDSFilterPanelComposite extends HostListenerMixin(StableSelectorMixin(LitElement)) {


### PR DESCRIPTION
### Related Ticket(s)

#6912 

### Description

This PR sets the correct element names for the filter panel and filter modal footer which resolves a docgen issue for Storybook prop tables. The story should now display the prop table as expected

![image](https://user-images.githubusercontent.com/8265238/129915382-c34e2159-1232-4309-8206-f4f8b456d505.png)


### Changelog

**Changed**

- update filter panel and filter modal footer JSDoc TS declarations

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
