### PR TITLE
fix(back-to-top): set z-index value

### DIFF
--- a/packages/styles/scss/components/back-to-top/_back-to-top.scss
+++ b/packages/styles/scss/components/back-to-top/_back-to-top.scss
@@ -17,6 +17,7 @@
     padding-right: $carbon--spacing-05;
     outline: none;
     height: 0;
+    z-index: 9999;
 
     .#{$prefix}--back-to-top__btn {
       position: relative;


### PR DESCRIPTION
### Related Ticket(s)

#6678

### Description

This PR sets an explicit z-index value on the back-to-top component so that it remains above other page elements in the stacking order.

This can be tested by clicking on the back-to-top component in storybook when it overlaps with the section cards. The cards link out to example.com so clicking the back-to-top component should no longer navigate the page anywhere

https://user-images.githubusercontent.com/8265238/138164448-85868e12-ec51-4866-a3e3-20c7df8ec864.mov

I'm unsure why the card pseudoelements have a z-index of 1 but setting a z-index on the back-to-top component should also cover any instances where a consumer has another element on the page with a z-index value below 9999. In any case the value can be adjusted as needed

### Changelog

**Changed**

- `z-index` on back-to-top component

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
