### PR TITLE
test(e2e): increase timeout threshold for web components e2e tests

### DIFF
--- a/packages/web-components/tests/e2e-storybook/cypress.json
+++ b/packages/web-components/tests/e2e-storybook/cypress.json
@@ -12,6 +12,6 @@
   "nodeVersion": "system",
   "includeShadowDom": true,
   "testFiles": "**/*.e2e.js",
-  "pageLoadTimeout": 30000,
-  "defaultCommandTimeout": 30000
+  "pageLoadTimeout": 40000,
+  "defaultCommandTimeout": 40000
 }


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

I'm still noticing e2e test failures which might be because the CI is taking awhile to load the storybook pages. This bump in the timeout configs might help.

### Changelog

**Changed**

- `cypress.json`
