### PR TITLE
fix(video): remove autoplay from lightbox story

### DIFF
--- a/packages/react/src/components/VideoPlayer/__stories__/VideoPlayer.stories.js
+++ b/packages/react/src/components/VideoPlayer/__stories__/VideoPlayer.stories.js
@@ -106,6 +106,7 @@ withLightboxMediaViewer.story = {
         aspectRatio: 'default',
         videoId: '1_p2osmd1z',
         playingMode: 'lightbox',
+        autoPlay: false,
       }),
     },
   },


### PR DESCRIPTION
### Description

# Just a test.

Testing `autoPlay` behavior for `Video player - with lightbox media viewer` in hosted environment.


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
