### PR TITLE
feat(link-list-section): create react wrapper

### DIFF
--- a/packages/web-components/src/components/link-list-section/link-list-section.ts
+++ b/packages/web-components/src/components/link-list-section/link-list-section.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -60,4 +60,5 @@ class DDSLinkListSection extends StableSelectorMixin(DDSContentSection) {
   }
 }
 
+/* @__GENERATE_REACT_CUSTOM_ELEMENT_TYPE__ */
 export default DDSLinkListSection;


### PR DESCRIPTION
### Related Ticket(s)
Needed for #6732

### Description
Just adding the annotation to generate the Linklist React wrapper.

### Changelog

**New**

- created `<dds-link-list-section>` react wrapper

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
