### PR TITLE
chore(issue-template): add additional instructions for review tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/review_tracking.yaml
+++ b/.github/ISSUE_TEMPLATE/review_tracking.yaml
@@ -2,10 +2,13 @@ name: (C4IBM.com team only) Review tracking
 description:
   Carbon for IBM.com team members can track their pull request review time here
 title: '[PR Reviews]: Your name - Sprint Number'
+labels: ['housekeeping']
 body:
   - type: markdown
     attributes:
       value: "This issue is to track the pull request reviews performed in a given sprint.
+
+- Assign to yourself, and set the pipeline to `Doing`
 
 - Add the corresponding milestone and storypoints once created.
 


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Tweaking the instructions for the review tracking form to also mention assigning to self and setting the pipeline. This also adds the `housekeeping` label automatically.

### Changelog

**Changed**

- `review_tracking.yaml`
