### PR TITLE
chore(masthead): remove lint warning

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-global-bar.ts
+++ b/packages/web-components/src/components/masthead/masthead-global-bar.ts
@@ -40,7 +40,6 @@ class DDSMastheadGlobalBar extends FocusMixin(HostListenerMixin(StableSelectorMi
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleSearchToggle = (event: Event) => {
     this._hasSearchActive = (event as CustomEvent).detail.active;
-    console.log(this._hasSearchActive);
   };
 
   /**


### PR DESCRIPTION
### Description

This PR removes an unneeded console statement which was emitting a warning when running `yarn lint` and in vscode

```
/carbon-for-ibm-dotcom/packages/web-components/src/components/masthead/masthead-global-bar.ts
  43:5  warning  Unexpected console statement  no-console

✖ 1 problem (0 errors, 1 warning)
```

![image](https://user-images.githubusercontent.com/8265238/129977093-7d1f3545-fea4-4a0f-a3f8-7e928eb26f63.png)

**Removed**

- `console.log` statement in `masthead-global-bar.ts`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
