### PR TITLE
fix(left-nav): calculate offsetTop to set top of left-nav

### DIFF
--- a/packages/web-components/src/components/masthead/left-nav-overlay.ts
+++ b/packages/web-components/src/components/masthead/left-nav-overlay.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -25,6 +25,18 @@ class DDSLeftNavOverlay extends LitElement {
    */
   @property({ type: Boolean, reflect: true })
   active = false;
+
+  updated(changedProperties) {
+    super.updated(changedProperties);
+    if (changedProperties.has('active')) {
+      const doc = this.getRootNode() as Document;
+      if (this.active) {
+        const masthead: HTMLElement | null = doc?.querySelector('dds-masthead');
+        const mastheadTopOffset = masthead?.offsetTop;
+        this.style.top = `${mastheadTopOffset}px`;
+      }
+    }
+  }
 
   render() {
     return html`

--- a/packages/web-components/src/components/masthead/left-nav.ts
+++ b/packages/web-components/src/components/masthead/left-nav.ts
@@ -136,6 +136,12 @@ class DDSLeftNav extends StableSelectorMixin(BXSideNav) {
       if (expanded) {
         this._hFocusWrap = focuswrap(this.shadowRoot!, [startSentinelNode, endSentinelNode]);
         doc.body.style.overflow = `hidden`;
+
+        // TODO: remove this logic once masthead can account for banners.
+        // calculate top offset to display left-nav correctly when page has banner above masthead
+        const masthead: HTMLElement | null = doc?.querySelector('dds-masthead');
+        const mastheadTopOffset = masthead?.offsetTop;
+        this.style.top = `${mastheadTopOffset}px`;
       } else {
         const { selectorMenuSections, selectorFirstMenuSection } = this.constructor as typeof DDSLeftNav;
         doc.body.style.overflow = `auto`;


### PR DESCRIPTION
### Related Ticket(s)

[Cloud-Masthead]: Calculate the offset top-position of the Mobile Left-Nav component when there's a local banner #7211

### Description

Calculate the offsetTop of the masthead, and set the `top` positioning of the `left-nav` and `left-nav-overlay`.

Fix looks something like this when there is a banner above:
<img width="387" alt="Screen Shot 2021-09-21 at 3 46 15 PM" src="https://user-images.githubusercontent.com/54281166/134238722-2b529d16-fd9a-477e-b238-9eaaddd49430.png">

### Changelog

**New**

- get `offsetTop` from masthead and set `top` styling of `left-nav` and `left-nav-overlay`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
