### PR TITLE
fix(tabs-extended): add word break

### DIFF
--- a/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
+++ b/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
@@ -90,6 +90,7 @@
           overflow: hidden;
           height: 100%;
           line-height: 1.375rem;
+          word-break: break-word;
 
           @include type-style('body-short-02');
         }


### PR DESCRIPTION
### Related Ticket(s)
#7011 

### Description
On Tabs Extended this PR allows for word breaks on long words. Example:

Before:
![Screen Shot 2021-08-30 at 2 27 24 PM](https://user-images.githubusercontent.com/24970122/131503548-6aa22e83-f617-454a-b0a4-f702a6aaa8bd.png)

After:
![Screen Shot 2021-08-30 at 2 27 32 PM](https://user-images.githubusercontent.com/24970122/131503553-12405c97-73ad-48bb-8723-8da4fb7a518e.png)


### Changelog

**New**

- add word break to the buttons in Tabs extended

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
