### PR TITLE
fix(masthead): Prevent focusing hidden elements

### DIFF
--- a/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
+++ b/packages/web-components/src/components/masthead/megamenu-top-nav-menu.ts
@@ -10,6 +10,7 @@
 import { customElement, query, internalProperty } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
+import HostListener from 'carbon-web-components/es/globals/decorators/host-listener';
 import { forEach } from '../../globals/internal/collection-helpers';
 import DDSTopNavMenu from './top-nav-menu';
 import DDSMegaMenuOverlay from './megamenu-overlay';
@@ -70,6 +71,23 @@ class DDSMegaMenuTopNavMenu extends DDSTopNavMenu {
     // https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/4493
     const { customPropertyViewportWidth } = this.constructor as typeof DDSMegaMenuTopNavMenu;
     this.style.setProperty(customPropertyViewportWidth, `${contentRect.width}px`);
+  };
+
+  @HostListener('shadowRoot:focusin')
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  private _handleFocusIn = (event: Event) => {
+    if (event.target instanceof Element) {
+      const focusedItem = event.target;
+      const topNavItem = focusedItem.getRootNode().host;
+      const topNav = topNavItem.parentElement;
+      topNav.dispatchEvent(
+        new CustomEvent('requestScroll', {
+          detail: {
+            requestingItem: topNavItem,
+          },
+        })
+      );
+    }
   };
 
   connectedCallback() {

--- a/packages/web-components/src/components/masthead/top-nav.ts
+++ b/packages/web-components/src/components/masthead/top-nav.ts
@@ -292,6 +292,28 @@ class DDSTopNav extends StableSelectorMixin(HostListenerMixin(BXHeaderNav)) {
     }
   };
 
+  @HostListener('requestScroll')
+  protected _handleRequestScroll = (event: CustomEvent) => {
+    if (event.detail.requestingItem !== undefined && this._contentContainerNode !== undefined) {
+      const { requestingItem } = event.detail;
+      const { _contentContainerNode: contentContainerNode } = this;
+
+      const containerRect = contentContainerNode.getBoundingClientRect();
+      const itemRect = requestingItem.getBoundingClientRect();
+
+      const isOverflowingLeft = itemRect.left < containerRect.left;
+      const isOverflowingRight = itemRect.right > containerRect.right;
+
+      if (isOverflowingLeft) {
+        this._paginateLeft();
+      }
+
+      if (isOverflowingRight) {
+        this._paginateRight();
+      }
+    }
+  };
+
   /**
    * `true` to hide the divider.
    */


### PR DESCRIPTION
### Related Ticket(s)
Fixes #5895 

### Description
Prevents focus going to hidden elements by paginating the dds-top-nav element when elements that overflow the scroll container receive focus

![Screen Recording 2021-09-08 at 5 01 33 PM](https://user-images.githubusercontent.com/25532785/132585280-521ec408-9502-4fc8-9c78-c717818fafe6.gif)


### Changelog

**Changed**

- Masthead top-nav items will focus as hidden elements are focused to via keyboard navigation
