### PR TITLE
feat(content-block-simple): add react wrapper

### DIFF
--- a/packages/web-components/src/components/content-block-simple/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-block-simple/__stories__/README.stories.react.mdx
@@ -1,0 +1,58 @@
+import { Preview, Props, Description, Story } from '@storybook/addon-docs/blocks';
+import contributing from '../../../../../../docs/contributing-license.md';
+import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-react/content-block-simple/content-block-simple';
+
+# Back to top
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/components/content-block-simple)
+> example implementation.
+
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/components/content-block-simple)
+
+## Getting started
+
+Here's a quick example to get you started.
+
+### JS
+
+```javascript
+import '@carbon/ibmdotcom-web-components/es/components/content-block-simple/index.js';
+
+function App() {
+  return (
+    <main id="example-main-content">
+      <DDSContentBlockSimple>
+        <DDSContentBlockHeading>Heading</DDSContentBlockHeading>
+        <DDSContentBlockCopy size="sm">Content copy</DDSContentBlockCopy>
+          <DDSTextCTA cta-type={ctaType} slot="footer" href="#" icon-placement="right">
+            Text CTA
+          </DDSTextCTA>
+      </DDSContentBlockSimple>
+    </main>
+  );
+}
+```
+
+### HTML
+
+> The Content Block - Simple pattern is a variant of `<dds-content-block>`, and
+> includes a single content item, optional media (image), and ends with a CTA.
+
+```html
+<dds-content-block-simple></dds-content-block-simple>
+```
+
+## Props
+
+<Props of={PropTypesRef} />
+
+## Stable selectors
+
+See [our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components#stable-selectors-for-analytics-and-integratione2e-testing-in-web-components) to see how Web Components selector and `data-autoid` should be used.
+
+| Web Components selector | Compatibility selector           | Description |
+| ----------------------- | -------------------------------- | ----------- |
+| `<dds-content-block-simple>`     | `data-autoid="dds--content-block-simple"` | Component   |
+
+<Description markdown={contributing} />

--- a/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.react.tsx
+++ b/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.react.tsx
@@ -1,0 +1,111 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { text, select } from '@storybook/addon-knobs';
+import React from 'react';
+import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20.js';
+// Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
+// In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
+/* eslint-disable max-len */
+import DDSContentBlockSimple from '@carbon/ibmdotcom-web-components/es/components-react/content-block-simple/content-block-simple';
+import DDSContentBlockHeading from '@carbon/ibmdotcom-web-components/es/components-react/content-block/content-block-heading';
+import DDSContentBlockCopy from '@carbon/ibmdotcom-web-components/es/components-react/content-block/content-block-copy';
+import DDSTextCTA from '@carbon/ibmdotcom-web-components/es/components-react/cta/text-cta';
+import DDSCardLink from '@carbon/ibmdotcom-web-components/es/components-react/card-link/card-link';
+import DDSCardLinkHeading from '@carbon/ibmdotcom-web-components/es/components-react/card-link/card-link-heading';
+import DDSCardFooter from '@carbon/ibmdotcom-web-components/es/components-react/card/card-footer';
+import { CONTENT_BLOCK_COPY_SIZE } from '../../content-block/content-block-copy';
+import { CTA_STYLE, CTA_TYPE } from '../../cta/defs';
+import readme from './README.stories.react.mdx';
+import styles from './content-block-simple.stories.scss';
+
+const copy = `Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+  nulla quis, *consequat* libero. Here are
+  some common categories:
+
+  Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit.
+  Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
+  Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  Aenean et ultricies est.
+  Mauris iaculis eget dolor nec hendrerit.
+  Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+
+  - [list item](https://www.ibm.com)
+    - list item 1a
+  1. list item 2
+    1. list item 2a
+`;
+
+const ctaTypes = {
+  [`Local (${CTA_TYPE.LOCAL})`]: CTA_TYPE.LOCAL,
+  [`Jump (${CTA_TYPE.JUMP})`]: CTA_TYPE.JUMP,
+  [`External (${CTA_TYPE.EXTERNAL})`]: CTA_TYPE.EXTERNAL,
+};
+
+const ctaStyles = {
+  [`Card (${CTA_STYLE.CARD})`]: CTA_STYLE.CARD,
+  [`Text (${CTA_STYLE.TEXT})`]: CTA_STYLE.TEXT,
+};
+
+export const Default = ({ parameters }) => {
+  const { heading, ctaStyle, ctaType } = parameters?.props?.ContentBlockSimple ?? {};
+  return (
+    <>
+      <DDSContentBlockSimple>
+        <DDSContentBlockHeading>{heading}</DDSContentBlockHeading>
+        <DDSContentBlockCopy size={CONTENT_BLOCK_COPY_SIZE.SMALL}>{copy}</DDSContentBlockCopy>
+        {ctaStyle === 'card' ? (
+          <DDSCardLink cta-type={ctaType} slot="footer" href="https://example.com">
+            <DDSCardLinkHeading>Lorem ipsum dolor sit amet</DDSCardLinkHeading>
+            <DDSCardFooter>
+              <ArrowRight20 slot="icon" />
+            </DDSCardFooter>
+          </DDSCardLink>
+        ) : (
+          <DDSTextCTA cta-type={ctaType} slot="footer" href="#" icon-placement="right">
+            Lorem ipsum dolor sit amet
+          </DDSTextCTA>
+        )}
+      </DDSContentBlockSimple>
+    </>
+  );
+};
+
+Default.story = {
+  parameters: {
+    knobs: {
+      ContentBlockSimple: () => ({
+        heading: text('Heading (required)', 'Curabitur malesuada varius mi eu posuere'),
+        copy,
+        ctaStyle: select('CTA style', ctaStyles, CTA_STYLE.TEXT),
+        ctaType: select('CTA type (cta-type)', ctaTypes, CTA_TYPE.LOCAL),
+      }),
+    },
+  },
+};
+
+export default {
+  title: 'Components/Content block simple',
+  decorators: [
+    story => {
+      return (
+        <>
+          <style type="text/css">{styles.cssText}</style>
+          {story()}
+        </>
+      );
+    },
+  ],
+  parameters: {
+    ...readme.parameters,
+  },
+};

--- a/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.scss
+++ b/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.scss
@@ -1,0 +1,9 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+.dds-ce-demo-devenv--container {
+  padding: 0;
+}

--- a/packages/web-components/src/components/content-block-simple/content-block-simple.ts
+++ b/packages/web-components/src/components/content-block-simple/content-block-simple.ts
@@ -32,4 +32,5 @@ class DDSContentBlockSimple extends StableSelectorMixin(DDSContentBlock) {
   }
 }
 
+/* @__GENERATE_REACT_CUSTOM_ELEMENT_TYPE__ */
 export default DDSContentBlockSimple;


### PR DESCRIPTION
### Description

This adds the `content-block-simple` React wrapper.

Note: the `card` style CTA layout is slightly off (missing top margin) because the `CTA` component React wrapper has not been created yet. Will create a separate issue to track that work.

### Changelog

**New**

- `content-block-simple` React wrapper


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
