### PR TITLE
fix(gulp): adjustment to react vendor builds

### DIFF
--- a/packages/react/gulp-tasks/vendor.js
+++ b/packages/react/gulp-tasks/vendor.js
@@ -111,7 +111,7 @@ function convert({ table }) {
 
             if (tableForModule) {
               const names = specifiers.map(
-                specifier => specifier.imported.name
+                specifier => specifier.imported?.name
               );
               const unknownImportNames = names.filter(
                 name => !tableForModule[name]


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

While monitoring the `10.46.0` upgrade of Carbon, it appears that the vendor script is failing when upgrading to the latest `carbon-components-react`. This tweak seems to fix the build issues.

This is the build issue identified:

![image](https://user-images.githubusercontent.com/1641214/137399649-51e3fd19-5dc5-415e-9baa-61318dbfe854.png)

It appears to be something happening in `@carbon/feature-flags`, and is particularly breaking when trying to find `FeatureFlags`.

### Changelog

**Changed**

- `vendor` script in react gulp
