### PR TITLE
fix(footer): Remove role=complimentary from footer legal-nav

### DIFF
--- a/packages/web-components/src/components/footer/legal-nav.ts
+++ b/packages/web-components/src/components/footer/legal-nav.ts
@@ -60,8 +60,8 @@ class DDSLegalNav extends StableSelectorMixin(LitElement) {
   slot = 'legal-nav';
 
   connectedCallback() {
-    if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'complementary');
+    if (this.hasAttribute('role')) {
+      this.removeAttribute('role');
     }
     super.connectedCallback();
   }

--- a/packages/web-components/tests/snapshots/dds-footer-composite.md
+++ b/packages/web-components/tests/snapshots/dds-footer-composite.md
@@ -26,7 +26,6 @@
     </dds-locale-button>
     <dds-legal-nav
       data-autoid="dds--footer-legal-nav"
-      role="complementary"
       size=""
     >
       <dds-legal-nav-cookie-preferences-placeholder data-autoid="dds--privacy-cp">
@@ -102,7 +101,6 @@
     </dds-locale-button>
     <dds-legal-nav
       data-autoid="dds--footer-legal-nav"
-      role="complementary"
       size=""
     >
       <dds-legal-nav-item


### PR DESCRIPTION
### Related Ticket(s)
Fixes #6784 

### Description
This PR removes the role attribute from the `dds-legal-nav` element found within the `dds-footer`

### Changelog

**Changed**

- `dds-legal-nav` no longer has a role.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
