### PR TITLE
fix(cloud-masthead-6956): Safari text showing issue on cloud-top-nav-name

### DIFF
--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -117,11 +117,7 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
           <dds-cloud-megamenu-tabs value="${sortedMenuItems[0]?.itemKey}">
             ${sortedMenuItems.map(item => {
               return html`
-                <dds-cloud-megamenu-tab
-                  tabIndex="0"
-                  id="tab-${item.itemKey}"
-                  target="panel-${item.itemKey}"
-                  value="${item.itemKey}"
+                <dds-cloud-megamenu-tab id="tab-${item.itemKey}" target="panel-${item.itemKey}" value="${item.itemKey}"
                   >${item.title}</dds-cloud-megamenu-tab
                 >
               `;

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -117,7 +117,11 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
           <dds-cloud-megamenu-tabs value="${sortedMenuItems[0]?.itemKey}">
             ${sortedMenuItems.map(item => {
               return html`
-                <dds-cloud-megamenu-tab id="tab-${item.itemKey}" target="panel-${item.itemKey}" value="${item.itemKey}"
+                <dds-cloud-megamenu-tab
+                  tabIndex="0"
+                  id="tab-${item.itemKey}"
+                  target="panel-${item.itemKey}"
+                  value="${item.itemKey}"
                   >${item.title}</dds-cloud-megamenu-tab
                 >
               `;

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
@@ -56,6 +56,9 @@
 
 :host(#{$dds-prefix}-cloud-top-nav-name) {
   outline: none;
+  position: relative;
+  z-index: 1;
+  background-color: $ui-background;
 
   a.#{$prefix}--header__name {
     margin-left: 0;


### PR DESCRIPTION
### Related Ticket(s)

- https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6956

### Description
- This PR fixes one of the issues mentioned within this issue - https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6956

### Changelog

**Changed**

- make sure the menu items do not appear behind the Cloud platform name

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
