### PR TITLE
fix(github-action): fix to the github action to have push access

### DIFF
--- a/.github/workflows/snapshot-update.yml
+++ b/.github/workflows/snapshot-update.yml
@@ -14,6 +14,8 @@ jobs:
         node-version: ['14.x']
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{secrets.MERGE_ACTION}}
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
@@ -36,7 +38,6 @@ jobs:
           else
             git config --global user.email ${{ secrets.BOT_EMAIL }}
             git config --global user.name ${{ secrets.BOT_NAME }}
-            git config --global github.token ${{secrets.MERGE_ACTION}}
 
             git add -A
             git commit -m "chore(snapshot): update react snapshot files"


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The Github Action to update the react snapshot is still failing due to permissions issues. This is another attempt to remedy the permissions issue so that the github actions bot can successfully update the snapshot files.

### Changelog

**Changed**

- `snapshot-update.yml`
- Updated react snapshot files
