### PR TITLE
chore(content-block): fixed width of card group on md viewport

### DIFF
--- a/packages/web-components/.storybook/container.scss
+++ b/packages/web-components/.storybook/container.scss
@@ -116,6 +116,7 @@ html {
   .dds-ce-demo-devenv--simple-grid--content-layout--with-complementary,
   .dds-ce-demo-devenv--simple-grid--content-block-horizontal,
   .dds-ce-demo-devenv--simple-grid--content-section,
+  .dds-ce-demo-devenv--simple-grid--content-block-cards,
   .dds-ce-demo-devenv--simple-grid--logo-grid,
   .dds-ce-demo-devenv--simple-grid--card-in-card {
     > * {


### PR DESCRIPTION
### Related Ticket(s)

[ContentBlock components] Storybooks QA #5533

### Description

{{Add a human-readable description / detail summary of what the PR is changing and any details around how and why}}

{{If applicable, include a screenshot indicating an example or examples of what the PR is changing in the application}}

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
