### PR TITLE
fix(card-link): pass heading into the `heading` field in storybook

### DIFF
--- a/packages/react/src/components/CardLink/__stories__/CardLink.stories.js
+++ b/packages/react/src/components/CardLink/__stories__/CardLink.stories.js
@@ -16,8 +16,8 @@ const getBaseKnobs = ({ groupId }) => {
   const iconStyle = disabled ? Error20 : ArrowRight20;
   return {
     card: {
-      copy: text(
-        'Card Heading (card.copy):',
+      heading: text(
+        'Card Heading (card.heading):',
         'Explore AI use cases in all industries',
         groupId
       ),


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This addresses an incorrect heading set for `<CardLink>` in React. It was being set as `copy`, where it seems that it should be set as `heading` instead.

This addresses the issue identified in PR #7012:

6. Card link (React) looks like current heading is using the `<p>` styling. Should be `expressive-heading-02` which is 16px semibold
![image](https://user-images.githubusercontent.com/15144993/131727696-4fc815ec-3df1-478c-9535-aba04c00a1a2.png)

### Changelog

**Changed**

- `CardLink` story setting heading as `heading` instead of `copy`.
