### PR TITLE
fix(locale-modal-composite): set region item as invalid if locale not configured

### DIFF
--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -8,19 +8,19 @@
 <link rel="alternate" hreflang="es-ar" href="iframe.html?id=components-dotcom-shell--default&cc=ar&lc=es" />
 <link rel="alternate" hreflang="en-aw" href="iframe.html?id=components-dotcom-shell--default&cc=aw&lc=en" />
 <link rel="alternate" hreflang="en-au" href="iframe.html?id=components-dotcom-shell--default&cc=au&lc=en" />
-<link rel="alternate" hreflang="de-at" href="iframe.html?id=components-dotcom-shell--default&cc=at&lc=de" />
+<!-- <link rel="alternate" hreflang="de-at" href="iframe.html?id=components-dotcom-shell--default&cc=at&lc=de" /> -->
 <link rel="alternate" hreflang="en-bs" href="iframe.html?id=components-dotcom-shell--default&cc=bs&lc=en" />
 <link rel="alternate" hreflang="en-bh" href="iframe.html?id=components-dotcom-shell--default&cc=bh&lc=en" />
 <link rel="alternate" hreflang="en-bd" href="iframe.html?id=components-dotcom-shell--default&cc=bd&lc=en" />
 <link rel="alternate" hreflang="en-bb" href="iframe.html?id=components-dotcom-shell--default&cc=bb&lc=en" />
-<link rel="alternate" hreflang="en-be" href="iframe.html?id=components-dotcom-shell--default&cc=be&lc=en" />
+<!-- <link rel="alternate" hreflang="en-be" href="iframe.html?id=components-dotcom-shell--default&cc=be&lc=en" /> -->
 <link rel="alternate" hreflang="en-bm" href="iframe.html?id=components-dotcom-shell--default&cc=bm&lc=en" />
 <link rel="alternate" hreflang="es-bo" href="iframe.html?id=components-dotcom-shell--default&cc=bo&lc=es" />
 <link rel="alternate" hreflang="en-bw" href="iframe.html?id=components-dotcom-shell--default&cc=bw&lc=en" />
 <link rel="alternate" hreflang="pt-br" href="iframe.html?id=components-dotcom-shell--default&cc=br&lc=pt" />
 <link rel="alternate" hreflang="en-vg" href="iframe.html?id=components-dotcom-shell--default&cc=vg&lc=en" />
 <link rel="alternate" hreflang="en-bn" href="iframe.html?id=components-dotcom-shell--default&cc=bn&lc=en" />
-<link rel="alternate" hreflang="en-bg" href="iframe.html?id=components-dotcom-shell--default&cc=bg&lc=en" />
+<!-- <link rel="alternate" hreflang="en-bg" href="iframe.html?id=components-dotcom-shell--default&cc=bg&lc=en" /> -->
 <link rel="alternate" hreflang="fr-bf" href="iframe.html?id=components-dotcom-shell--default&cc=bf&lc=fr" />
 <link rel="alternate" hreflang="en-kh" href="iframe.html?id=components-dotcom-shell--default&cc=kh&lc=en" />
 <link rel="alternate" hreflang="fr-cm" href="iframe.html?id=components-dotcom-shell--default&cc=cm&lc=fr" />
@@ -36,43 +36,43 @@
 <link rel="alternate" hreflang="es-cr" href="iframe.html?id=components-dotcom-shell--default&cc=cr&lc=es" />
 <link rel="alternate" hreflang="en-hr" href="iframe.html?id=components-dotcom-shell--default&cc=hr&lc=en" />
 <link rel="alternate" hreflang="en-cw" href="iframe.html?id=components-dotcom-shell--default&cc=cw&lc=en" />
-<link rel="alternate" hreflang="en-cy" href="iframe.html?id=components-dotcom-shell--default&cc=cy&lc=en" />
-<link rel="alternate" hreflang="en-cz" href="iframe.html?id=components-dotcom-shell--default&cc=cz&lc=en" />
+<!-- <link rel="alternate" hreflang="en-cy" href="iframe.html?id=components-dotcom-shell--default&cc=cy&lc=en" /> -->
+<!-- <link rel="alternate" hreflang="en-cz" href="iframe.html?id=components-dotcom-shell--default&cc=cz&lc=en" /> -->
 <link rel="alternate" hreflang="en-dm" href="iframe.html?id=components-dotcom-shell--default&cc=dm&lc=en" />
