### PR TITLE
fix(cloud-masthead): prevent masthead shifting on top of page (#6947)

### DIFF
--- a/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
+++ b/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
@@ -101,19 +101,33 @@ class DDSMegaMenuTopNavMenu extends DDSTopNavMenu {
         .querySelector('dds-masthead')
         ?.shadowRoot?.querySelector('.bx--masthead__l0');
 
+      // determine whether to apply margin-right on expand as HC has extra masthead styling
+      const cloudMasthead: HTMLElement | null | undefined = doc
+        .querySelector('dds-cloud-masthead-container')
+        ?.querySelector('dds-masthead')
+        ?.shadowRoot?.querySelector('.bx--masthead__l0');
+
       if (this.expanded) {
         doc.body.style.marginRight = `${this._scrollBarWidth}px`;
         doc.body.style.overflow = `hidden`;
         forEach(doc.querySelectorAll((this.constructor as typeof DDSMegaMenuTopNavMenu).selectorOverlay), item => {
           (item as DDSMegaMenuOverlay).active = this.expanded;
         });
-        if (masthead) {
+        if (cloudMasthead) {
+          if (doc.body.classList.contains('ibm-masthead-sticky') && doc.body.classList.contains('ibm-masthead-sticky-showing')) {
+            cloudMasthead.style.marginRight = `${this._scrollBarWidth}px`;
+          }
+        } else if (masthead) {
           masthead.style.marginRight = `${this._scrollBarWidth}px`;
         }
       } else {
         doc.body.style.marginRight = '0px';
         doc.body.style.overflow = ``;
-        if (masthead) {
+        if (cloudMasthead) {
+          if (doc.body.classList.contains('ibm-masthead-sticky') && doc.body.classList.contains('ibm-masthead-sticky-showing')) {
+            cloudMasthead.style.marginRight = '0px';
+          }
+        } else if (masthead) {
           masthead.style.marginRight = '0px';
         }
       }


### PR DESCRIPTION
### Related Ticket(s)

[Cloud Masthead] Slight page shift when the Mega Menu is opened on machines where scrollbar is set to visible #6831

### Description

Problem:
The Cloud Masthead shifts when user is on top of the page. The cloud team has applied extra styling to set the position of the masthead to `static` when on top of page. This is so it doesn't overlap their L1. When user scrolls, the `ibm-masthead-sticky ibm-masthead-sticky-showing` v18 classes are applied to the `body` element. This also sets the position of the masthead back to `fixed`. When expanding the megamenu, a `margin-right` needs to be applied to balance out the disappearing scrollbar when position is `fixed`. This `margin-right` is unnecessary when position is `static`.

Solution:
When megamenu is expanded, detect whether the `body` element has the `ibm-masthead-sticky ibm-masthead-sticky-showing` classes applied before setting the `margin-right`.

### Changelog

**Changed**

- only set the `margin-right` for cloud-masthead when the specific v18 classes are applied.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
