### PR TITLE
fix(card): add Tag group to the bottom of the card component

### DIFF
--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -67,6 +67,10 @@
       @include carbon--type-style('body-short-02');
 
       margin-bottom: $carbon--spacing-07;
+
+      ::slotted(#{$dds-prefix}-tag-group) {
+        margin-top: $spacing-03;
+      }
     }
 
     &:focus-within {
@@ -131,7 +135,7 @@
     // styles the React wrapper version of Tag Group within Card
     /* stylelint-disable-next-line selector-type-no-unknown */
     dds-tag-group {
-      margin-bottom: $spacing-05;
+      margin-top: $spacing-05;
     }
   }
 
@@ -194,10 +198,6 @@
         &::after {
           position: relative;
         }
-      }
-
-      ::slotted(#{$dds-prefix}-tag-group) {
-        margin-bottom: $spacing-05;
       }
     }
     &[color-scheme='light'] {

--- a/packages/styles/scss/components/tag-group/_tag-group.scss
+++ b/packages/styles/scss/components/tag-group/_tag-group.scss
@@ -19,12 +19,12 @@
   }
 
   ::slotted(#{$prefix}-tag) {
-    margin: 0 $spacing-03 $spacing-03 0;
+    margin: $spacing-03 $spacing-03 0 0;
   }
 
   // !important necessary since Carbon React styles override margin without this
   ::slotted(.#{$prefix}--tag) {
     // stylelint-disable-next-line declaration-no-important
-    margin: 0 $spacing-03 $spacing-03 0 !important;
+    margin: $spacing-03 $spacing-03 0 0 !important;
   }
 }

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -41,13 +41,31 @@ const cardsCol = {
   '4 cards per row': 'dds-ce-demo-devenv--cards-in-row-4',
 };
 