-<link rel="alternate" hreflang="en-dk" href="iframe.html?id=components-dotcom-shell--default&cc=dk&lc=en" />
+<!-- <link rel="alternate" hreflang="en-dk" href="iframe.html?id=components-dotcom-shell--default&cc=dk&lc=en" /> -->
 <link rel="alternate" hreflang="es-ec" href="iframe.html?id=components-dotcom-shell--default&cc=ec&lc=es" />
 <link rel="alternate" hreflang="en-eg" href="iframe.html?id=components-dotcom-shell--default&cc=eg&lc=en" />
 <link rel="alternate" hreflang="en-ee" href="iframe.html?id=components-dotcom-shell--default&cc=ee&lc=en" />
 <link rel="alternate" hreflang="en-et" href="iframe.html?id=components-dotcom-shell--default&cc=et&lc=en" />
-<link rel="alternate" hreflang="en-fi" href="iframe.html?id=components-dotcom-shell--default&cc=fi&lc=en" />
-<link rel="alternate" hreflang="fr-fr" href="iframe.html?id=components-dotcom-shell--default&cc=fr&lc=fr" />
+<!-- <link rel="alternate" hreflang="en-fi" href="iframe.html?id=components-dotcom-shell--default&cc=fi&lc=en" /> -->
+<!-- <link rel="alternate" hreflang="fr-fr" href="iframe.html?id=components-dotcom-shell--default&cc=fr&lc=fr" /> -->
 <link rel="alternate" hreflang="fr-ga" href="iframe.html?id=components-dotcom-shell--default&cc=ga&lc=fr" />
-<link rel="alternate" hreflang="de-de" href="iframe.html?id=components-dotcom-shell--default&cc=de&lc=de" />
+<!-- <link rel="alternate" hreflang="de-de" href="iframe.html?id=components-dotcom-shell--default&cc=de&lc=de" /> -->
 <link rel="alternate" hreflang="en-gh" href="iframe.html?id=components-dotcom-shell--default&cc=gh&lc=en" />
-<link rel="alternate" hreflang="en-gr" href="iframe.html?id=components-dotcom-shell--default&cc=gr&lc=en" />
+<!-- <link rel="alternate" hreflang="en-gr" href="iframe.html?id=components-dotcom-shell--default&cc=gr&lc=en" /> -->
 <link rel="alternate" hreflang="en-gd" href="iframe.html?id=components-dotcom-shell--default&cc=gd&lc=en" />
 <link rel="alternate" hreflang="en-gy" href="iframe.html?id=components-dotcom-shell--default&cc=gy&lc=en" />
 <link rel="alternate" hreflang="en-hk" href="iframe.html?id=components-dotcom-shell--default&cc=hk&lc=en" />
-<link rel="alternate" hreflang="en-hu" href="iframe.html?id=components-dotcom-shell--default&cc=hu&lc=en" />
+<!-- <link rel="alternate" hreflang="en-hu" href="iframe.html?id=components-dotcom-shell--default&cc=hu&lc=en" /> -->
 <link rel="alternate" hreflang="en-in" href="iframe.html?id=components-dotcom-shell--default&cc=in&lc=en" />
 <link rel="alternate" hreflang="en-id" href="iframe.html?id=components-dotcom-shell--default&cc=id&lc=en" />
 <link rel="alternate" hreflang="en-iq" href="iframe.html?id=components-dotcom-shell--default&cc=iq&lc=en" />
-<link rel="alternate" hreflang="en-ie" href="iframe.html?id=components-dotcom-shell--default&cc=ie&lc=en" />
+<!-- <link rel="alternate" hreflang="en-ie" href="iframe.html?id=components-dotcom-shell--default&cc=ie&lc=en" /> -->
 <link rel="alternate" hreflang="en-il" href="iframe.html?id=components-dotcom-shell--default&cc=il&lc=en" />
-<link rel="alternate" hreflang="it-it" href="iframe.html?id=components-dotcom-shell--default&cc=it&lc=it" />
+<!-- <link rel="alternate" hreflang="it-it" href="iframe.html?id=components-dotcom-shell--default&cc=it&lc=it" /> -->
 <link rel="alternate" hreflang="fr-ci" href="iframe.html?id=components-dotcom-shell--default&cc=ci&lc=fr" />
 <link rel="alternate" hreflang="en-jm" href="iframe.html?id=components-dotcom-shell--default&cc=jm&lc=en" />
 <link rel="alternate" hreflang="ja-jp" href="iframe.html?id=components-dotcom-shell--default&cc=jp&lc=ja" />
 <link rel="alternate" hreflang="en-jo" href="iframe.html?id=components-dotcom-shell--default&cc=jo&lc=en" />
