### PR TITLE
docs(masthead): add codesandbox link for L1 to documentation

### DIFF
--- a/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
@@ -14,7 +14,13 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/components/masthead)
 > example implementation.
 
+### Masthead (L0):
+
 [![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/components/masthead)
+
+### Masthead (L1):
+
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components/examples/codesandbox/components/masthead-l1)
 
 ## Getting Started
 ##### Note: Masthead uses the Carbon White theme by design. Using other themes will not change the Masthead color scheme.


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This adds the codesandbox link for Masthead L1 to the README.

### Changelog

**Changed**

- Masthead README (web components)
