### PR TITLE
fix(table-of-contents): add default TOC styles

### DIFF
--- a/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
@@ -413,6 +413,10 @@ $hover-transition-timing: 95ms;
     }
   }
 
+  .#{$prefix}--toc__print-styles {
+    display: none;
+  }
+
   @media print {
     :host(#{$dds-prefix}-table-of-contents),
     .#{$prefix}--tableofcontents {


### PR DESCRIPTION
### Related Ticket(s)

#7369

### Description

Currently `table-of-contents` print styles are visible at all times. This fixes to show only when printing.


### Changelog

**New**

- default print styles to hidden when not printing

![image](https://user-images.githubusercontent.com/909118/136969276-4b49feeb-ce98-43e0-9396-527218c59d39.png)

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
