### PR TITLE
test(e2e): bumping up timeout configs for Github Actions

### DIFF
--- a/packages/react/tests/e2e/cypress.json
+++ b/packages/react/tests/e2e/cypress.json
@@ -11,6 +11,6 @@
   "pluginsFile": "tests/e2e/cypress/plugins/index.js",
   "nodeVersion": "system",
   "testFiles": "**/*.e2e.js",
-  "pageLoadTimeout": 10000,
-  "defaultCommandTimeout": 20000
+  "pageLoadTimeout": 40000,
+  "defaultCommandTimeout": 40000
 }

--- a/packages/web-components/tests/e2e/cypress.json
+++ b/packages/web-components/tests/e2e/cypress.json
@@ -12,6 +12,6 @@
   "nodeVersion": "system",
   "includeShadowDom": true,
   "testFiles": "**/*.e2e.js",
-  "pageLoadTimeout": 10000,
-  "defaultCommandTimeout": 20000
+  "pageLoadTimeout": 40000,
+  "defaultCommandTimeout": 40000
 }


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Noticed that Github Actions needs a little bit more time running tests on occasion. This will match the timeout amounts we have for e2e testing on storybook.

### Changelog

**Changed**

- `cypress.json` for csb testing
