### PR TITLE
fix(cta-block): clean up spacing

### DIFF
--- a/packages/web-components/src/components/cta-block/cta-block.scss
+++ b/packages/web-components/src/components/cta-block/cta-block.scss
@@ -28,7 +28,6 @@
   }
 
   ::slotted([slot='action']) {
-    margin-top: $carbon--layout-01;
     margin-bottom: $carbon--layout-04;
   }
 
@@ -45,6 +44,7 @@
 
     display: inline-block;
     max-width: 640px;
+    padding-left: 0;
 
     @include carbon--breakpoint('sm') {
       width: 100%;
@@ -53,8 +53,11 @@
     @include carbon--breakpoint('md') {
       width: 90%;
     }
+  }
 
-    padding-left: 0;
+  ::slotted(#{$dds-prefix}-button-group) {
+    // <dds-button-group-item> elements have top margins
+    margin-top: -#{$carbon--layout-02};
   }
 
   ::slotted(#{$dds-prefix}-link-list) {

--- a/packages/web-components/src/components/cta-block/cta-block.scss
+++ b/packages/web-components/src/components/cta-block/cta-block.scss
@@ -11,10 +11,9 @@
 :host(#{$dds-prefix}-cta-block) {
   @include cta-block--pattern;
 
+  display: block;
+
   .#{$prefix}--content-layout {
-    @include carbon--breakpoint('md') {
-      padding-left: 0;
-    }
     @include carbon--breakpoint('sm') {
       padding-left: $carbon--layout-01;
     }
@@ -27,8 +26,6 @@
   &.#{$prefix}--cta-block__border {
     border-bottom: 1px solid $ui-04;
   }
-
-  display: block;
 
   ::slotted([slot='action']) {
     margin-top: $carbon--layout-01;


### PR DESCRIPTION
### Related Ticket(s)

Resolves #5779

### Description

This PR adjusts some spacing rules for the `dds-cta-block` element and its intended subcomponents so they better align to the design spec.

_Before:_
<img width="1543" alt="Screen Shot 2021-09-15 at 12 19 14 PM" src="https://user-images.githubusercontent.com/12532727/133471170-8ef50081-2d92-48c9-a499-aeca4e94b8e2.png">

_After:_
<img width="1543" alt="Screen Shot 2021-09-15 at 12 18 54 PM" src="https://user-images.githubusercontent.com/12532727/133471198-f22f707c-37e3-48da-af1c-c62f0c0fd725.png">

### Changelog

**Changed**

- reduce spacing between `dds-cta-block`'s `copy` and `action` slots
- align `dds-cta-block`'s intended subcomponents to Carbon grid

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
