### PR TITLE
chore(card): cherry-pick 6b6a730 to test snapshots

### DIFF
--- a/packages/react/src/components/Card/Card.js
+++ b/packages/react/src/components/Card/Card.js
@@ -8,12 +8,14 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import CTALogic from '../CTA/CTALogic';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
+import DDSTagGroup from '@carbon/ibmdotcom-web-components/es/components-react/tag-group/tag-group';
 import { Image } from '../Image';
 import Link from '../../internal/vendor/carbon-components-react/components/Link/Link';
 import markdownToHtml from '@carbon/ibmdotcom-utilities/es/utilities/markdownToHtml/markdownToHtml';
 import on from 'carbon-components/es/globals/js/misc/on';
 import PropTypes from 'prop-types';
 import settings from 'carbon-components/es/globals/js/settings';
+import { Tag } from 'carbon-components-react';
 import { Tile } from '../../internal/vendor/carbon-components-react/components/Tile/Tile';
 
 const { stablePrefix } = ddsSettings;
@@ -30,6 +32,7 @@ export const Card = ({
   image,
   eyebrow,
   heading,
+  tags,
   customClassName,
   copy,
   cta,
@@ -83,6 +86,7 @@ export const Card = ({
         <div className={`${prefix}--card__content`}>
           {eyebrow && <p className={`${prefix}--card__eyebrow`}>{eyebrow}</p>}
           {heading && <h3 className={`${prefix}--card__heading`}>{heading}</h3>}
+          {optionalTagGroup(tags)}
           {optionalContent(copy)}
           {renderFooter(cta, copy, props.disabled, heading, pictogram)}
         </div>
@@ -90,6 +94,27 @@ export const Card = ({
     </Tile>
   );
 };
+
+/**
+ * Card Link optional content
+ *
+ * @param {object} tags object containing copy and color
+ * @returns {object} JSX object
+ */
+function optionalTagGroup(tags) {
+  return !tags ? null : (
+    <DDSTagGroup>
+      {tags &&
+        tags.map(tag => {
+          return (
+            <Tag type={tag.color} {...tag}>
+              {tag.copy}
+            </Tag>
+          );
+        })}
+    </DDSTagGroup>
+  );
+}
 
 /**
  * Card Link optional content
@@ -208,6 +233,25 @@ export const cardPropTypes = {
     alt: PropTypes.string.isRequired,
     longDescription: PropTypes.string,
   }),
+
+  /**
+   * Array of tag objects to render.
+   * Use the following for each items:
+   *
+   * | Name         | Data Type | Description                                                                                                                               |
+   * | ------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+   * | `copy`       | String    | Button copy                                                                                                                               |
+   * | `color`      | String    | Provide a different color than the default (green) for [Carbon's tag component](https://www.carbondesignsystem.com/components/tag/usage/) |
+   *
+   * Visit the [Tag documentation](https://react.carbondesignsystem.com/?path=/story/components-tag--default)
+   * from Carbon for a full list of available props.
+   */
+  tags: PropTypes.arrayOf(
+    PropTypes.shape({
+      copy: PropTypes.string,
+      color: PropTypes.string,
+    })
+  ),
 
   /**
    * `true` to set a 1px solid border around Card.

--- a/packages/react/src/components/Card/README.stories.mdx
+++ b/packages/react/src/components/Card/README.stories.mdx
@@ -64,12 +64,23 @@ to ensure the card is no longer clickable. To use it, be sure to pass in the `st
 
 ```javascript
 
+tags = [
+  {
+    copy: 'Most popular',
+  },
+  {
+    copy: 'Enterprise',
+    color: 'purple'
+  },
+]
+
 function App() {
   return (
     <Card 
       heading="Lorem ipsum dolor sit amet" 
       copy="Copy text"
       href="https://example.com"
+      tags={tags}
       static={true}
     />);
 }

--- a/packages/react/src/components/Card/__stories__/Card.stories.js
+++ b/packages/react/src/components/Card/__stories__/Card.stories.js
@@ -25,6 +25,7 @@ export default {
           : null;
 
         let outlinedCard = boolean('Outlined card', false, groupId);
+        let addTags = boolean('Add tags', false, groupId);
         return {
           image:
             (boolean('image', false, groupId) && {
@@ -46,6 +47,17 @@ export default {
             iconPlacement: 'right',
           },
           pictogram: showPictogram && DDS_CARD_WITH_PICTOGRAM ? <Bee /> : null,
+          tags: addTags
+            ? [
+                {
+                  copy: 'Most popular',
+                },
+                {
+                  copy: 'Enterprise',
+                  color: 'purple',
+                },
+              ]
+            : null,
         };
       },
     },
@@ -93,6 +105,7 @@ CardStatic.story = {
     knobs: {
       Card: ({ groupId }) => {
         let outlinedCard = boolean('Outlined card', true, groupId);
+        let addTags = boolean('Add tags', true, groupId);
         return {
           image:
             (boolean('image', false, groupId) && {
@@ -119,6 +132,17 @@ CardStatic.story = {
             },
             iconPlacement: 'right',
           },
+          tags: addTags
+            ? [
+                {
+                  copy: 'Most popular',
+                },
+                {
+                  copy: 'Enterprise',
+                  color: 'purple',
+                },
+              ]
+            : null,
         };
       },
     },

--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -133,10 +133,11 @@
     /* stylelint-disable-next-line selector-type-no-unknown */
     dds-tag-group {
       margin-top: $spacing-05;
+      margin-bottom: $spacing-05;
     }
   }
 
-  .#{$prefix}--card.#{$prefix}--card--light {
+  .#{$prefix}--card--light {
     background-color: $ui-02;
   }
 
@@ -144,20 +145,14 @@
     outline: none;
 
     .#{$prefix}--card__footer {
-      align-self: flex-start;
       &:hover {
         text-decoration: underline;
-
-        svg,
-        .#{$prefix}--card__cta__copy {
-          color: $hover-primary-text;
-        }
       }
 
       &:active,
       &:focus {
         align-self: flex-start;
-        outline: 1px solid $focus;
+        outline: auto;
       }
       &::after {
         position: relative;


### PR DESCRIPTION
### Related Ticket(s)

#6332 

### Description

Testing snapshot updates which were previously failing due to changes in https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/6b6a7302e7979e85f74291d37a3d000e82a0ce59.

### Changelog

**Changed**

- cherry-pick https://github.com/carbon-design-system/carbon-for-ibm-dotcom/commit/6b6a7302e7979e85f74291d37a3d000e82a0ce59 to test snapshots


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
