### PR TITLE
fix(footer): expressive sunset cleanup

### DIFF
--- a/packages/react/src/components/Footer/LanguageSelector.js
+++ b/packages/react/src/components/Footer/LanguageSelector.js
@@ -87,6 +87,7 @@ const LanguageSelector = ({
         direction="top"
         placeholder={labelText}
         titleText={labelText}
+        size="xl"
       />
       <Select
         defaultValue={selectedItem.id}

--- a/packages/styles/scss/components/footer/_language-selector.scss
+++ b/packages/styles/scss/components/footer/_language-selector.scss
@@ -31,7 +31,6 @@
       order: 0;
 
       @include carbon--breakpoint('md') {
-        @include carbon--make-col-ready;
         @include carbon--make-col(4, 4);
       }
 

--- a/packages/web-components/src/components/footer/footer.scss
+++ b/packages/web-components/src/components/footer/footer.scss
@@ -299,22 +299,6 @@
     bottom: rem(47px);
     max-height: 13.5rem;
   }
-
-  .#{$prefix}--list-box {
-    &__menu-icon {
-      top: carbon--mini-units(1.5);
-      svg {
-        height: carbon--mini-units(2.5);
-        width: carbon--mini-units(2.5);
-      }
-    }
-    &__selection {
-      svg {
-        height: carbon--mini-units(2.5);
-        width: carbon--mini-units(2.5);
-      }
-    }
-  }
 }
 
 :host(#{$dds-prefix}-language-selector-mobile[size='micro']) {


### PR DESCRIPTION
### Related Ticket(s)

#7094

### Description

This PR updates the footer and language selector to retain expressive theme styles

Web components language selector icon sizes should be 16px

![image](https://user-images.githubusercontent.com/8265238/132738382-8503f7f4-380c-4807-bf9f-d36cd2b77307.png)

React language selector height should be 48px

![image](https://user-images.githubusercontent.com/8265238/132738423-d40bd903-46d9-49cc-b0f8-e34c91b1fa8f.png)

React language selector container should no longer have extra side padding which indented the input field

![image](https://user-images.githubusercontent.com/8265238/132738617-f48fce8d-5eb6-4272-9b71-2e77f1869778.png)


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
