### PR TITLE
feat(masthead): masthead L0 selected when child item is current page

### DIFF
--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -33,7 +33,7 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
    * @returns {*} Top masthead navigation
    */
   const mastheadLinks = navigation.map((link, i) => {
-    const subMenuSelected = hasCurrentUrl(link, root.location.href);
+    const subMenuSelected = _hasCurrentUrl(link, root.location.href);
     const autoid = `${stablePrefix}--masthead-${topNavProps.navType}__l0-nav${i}`;
     const selected =
       link.titleEnglish === topNavProps.selectedMenuItem || subMenuSelected;
@@ -134,9 +134,10 @@ function renderNav(link, autoid) {
  *
  * @param {object} obj The navigation list to search
  * @param {string} target The URL to search for
+ * @private
  * @returns {boolean} Whether or not the URL is found in the navigation list
  */
-function hasCurrentUrl(obj, target) {
+const _hasCurrentUrl = (obj, target) => {
   const findUrl = obj => {
     /* eslint-disable no-unused-vars */
     for (const [key, val] of Object.entries(obj)) {
@@ -150,7 +151,7 @@ function hasCurrentUrl(obj, target) {
     }
   };
   return findUrl(obj);
-}
+};
 
 MastheadTopNav.propTypes = {
   /**

--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -15,6 +15,7 @@ import HeaderNavContainer from './HeaderNavContainer';
 import HeaderNavigation from '../../internal/vendor/carbon-components-react/components/UIShell/HeaderNavigation';
 import MegaMenu from './MastheadMegaMenu/MegaMenu';
 import PropTypes from 'prop-types';
+import root from 'window-or-global';
 import settings from 'carbon-components/es/globals/js/settings';
 
 const { stablePrefix } = ddsSettings;
@@ -32,8 +33,10 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
    * @returns {*} Top masthead navigation
    */
   const mastheadLinks = navigation.map((link, i) => {
+    const subMenuSelected = hasCurrentUrl(link, root.location.href);
     const autoid = `${stablePrefix}--masthead-${topNavProps.navType}__l0-nav${i}`;
-    const selected = link.titleEnglish === topNavProps.selectedMenuItem;
+    const selected =
+      link.titleEnglish === topNavProps.selectedMenuItem || subMenuSelected;
     const dataTitle = link.titleEnglish
       ? link.titleEnglish
           .replace(/[^-a-zA-Z0-9_ ]/g, '')
@@ -124,6 +127,29 @@ function renderNav(link, autoid) {
     });
   }
   return navItems;
+}
+
+/**
+ * Checks if the current url exists in the list of links
+ *
+ * @param {object} obj The navigation list to search
+ * @param {string} target The URL to search for
+ * @returns {boolean} Whether or not the URL is found in the navigation list
+ */
+function hasCurrentUrl(obj, target) {
+  const findUrl = obj => {
+    /* eslint-disable no-unused-vars */
+    for (const [key, val] of Object.entries(obj)) {
+      if (val === target) {
+        return true;
+      }
+      if (typeof val === 'object') {
+        const nextObj = findUrl(val);
+        if (nextObj) return nextObj;
+      }
+    }
+  };
+  return findUrl(obj);
 }
 
 MastheadTopNav.propTypes = {


### PR DESCRIPTION
### Related Ticket(s)

#6764 

### Description

React masthead L0 parent menu now shows selected state when the current page is a child item. Example can be seen [here](https://codesandbox.io/s/github/kennylam/masthead-submenu-csb) (must open into external window).

![Untitled-2](https://user-images.githubusercontent.com/909118/131708646-52fc129e-6aa3-4af2-8b25-01a11c359d4b.gif)


### Changelog

**New**

- L0 parent menu shows selected state when current page is a child item

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
