### PR TITLE
fix(masthead): expressive sunset cleanup

### DIFF
--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -234,17 +234,17 @@ function _renderLevel1Submenus(
                 }
               />
             );
-          } else {
-            return (
-              <SideNavMenuItem
-                href={item.url}
-                className={highlightedClass}
-                data-autoid={`${menu.autoid}-list${k}`}
-                key={item.title}>
-                {item.title}
-              </SideNavMenuItem>
-            );
           }
+
+          return (
+            <SideNavMenuItem
+              href={item.url}
+              className={highlightedClass}
+              data-autoid={`${menu.autoid}-list${k}`}
+              key={item.title}>
+              {item.title}
+            </SideNavMenuItem>
+          );
         })}
       </SideNavMenuSection>
     );

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -95,7 +95,8 @@ const MastheadLeftNav = ({
               selected && `${prefix}--masthead__side-nav--submemu--selected`
             }
             data-autoid={autoid}
-            key={link.title}>
+            key={link.title}
+            role="menuitem">
             {link.title}
           </SideNavMenuItem>
         );
@@ -241,7 +242,8 @@ function _renderLevel1Submenus(
               href={item.url}
               className={highlightedClass}
               data-autoid={`${menu.autoid}-list${k}`}
-              key={item.title}>
+              key={item.title}
+              role="menuitem">
               {item.title}
             </SideNavMenuItem>
           );
@@ -289,7 +291,8 @@ function _renderLevel2Submenus(
             <SideNavMenuItem
               href={item.url}
               data-autoid={`${menu.autoid}-item${k}`}
-              key={item.title}>
+              key={item.title}
+              role="menuitem">
               {item.title}
             </SideNavMenuItem>
           );

--- a/packages/react/src/components/Masthead/MastheadMegaMenu/RightNavigation.js
+++ b/packages/react/src/components/Masthead/MastheadMegaMenu/RightNavigation.js
@@ -35,7 +35,8 @@ const RightNavigation = ({
       <LinkWithIcon
         className={`${prefix}--masthead__megamenu__view-all-cta`}
         data-autoid={`${rest.autoid}-view-all`}
-        href={viewAllLinkHref}>
+        href={viewAllLinkHref}
+        iconInline={false}>
         <span>{viewAllLinkTitle}</span>
         <ArrowRight16 />
       </LinkWithIcon>

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -127,7 +127,6 @@ $search-transition-timing: 95ms;
     li:not([role='none']) {
       > a {
         align-items: flex-end;
-        padding-bottom: rem(10px);
       }
     }
 

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -411,10 +411,6 @@
     height: carbon--mini-units(6);
     width: 100%;
 
-    .#{$prefix}--side-nav__link-text {
-      margin-top: auto;
-    }
-
     &::after {
       content: '';
       width: 100%;

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -369,6 +369,9 @@
   :host(#{$dds-prefix}-left-nav-menu-category-heading) {
     @include type-style('body-long-01');
 
+    font-size: 1rem;
+    line-height: 1.5rem;
+    letter-spacing: normal;
     display: block;
     color: $text-02;
     padding: $spacing-02 0;

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -225,8 +225,12 @@
         .#{$prefix}--side-nav__link-text {
           @include carbon--type-style(body-short-02);
 
+          display: flex;
+          align-items: center;
           color: $text-02;
           width: 100%;
+          height: 100%;
+          border-bottom: 1px solid $ui-03;
           text-overflow: ellipsis;
         }
       }
@@ -410,13 +414,6 @@
     padding-left: $carbon--spacing-05;
     height: carbon--mini-units(6);
     width: 100%;
-
-    &::after {
-      content: '';
-      width: 100%;
-      margin-top: auto;
-      border-bottom: 1px solid $ui-03;
-    }
   }
 
   .#{$prefix}--masthead__side-nav__last-highlighted,
@@ -431,12 +428,12 @@
   .#{$prefix}--masthead__side-nav__last-highlighted
     .#{$prefix}--side-nav__submenu-content,
   .#{$prefix}--side-nav__menu-item.#{$prefix}--masthead__side-nav__last-highlighted
-    .#{$prefix}--side-nav__link::after,
+    .#{$prefix}--side-nav__link,
   :host(dds-left-nav-menu-section)
     .#{$prefix}--masthead__side-nav--submemu-back
-    .#{$prefix}--side-nav__link::after,
+    .#{$prefix}--side-nav__link,
   :host(#{$dds-prefix}-left-nav-menu-item[last-highlighted])
-    .#{$prefix}--side-nav__link[role='menuitem']::after {
+    .#{$prefix}--side-nav__link[role='menuitem'] {
     border-bottom: none;
   }
 

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -383,21 +383,10 @@
 :host(#{$dds-prefix}-left-nav-menu-item) a.#{$prefix}--side-nav__link[role='menuitem'] {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   padding-left: $carbon--spacing-05;
   height: carbon--mini-units(6);
   width: 100%;
-
-  .#{$prefix}--side-nav__link-text {
-    align-self: end;
-    margin-top: auto;
-  }
-
-  &::after {
-    content: '';
-    width: 100%;
-    margin-top: auto;
-    border-bottom: 1px solid $ui-03;
-  }
 }
 
 :host(#{$dds-prefix}-left-nav-item),


### PR DESCRIPTION
### Related Ticket(s)

#7087

### Description

This PR includes several fixes to the `web-components` and `react` masthead component

* "View all products" button should be center aligned in the React version:

![image](https://user-images.githubusercontent.com/8265238/132712466-1bb3d70d-bc94-4f4d-bb68-d75df09a503c.png)

* L1 menu headers should be vertically centered in the React version:

![image](https://user-images.githubusercontent.com/8265238/132714834-d58eb35b-0cbf-4419-8f94-a7ed07b5f905.png)

Mobile view

* Back button should be properly positioned in the web components version
* "The essentials" should be 32px tall + 1px for the bottom border in the mobile WC and React versions
* "View all products" should appear correct in the React version

![image](https://user-images.githubusercontent.com/8265238/132715222-fafb2f01-7941-47ac-9b30-272199895929.png)

### Changelog

**Changed**

- explicitly set `iconInline` in right nav link with icon
- remove React specific padding rule in L1 masthead
- **manually override `body-long-01` styles in masthead leftnav (appears to be due to base font size differences)**
- fix back button positioning
- add `role="menuitem"` to React sidenav menu items

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
