### PR TITLE
fix(cloud-masthead): adjust has-contact attribute to accept string

### DIFF
--- a/packages/web-components/src/components/masthead/__stories__/cloud-masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/cloud-masthead.stories.ts
@@ -58,10 +58,14 @@ export const Default = !DDS_CLOUD_MASTHEAD
                 platform="Cloud"
                 .platformUrl="${ifNonNull(platformData.url)}"
                 selected-menu-item="${ifNonNull(selectedMenuItem)}"
+                has-contact="${hasContact
+                  ? html`
+                      true
+                    `
+                  : `false`}"
                 user-status="${ifNonNull(userStatus)}"
                 searchPlaceholder="${ifNonNull(searchPlaceholder)}"
                 .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
-                ?has-contact="${hasContact}"
                 ?has-profile="${hasProfile}"
                 ?has-search="${hasSearch}"
                 .navLinks="${navLinks}"
@@ -73,7 +77,11 @@ export const Default = !DDS_CLOUD_MASTHEAD
                 platform="Cloud"
                 .platformUrl="${ifNonNull(urlObject)}"
                 selected-menu-item="${ifNonNull(selectedMenuItem)}"
-                ?has-contact="${hasContact}"
+                has-contact="${hasContact
+                  ? html`
+                      true
+                    `
+                  : `false`}"
                 auth-method="cookie"
                 user-status="${ifNonNull(userStatus)}"
                 searchPlaceholder="${ifNonNull(searchPlaceholder)}"

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -64,8 +64,8 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
   /**
    * `true` if Contact us should be shown.
    */
-  @property({ type: Boolean, reflect: true, attribute: 'has-contact' })
-  hasContact = true;
+  @property({ type: String, reflect: true, attribute: 'has-contact' })
+  hasContact = 'true';
 
   /**
    * The profile items for unauthenticated state.
@@ -282,6 +282,8 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
         platformAltUrl = platformUrl[formattedLang].url || platformUrl;
       }
     }
+    console.log(hasContact);
+
     return html`
       <dds-left-nav-overlay cloud></dds-left-nav-overlay>
       <dds-left-nav cloud>
@@ -331,13 +333,13 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
                       `
                   )}
                 </dds-cloud-masthead-profile>
-                ${hasContact
-                  ? html`
+                ${hasContact === 'false'
+                  ? ''
+                  : html`
                       <dds-cloud-button-cta kind="ghost" data-ibm-contact="contact-link"
                         ><span>${contactUsButton?.title}</span></dds-cloud-button-cta
                       >
-                    `
-                  : undefined}
+                    `}
                 ${ctaButtons?.map(
                   ({ title, url }) =>
                     html`
@@ -348,13 +350,13 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
             `
           : html`
               <dds-cloud-masthead-global-bar>
-                ${hasContact
-                  ? html`
+                ${hasContact === 'false'
+                  ? ''
+                  : html`
                       <dds-cloud-button-cta kind="ghost" data-ibm-contact="contact-link"
                         ><span>${contactUsButton?.title}</span></dds-cloud-button-cta
                       >
-                    `
-                  : undefined}
+                    `}
                 ${profileItems?.map(
                   ({ title, url }) =>
                     html`


### PR DESCRIPTION
### Related Ticket(s)

GH Issue: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7061
HC JIRA Ticket: https://jsw.ibm.com/browse/HC-2179

### Description

- This is a follow-up PR for an issue that was closed, however, still an issue for adopters using the `has-contact="false"` to optionally hide the "Contact us" button.
- This PR sets the `has-contact` prop to accept a string.

### Testing Instruction

- Pull down the changes of this PR in a test preview and sets the following markup with the `has-contact` attribute sets to `false`.
- Ensure that the "Contact us" button is removed when the attribute is set to `false`. If the `has-contact` is not defined or set to `true`, the "Contact us" button should be set visible.

```
<dds-cloud-masthead-container
  platform="Cloud"
  auth-method="API"
  has-contact="false"
  data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead"
></dds-cloud-masthead-container>
```


### Expected Display

![Screen Shot 2021-09-09 at 3 20 57 PM](https://user-images.githubusercontent.com/1815714/132749577-05b55304-87c9-4595-834e-c40a61c34afa.png)


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
