### PR TITLE
chore(styles): remove global deprecation notice

### DIFF
--- a/packages/styles/scss/themes/expressive/index.scss
+++ b/packages/styles/scss/themes/expressive/index.scss
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@warn 'The Expressive Theme has been integrated into Carbon Design System’s core library. This means that expressive continues to be available to IBM.com, but now all Carbon adopters can get both productive and expressive experiences from the same library source. This change will be seamless for current adopters of Carbon for IBM.com. In the next few sprints, we will be shifting to use expressive styling and elements from core, then the Expressive Theme within Carbon for IBM.com will no longer be maintained.';
-
 @import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import 'carbon-components/scss/globals/scss/vars';
 @import 'tokens';


### PR DESCRIPTION
### Description

Remove scss warning for expressive theme deprecation from global imports. The deprecation notice can now be seen in the `Styles` section of the [release notes](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/releases/tag/v1.24.0).

### Changelog

**Removed**

- expressive theme deprecation notice

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
