### PR TITLE
chore(leadspace): updating gradient for centered variation

### DIFF
--- a/packages/react/src/components/LeadSpace/LeadSpace.js
+++ b/packages/react/src/components/LeadSpace/LeadSpace.js
@@ -93,9 +93,9 @@ const LeadSpace = ({
                     {type === 'centered' ? (
                       <>
                         <stop offset="0%" />
-                        <stop offset="27%" />
-                        <stop offset="53%" />
-                        <stop offset="80%" />
+                        <stop offset="54%" />
+                        <stop offset="77%" />
+                        <stop offset="100%" />
                       </>
                     ) : (
                       <>

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -189,9 +189,9 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
                         type === LEADSPACE_TYPE.CENTERED
                           ? svg`
                           <stop offset="0%" />
-                          <stop offset="27%" />
-                          <stop offset="53%" />
-                          <stop offset="80%" />
+                          <stop offset="54%" />
+                          <stop offset="77%" />
+                          <stop offset="100%" />
                         `
                           : svg`
                           <stop offset="0%" />


### PR DESCRIPTION
### Related Ticket(s)

[Lead space centered] Gradient over image not to spec #6351

### Description

{{Add a human-readable description / detail summary of what the PR is changing and any details around how and why}}

{{If applicable, include a screenshot indicating an example or examples of what the PR is changing in the application}}

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
