### PR TITLE
fix(LightboxMediaPlayer): set `autoPlay` based on modal open state

### DIFF
--- a/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
+++ b/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
@@ -105,7 +105,7 @@ const LightboxMediaViewer = ({ media, onClose, ...modalProps }) => {
               <div
                 className={`${prefix}--lightbox-media-viewer__media ${prefix}--no-gutter`}>
                 {media.type === 'video' ? (
-                  <VideoPlayer videoId={media.src} autoPlay />
+                  <VideoPlayer videoId={media.src} autoPlay={modalProps.open} />
                 ) : (
                   <Image defaultSrc={media.src} alt={videoData.alt} />
                 )}


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6953

related PR https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/6958

### Description

This PR updates the `autoPlay` prop on lightbox media viewers with embedded video players so that it is dependent on whether or not the lightbox modal is open. The original issue stemmed from how the video player with lightbox media viewer recursively creates `VideoPlayer` components

Reviewers should confirm that the fix from #6958 is preserved and that switching between `VideoPlayer` stories does not trigger autoplay in the background

### Changelog

**Changed**

- `autoPlay` logic in `LightboxMediaViewer`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
