### PR TITLE
feat(card-group): modify to allow Card link design pattern

### DIFF
--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -412,12 +412,22 @@
     }
   }
 
-  :host(#{$dds-prefix}-card-heading) {
-    @include carbon--type-style('expressive-heading-03', true);
+  :host(#{$dds-prefix}-card-heading),
+  :host(#{$dds-prefix}-card-link-heading) {
     @include content-width;
 
     color: $text-01;
     margin-bottom: $carbon--layout-05;
+  }
+
+  :host(#{$dds-prefix}-card-heading) {
+    @include carbon--type-style('expressive-heading-03', true);
+  }
+
+  :host(#{$dds-prefix}-card-link-heading) {
+    @include carbon--type-style('expressive-heading-02', true);
+
+    margin-bottom: 0;
   }
 
   :host(#{$dds-prefix}-card)[color-scheme='inverse'],

--- a/packages/web-components/src/components/card-group/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-group/__stories__/README.stories.mdx
@@ -102,6 +102,42 @@ import '@carbon/ibmdotcom-web-components/es/components/card-in-card/index.js';
 </dds-card-group>
 ```
 
+### HTML (with Card Link)
+
+```html
+<dds-card-group grid-mode="narrow">
+  <dds-card-group-item href="https://example.com" pattern-background>
+    <dds-card-link-heading slot="heading">IBM Developer - Card 01</dds-card-link-heading>
+    <p>Learn, code and connect with your community</p>
+    <dds-card-cta-footer slot="footer">
+      <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+        <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+      </svg>
+    </dds-card-cta-footer>
+  </dds-card-group-item>
+
+  <dds-card-group-item href="https://example.com" pattern-background>
+    <dds-card-link-heading slot="heading">IBM Developer - Card 02</dds-card-link-heading>
+    <p>Learn, code and connect with your community</p>
+    <dds-card-cta-footer slot="footer">
+      <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+        <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+      </svg>
+    </dds-card-cta-footer>
+  </dds-card-group-item>
+
+  <dds-card-group-item href="https://example.com" pattern-background>
+    <dds-card-link-heading slot="heading">IBM Developer - Card 03</dds-card-link-heading>
+    <p>Learn, code and connect with your community</p>
+    <dds-card-cta-footer slot="footer">
+      <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+        <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+      </svg>
+    </dds-card-cta-footer>
+  </dds-card-group-item>
+</dds-card-group>
+```
+
 ## Props
 
 ### `<dds-card-group>`

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -106,7 +106,7 @@ const cardGroupItemWithCTAs = html`
 `;
 
 const cardGroupItemWithCardLinks = html`
-  <dds-card-group-item href="https://example.com" pattern-background border>
+  <dds-card-group-item href="https://example.com" pattern-background>
     <dds-card-link-heading slot="heading">IBM Developer</dds-card-link-heading>
     <p>Learn, code and connect with your community</p>
     <dds-card-cta-footer slot="footer">
@@ -306,14 +306,10 @@ withCardInCardAndImageCards.story = {
 };
 
 export const withCardLink = ({ parameters }) => {
-  const { cards, cardsPerRow } = parameters?.props?.CardGroup ?? {};
-  const classes = classMap({
-    [cardsPerRow]: cardsPerRow,
-  });
-  const colCount = cardsPerRow[cardsPerRow.length - 1];
+  const { cards } = parameters?.props?.CardGroup ?? {};
 
   return html`
-    <dds-card-group cards-per-row="${colCount}" class="${classes}">
+    <dds-card-group grid-mode="narrow">
       ${cards}
     </dds-card-group>
   `;
@@ -327,7 +323,6 @@ withCardLink.story = {
         cards: Array.from({
           length: number('Number of cards', 8, {}, groupId),
         }).map(() => cardGroupItemWithCardLinks),
-        cardsPerRow: select('Number of cards per row (cards-per-row):', cardsCol, cardsCol['3 cards per row (Default)'], groupId),
       }),
     },
   },

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -105,6 +105,16 @@ const cardGroupItemWithCTAs = html`
   </dds-card-group-item>
 `;
 
+const cardGroupItemWithCardLinks = html`
+  <dds-card-group-item href="https://example.com" pattern-background border>
+    <dds-card-link-heading slot="heading">IBM Developer</dds-card-link-heading>
+    <p>Learn, code and connect with your community</p>
+    <dds-card-cta-footer slot="footer">
+      ${ArrowRight20({ slot: 'icon' })}
+    </dds-card-cta-footer>
+  </dds-card-group-item>
+`;
+
 export const Default = ({ parameters }) => {
   const { cards, cardsPerRow, offset, optionalBorder } = parameters?.props?.CardGroup ?? {};
   const classes = classMap({
@@ -290,6 +300,34 @@ withCardInCardAndImageCards.story = {
         cards: Array.from({
           length: number('Number of cards', 3, {}, groupId),
         }).map(() => cardGroupItemWithImages),
+      }),
+    },
+  },
+};
+
+export const withCardLink = ({ parameters }) => {
+  const { cards, cardsPerRow } = parameters?.props?.CardGroup ?? {};
+  const classes = classMap({
+    [cardsPerRow]: cardsPerRow,
+  });
+  const colCount = cardsPerRow[cardsPerRow.length - 1];
+
+  return html`
+    <dds-card-group cards-per-row="${colCount}" class="${classes}">
+      ${cards}
+    </dds-card-group>
+  `;
+};
+
+withCardLink.story = {
+  parameters: {
+    ...readme.parameters,
+    knobs: {
+      CardGroup: ({ groupId }) => ({
+        cards: Array.from({
+          length: number('Number of cards', 8, {}, groupId),
+        }).map(() => cardGroupItemWithCardLinks),
+        cardsPerRow: select('Number of cards per row (cards-per-row):', cardsCol, cardsCol['3 cards per row (Default)'], groupId),
       }),
     },
   },

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -305,7 +305,7 @@ withCardInCardAndImageCards.story = {
   },
 };
 
