### PR TITLE
fix(locale-modal): correct modal close button positioning

### DIFF
--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -95,11 +95,6 @@
         top: 3rem;
       }
 
-      .#{$prefix}--modal-close {
-        top: $carbon--spacing-05;
-        right: $carbon--spacing-05;
-      }
-
       .#{$prefix}--modal-header {
         padding-left: $carbon--spacing-07;
         padding-top: $carbon--spacing-05;


### PR DESCRIPTION
### Related Ticket(s)

#7079

### Description

This PR updates the locale modal styles so that the React version of the component follows the [component spec](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/wiki/Locale-modal). The styles should be directly inherited from the composed modal in `carbon-web-components`

Confirm that the React locale modal close button renders in the correct position and there are no regressions with the web component version

![image](https://user-images.githubusercontent.com/8265238/132414195-c216daf5-fdc5-4859-9def-4711699c266b.png)

### Changelog

**Changed**

- locale modal close button positioning

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
