### PR TITLE
chore(leadspace): loading overlay background

### DIFF
--- a/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
+++ b/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
@@ -9,6 +9,7 @@
 
 import { text, select, number } from '@storybook/addon-knobs';
 import { html } from 'lit-element';
+import on from 'carbon-components/es/globals/js/misc/on';
 import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20.js';
 import ArrowDown20 from 'carbon-web-components/es/icons/arrow--down/20.js';
 import Pdf20 from 'carbon-web-components/es/icons/PDF/20.js';
@@ -75,6 +76,7 @@ export const TallWithImage = ({ parameters }) => {
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
       default-src="${ifNonNull(defaultSrc)}"
+      loading
     >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
@@ -94,6 +96,9 @@ export const TallWithImage = ({ parameters }) => {
         <dds-image-item media="(min-width: 0)" srcset="${image}"></dds-image-item>
       </dds-leadspace-image>
     </dds-leadspace>
+    <div>
+      <button id="btn-leadspace">click me</button>
+    </div>
   `;
 };
 
@@ -297,11 +302,18 @@ const iconOptions = {
 export default {
   title: 'Components/Lead space',
   decorators: [
-    story => html`
-      <div class="bx--grid bx--no-gutter dds-ce-demo-devenv--grid--stretch">
-        ${story()}
-      </div>
-    `,
+    story => {
+      if (!(window as any)._hPageShow) {
+        (window as any)._hPageShow = on(window, 'pageshow', () => {
+          const leadspaceBtn = document.getElementById('btn-leadspace');
+          const leadspace = document.querySelector('dds-leadspace');
+          leadspaceBtn?.addEventListener('click', () => {
+            leadspace?.toggleAttribute('loading');
+          });
+        });
+      }
+      return story();
+    },
   ],
   parameters: {
     ...readme.parameters,

--- a/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
+++ b/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
@@ -9,7 +9,6 @@
 
 import { text, select, number } from '@storybook/addon-knobs';
 import { html } from 'lit-element';
-import on from 'carbon-components/es/globals/js/misc/on';
 import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20.js';
 import ArrowDown20 from 'carbon-web-components/es/icons/arrow--down/20.js';
 import Pdf20 from 'carbon-web-components/es/icons/PDF/20.js';
@@ -76,7 +75,6 @@ export const TallWithImage = ({ parameters }) => {
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
       default-src="${ifNonNull(defaultSrc)}"
-      loading
     >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
@@ -96,9 +94,6 @@ export const TallWithImage = ({ parameters }) => {
         <dds-image-item media="(min-width: 0)" srcset="${image}"></dds-image-item>
       </dds-leadspace-image>
     </dds-leadspace>
-    <div>
-      <button id="btn-leadspace">click me</button>
-    </div>
   `;
 };
 
@@ -302,18 +297,11 @@ const iconOptions = {
 export default {
   title: 'Components/Lead space',
   decorators: [
-    story => {
-      if (!(window as any)._hPageShow) {
-        (window as any)._hPageShow = on(window, 'pageshow', () => {
-          const leadspaceBtn = document.getElementById('btn-leadspace');
-          const leadspace = document.querySelector('dds-leadspace');
-          leadspaceBtn?.addEventListener('click', () => {
-            leadspace?.toggleAttribute('loading');
-          });
-        });
-      }
-      return story();
-    },
+    story => html`
+      <div class="bx--grid bx--no-gutter dds-ce-demo-devenv--grid--stretch">
+        ${story()}
+      </div>
+    `,
   ],
   parameters: {
     ...readme.parameters,

--- a/packages/web-components/src/components/leadspace/leadspace.scss
+++ b/packages/web-components/src/components/leadspace/leadspace.scss
@@ -20,7 +20,7 @@
     width: 100%;
     height: 100%;
     z-index: -1;
-    background: linear-gradient(270deg, #a8a8a8, #c6c6c6);
+    background: linear-gradient(270deg, #c6c6c6, #a8a8a8);
     background-size: 100% 100%;
     animation: loadingAnimation 2000ms ease infinite;
     transition: all 800ms cubic-bezier(0.4, 0.14, 0.3, 1);

--- a/packages/web-components/src/components/leadspace/leadspace.scss
+++ b/packages/web-components/src/components/leadspace/leadspace.scss
@@ -11,6 +11,27 @@
 
 :host(#{$dds-prefix}-leadspace) {
   display: block;
+  position: relative;
+
+  &::before {
+    content: '';
+    opacity: 0;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    background: linear-gradient(270deg, #a8a8a8, #c6c6c6);
+    background-size: 100% 100%;
+    animation: loadingAnimation 2000ms ease infinite;
+    transition: all 800ms cubic-bezier(0.4, 0.14, 0.3, 1);
+  }
+
+  &[loading] {
+    &::before {
+      z-index: 5;
+      opacity: 1;
+    }
+  }
 }
 
 :host(#{$dds-prefix}-breadcrumb) {
@@ -31,4 +52,16 @@
 
 :host(#{$dds-prefix}-breadcrumb-link) {
   @extend :host(#{$prefix}-breadcrumb-link);
+}
+
+@keyframes loadingAnimation {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

#7008 

### Description

This adds a `loading` attribute to the `leadspace` component. When present, a background overlay will be present, allowing leadspace content some time to load and to prevent flickering issues. Codesandbox example can be seen [here](https://codesandbox.io/s/github/kennylam/leadspace-loading-csb?file=/src/index.js).

### Changelog

**New**

- `loading` attribute for leadspace

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