-<link rel="alternate" hreflang="en-kz" href="iframe.html?id=components-dotcom-shell--default&cc=kz&lc=en" />
+<!-- <link rel="alternate" hreflang="en-kz" href="iframe.html?id=components-dotcom-shell--default&cc=kz&lc=en" /> -->
 <link rel="alternate" hreflang="en-ke" href="iframe.html?id=components-dotcom-shell--default&cc=ke&lc=en" />
 <link rel="alternate" hreflang="ko-kr" href="iframe.html?id=components-dotcom-shell--default&cc=kr&lc=ko" />
 <link rel="alternate" hreflang="en-kw" href="iframe.html?id=components-dotcom-shell--default&cc=kw&lc=en" />
-<link rel="alternate" hreflang="en-lv" href="iframe.html?id=components-dotcom-shell--default&cc=lv&lc=en" />
+<!-- <link rel="alternate" hreflang="en-lv" href="iframe.html?id=components-dotcom-shell--default&cc=lv&lc=en" /> -->
 <link rel="alternate" hreflang="en-lb" href="iframe.html?id=components-dotcom-shell--default&cc=lb&lc=en" />
 <link rel="alternate" hreflang="en-ly" href="iframe.html?id=components-dotcom-shell--default&cc=ly&lc=en" />
 <link rel="alternate" hreflang="fr-mg" href="iframe.html?id=components-dotcom-shell--default&cc=mg&lc=fr" />
-<link rel="alternate" hreflang="en-lt" href="iframe.html?id=components-dotcom-shell--default&cc=lt&lc=en" />
+<!-- <link rel="alternate" hreflang="en-lt" href="iframe.html?id=components-dotcom-shell--default&cc=lt&lc=en" /> -->
 <link rel="alternate" hreflang="en-mw" href="iframe.html?id=components-dotcom-shell--default&cc=mw&lc=en" />
 <link rel="alternate" hreflang="en-my" href="iframe.html?id=components-dotcom-shell--default&cc=my&lc=en" />
 <link rel="alternate" hreflang="fr-mu" href="iframe.html?id=components-dotcom-shell--default&cc=mu&lc=fr" />
@@ -82,56 +82,56 @@
 <link rel="alternate" hreflang="pt-mz" href="iframe.html?id=components-dotcom-shell--default&cc=mz&lc=pt" />
 <link rel="alternate" hreflang="en-na" href="iframe.html?id=components-dotcom-shell--default&cc=na&lc=en" />
 <link rel="alternate" hreflang="en-np" href="iframe.html?id=components-dotcom-shell--default&cc=np&lc=en" />
-<link rel="alternate" hreflang="en-nl" href="iframe.html?id=components-dotcom-shell--default&cc=nl&lc=en" />
+<!-- <link rel="alternate" hreflang="en-nl" href="iframe.html?id=components-dotcom-shell--default&cc=nl&lc=en" /> -->
 <link rel="alternate" hreflang="en-nz" href="iframe.html?id=components-dotcom-shell--default&cc=nz&lc=en" />
 <link rel="alternate" hreflang="fr-ne" href="iframe.html?id=components-dotcom-shell--default&cc=ne&lc=fr" />
 <link rel="alternate" hreflang="en-ng" href="iframe.html?id=components-dotcom-shell--default&cc=ng&lc=en" />
-<link rel="alternate" hreflang="en-no" href="iframe.html?id=components-dotcom-shell--default&cc=no&lc=en" />
+<!-- <link rel="alternate" hreflang="en-no" href="iframe.html?id=components-dotcom-shell--default&cc=no&lc=en" /> -->
 <link rel="alternate" hreflang="en-om" href="iframe.html?id=components-dotcom-shell--default&cc=om&lc=en" />
 <link rel="alternate" hreflang="en-pk" href="iframe.html?id=components-dotcom-shell--default&cc=pk&lc=en" />
 <link rel="alternate" hreflang="es-py" href="iframe.html?id=components-dotcom-shell--default&cc=py&lc=es" />
 <link rel="alternate" hreflang="es-pe" href="iframe.html?id=components-dotcom-shell--default&cc=pe&lc=es" />
 <link rel="alternate" hreflang="en-ph" href="iframe.html?id=components-dotcom-shell--default&cc=ph&lc=en" />
-<link rel="alternate" hreflang="pl-pl" href="iframe.html?id=components-dotcom-shell--default&cc=pl&lc=pl" />
+<!-- <link rel="alternate" hreflang="pl-pl" href="iframe.html?id=components-dotcom-shell--default&cc=pl&lc=pl" /> -->
 <link rel="alternate" hreflang="pt-pt" href="iframe.html?id=components-dotcom-shell--default&cc=pt&lc=pt" />
