### PR TITLE
fix(content-block-media): add missing style import

### DIFF
--- a/packages/styles/scss/components/content-block-media/_content-block-media.scss
+++ b/packages/styles/scss/components/content-block-media/_content-block-media.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -23,6 +23,10 @@
 
     .#{$prefix}--content-group:last-child {
       margin-bottom: 0;
+    }
+
+    .#{$prefix}--feature-card {
+      max-width: rem(640px);
     }
   }
 

--- a/packages/styles/scss/components/content-block-media/index.scss
+++ b/packages/styles/scss/components/content-block-media/index.scss
@@ -12,4 +12,5 @@
 @import '../card/index';
 @import '../content-group-simple/index';
 @import '../image-with-caption/image-with-caption';
+@import '../feature-card/feature-card';
 @import 'content-block-media';

--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -37,6 +37,7 @@ $fcb-breakpoint-up--lg: map-get(
   .#{$prefix}--card__heading,
   ::slotted(#{$dds-prefix}-card-heading) {
     margin-bottom: $layout-03;
+    color: $inverse-01;
   }
 
   &:focus-within {


### PR DESCRIPTION
### Description

Fixes various style issues for `content-block-media`.

### Changelog

**New**

- add `feature-card.scss`

**Changed**

- update max width styles for `feature-card` CTA

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
