### PR TITLE
feat(typescript): upgrade to typescript v4.3.5

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -247,7 +247,7 @@
     "through2": "^3.0.0",
     "ts-loader": "^6.0.0",
     "tsickle": "^0.37.0",
-    "typescript": "~3.9.0",
+    "typescript": "~4.3.5",
     "web-component-analyzer": "^1.0.0",
     "webpack": "^4.28.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -26970,6 +26970,11 @@ typescript@~3.9.0:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
 
+typescript@~4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
 ua-parser-js@^0.7.18:
   version "0.7.20"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"


### PR DESCRIPTION
### Related Ticket(s)

Refs #6792 

### Description

This PR is upgrading `web-components` to `v4.3.5`. 

~~This is currently in draft for now so that testing can be done on this branch.~~
All automated testing seemed to clear!

### Changelog

**Changed**

- Upgrade `typescript` to `v4.3.5`