-<link rel="alternate" hreflang="en-pt" href="iframe.html?id=components-dotcom-shell--default&cc=pt&lc=en" />
+<!-- <link rel="alternate" hreflang="en-pt" href="iframe.html?id=components-dotcom-shell--default&cc=pt&lc=en" /> -->
 <link rel="alternate" hreflang="en-qa" href="iframe.html?id=components-dotcom-shell--default&cc=qa&lc=en" />
-<link rel="alternate" hreflang="en-ro" href="iframe.html?id=components-dotcom-shell--default&cc=ro&lc=en" />
-<link rel="alternate" hreflang="ru-ru" href="iframe.html?id=components-dotcom-shell--default&cc=ru&lc=ru" />
+<!-- <link rel="alternate" hreflang="en-ro" href="iframe.html?id=components-dotcom-shell--default&cc=ro&lc=en" /> -->
+<!-- <link rel="alternate" hreflang="ru-ru" href="iframe.html?id=components-dotcom-shell--default&cc=ru&lc=ru" /> -->
 <link rel="alternate" hreflang="en-kn" href="iframe.html?id=components-dotcom-shell--default&cc=kn&lc=en" />
 <link rel="alternate" hreflang="en-lc" href="iframe.html?id=components-dotcom-shell--default&cc=lc&lc=en" />
 <link rel="alternate" hreflang="en-vc" href="iframe.html?id=components-dotcom-shell--default&cc=vc&lc=en" />
 <link rel="alternate" hreflang="en-sa" href="iframe.html?id=components-dotcom-shell--default&cc=sa&lc=en" />
 <link rel="alternate" hreflang="ar-sa" href="iframe.html?id=components-dotcom-shell--default&cc=sa&lc=ar" />
 <link rel="alternate" hreflang="fr-sn" href="iframe.html?id=components-dotcom-shell--default&cc=sn&lc=fr" />
-<link rel="alternate" hreflang="en-rs" href="iframe.html?id=components-dotcom-shell--default&cc=rs&lc=en" />
+<!-- <link rel="alternate" hreflang="en-rs" href="iframe.html?id=components-dotcom-shell--default&cc=rs&lc=en" /> -->
 <link rel="alternate" hreflang="fr-sc" href="iframe.html?id=components-dotcom-shell--default&cc=sc&lc=fr" />
 <link rel="alternate" hreflang="en-sl" href="iframe.html?id=components-dotcom-shell--default&cc=sl&lc=en" />
 <link rel="alternate" hreflang="en-sg" href="iframe.html?id=components-dotcom-shell--default&cc=sg&lc=en" />
-<link rel="alternate" hreflang="en-sk" href="iframe.html?id=components-dotcom-shell--default&cc=sk&lc=en" />
-<link rel="alternate" hreflang="en-si" href="iframe.html?id=components-dotcom-shell--default&cc=si&lc=en" />
+<!-- <link rel="alternate" hreflang="en-sk" href="iframe.html?id=components-dotcom-shell--default&cc=sk&lc=en" /> -->
+<!-- <link rel="alternate" hreflang="en-si" href="iframe.html?id=components-dotcom-shell--default&cc=si&lc=en" /> -->
 <link rel="alternate" hreflang="en-za" href="iframe.html?id=components-dotcom-shell--default&cc=za&lc=en" />
-<link rel="alternate" hreflang="es-es" href="iframe.html?id=components-dotcom-shell--default&cc=es&lc=es" />
+<!-- <link rel="alternate" hreflang="es-es" href="iframe.html?id=components-dotcom-shell--default&cc=es&lc=es" /> -->
 <link rel="alternate" hreflang="en-lk" href="iframe.html?id=components-dotcom-shell--default&cc=lk&lc=en" />
 <link rel="alternate" hreflang="en-sr" href="iframe.html?id=components-dotcom-shell--default&cc=sr&lc=en" />
