### PR TITLE
fix(card cta): Add video duration to aria-label if present

### DIFF
--- a/packages/web-components/src/components/cta/card-cta.ts
+++ b/packages/web-components/src/components/cta/card-cta.ts
@@ -134,7 +134,16 @@ class DDSCardCTA extends VideoCTAMixin(CTAMixin(DDSCard)) {
       const headingText = this.querySelector(`${ddsPrefix}-card-heading`)?.textContent;
       const copyText = this.textContent;
       if (footer) {
-        (footer as DDSCardCTAFooter).altAriaLabel = videoName || headingText || copyText;
+        const ariaSource = videoName || headingText || copyText;
+        let ariaWithDuration;
+        if (videoDuration !== undefined) {
+          const minVal = (videoDuration - (videoDuration % 60)) / 60;
+          const secVal = videoDuration % 60;
+          const minutes = minVal !== 1 ? `${minVal} minutes` : `${minVal} minute`;
+          const seconds = secVal !== 1 ? `${secVal} seconds` : `${secVal} second`;
+          ariaWithDuration = `${ariaSource}, duration: ${minutes} and ${seconds}`;
+        }
+        (footer as DDSCardCTAFooter).altAriaLabel = videoDuration ? ariaWithDuration : ariaSource;
         (footer as DDSCardCTAFooter).ctaType = ctaType;
         (footer as DDSCardCTAFooter).videoDuration = videoDuration;
         (footer as DDSCardCTAFooter).videoName = videoName;

--- a/packages/web-components/tests/snapshots/dds-card-cta.md
+++ b/packages/web-components/tests/snapshots/dds-card-cta.md
@@ -83,7 +83,7 @@
 
 ```
 <a
-  aria-label="video-name-foo - This link plays a video"
+  aria-label="video-name-foo, duration: 3 minutes and 0 seconds - This link plays a video"
   class="bx--card__footer bx--link bx--link--lg bx--link-with-icon bx--link-with-icon--inline-icon bx--link-with-icon__icon-right dds-ce--card__footer"
   href="#"
   id="link"


### PR DESCRIPTION
### Related Ticket(s)

Fixes #7288

### Description

Calculates video duration into whole minutes and seconds and adds that information to the DDSCardCTAFooter component's altAriaLabel value

### Changelog

**Changed**

- Includes video duration in card cta aria label if present
