### PR TITLE
fix(video-player): set tabindex of 0 to dds-video-player

### DIFF
--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -182,6 +182,10 @@ class DDSVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
     }
   }
 
+  firstUpdated() {
+    this.tabIndex = 0;
+  }
+
   /**
    * The name of the custom event fired after video content state is changed upon a user gesture.
    */


### PR DESCRIPTION
### Related Ticket(s)

GH Issue: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6944
HC JIRA Ticket: https://jsw.ibm.com/browse/HC-2168

### Description

- This PR adds a `tabindex` of `0` to `dds-video-player` component so that it receives the focus with Firefox.


### Testing Instruction

- Visit the `Video Player` component in Firefox - `/iframe.html?id=components-video-player--default`
- Ensure that the blue focus outline is visible.

### Expected Display

![Screen Shot 2021-09-09 at 11 33 57 AM](https://user-images.githubusercontent.com/1815714/132716727-5ad07040-7a51-4fc5-b725-775148c1c406.png)


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
