### PR TITLE
test(cypress): bumping timeout configuration for web components e2e

### DIFF
--- a/packages/web-components/tests/e2e-storybook/cypress.json
+++ b/packages/web-components/tests/e2e-storybook/cypress.json
@@ -12,6 +12,6 @@
   "nodeVersion": "system",
   "includeShadowDom": true,
   "testFiles": "**/*.e2e.js",
-  "pageLoadTimeout": 20000,
-  "defaultCommandTimeout": 20000
+  "pageLoadTimeout": 30000,
+  "defaultCommandTimeout": 30000
 }


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

When enabling web components e2e tests, the CI seems to need additional time to run some tests, so this will bump up the timeout to accommodate.

### Changelog

**Changed**

- `cypress.json` config for web components
