### PR TITLE
fix(cloud-masthead): ensure that true is passed to the has-contact attribute

### DIFF
--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -64,7 +64,7 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
   /**
    * `true` if Contact us should be shown.
    */
-  @property({ type: Boolean, attribute: 'has-contact' })
+  @property({ type: Boolean, reflect: true, attribute: 'has-contact' })
   hasContact = true;
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

GH Issue: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7061
HC JIRA Ticket: https://jsw.ibm.com/browse/HC-2179

### Description

- This PR adds the `reflect: true` to the property parameter object so that value is passed correctly to the `has-contact` attribute.

### Testing Instruction

- Pull down the changes of this PR in a test preview and sets the following markup with the `has-contact` attribute sets to `false` or remove from the markup.
- Ensure that the "Contact us" button is removed when the attribute is set to `false` or not defined within the markup.

```
<dds-cloud-masthead-container
  platform="Cloud"
  auth-method="API"
  has-contact=false
  data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead"
></dds-cloud-masthead-container>
```


### Expected Display

![Screen Shot 2021-09-09 at 3 20 57 PM](https://user-images.githubusercontent.com/1815714/132749577-05b55304-87c9-4595-834e-c40a61c34afa.png)



<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
