### PR TITLE
fix(dotcom-shell): ensure locale modal opens with scrollbars on

### DIFF
--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
@@ -169,13 +169,13 @@ class DDSDotcomShellComposite extends LitElement {
           this._masthead!.style.top = '0';
         }
       }
+      this._lastScrollPosition = window.scrollY;
     } else if (l1Element) {
       this._masthead!.style.top = `-${Math.min(
         this._masthead!.offsetHeight - l1Element.offsetHeight,
         Math.abs(window.scrollY)
       )}px`;
     }
-    this._lastScrollPosition = window.scrollY;
   };
 
   connectedCallback() {


### PR DESCRIPTION
### Related Ticket(s)
#7050

### Description
This bug occurs when scrollbars are always active. Make sure to activate this setting on MacOS for testing purposes.

 Opening the modal causes the scrollbar to disappear and resize the page, which called the scroll handler, closing the modal immediately as its considered an "out of modal" action/click event. In other words, the modal closed immediately as it opened. 

This PR ensures that this resize change only affects the code when it's actually scrolling.

### Changelog

**Changed**

- moved a variable update to within the conditional that uses its value

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
