### PR TITLE
fix(dotcom-shell): adding missing dependency for codesandbox example

### DIFF
--- a/packages/react/examples/codesandbox/components/DotcomShell/package.json
+++ b/packages/react/examples/codesandbox/components/DotcomShell/package.json
@@ -11,6 +11,7 @@
     "@carbon/ibmdotcom-react": "latest",
     "@carbon/ibmdotcom-styles": "latest",
     "@carbon/icons-react": "latest",
+    "carbon-components-react": "^7.43.0",
     "react": "16.13.0",
     "react-dom": "16.13.0"
   },


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The React codesandbox build was failing as it was not finding a dependency in the DotcomShell codesandbox example. This should fix the issue.

### Changelog

**Changed**

- React codesandbox for DotcomShell adding `carbon-components-react` dependency
