### PR TITLE
fix(cloud-masthead-contact-btn): change data-ibm-contact to contact-link

### DIFF
--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -335,8 +335,8 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
                 </dds-cloud-masthead-profile>
                 ${hasContact
                   ? html`
-                      <dds-cloud-button-cta kind="ghost" data-ibm-contact="chat-link"
-                        >${contactUsButton?.title}</dds-cloud-button-cta
+                      <dds-cloud-button-cta kind="ghost" data-ibm-contact="contact-link"
+                        ><span>${contactUsButton?.title}</span></dds-cloud-button-cta
                       >
                     `
                   : undefined}
@@ -352,8 +352,8 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
               <dds-cloud-masthead-global-bar>
                 ${hasContact
                   ? html`
-                      <dds-cloud-button-cta kind="ghost" data-ibm-contact="chat-link"
-                        >${contactUsButton?.title}</dds-cloud-button-cta
+                      <dds-cloud-button-cta kind="ghost" data-ibm-contact="contact-link"
+                        ><span>${contactUsButton?.title}</span></dds-cloud-button-cta
                       >
                     `
                   : undefined}


### PR DESCRIPTION
### Related Ticket(s)

- https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6916

### Description

- This PR changes the value within the Cloud contact CTA attribute `data-ibm-contact` from `chat-link` to `contact-link`.
- During the latest testing of the new Cloud Masthead, we noticed that the CTA button is not visible despite having `has-contact` sets to true. We realized that v18 stylesheet and JS script are automatically hiding this button and altering the text copy on certain pages.

Screenshot of the issue seen on different adopters.
![IBM_Cloud_Architectures](https://user-images.githubusercontent.com/1815714/129943593-79b439b5-3abb-4295-bc6d-6e1f21d59359.jpg)
![Screen_Shot_2021-08-18_at_12_49_15_PM](https://user-images.githubusercontent.com/1815714/129943673-12d01bd0-4ff0-4e71-9e46-797b6c2b1287.jpg)


### Changelog

**New**

- Change CTA attribute `data-ibm-contact` from `chat-link` to `contact-link`.
- Adds `<span>` tag to prevent the copy changing.