### PR TITLE
fix(feature-card): ensure arrow stays at the bottom

### DIFF
--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -159,6 +159,11 @@ $fcb-breakpoint-up--lg: map-get(
         width: 50%;
         height: auto;
       }
+
+      .#{$prefix}--card__content {
+        height: auto;
+        min-height: 100%;
+      }
     }
 
     // image

--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -159,10 +159,6 @@ $fcb-breakpoint-up--lg: map-get(
         width: 50%;
         height: auto;
       }
-
-      .#{$prefix}--card__content {
-        height: auto;
-      }
     }
 
     // image


### PR DESCRIPTION
### Related Ticket(s)
#6689

### Description
In mobile breakpoint, the arrow did not move to the bottom. This PR ensures that it does.

### Changelog

**Removed**

- removed unnecessary `height: auto` from a feature-card class

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
