### PR TITLE
fix(node): adding default package exports for services/utilities

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -8,6 +8,10 @@
   "repository": "https://github.com/carbon-design-system/carbon-for-ibm-dotcom",
   "bugs": "https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues",
   "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js"
+    },
     "./es": "./es/index.js",
     "./es/": "./es/",
     "./lib": "./lib/index.js",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -8,6 +8,10 @@
   "repository": "https://github.com/carbon-design-system/carbon-for-ibm-dotcom",
   "bugs": "https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues",
   "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js"
+    },
     "./es": "./es/index.js",
     "./es/": "./es/",
     "./lib": "./lib/index.js",


### PR DESCRIPTION
### Related Ticket(s)

Refs https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6203

### Description

This fixes an import issue for `services` and `utilities` if they are used in Node 14.

### Changelog

**Changed**

- Updated `exports` configuration for `services` and `utilities`
