### PR TITLE
fix(image-with-caption): update expressive modal prop to expressive-size

### DIFF
--- a/packages/web-components/src/components/image-with-caption/image-with-caption.ts
+++ b/packages/web-components/src/components/image-with-caption/image-with-caption.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -150,7 +150,7 @@ class DDSImageWithCaption extends StableSelectorMixin(ModalRenderMixin(FocusMixi
     return !lightbox
       ? undefined
       : html`
-          <dds-expressive-modal ?open="${open}" size="full-width">
+          <dds-expressive-modal ?open="${open}" expressive-size="full-width">
             <dds-expressive-modal-close-button></dds-expressive-modal-close-button>
             <dds-lightbox-image-viewer
               alt="${ifNonNull(alt)}"


### PR DESCRIPTION
### Related Ticket(s)

#7073 

### Description

Image with caption modal not displaying properly in large breakpoints

### Changelog


**Changed**

- updated prop from `size` to `expressive-size`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
