### PR TITLE
feat(image): support optional image borders

### DIFF
--- a/packages/styles/scss/components/image/_image.scss
+++ b/packages/styles/scss/components/image/_image.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,6 +17,10 @@
     height: 100%;
     object-fit: cover;
     display: block;
+  }
+
+  .#{$prefix}--image__img--border {
+    outline: 1px solid $decorative-01;
   }
 
   .#{$prefix}--image__longdescription {

--- a/packages/web-components/src/components/image/__stories__/image.stories.ts
+++ b/packages/web-components/src/components/image/__stories__/image.stories.ts
@@ -10,7 +10,7 @@
 import '../image';
 import { html } from 'lit-element';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
-import { select } from '@storybook/addon-knobs';
+import { select, boolean } from '@storybook/addon-knobs';
 // eslint-disable-next-line sort-imports
 import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--005.jpg';
 import imgLg2x1 from '../../../../../storybook-images/assets/720/fpo--2x1--720x360--005.jpg';
@@ -32,11 +32,11 @@ const srcsets = {
 };
 
 export const Default = ({ parameters }) => {
-  const { alt, defaultSrc } = parameters?.props?.['dds-image'] ?? {};
+  const { alt, defaultSrc, border } = parameters?.props?.['dds-image'] ?? {};
   // TODO: See if we can fix unwanted `&` to `&amp` conversion upon changing the select knob
   const srcset = srcsets[defaultSrc?.replace(/&amp;/, '&')];
   return html`
-    <dds-image alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}">
+    <dds-image alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}" ?border=${border}>
       ${!srcset
         ? undefined
         : html`
@@ -68,6 +68,7 @@ export default {
       'dds-image': ({ groupId }) => ({
         alt: textNullable('Alt text', 'Image alt text', groupId),
         defaultSrc: select('Default image (default-src)', images, imgLg2x1, groupId),
+        border: boolean('Border', false, groupId),
       }),
     },
   },

--- a/packages/web-components/src/components/image/image.ts
+++ b/packages/web-components/src/components/image/image.ts
@@ -8,6 +8,7 @@
  */
 
 import { html, property, internalProperty, customElement, LitElement } from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
@@ -70,9 +71,10 @@ class DDSImage extends StableSelectorMixin(LitElement) {
 
   render() {
     const { alt, defaultSrc, _images: images, _handleSlotChange: handleSlotChange } = this;
-    const imgClasses = [`${prefix}--image__img`, this.hasAttribute('border') ? `${prefix}--image__img--border` : null]
-      .filter(className => className !== null)
-      .join(' ');
+    const imgClasses = classMap({
+      [`${prefix}--image__img`]: true,
+      [`${prefix}--image__img--border`]: this.hasAttribute('border'),
+    });
 
     return html`
       <slot @slotchange="${handleSlotChange}"></slot>

--- a/packages/web-components/src/components/image/image.ts
+++ b/packages/web-components/src/components/image/image.ts
@@ -62,15 +62,25 @@ class DDSImage extends StableSelectorMixin(LitElement) {
   @property({ attribute: 'default-src' })
   defaultSrc = '';
 
+  /**
+   * Whether or not to apply a border around the image.
+   */
+  @property({ type: Boolean, reflect: true })
+  border = false;
+
   render() {
     const { alt, defaultSrc, _images: images, _handleSlotChange: handleSlotChange } = this;
+    const imgClasses = [`${prefix}--image__img`, this.hasAttribute('border') ? `${prefix}--image__img--border` : null]
+      .filter(className => className !== null)
+      .join(' ');
+
     return html`
       <slot @slotchange="${handleSlotChange}"></slot>
       <picture>
         ${images.map(
           image => html`<source media="${image.getAttribute('media')}" srcset="${image.getAttribute('srcset')}"></source>`
         )}
-        <img class="${prefix}--image__img" src="${defaultSrc}" alt="${alt}" aria-describedby="long-description" loading="lazy" />
+        <img class="${imgClasses}" src="${defaultSrc}" alt="${alt}" aria-describedby="long-description" loading="lazy" />
       </picture>
       <div id="long-description" class="${prefix}--image__longdescription">
         <slot name="long-description"></slot>


### PR DESCRIPTION
### Related Ticket(s)

Resolves #6528

### Description

This PR adds the ability to toggle an optional border around `<dds-image>` elements. Adopters can enable the border by adding the `border` attribute to the element:
```
<dds-image border>
```

### Changelog

**New**

- Adds support for a `border` attribute on the `<dds-image>` element that, when present, applies a border around the image.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