-export const withCardLink = ({ parameters }) => {
+export const withCardLinks = ({ parameters }) => {
   const { cards } = parameters?.props?.CardGroup ?? {};
 
   return html`
@@ -315,7 +315,7 @@ export const withCardLink = ({ parameters }) => {
   `;
 };
 
-withCardLink.story = {
+withCardLinks.story = {
   parameters: {
     ...readme.parameters,
     knobs: {

--- a/packages/web-components/src/components/card-group/card-group-item.ts
+++ b/packages/web-components/src/components/card-group/card-group-item.ts
@@ -33,6 +33,12 @@ class DDSCardGroupItem extends DDSCardCTA {
   @property({ type: Boolean, reflect: true })
   empty = false;
 
+  /**
+   * `true` if the card group item has the same background color as the pattern container.
+   */
+  @property({ type: Boolean, reflect: true })
+  patternBackground = false;
+
   static get stableSelector() {
     return `${ddsPrefix}--card-group-item`;
   }

--- a/packages/web-components/src/components/card-group/card-group.scss
+++ b/packages/web-components/src/components/card-group/card-group.scss
@@ -82,7 +82,9 @@
   }
 
   &[pattern-background] {
-    padding-right: 0;
+    .#{$prefix}--card {
+      border-bottom: 1px solid $ui-03;
+    }
 
     .#{$prefix}--card,
     .#{$prefix}--card__wrapper {

--- a/packages/web-components/src/components/card-group/card-group.scss
+++ b/packages/web-components/src/components/card-group/card-group.scss
@@ -80,4 +80,13 @@
       }
     }
   }
+
+  &[pattern-background] {
+    padding-right: 0;
+
+    .#{$prefix}--card,
+    .#{$prefix}--card__wrapper {
+      background: $ui-background;
+    }
+  }
 }

--- a/packages/web-components/src/components/card-group/index.ts
+++ b/packages/web-components/src/components/card-group/index.ts
@@ -11,4 +11,5 @@ import './card-group';
 import './card-group-item';
 import '../cta/card-cta-footer';
 import '../card/index';
+import '../card-link/card-link-heading';
 import '../card-section-images/card-section-images';

