### PR TITLE
fix(card-section-simple): aligning component in storybook

### DIFF
--- a/packages/web-components/src/components/card-section-simple/__stories__/card-section-simple.stories.ts
+++ b/packages/web-components/src/components/card-section-simple/__stories__/card-section-simple.stories.ts
@@ -59,12 +59,8 @@ export default {
   title: 'Components/Card section simple',
   decorators: [
     story => html`
-      <div class="bx--grid bx--content-group-story dds-ce-demo-devenv--grid--stretch">
-        <div class="bx--row dds-ce-demo-devenv--grid-row">
-          <div class="bx--col-sm-4">
-            ${story()}
-          </div>
-        </div>
+      <div class="bx--grid bx--row">
+        ${story()}
       </div>
     `,
   ],


### PR DESCRIPTION
### Related Ticket(s)
#5857

### Description
In the current Storybook example in Card Section Simple, it still has the old demo classes. This PR ensures that it only uses the `bx--grid` classes only so it aligns to the grid properly.

### Changelog
**Changed**

- Card Section Simple story now uses `bx--grid` classes

**Removed**

- removed demo classes from the Card Section Simple story in Web Components

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