-<link rel="alternate" hreflang="en-se" href="iframe.html?id=components-dotcom-shell--default&cc=se&lc=en" />
-<link rel="alternate" hreflang="fr-ch" href="iframe.html?id=components-dotcom-shell--default&cc=ch&lc=fr" />
-<link rel="alternate" hreflang="de-ch" href="iframe.html?id=components-dotcom-shell--default&cc=ch&lc=de" />
+<!-- <link rel="alternate" hreflang="en-se" href="iframe.html?id=components-dotcom-shell--default&cc=se&lc=en" /> -->
+<!-- <link rel="alternate" hreflang="fr-ch" href="iframe.html?id=components-dotcom-shell--default&cc=ch&lc=fr" /> -->
+<!-- <link rel="alternate" hreflang="de-ch" href="iframe.html?id=components-dotcom-shell--default&cc=ch&lc=de" /> -->
 <link rel="alternate" hreflang="zh-tw" href="iframe.html?id=components-dotcom-shell--default&cc=tw&lc=zh" />
 <link rel="alternate" hreflang="en-tz" href="iframe.html?id=components-dotcom-shell--default&cc=tz&lc=en" />
 <link rel="alternate" hreflang="en-th" href="iframe.html?id=components-dotcom-shell--default&cc=th&lc=en" />
 <link rel="alternate" hreflang="en-tt" href="iframe.html?id=components-dotcom-shell--default&cc=tt&lc=en" />
 <link rel="alternate" hreflang="fr-tn" href="iframe.html?id=components-dotcom-shell--default&cc=tn&lc=fr" />
-<link rel="alternate" hreflang="tr-tr" href="iframe.html?id=components-dotcom-shell--default&cc=tr&lc=tr" />
+<!-- <link rel="alternate" hreflang="tr-tr" href="iframe.html?id=components-dotcom-shell--default&cc=tr&lc=tr" /> -->
 <link rel="alternate" hreflang="en-ye" href="iframe.html?id=components-dotcom-shell--default&cc=ye&lc=en" />
 <link rel="alternate" hreflang="en-tc" href="iframe.html?id=components-dotcom-shell--default&cc=tc&lc=en" />
-<link rel="alternate" hreflang="en-ua" href="iframe.html?id=components-dotcom-shell--default&cc=ua&lc=en" />
+<!-- <link rel="alternate" hreflang="en-ua" href="iframe.html?id=components-dotcom-shell--default&cc=ua&lc=en" /> -->
 <link rel="alternate" hreflang="en-ug" href="iframe.html?id=components-dotcom-shell--default&cc=ug&lc=en" />
 <link rel="alternate" hreflang="en-ae" href="iframe.html?id=components-dotcom-shell--default&cc=ae&lc=en" />
 <link rel="alternate" hreflang="ar-ae" href="iframe.html?id=components-dotcom-shell--default&cc=ae&lc=ar" />
-<link rel="alternate" hreflang="en-gb" href="iframe.html?id=components-dotcom-shell--default&cc=uk&lc=en" />
+<!-- <link rel="alternate" hreflang="en-gb" href="iframe.html?id=components-dotcom-shell--default&cc=uk&lc=en" /> -->
 <link rel="alternate" hreflang="es-uy" href="iframe.html?id=components-dotcom-shell--default&cc=uy&lc=es" />
-<link rel="alternate" hreflang="en-uz" href="iframe.html?id=components-dotcom-shell--default&cc=uz&lc=en" />
+<!-- <link rel="alternate" hreflang="en-uz" href="iframe.html?id=components-dotcom-shell--default&cc=uz&lc=en" /> -->
 <link rel="alternate" hreflang="es-ve" href="iframe.html?id=components-dotcom-shell--default&cc=ve&lc=es" />
 <link rel="alternate" hreflang="en-vn" href="iframe.html?id=components-dotcom-shell--default&cc=vn&lc=en" />
 <link rel="alternate" hreflang="en-zm" href="iframe.html?id=components-dotcom-shell--default&cc=zm&lc=en" />

--- a/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
@@ -149,11 +149,14 @@ class DDSLocaleModalComposite extends HybridRenderMixin(LitElement) {
         ?open="${open}"
       >
         <dds-regions>
-          ${regionList?.map(
-            ({ countryList, name }) => html`
-              <dds-region-item ?invalid="${countryList.length === 0}" name="${name}"></dds-region-item>
-            `
-          )}
+          ${regionList?.map(({ countryList, name }) => {
+            return html`
+              <dds-region-item
+                ?invalid="${countryList.length === 0 || massagedCountryList?.find(({ region }) => region === name) === undefined}"
+                name="${name}"
+              ></dds-region-item>
+            `;
+          })}
         </dds-regions>
         <dds-locale-search
           close-button-assistive-text="${ifNonNull(searchClearText)}"


### PR DESCRIPTION
### Related Ticket(s)

#6761

### Description

This PR marks region items as invalid in the locale modal if a locale is not configured in the given region

![image](https://user-images.githubusercontent.com/8265238/135635676-6e1d6274-0bdb-4069-a6c0-579645081ab2.png)

~~The storybook preview locales have been reviewed for testing but will be restored prior to merging~~

EU locales have been commented out for future testing

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
