### PR TITLE
fix(VideoPlayer): restrict lightbox variant autoplay to modal open state

### DIFF
--- a/packages/react/examples/codesandbox/components/VideoPlayer/src/index.js
+++ b/packages/react/examples/codesandbox/components/VideoPlayer/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,7 +15,7 @@ const App = () => (
   <div className="bx--grid">
     <div className="bx--row">
       <div className="bx--col-sm-4 bx--col-lg-12">
-        <VideoPlayer inverse={false} videoId="1_9h94wo6b" showCaption={true} />
+        <VideoPlayer inverse={false} videoId="1_9h94wo6b" showCaption />
       </div>
     </div>
   </div>

--- a/packages/react/examples/codesandbox/components/VideoPlayer/src/styles.scss
+++ b/packages/react/examples/codesandbox/components/VideoPlayer/src/styles.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,3 +14,4 @@
 }
 
 @import '@carbon/ibmdotcom-styles/scss/components/video-player/_video-player.scss';
+@import '@carbon/ibmdotcom-styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss';

--- a/packages/react/src/components/VideoPlayer/VideoImageOverlay.js
+++ b/packages/react/src/components/VideoPlayer/VideoImageOverlay.js
@@ -18,12 +18,27 @@ const { prefix } = settings;
 /**
  * VideoPlayer Image Overlay component
  */
-const VideoImageOverlay = ({ videoId, videoData, embedVideo, playingMode }) => {
+const VideoImageOverlay = ({
+  videoId,
+  videoData,
+  embedVideo,
+  playingMode,
+  ...rest
+}) => {
+  const handleClick = event => {
+    const { onClick } = rest;
+    onClick && onClick(event);
+
+    if (playingMode === 'inline') {
+      _embedPlayer(event, embedVideo);
+    }
+  };
+
   return (
     <button
       className={`${prefix}--video-player__image-overlay`}
       data-autoid={`${stablePrefix}--video-player__image-overlay`}
-      onClick={() => _embedPlayer(event, embedVideo, playingMode)}>
+      onClick={handleClick}>
       <Image
         defaultSrc={KalturaPlayerAPI.getThumbnailUrl({
           mediaId: videoId,
@@ -36,11 +51,9 @@ const VideoImageOverlay = ({ videoId, videoData, embedVideo, playingMode }) => {
   );
 };
 
-const _embedPlayer = (e, embedVideo, playingMode) => {
-  if (playingMode === 'inline') {
-    const element = e.target;
-    element.remove();
-  }
+const _embedPlayer = (e, embedVideo) => {
+  const element = e.target;
+  element.remove();
   embedVideo(true);
 };
 

--- a/packages/react/src/components/VideoPlayer/VideoPlayer.js
+++ b/packages/react/src/components/VideoPlayer/VideoPlayer.js
@@ -76,6 +76,7 @@ const VideoPlayer = ({
           videoData={videoData}
           embedVideo={setEmbedVideo}
           playingMode={playingMode}
+          onClick={() => setEmbedVideo(true)}
         />
       </div>
       <LightboxMediaViewer

--- a/packages/react/src/components/VideoPlayer/__stories__/VideoPlayer.stories.js
+++ b/packages/react/src/components/VideoPlayer/__stories__/VideoPlayer.stories.js
@@ -85,7 +85,7 @@ aspectRatio4x3.story = {
         return {
           showCaption: boolean('Show caption (showCaption):', true, groupId),
           aspectRatio: '4x3',
-          videoId: '1_p2osmd1z',
+          videoId: '1_9h94wo6b',
           playingMode: 'inline',
         };
       },
@@ -104,7 +104,7 @@ withLightboxMediaViewer.story = {
       VideoPlayer: ({ groupId }) => ({
         showCaption: boolean('Show caption (showCaption):', true, groupId),
         aspectRatio: 'default',
-        videoId: '1_p2osmd1z',
+        videoId: '1_9h94wo6b',
         playingMode: 'lightbox',
       }),
     },


### PR DESCRIPTION
### Related Ticket(s)

#6953

### Description

This PR resolves an issue with the video player with lightbox media viewer, where the video would autoplay on page render (ignoring the open/closed state of the lightbox media viewer modal). The video should now only autoplay after the lightbox modal is launched

### Changelog

**Changed**

- add click handler to `<LightboxMediaViewer>` to autoplay videos only when the lightbox is launched
- fix missing styles in code sandbox example
- update storybook video IDs so that video examples play properly

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
