### PR TITLE
chore(snapshot): update snapshot and workflow token

### DIFF
--- a/.github/workflows/snapshot-update.yml
+++ b/.github/workflows/snapshot-update.yml
@@ -36,6 +36,7 @@ jobs:
           else
             git config --global user.email ${{ secrets.BOT_EMAIL }}
             git config --global user.name ${{ secrets.BOT_NAME }}
+            git config --global github.token ${{secrets.MERGE_ACTION}}
 
             git add -A
             git commit -m "chore(snapshot): update react snapshot files"


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The react snapshot update workflow failed because it didn't have the right permissions to push. This should hopefully fix it, as well as updating the existing snapshots so that it clears.

### Changelog

**Changed**

- Updated snapshot-update.yml
- Updated react snapshot file