--- a/packages/web-components/src/components/card-link/__stories__/card-link.stories.ts
+++ b/packages/web-components/src/components/card-link/__stories__/card-link.stories.ts
@@ -20,7 +20,7 @@ export const Default = ({ parameters }) => {
   const { disabled, href, heading, copy } = parameters?.props?.CardLink ?? {};
   return html`
     <dds-card-link ?disabled=${disabled} href=${ifNonNull(href || undefined)}>
-      <dds-card-heading>${heading}</dds-card-heading>
+      <dds-card-link-heading>${heading}</dds-card-link-heading>
       ${copy
         ? html`
             <p>${copy}</p>

--- a/packages/web-components/src/components/card-link/card-link-heading.ts
+++ b/packages/web-components/src/components/card-link/card-link-heading.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { customElement } from 'lit-element';
+import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
+import DDSCardHeading from '../card/card-heading';
+import styles from './card-link.scss';
+
+const { stablePrefix: ddsPrefix } = ddsSettings;
+
+/**
+ * Card Link Heading.
+ *
+ * @element dds-card-link-heading
+ */
+@customElement(`${ddsPrefix}-card-link-heading`)
+class DDSCardLinkHeading extends DDSCardHeading {
+  static get stableSelector() {
+    return `${ddsPrefix}--card-link-heading`;
+  }
+
+  static styles = styles;
+}
+
+export default DDSCardLinkHeading;

--- a/packages/web-components/src/components/card-link/index.ts
+++ b/packages/web-components/src/components/card-link/index.ts
@@ -8,6 +8,6 @@
  */
 
 import './card-link';
+import './card-link-heading';
 import '../button-group/index';
-import '../card/card-heading';
 import '../card/card-footer';

--- a/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
+++ b/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
@@ -10,7 +10,8 @@
 import { html } from 'lit-element';
 import '../index';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
-import { select } from '@storybook/addon-knobs';
+import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
+import { select, number } from '@storybook/addon-knobs';
 import { ORIENTATION } from '../defs';
 import readme from './README.stories.mdx';
 
@@ -19,8 +20,18 @@ const orientationType = {
   [`Vertical`]: ORIENTATION.VERTICAL,
 };
 
+const cardGroupItemWithCardLinks = html`
+  <dds-card-group-item href="https://example.com" pattern-background>
+    <dds-card-link-heading slot="heading">IBM Developer</dds-card-link-heading>
+    <p>Learn, code and connect with your community</p>
+    <dds-card-cta-footer slot="footer">
+      ${ArrowRight20({ slot: 'icon' })}
+    </dds-card-cta-footer>
+  </dds-card-group-item>
+`;
+
 export const Default = ({ parameters }) => {
-  const { orientation } = parameters?.props?.['dds-tabs-extended'] ?? {};
+  const { orientation } = parameters?.props?.TabExtended ?? {};
   return html`
     <dds-tabs-extended orientation="${ifNonNull(orientation)}">
       <dds-tab
@@ -45,6 +56,38 @@ export const Default = ({ parameters }) => {
   `;
 };
 
+export const withCardGroupCardLink = ({ parameters }) => {
+  const { cards } = parameters?.props?.TabExtended ?? {};
+  return html`
+    <dds-tabs-extended orientation="vertical">
+      <dds-tab label="Tools for developers" selected="true">
+        <dds-card-group grid-mode="narrow">
+          ${cards}
+        </dds-card-group>
+      </dds-tab>
+      <dds-tab label="Tools for business">
+        <p>Content for second tab goes here.</p>
+      </dds-tab>
+      <dds-tab label="Trending in tech">
+        <p>Content for third tab goes here.</p>
+      </dds-tab>
+    </dds-tabs-extended>
+  `;
+};
+
+withCardGroupCardLink.story = {
+  parameters: {
+    ...readme.parameters,
+    knobs: {
+      TabExtended: ({ groupId }) => ({
+        cards: Array.from({
+          length: number('Number of cards', 8, {}, groupId),
+        }).map(() => cardGroupItemWithCardLinks),
+      }),
+    },
+  },
+};
+
 export default {
   title: 'Components/Tabs extended',
   decorators: [
@@ -59,7 +102,7 @@ export default {
     useRawContainer: true,
     hasGrid: true,
     knobs: {
-      'dds-tabs-extended': ({ groupId }) => ({
+      TabExtended: ({ groupId }) => ({
         orientation: select('Orientation (orientation):', orientationType, ORIENTATION.HORIZONTAL, groupId),
       }),
     },

--- a/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
+++ b/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
@@ -56,7 +56,7 @@ export const Default = ({ parameters }) => {
   `;
 };
 
-export const withCardGroupCardLink = ({ parameters }) => {
+export const withCardGroupCardLinks = ({ parameters }) => {
   const { cards } = parameters?.props?.TabExtended ?? {};
   return html`
     <dds-tabs-extended orientation="vertical">
@@ -75,7 +75,7 @@ export const withCardGroupCardLink = ({ parameters }) => {
   `;
 };
 
-withCardGroupCardLink.story = {
+withCardGroupCardLinks.story = {
   parameters: {
     ...readme.parameters,
     knobs: {


### PR DESCRIPTION
### Related Ticket(s)

DDS Consulting Issue: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6876
HC JIRA Ticket: https://jsw.ibm.com/browse/HC-2138

### Description
- This PR is a follow-up based on the discussion mentioned in this PR - https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/6826

### Design & Functional Specs
- https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/wiki/Tabs-extended#22-orientation 
- https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/wiki/Card-link

![Screen Shot 2021-08-19 at 5 24 54 PM](https://user-images.githubusercontent.com/1815714/130146499-f0f9612d-fce4-4734-b900-b50cb1f1353a.png)
![Screen Shot 2021-08-19 at 5 25 00 PM](https://user-images.githubusercontent.com/1815714/130146513-553f77c2-a787-49d1-86fc-89a27b6587ce.png)


### Changelog

**New Components/Props**

- `pattern-background` - this prop/attribute is used when the card group item has the same background color as the pattern container.
- `<dds-card-link-heading>` - a component extended from `<dds-card-heading>` that captures the proper expressive heading styling for the `Card Link UI` component.

**Removed**

- N/A

### HTML (with Card Link)

```html
<dds-card-group grid-mode="narrow">
  <dds-card-group-item href="https://example.com" pattern-background>
    <dds-card-link-heading slot="heading">IBM Developer - Card 01</dds-card-link-heading>
    <p>Learn, code and connect with your community</p>
    <dds-card-cta-footer slot="footer">
      <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
        <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
      </svg>
    </dds-card-cta-footer>
  </dds-card-group-item>
</dds-card-group>
```

### Testing Instructions
- Visit the `Card Group with Card Links` layout component - `/?path=/story/components-card-group--with-card-links`
- Ensure that the `Card links` look good within the `Card group` layout component in all breakpoints.
- Visit the `Tab Extended with Card Group Card Links` layout component - `/?path=/story/components-tabs-extended--with-card-group-card-links`
- Ensure that the "Vertical" tabs component matches with the design specs for all breakpoints.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
