### PR TITLE
feat(video-player-composite): support image and caption overrides

### DIFF
--- a/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
@@ -14,19 +14,20 @@ import '../video-player-container';
 import '../../lightbox-media-viewer/lightbox-video-player-container';
 
 export const Default = ({ parameters }) => {
-  const { caption, hideCaption, videoId } = parameters?.props?.VideoPlayer ?? {};
+  const { caption, hideCaption, thumbnail, videoId } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       playing-mode="inline"
       video-id=${videoId}
       caption=${caption}
       ?hide-caption=${hideCaption}
+      thumbnail=${thumbnail}
     ></dds-video-player-container>
   `;
 };
 
 export const aspectRatio1x1 = ({ parameters }) => {
-  const { aspectRatio, caption, hideCaption, videoId } = parameters?.props?.VideoPlayer ?? {};
+  const { aspectRatio, caption, hideCaption, thumbnail, videoId } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       playing-mode="inline"
@@ -34,12 +35,13 @@ export const aspectRatio1x1 = ({ parameters }) => {
       aspect-ratio=${aspectRatio}
       caption=${caption}
       ?hide-caption=${hideCaption}
+      thumbnail=${thumbnail}
     ></dds-video-player-container>
   `;
 };
 
 export const aspectRatio4x3 = ({ parameters }) => {
-  const { aspectRatio, caption, hideCaption, videoId } = parameters?.props?.VideoPlayer ?? {};
+  const { aspectRatio, caption, hideCaption, thumbnail, videoId } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       playing-mode="inline"
@@ -47,18 +49,20 @@ export const aspectRatio4x3 = ({ parameters }) => {
       aspect-ratio=${aspectRatio}
       caption=${caption}
       ?hide-caption=${hideCaption}
+      thumbnail=${thumbnail}
     ></dds-video-player-container>
   `;
 };
 
 export const withLightboxMediaViewer = ({ parameters }) => {
-  const { aspectRatio, caption, hideCaption, videoId } = parameters?.props?.VideoPlayer ?? {};
+  const { aspectRatio, caption, hideCaption, thumbnail, videoId } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       video-id=${videoId}
       aspect-ratio=${aspectRatio}
       caption=${caption}
       ?hide-caption=${hideCaption}
+      thumbnail=${thumbnail}
       playing-mode="lightbox"
     >
     </dds-video-player-container>
@@ -75,6 +79,7 @@ aspectRatio4x3.story = {
           aspectRatio: '4x3',
           caption: text('Custom caption (caption):', '', groupId),
           hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
+          thumbnail: text('Custom thumbnail (thumbnail):', '', groupId),
           videoId: '1_9h94wo6b',
         };
       },
@@ -91,6 +96,7 @@ aspectRatio1x1.story = {
           aspectRatio: '1x1',
           caption: text('Custom caption (caption):', '', groupId),
           hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
+          thumbnail: text('Custom thumbnail (thumbnail):', '', groupId),
           videoId: '1_9h94wo6b',
         };
       },
@@ -107,6 +113,7 @@ withLightboxMediaViewer.story = {
           aspectRatio: '16x9',
           caption: text('Custom caption (caption):', '', groupId),
           hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
+          thumbnail: text('Custom thumbnail (thumbnail):', '', groupId),
           videoId: '1_9h94wo6b',
         };
       },
@@ -133,6 +140,7 @@ export default {
       VideoPlayer: ({ groupId }) => ({
         caption: text('Custom caption (caption):', '', groupId),
         hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
+        thumbnail: text('Custom thumbnail (thumbnail):', '', groupId),
         videoId: '1_9h94wo6b',
       }),
     },

--- a/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
@@ -8,52 +8,56 @@
  */
 
 import { html } from 'lit-element';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import readme from './README.stories.mdx';
 import '../video-player-container';
 import '../../lightbox-media-viewer/lightbox-video-player-container';
 
 export const Default = ({ parameters }) => {
-  const { hideCaption } = parameters?.props?.VideoPlayer ?? {};
+  const { caption, hideCaption } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       playing-mode="inline"
       video-id="1_9h94wo6b"
+      caption=${caption}
       ?hide-caption=${hideCaption}
     ></dds-video-player-container>
   `;
 };
 
 export const aspectRatio1x1 = ({ parameters }) => {
-  const { hideCaption, videoId, aspectRatio } = parameters?.props?.VideoPlayer ?? {};
+  const { aspectRatio, caption, hideCaption, videoId } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       playing-mode="inline"
       video-id=${videoId}
       aspect-ratio=${aspectRatio}
+      caption=${caption}
       ?hide-caption=${hideCaption}
     ></dds-video-player-container>
   `;
 };
 
 export const aspectRatio4x3 = ({ parameters }) => {
-  const { hideCaption, videoId, aspectRatio } = parameters?.props?.VideoPlayer ?? {};
+  const { aspectRatio, caption, hideCaption, videoId } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       playing-mode="inline"
       video-id=${videoId}
       aspect-ratio=${aspectRatio}
+      caption=${caption}
       ?hide-caption=${hideCaption}
     ></dds-video-player-container>
   `;
 };
 
 export const withLightboxMediaViewer = ({ parameters }) => {
-  const { hideCaption, videoId, aspectRatio } = parameters?.props?.VideoPlayer ?? {};
+  const { aspectRatio, caption, hideCaption, videoId } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       video-id=${videoId}
       aspect-ratio=${aspectRatio}
+      caption=${caption}
       ?hide-caption=${hideCaption}
       playing-mode="lightbox"
     >
@@ -70,6 +74,7 @@ aspectRatio4x3.story = {
         return {
           aspectRatio: '4x3',
           videoId: '1_9h94wo6b',
+          caption: text('Custom caption (caption):', '', groupId),
           hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
         };
       },
@@ -85,6 +90,7 @@ aspectRatio1x1.story = {
         return {
           aspectRatio: '1x1',
           videoId: '1_9h94wo6b',
+          caption: text('Custom caption (caption):', '', groupId),
           hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
         };
       },
@@ -100,6 +106,7 @@ withLightboxMediaViewer.story = {
         return {
           aspectRatio: '16x9',
           videoId: '1_9h94wo6b',
+          caption: text('Custom caption (caption):', '', groupId),
           hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
         };
       },
@@ -124,6 +131,7 @@ export default {
     ...readme.parameters,
     knobs: {
       VideoPlayer: ({ groupId }) => ({
+        caption: text('Custom caption (caption):', '', groupId),
         hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
       }),
     },

--- a/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
@@ -8,40 +8,55 @@
  */
 
 import { html } from 'lit-element';
+import { boolean } from '@storybook/addon-knobs';
 import readme from './README.stories.mdx';
 import '../video-player-container';
 import '../../lightbox-media-viewer/lightbox-video-player-container';
 
-export const Default = () => html`
-  <dds-video-player-container playing-mode="inline" video-id="1_9h94wo6b"></dds-video-player-container>
-`;
+export const Default = ({ parameters }) => {
+  const { hideCaption } = parameters?.props?.VideoPlayer ?? {};
+  return html`
+    <dds-video-player-container
+      playing-mode="inline"
+      video-id="1_9h94wo6b"
+      ?hide-caption=${hideCaption}
+    ></dds-video-player-container>
+  `;
+};
 
 export const aspectRatio1x1 = ({ parameters }) => {
-  const { videoId, aspectRatio } = parameters?.props?.VideoPlayer ?? {};
+  const { hideCaption, videoId, aspectRatio } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       playing-mode="inline"
       video-id=${videoId}
       aspect-ratio=${aspectRatio}
+      ?hide-caption=${hideCaption}
     ></dds-video-player-container>
   `;
 };
 
 export const aspectRatio4x3 = ({ parameters }) => {
-  const { videoId, aspectRatio } = parameters?.props?.VideoPlayer ?? {};
+  const { hideCaption, videoId, aspectRatio } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       playing-mode="inline"
       video-id=${videoId}
       aspect-ratio=${aspectRatio}
+      ?hide-caption=${hideCaption}
     ></dds-video-player-container>
   `;
 };
 
 export const withLightboxMediaViewer = ({ parameters }) => {
-  const { videoId, aspectRatio } = parameters?.props?.VideoPlayer ?? {};
+  const { hideCaption, videoId, aspectRatio } = parameters?.props?.VideoPlayer ?? {};
   return html`
-    <dds-video-player-container video-id=${videoId} aspect-ratio=${aspectRatio} playing-mode="lightbox">
+    <dds-video-player-container
+      video-id=${videoId}
+      aspect-ratio=${aspectRatio}
+      ?hide-caption=${hideCaption}
+      playing-mode="lightbox"
+    >
     </dds-video-player-container>
     <dds-lightbox-video-player-container></dds-lightbox-video-player-container>
   `;
@@ -51,10 +66,11 @@ aspectRatio4x3.story = {
   name: 'Aspect ratio 4:3',
   parameters: {
     knobs: {
-      VideoPlayer: () => {
+      VideoPlayer: ({ groupId }) => {
         return {
           aspectRatio: '4x3',
           videoId: '1_9h94wo6b',
+          hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
         };
       },
     },
@@ -65,10 +81,11 @@ aspectRatio1x1.story = {
   name: 'Aspect ratio 1:1',
   parameters: {
     knobs: {
-      VideoPlayer: () => {
+      VideoPlayer: ({ groupId }) => {
         return {
           aspectRatio: '1x1',
           videoId: '1_9h94wo6b',
+          hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
         };
       },
     },
@@ -79,10 +96,11 @@ withLightboxMediaViewer.story = {
   name: 'With lightbox media viewer',
   parameters: {
     knobs: {
-      VideoPlayer: () => {
+      VideoPlayer: ({ groupId }) => {
         return {
           aspectRatio: '16x9',
           videoId: '1_9h94wo6b',
+          hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
         };
       },
     },
@@ -104,6 +122,11 @@ export default {
   ],
   parameters: {
     ...readme.parameters,
+    knobs: {
+      VideoPlayer: ({ groupId }) => ({
+        hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
+      }),
+    },
     hasGrid: true,
     hasVerticalSpacingInComponent: true,
     percy: {

--- a/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
@@ -14,11 +14,11 @@ import '../video-player-container';
 import '../../lightbox-media-viewer/lightbox-video-player-container';
 
 export const Default = ({ parameters }) => {
-  const { caption, hideCaption } = parameters?.props?.VideoPlayer ?? {};
+  const { caption, hideCaption, videoId } = parameters?.props?.VideoPlayer ?? {};
   return html`
     <dds-video-player-container
       playing-mode="inline"
-      video-id="1_9h94wo6b"
+      video-id=${videoId}
       caption=${caption}
       ?hide-caption=${hideCaption}
     ></dds-video-player-container>
@@ -73,9 +73,9 @@ aspectRatio4x3.story = {
       VideoPlayer: ({ groupId }) => {
         return {
           aspectRatio: '4x3',
-          videoId: '1_9h94wo6b',
           caption: text('Custom caption (caption):', '', groupId),
           hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
+          videoId: '1_9h94wo6b',
         };
       },
     },
@@ -89,9 +89,9 @@ aspectRatio1x1.story = {
       VideoPlayer: ({ groupId }) => {
         return {
           aspectRatio: '1x1',
-          videoId: '1_9h94wo6b',
           caption: text('Custom caption (caption):', '', groupId),
           hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
+          videoId: '1_9h94wo6b',
         };
       },
     },
@@ -105,9 +105,9 @@ withLightboxMediaViewer.story = {
       VideoPlayer: ({ groupId }) => {
         return {
           aspectRatio: '16x9',
-          videoId: '1_9h94wo6b',
           caption: text('Custom caption (caption):', '', groupId),
           hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
+          videoId: '1_9h94wo6b',
         };
       },
     },
@@ -133,6 +133,7 @@ export default {
       VideoPlayer: ({ groupId }) => ({
         caption: text('Custom caption (caption):', '', groupId),
         hideCaption: boolean('Hide caption (hideCaption):', false, groupId),
+        videoId: '1_9h94wo6b',
       }),
     },
     hasGrid: true,

--- a/packages/web-components/src/components/video-player/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player/video-player-composite.ts
@@ -91,9 +91,9 @@ class DDSVideoPlayerComposite extends HybridRenderMixin(HostListenerMixin(LitEle
   embeddedVideos?: { [videoId: string]: any };
 
   /**
-   * An optional custom video caption.
+   * Optional custom video caption.
    */
-  @property()
+  @property({ reflect: true, attribute: 'caption' })
   caption?: '';
 
   /**
@@ -141,6 +141,12 @@ class DDSVideoPlayerComposite extends HybridRenderMixin(HostListenerMixin(LitEle
   playingMode = VIDEO_PLAYER_PLAYING_MODE.INLINE;
 
   /**
+   * Optional custom video thumbnail
+   */
+  @property({ reflect: true, attribute: 'thumbnail' })
+  thumbnail?: '';
+
+  /**
    * The video thumbnail width.
    */
   @property({ type: Number, attribute: 'video-thumbnail-width' })
@@ -169,14 +175,17 @@ class DDSVideoPlayerComposite extends HybridRenderMixin(HostListenerMixin(LitEle
       mediaData = {},
       videoId,
       videoThumbnailWidth,
+      thumbnail,
       playingMode,
     } = this;
     const { [videoId]: currentVideoData = {} as MediaData } = mediaData;
     const { duration, name } = currentVideoData;
-    const thumbnailUrl = KalturaPlayerAPI.getThumbnailUrl({
-      mediaId: videoId,
-      width: String(videoThumbnailWidth),
-    });
+    const thumbnailUrl =
+      thumbnail ||
+      KalturaPlayerAPI.getThumbnailUrl({
+        mediaId: videoId,
+        width: String(videoThumbnailWidth),
+      });
     return html`
       <dds-video-player
         duration="${ifNonNull(duration)}"

--- a/packages/web-components/src/components/video-player/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player/video-player-composite.ts
@@ -91,6 +91,12 @@ class DDSVideoPlayerComposite extends HybridRenderMixin(HostListenerMixin(LitEle
   embeddedVideos?: { [videoId: string]: any };
 
   /**
+   * An optional custom video caption.
+   */
+  @property()
+  caption?: '';
+
+  /**
    * The formatter for the video caption, composed with the video name and the video duration.
    * Should be changed upon the locale the UI is rendered with.
    */
@@ -159,6 +165,7 @@ class DDSVideoPlayerComposite extends HybridRenderMixin(HostListenerMixin(LitEle
       formatCaption,
       formatDuration,
       hideCaption,
+      caption,
       mediaData = {},
       videoId,
       videoThumbnailWidth,
@@ -174,7 +181,7 @@ class DDSVideoPlayerComposite extends HybridRenderMixin(HostListenerMixin(LitEle
       <dds-video-player
         duration="${ifNonNull(duration)}"
         ?hide-caption=${hideCaption}
-        name="${ifNonNull(name)}"
+        name="${ifNonNull(caption || name)}"
         thumbnail-url="${ifNonNull(thumbnailUrl)}"
         video-id="${ifNonNull(videoId)}"
         aspect-ratio="${ifNonNull(aspectRatio)}"


### PR DESCRIPTION
### Related Ticket(s)

#6195

### Description

This PR adds support for custom thumbnails and video captions in the `<video-player-container>/<video-player-composite>` web component. If no custom overrides are provided the values will be taken from the Kaltura API

![image](https://user-images.githubusercontent.com/8265238/131560990-114417a2-055b-40aa-b815-2eacfb5d89e2.png)


### Changelog

**New**

- `thumbnail` and `caption` properties on `<video-player-container>`/`<video-player-composite>`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
