### PR TITLE
fix(cta): fix video name & desc SB rendering issue

### DIFF
--- a/packages/web-components/src/components/cta/__stories__/cta.stories.ts
+++ b/packages/web-components/src/components/cta/__stories__/cta.stories.ts
@@ -191,6 +191,8 @@ export const Card = ({ parameters }) => {
       <dds-card-cta-footer
         cta-type="${ifNonNull(ctaType)}"
         download="${ifNonNull(footerDownload)}"
+        video-name="${ifNonNull(customVideoTitle)}"
+        video-description="${ifNonNull(customVideoDescription)}"
         href="${ifNonNull(footerHref)}"
       >
         ${ctaType === 'local' ? footerCopy || ArrowRight20({ slot: 'icon' }) : ''}
@@ -260,6 +262,8 @@ export const CardLink = ({ parameters }) => {
       <dds-card-cta-footer
         cta-type="${ifNonNull(ctaType)}"
         download="${ifNonNull(footerDownload)}"
+        video-name="${ifNonNull(customVideoTitle)}"
+        video-description="${ifNonNull(customVideoDescription)}"
         href="${ifNonNull(footerHref)}"
       >
         ${ctaType === 'local' ? footerCopy || ArrowRight20({ slot: 'icon' }) : ''}
@@ -338,6 +342,8 @@ export const Feature = ({ parameters }) => {
       <dds-feature-cta-footer
         cta-type="${ifNonNull(ctaType)}"
         download="${ifNonNull(footerDownload)}"
+        video-name="${ifNonNull(customVideoTitle)}"
+        video-description="${ifNonNull(customVideoDescription)}"
         href="${ifNonNull(footerHref)}"
       >
         ${footerCopy}

--- a/packages/web-components/src/components/cta/card-cta.ts
+++ b/packages/web-components/src/components/cta/card-cta.ts
@@ -122,7 +122,8 @@ class DDSCardCTA extends VideoCTAMixin(CTAMixin(DDSCard)) {
       changedProperties.has('ctaType') ||
       changedProperties.has('formatCaption') ||
       changedProperties.has('formatDuration') ||
-      changedProperties.has('videoDuration')
+      changedProperties.has('videoDuration') ||
+      changedProperties.has('videoName')
     ) {
       const {
         ctaType,


### PR DESCRIPTION
### Related Ticket(s)

DDS Issue: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7287
HC JIRA Ticket: https://jsw.ibm.com/browse/HC-2255

### Description
- This PR fixes the rendering issue where the text changes in the "Custom video title" and "Custom video description" knobs are not updating within the video lightbox viewer.

### Testing Instructions

- Visit the `CTA` UI Component with the Card variant - `/?path=/story/components-cta--card`.
- Adjust the `CTA type` to `Video`
- Adjust the string of the "Custom video title" and "Custom video description" text knobs 
- Click on the card and ensure that the updated strings are showing up correctly.

![Screen Shot 2021-10-13 at 3 00 06 PM](https://user-images.githubusercontent.com/1815714/137196552-c75e5445-6e27-43e7-bdc0-c7f85b4eda1b.png)

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
