### PR TITLE
fix(cta): updated button to use expressive

### DIFF
--- a/packages/web-components/src/components/button/button.ts
+++ b/packages/web-components/src/components/button/button.ts
@@ -52,6 +52,7 @@ class DDSButtonExpressive extends FocusMixin(StableSelectorMixin(LitElement)) {
       [`${prefix}--btn--${kind}`]: kind,
       [`${prefix}--btn--disabled`]: disabled,
       [`${prefix}--btn--icon-only`]: hasIcon && !hasMainContent,
+      [`${prefix}--btn--expressive`]: true,
       [`${prefix}--btn--${size}`]: size,
       [`${prefix}-ce--btn--has-icon`]: hasIcon,
     });

--- a/packages/web-components/tests/snapshots/dds-button-group.md
+++ b/packages/web-components/tests/snapshots/dds-button-group.md
@@ -12,7 +12,7 @@
 
 ```
 <a
-  class="bx--btn bx--btn--primary"
+  class="bx--btn bx--btn--expressive bx--btn--primary"
   href="https://example.com"
   id="button"
   part="button"


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6141

### Description

CTA text already using lg size, updated Button to use expressive

![image](https://user-images.githubusercontent.com/4054756/131534111-5b6e43e0-086b-4eaf-aa63-eae02cdaff34.png)


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