-const cardsDiffLengthPhrase = (index, border) => {
+const cardsDiffLengthPhrase = (index, border, tagGroup, defaultSrc, image) => {
   const defaultCardGroupItem = html`
     <dds-card-group-item href="https://example.com" color-scheme=${border ? 'light' : null}>
+      ${image
+        ? html`
+            <dds-image slot="image" alt="Image Alt Text" default-src="${ifNonNull(defaultSrc)}"></dds-image>
+          `
+        : ``}
+      <dds-card-eyebrow>Topic</dds-card-eyebrow>
       <dds-card-heading>${index < 5 ? phraseArray[index] : 'Lorem ipsum dolor sit amet'}</dds-card-heading>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.'
       </p>
+      ${tagGroup
+        ? html`
+            <dds-tag-group>
+              <bx-tag type="cool-gray">
+                Systems w/TPS
+              </bx-tag>
+              <bx-tag type="cool-gray">
+                Virtual
+              </bx-tag>
+            </dds-tag-group>
+          `
+        : ''}
       <dds-card-cta-footer slot="footer">
         ${ArrowRight20({ slot: 'icon' })}
       </dds-card-cta-footer>
@@ -58,14 +76,32 @@ const cardsDiffLengthPhrase = (index, border) => {
   return defaultCardGroupItem;
 };
 
-const longHeadingCardGroupItem = border => {
+const longHeadingCardGroupItem = (border, tagGroup, defaultSrc, image) => {
   return html`
     <dds-card-group-item href="https://example.com" color-scheme=${border ? 'light' : null}>
+      ${image
+        ? html`
+            <dds-image slot="image" alt="Image Alt Text" default-src="${ifNonNull(defaultSrc)}"></dds-image>
+          `
+        : ``}
+      <dds-card-eyebrow>Topic</dds-card-eyebrow>
       <dds-card-heading>Nunc convallis lobortis Nunc convallis lobortis Nunc convallis lobortis</dds-card-heading>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
         Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
+      ${tagGroup
+        ? html`
+            <dds-tag-group>
+              <bx-tag type="cool-gray">
+                Systems w/TPS
+              </bx-tag>
+              <bx-tag type="cool-gray">
+                Virtual
+              </bx-tag>
+            </dds-tag-group>
+          `
+        : ''}
       <dds-card-cta-footer slot="footer">
         ${ArrowRight20({ slot: 'icon' })}
       </dds-card-cta-footer>
@@ -116,7 +152,7 @@ const cardGroupItemWithCardLinks = html`
 `;
 
 export const Default = ({ parameters }) => {
-  const { cards, cardsPerRow, offset, optionalBorder } = parameters?.props?.CardGroup ?? {};
+  const { cards, cardsPerRow, offset, optionalBorder, tagGroup, defaultSrc, image } = parameters?.props?.CardGroup ?? {};
   const classes = classMap({
     [cardsPerRow]: cardsPerRow,
   });
@@ -124,9 +160,9 @@ export const Default = ({ parameters }) => {
   if (offset === '1') {
     allCards.push(emptyCard);
   }
-  allCards.push(longHeadingCardGroupItem(optionalBorder));
+  allCards.push(longHeadingCardGroupItem(optionalBorder, tagGroup, defaultSrc, image));
   for (let i = 1; i < cards; i++) {
-    allCards.push(cardsDiffLengthPhrase(i, optionalBorder));
+    allCards.push(cardsDiffLengthPhrase(i, optionalBorder, tagGroup, defaultSrc, image));
   }
   const colCount = cardsPerRow[cardsPerRow.length - 1];
 
@@ -351,6 +387,9 @@ export default {
     hasCardGroupStandalone: true,
     knobs: {
       CardGroup: ({ groupId }) => ({
+        defaultSrc: imgXlg4x3,
+        tagGroup: boolean('Add tags', false, groupId),
+        image: boolean('Add image', false, groupId),
         cards: number('Number of cards', 5, {}, groupId),
         optionalBorder: boolean('Outlined cards:', false, groupId),
         cardsPerRow: select('Number of cards per row (cards-per-row):', cardsCol, cardsCol['3 cards per row (Default)'], groupId),

--- a/packages/web-components/src/components/card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card/__stories__/README.stories.mdx
@@ -97,19 +97,19 @@ where the card is no longer clickable and optional `Tag` elements can also be ad
 ```html
 <dds-card>
   <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
-  <dds-tag-group>
-    <bx-tag>
-      Most popular
-    </bx-tag>
-    <bx-tag type='purple'>
-      Enterprise
-    </bx-tag>
-  </dds-tag-group>
   ${copy
     ? html`
         <p>${copy}</p>
       `
     : ``}
+  <dds-tag-group>
+    <bx-tag>
+      Most popular
+    </bx-tag>
+    <bx-tag type="purple">
+      Enterprise
+    </bx-tag>
+  </dds-tag-group>
   <dds-card-footer href='https://example.com' icon-placement="right">
     Card CTA text
     <svg

--- a/packages/web-components/src/components/card/__stories__/card.stories.ts
+++ b/packages/web-components/src/components/card/__stories__/card.stories.ts
@@ -16,6 +16,7 @@ import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 import { html } from 'lit-element';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null';
 import imgLg2x1 from '../../../../../storybook-images/assets/720/fpo--2x1--720x360--003.jpg';
+import imgXlg4x3 from '../../../../../storybook-images/assets/1312/fpo--4x3--1312x984--003.jpg';
 import { PICTOGRAM_PLACEMENT } from '../defs';
 import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';
@@ -31,6 +32,11 @@ export const Default = ({ parameters }) => {
         : ``}
       <dds-card-eyebrow>Eyebrow</dds-card-eyebrow>
       <dds-card-heading>${heading}</dds-card-heading>
+      ${copy
+        ? html`
+            <p>${copy}</p>
+          `
+        : ``}
       ${tagGroup
         ? html`
             <dds-tag-group>
@@ -43,11 +49,6 @@ export const Default = ({ parameters }) => {
             </dds-tag-group>
           `
         : ''}
-      ${copy
-        ? html`
-            <p>${copy}</p>
-          `
-        : ``}
       <dds-card-footer icon-placement="${iconPlacement}">
         ${footer}${ArrowRight20({ slot: 'icon' })}
       </dds-card-footer>
@@ -72,8 +73,9 @@ Default.story = {
     knobs: {
       Card: ({ groupId }) => ({
         alt: 'Image alt text',
-        defaultSrc: imgLg2x1,
+        defaultSrc: imgXlg4x3,
         tagGroup: boolean('Add tags', false, groupId),
+        image: boolean('Add image', false, groupId),
         heading: textNullable('Card Heading:', 'Lorem ipsum dolor sit amet', groupId),
         copy: textNullable('Card body copy:', '', groupId),
         href: 'https://example.com',
@@ -89,6 +91,11 @@ export const Pictogram = ({ parameters }) => {
   return html`
     <dds-card pictogram-placement="${pictogramPlacement}" href=${ifNonNull(href || undefined)}>
       <dds-card-heading>${heading}</dds-card-heading>
+      ${copy
+        ? html`
+            <p>${copy}</p>
+          `
+        : ``}
       ${tagGroup
         ? html`
             <dds-tag-group>
@@ -101,11 +108,6 @@ export const Pictogram = ({ parameters }) => {
             </dds-tag-group>
           `
         : ''}
-      ${copy
-        ? html`
-            <p>${copy}</p>
-          `
-        : ``}
       <svg
         slot="pictogram"
         focusable="false"
@@ -139,7 +141,6 @@ Pictogram.story = {
         alt: 'Image alt text',
         defaultSrc: imgLg2x1,
         pictogramPlacement: select('Pictogram placement', pictogramPlacements, pictogramPlacements.top, groupId),
-        tagGroup: boolean('Add tags', false, groupId),
         heading: textNullable('Card Heading:', 'Lorem ipsum dolor sit amet', groupId),
         copy: textNullable(
           'Card body copy:',
@@ -169,6 +170,11 @@ export const Static = ({ parameters }) => {
           `
         : ``}
       <dds-card-heading>${heading}</dds-card-heading>
+      ${copy
+        ? html`
+            <p>${copy}</p>
+          `
+        : ``}
       ${tagGroup
         ? html`
             <dds-tag-group>
@@ -181,11 +187,6 @@ export const Static = ({ parameters }) => {
             </dds-tag-group>
           `
         : ''}
-      ${copy
-        ? html`
-            <p>${copy}</p>
-          `
-        : ``}
       <dds-card-footer href="${href}" icon-placement="${iconPlacement}">
         ${footer}${ArrowRight20({ slot: 'icon' })}
       </dds-card-footer>
@@ -199,7 +200,7 @@ Static.story = {
     knobs: {
       Card: ({ groupId }) => ({
         alt: 'Image alt text',
-        defaultSrc: imgLg2x1,
+        defaultSrc: imgXlg4x3,
         outlinedCard: boolean('Outlined card', true, groupId),
         tagGroup: boolean('Add tags', true, groupId),
         image: boolean('Add image', false, groupId),

--- a/packages/web-components/src/components/card/index.ts
+++ b/packages/web-components/src/components/card/index.ts
@@ -11,3 +11,4 @@ import './card';
 import './card-eyebrow';
 import './card-footer';
 import './card-heading';
+import '../tag-group/index';


### PR DESCRIPTION
### Related Ticket(s)

DDS Consulting Issue: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7293
HC JIRA Ticket: https://jsw.ibm.com/browse/HC-2231

### Description
- This PR moves the <dds-tag-group> below the card copy within the Storybook preview of the `Card` and `Card Group` components.
- Adjust the spacing between the body copy and the tags.

### Testing Instructions
![Screen Shot 2021-10-05 at 11 24 22 AM](https://user-images.githubusercontent.com/1815714/136053863-7a8ecd6b-5e9b-4888-8cf0-205c58157dbf.png)
![Screen Shot 2021-10-05 at 11 25 03 AM](https://user-images.githubusercontent.com/1815714/136053877-09def854-b821-4c59-bc62-a0423a56642b.png)

- Visit the `Card Group (Default)` layout Component - `?path=/story/components-card-group--default`.
- Navigate to the knobs and click on the "Add Tags" and "Add Image" booleans.
- Ensure that the Tags are placed below the card body copy and that the spacing is `16px`.
- Visit the `Card (Static)`  Component - `?path=/story/components-card--static`
- Navigate to the knobs and click on the "Add Tags" and "Add Image" booleans.
- Ensure that the Tags are placed below the card body copy and that the spacing is `16px`.

### Changes
- No component changes, just the markup within the SB preview and docs.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
