### PR TITLE
docs(storybook): remove EU locales

### DIFF
--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -34,7 +34,7 @@
 <link rel="alternate" hreflang="fr-cd" href="iframe.html?id=components-dotcom-shell--default&cc=cd&lc=fr" />
 <link rel="alternate" hreflang="fr-cg" href="iframe.html?id=components-dotcom-shell--default&cc=cg&lc=fr" />
 <link rel="alternate" hreflang="es-cr" href="iframe.html?id=components-dotcom-shell--default&cc=cr&lc=es" />
-<link rel="alternate" hreflang="en-hr" href="iframe.html?id=components-dotcom-shell--default&cc=hr&lc=en" />
+<!-- <link rel="alternate" hreflang="en-hr" href="iframe.html?id=components-dotcom-shell--default&cc=hr&lc=en" /> -->
 <link rel="alternate" hreflang="en-cw" href="iframe.html?id=components-dotcom-shell--default&cc=cw&lc=en" />
 <!-- <link rel="alternate" hreflang="en-cy" href="iframe.html?id=components-dotcom-shell--default&cc=cy&lc=en" /> -->
 <!-- <link rel="alternate" hreflang="en-cz" href="iframe.html?id=components-dotcom-shell--default&cc=cz&lc=en" /> -->
@@ -42,7 +42,7 @@
 <!-- <link rel="alternate" hreflang="en-dk" href="iframe.html?id=components-dotcom-shell--default&cc=dk&lc=en" /> -->
 <link rel="alternate" hreflang="es-ec" href="iframe.html?id=components-dotcom-shell--default&cc=ec&lc=es" />
 <link rel="alternate" hreflang="en-eg" href="iframe.html?id=components-dotcom-shell--default&cc=eg&lc=en" />
-<link rel="alternate" hreflang="en-ee" href="iframe.html?id=components-dotcom-shell--default&cc=ee&lc=en" />
+<!-- <link rel="alternate" hreflang="en-ee" href="iframe.html?id=components-dotcom-shell--default&cc=ee&lc=en" /> -->
 <link rel="alternate" hreflang="en-et" href="iframe.html?id=components-dotcom-shell--default&cc=et&lc=en" />
 <!-- <link rel="alternate" hreflang="en-fi" href="iframe.html?id=components-dotcom-shell--default&cc=fi&lc=en" /> -->
 <!-- <link rel="alternate" hreflang="fr-fr" href="iframe.html?id=components-dotcom-shell--default&cc=fr&lc=fr" /> -->


### PR DESCRIPTION
### Related Ticket(s)

#6761

### Description

2 EU locales weren't removed in the latest commit pushed up to #7302 so this PR removes them

![image](https://user-images.githubusercontent.com/8265238/135689213-1588ba9f-36bd-4e1f-98da-0540d6195d90.png)


### Changelog

**Removed**

- final 2 EU locales to disable region selector in locale modal

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
