### PR TITLE
docs(storybook): add package version to storybook titles

### DIFF
--- a/packages/react/.storybook/theme.js
+++ b/packages/react/.storybook/theme.js
@@ -1,17 +1,18 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { create } from '@storybook/theming';
+import packageJson from '../package.json';
 
 export default create({
   base: 'light',
-  brandTitle: 'Carbon for IBM.com React',
+  brandTitle: `Carbon for IBM.com React v${packageJson.version}`,
   brandUrl:
     'https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/react',
   fontBase: '"IBM Plex Sans", "Helvetica Neue", Arial, sans-serif',

--- a/packages/web-components/.storybook/react/theme.js
+++ b/packages/web-components/.storybook/react/theme.js
@@ -1,15 +1,16 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { create } from '@storybook/theming';
+import packageJson from '../../package.json';
 
 export default create({
-  brandTitle: 'Carbon for IBM.com Web Components with React',
+  brandTitle: `Carbon for IBM.com Web Components with React v${packageJson.version}`,
   brandUrl: 'https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components',
 });

--- a/packages/web-components/.storybook/theme.js
+++ b/packages/web-components/.storybook/theme.js
@@ -1,17 +1,18 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { create } from '@storybook/theming';
+import packageJson from '../package.json';
 
 export default create({
   base: 'light',
-  brandTitle: 'Carbon for IBM.com Web Components',
+  brandTitle: `Carbon for IBM.com Web Components v${packageJson.version}`,
   brandUrl: 'https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components',
   fontBase: '"IBM Plex Sans", "Helvetica Neue", Arial, sans-serif',
   fontCode: '"IBM Plex Mono", Menlo, "DejaVu Sans Mono", "Bitstream Vera Sans Mono", Courier, monospace',


### PR DESCRIPTION
### Related Ticket(s)

#6914

### Description

This PR adds package version info to our Storybook titles

web components

![image](https://user-images.githubusercontent.com/8265238/129976320-3e13b584-c33b-4ceb-b897-22a772a5187d.png)

react

![image](https://user-images.githubusercontent.com/8265238/129976449-805cd28c-c115-4d08-906c-e647aed60728.png)


web components w/ react

![image](https://user-images.githubusercontent.com/8265238/129976417-c3892ef8-2ecc-432c-8bd5-eea1b16637c4.png)

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
