### PR TITLE
fix(cloud-masthead): adjust the cookie to PROD ID & overlapping issue on v18 L1 Nav (#7037)

### DIFF
--- a/packages/services/src/services/CloudAccountAuth/CloudAccountAuth.js
+++ b/packages/services/src/services/CloudAccountAuth/CloudAccountAuth.js
@@ -13,7 +13,7 @@ import Cookies from 'js-cookie';
  * @type {string}
  * @private
  */
-const _cookieName = 'com.ibm.cloud.iam.LoggedIn.manual';
+const _cookieName = 'com.ibm.cloud.iam.LoggedIn.prod';
 
 class CloudAccountAuthAPI {
   /**

--- a/packages/services/src/services/CloudAccountAuth/__tests__/CloudAccountAuth.test.js
+++ b/packages/services/src/services/CloudAccountAuth/__tests__/CloudAccountAuth.test.js
@@ -11,7 +11,7 @@ describe('CloudAccountAuth cookie utility', () => {
   it('should fetch the CloudAccountAuth cookie and return the authenticated string', () => {
     Object.defineProperty(window.document, 'cookie', {
       writable: true,
-      value: 'com.ibm.cloud.iam.LoggedIn.manual=1',
+      value: 'com.ibm.cloud.iam.LoggedIn.prod=1',
     });
 
     const loginStatus = CloudAccountAuthAPI.checkCookie();
@@ -21,7 +21,7 @@ describe('CloudAccountAuth cookie utility', () => {
   it('should fetch the CloudAccountAuth cookie and return the anonymous string', () => {
     Object.defineProperty(window.document, 'cookie', {
       writable: true,
-      value: 'com.ibm.cloud.iam.LoggedIn.manual=0',
+      value: 'com.ibm.cloud.iam.LoggedIn.prod=0',
     });
 
     const loginStatus = CloudAccountAuthAPI.checkCookie();

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -249,6 +249,9 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
     }
     this._loadTranslation?.(language, dataEndpoint).catch(() => {}); // The error is logged in the Redux store
     this._loadUserStatus?.(this.authMethod);
+
+    // This is a temp fix until we figure out why we can't set styles to the cloud-masthead-container with stylesheets
+    this.style.zIndex = '999';
   }
 
   render() {

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
@@ -10,9 +10,10 @@
 
 // Cloud Masthead.
 
-:host(#{$dds-prefix}-cloud-masthead-container) {
+:host(#{$dds-prefix}-cloud-masthead-container),
+#{$dds-prefix}-cloud-masthead-container {
   position: relative;
-  z-index: 99;
+  z-index: 999;
 }
 
 :host(#{$dds-prefix}-cloud-masthead-global-bar) {


### PR DESCRIPTION
cherry pick #7037 for `v1.24.0` release

> ### Related Ticket(s)
> 
> https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7032
> 
> ### Description
> 
> - This PR addresses the two bugs that we've discovered after the launch of the new Cloud Masthead on the Drupal PROD environment (see - https://www.ibm.com/cloud?bust=foo).
> - See this issue for more detail - https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7032
> 
> ### Changelog
> 
> **New**
> 
> - {{new thing}}
> 
> **Changed**
> 
> - {{changed thing}}
> 
> **Removed**
> 
> - {{removed thing}}
> 
> <!-- React and Web Component deploy previews are enabled by default. -->
> <!-- To enable additional available deploy previews, apply the following -->
> <!-- labels for the corresponding package: -->
> <!-- *** "package: services": Services -->
> <!-- *** "package: utilities": Utilities -->
> <!-- *** "package: styles": Carbon Expressive -->
> <!-- *** "RTL": React / Web Components (RTL) -->
> <!-- *** "feature flag": React / Web Components (experimental) -->
> 
> ### Related Ticket(s)
> 
> {{Provide url(s) to the related ticket(s) that this pull request addresses}}
> 
> ### Description
> 
> {{Add a human-readable description / detail summary of what the PR is changing and any details around how and why}}
> 
> {{If applicable, include a screenshot indicating an example or examples of what the PR is changing in the application}}
> 
> ### Changelog
> 
> **New**
> 
> - {{new thing}}
> 
> **Changed**
> 
> - {{changed thing}}
> 
> **Removed**
> 
> - {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
