### PR TITLE
fix(storybook): added react wrapper link to search with typeahead

### DIFF
--- a/packages/react/src/components/SearchWithTypeahead/README.stories.mdx
+++ b/packages/react/src/components/SearchWithTypeahead/README.stories.mdx
@@ -1,0 +1,3 @@
+# Tag link
+
+This component is maintained in `@carbon/ibmdotcom-web-components` library with a [React wrapper](https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-search-with-typeahead).

--- a/packages/react/src/components/SearchWithTypeahead/__stories__/SearchWithTypeahead.stories.js
+++ b/packages/react/src/components/SearchWithTypeahead/__stories__/SearchWithTypeahead.stories.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import readme from '../README.stories.mdx';
+
+export default {
+  title: 'Components|Seach With Typeahead',
+  parameters: {
+    ...readme.parameters,
+    percy: {
+      skip: true,
+    },
+    proxy: true,
+  },
+};
+
+export const Default = () => {
+  return (
+    <p>
+      This component is maintained in{' '}
+      <code>@carbon/ibmdotcom-web-components</code> library with a{' '}
+      <a
+        className="bx--link"
+        target="_blank"
+        href="https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-search-with-typeahead--default">
+        React wrapper
+      </a>
+      .
+    </p>
+  );
+};


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7018

### Description

The react storybook was missing a link to the react wrapper Search with typeahead component

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
