### PR TITLE
fix(tabs-extended): remove disabled label color override

### DIFF
--- a/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
+++ b/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
@@ -92,8 +92,6 @@
           line-height: 1.375rem;
 
           @include type-style('body-short-02');
-
-          color: $text-02;
         }
         /* stylelint-enable value-no-vendor-prefix, property-no-vendor-prefix */
       }

--- a/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
+++ b/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
@@ -16,7 +16,7 @@ import readme from './README.stories.mdx';
 
 const orientationType = {
   [`horizontal`]: ORIENTATION.HORIZONTAL,
-  [`Vertical`]: ORIENTATION.VERTICAL,
+  [`vertical`]: ORIENTATION.VERTICAL,
 };
 
 export const Default = ({ parameters }) => {

--- a/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
+++ b/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
@@ -38,7 +38,7 @@ export const Default = ({ parameters }) => {
       <dds-tab label="Fourth tab">
         <p>Content for fourth tab goes here.</p>
       </dds-tab>
-      <dds-tab label="Fifth tab (disabled)" disabled="true">
+      <dds-tab label="Fifth tab" disabled="true">
         <p>Content for fifth tab goes here.</p>
       </dds-tab>
     </dds-tabs-extended>


### PR DESCRIPTION
### Related Ticket(s)

#6939

### Description

This PR reverts the extended tabs disabled label color changes to remove a style regression. The disabled tab should now receive the correct color rule

![image](https://user-images.githubusercontent.com/8265238/130682324-a5be4ea1-5a22-4c37-86b1-3c6886419e14.png)

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
