### PR TITLE
fix(cloud-masthead): set masthead position to fixed on menu open

### DIFF
--- a/packages/web-components/src/components/masthead/left-nav-overlay.ts
+++ b/packages/web-components/src/components/masthead/left-nav-overlay.ts
@@ -26,18 +26,6 @@ class DDSLeftNavOverlay extends LitElement {
   @property({ type: Boolean, reflect: true })
   active = false;
 
-  updated(changedProperties) {
-    super.updated(changedProperties);
-    if (changedProperties.has('active')) {
-      const doc = this.getRootNode() as Document;
-      if (this.active) {
-        const masthead: HTMLElement | null = doc?.querySelector('dds-masthead');
-        const mastheadTopOffset = masthead?.offsetTop;
-        this.style.top = `${mastheadTopOffset}px`;
-      }
-    }
-  }
-
   render() {
     return html`
       <slot></slot>

--- a/packages/web-components/src/components/masthead/left-nav.ts
+++ b/packages/web-components/src/components/masthead/left-nav.ts
@@ -133,18 +133,28 @@ class DDSLeftNav extends StableSelectorMixin(BXSideNav) {
         (item as DDSLeftNavOverlay).active = this.expanded;
       });
       const { expanded, _startSentinelNode: startSentinelNode, _endSentinelNode: endSentinelNode } = this;
+
+      const masthead: HTMLElement | null | undefined = doc
+        ?.querySelector('dds-cloud-masthead-container')
+        ?.querySelector('dds-masthead');
       if (expanded) {
         this._hFocusWrap = focuswrap(this.shadowRoot!, [startSentinelNode, endSentinelNode]);
         doc.body.style.overflow = `hidden`;
 
         // TODO: remove this logic once masthead can account for banners.
-        // calculate top offset to display left-nav correctly when page has banner above masthead
-        const masthead: HTMLElement | null = doc?.querySelector('dds-masthead');
-        const mastheadTopOffset = masthead?.offsetTop;
-        this.style.top = `${mastheadTopOffset}px`;
+        // set masthead position to `fixed` when left-nav is open for cloud-mastead
+        if (masthead) {
+          masthead.style.position = 'fixed';
+        }
       } else {
         const { selectorMenuSections, selectorFirstMenuSection } = this.constructor as typeof DDSLeftNav;
         doc.body.style.overflow = `auto`;
+
+        // TODO: remove this logic once masthead can account for banners.
+        // remove set position from mastead when left-nav is closed for cloud-mastead
+        if (masthead) {
+          masthead.style.position = '';
+        }
 
         this.querySelectorAll(selectorMenuSections).forEach(ddsLeftNavMenuSection => {
           (ddsLeftNavMenuSection as DDSLeftNavMenuSection).expanded = false;


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description
To unblock users on the cloud pages with locale banners, set the position of the masthead to `fixed` when menu is opened.

Previous attempts to set offset of the menu haven't been successful, so this will be a temporary workaround

![Sep-23-2021 17-44-34](https://user-images.githubusercontent.com/54281166/134588512-47b8737b-c354-4c1e-800e-5ae9089eb525.gif)


### Changelog

**Changed**

- query for the `cloud-masthead-container` masthead and set position to `fixed` on `expanded`

**Removed**

- remove top offset calculation logic for the `left-nav-overlay`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
