### PR TITLE
fix(masthead): add check for focus elem in Masthead SideNavMenuSection to prevent type error

### DIFF
--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuSection.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuSection.js
@@ -41,12 +41,11 @@ const SideNavMenuSection = ({
           'transitionend',
           function focus(event) {
             if (
-              focusElement &&
-              (event.propertyName === 'left' ||
-                event.propertyName === 'background-color' ||
-                event.propertyName === 'color')
+              event.propertyName === 'left' ||
+              event.propertyName === 'background-color' ||
+              event.propertyName === 'color'
             ) {
-              focusElement.focus();
+              focusElement?.focus();
             }
             menuSectionRef.current?.removeEventListener('transitionend', focus);
           }

--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuSection.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuSection.js
@@ -41,9 +41,10 @@ const SideNavMenuSection = ({
           'transitionend',
           function focus(event) {
             if (
-              event.propertyName === 'left' ||
-              event.propertyName === 'background-color' ||
-              event.propertyName === 'color'
+              focusElement &&
+              (event.propertyName === 'left' ||
+                event.propertyName === 'background-color' ||
+                event.propertyName === 'color')
             ) {
               focusElement.focus();
             }


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Type error was occurring when user hovered over the mobile nav items in smaller breakpoints. This was happening because there is a `transitionend` listener needed to provide focus for tabbing through the menu. Add a check for the `focusElement` to prevent error.

### Changelog

**Changed**

- add check for `focusElement` before setting focus

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
