### PR TITLE
fix(e2e): removed `test-e2e` percy base update and added to react e2e

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -41,20 +41,6 @@ jobs:
           cf-app: ibmdotcom-react-canary
           cf-manifest: manifest-canary.yml
           deploy-dir: packages/react
-      - name: Set env vars for e2e percy snapshots
-        uses: ./.github/actions/set-dotenv
-        with:
-          env-file: packages/tests-e2e/.env
-        env:
-          SELENIUM_HOST: https://ibmdotcom-react-canary.mybluemix.net
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_REACT_E2E }}
-      - name: Create e2e percy snapshots
-        run: yarn test:e2e
-        working-directory: packages/tests-e2e
-      - uses: act10ns/slack@v1
-        with:
-          status: ${{ job.status }}
-        if: failure()
   react-experimental:
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -7,7 +7,7 @@ on:
       - release/*
 
 jobs:
-  react:
+  react-storybook:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -34,6 +34,32 @@ jobs:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_REACT }}
       - name: Run percy-storybook
         run: yarn visual-snapshot
+        working-directory: packages/react
+  react-storybook-e2e:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [ '14.x' ]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn install
+      - name: Install xvfb
+        run: sudo apt-get install xvfb
+      - name: Build
+        run: yarn lerna run --stream --ignore @carbon/ibmdotcom-services-store --ignore @carbon/ibmdotcom-web-components build
+      - name: Set env vars
+        uses: ./.github/actions/set-dotenv
+        with:
+          env-file: packages/react/.env
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_REACT_E2E }}
+      - name: Run e2e tests
+        run: yarn build-storybook && yarn test:e2e-storybook:test
         working-directory: packages/react
   web-components:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### Related Ticket(s)

Refs #6139

### Description

I missed removing this workflow in Github Actions, removed and added the new one to `percy-update-base.yml`.

### Changelog

**Changed**

- Added react e2e percy update
- Removed `test-e2e` workflow in deploy-canary
