### PR TITLE
fix(footer): Set dds-footer role to contentinfo

### DIFF
--- a/packages/web-components/src/components/footer/footer.ts
+++ b/packages/web-components/src/components/footer/footer.ts
@@ -36,9 +36,7 @@ class DDSFooter extends StableSelectorMixin(LitElement) {
   size = FOOTER_SIZE.REGULAR;
 
   connectedCallback() {
-    if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'footer');
-    }
+    this.setAttribute('role', 'contentinfo');
 
     if (!this.hasAttribute('aria-label')) {
       this.setAttribute('aria-label', 'footer');

--- a/packages/web-components/tests/snapshots/dds-footer-composite.md
+++ b/packages/web-components/tests/snapshots/dds-footer-composite.md
@@ -9,7 +9,7 @@
   <dds-footer
     aria-label="footer"
     data-autoid="dds--footer"
-    role="footer"
+    role="contentinfo"
     size=""
   >
     <dds-footer-logo data-autoid="dds--footer-logo">
@@ -48,7 +48,7 @@
   <dds-footer
     aria-label="footer"
     data-autoid="dds--footer"
-    role="footer"
+    role="contentinfo"
     size=""
   >
     <dds-footer-logo data-autoid="dds--footer-logo">


### PR DESCRIPTION
### Related Ticket(s)
Fixes #6890 

### Description
This PR sets the `dds-footer` element's role to `contentinfo` overriding any pre-existing roles that may have been set on the element.

### Changelog

**Changed**
- `dds-footer` has `contentinfo` landmark role
