### PR TITLE
test(masthead): remove unnecessary percy and cy snapshots

### DIFF
--- a/packages/react/tests/e2e-storybook/cypress/integration/Masthead/Masthead.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/Masthead/Masthead.e2e.js
@@ -41,12 +41,6 @@ describe('Masthead | default (desktop)', () => {
       const url = $link.prop('href');
       expect(url).not.to.be.empty;
     });
-
-    cy.screenshot();
-    // Take a snapshot for visual diffing
-    cy.percySnapshot('Masthead | IBM logo', {
-      widths: [1280],
-    });
   });
 
   it('should load menu item with selected state', () => {
@@ -65,12 +59,6 @@ describe('Masthead | default (desktop)', () => {
 
   it('should render 4 menu items', () => {
     cy.get('.bx--masthead__megamenu__l0-nav').should('have.length', 4);
-
-    cy.screenshot();
-    // Take a snapshot for visual diffing
-    cy.percySnapshot('Masthead | Number of menu items', {
-      widths: [1280],
-    });
   });
 
   it('should load the megamenu - first nav item', () => {
@@ -127,12 +115,6 @@ describe('Masthead | default (desktop)', () => {
       const url = $link.prop('href');
       expect(url).not.to.be.empty;
     });
-
-    cy.screenshot();
-    // Take a snapshot for visual diffing
-    cy.percySnapshot('Masthead | megamenu sublinks have urls', {
-      widths: [1280],
-    });
   });
 
   it('should open the login menu', () => {
@@ -148,12 +130,6 @@ describe('Masthead | default (desktop)', () => {
   it('should have 2 menu items under the login menu', () => {
     cy.get('[data-autoid="dds--masthead-default__l0-account"]').click();
     cy.get('.bx--masthead__profile-item').should('have.length', 2);
-
-    cy.screenshot();
-    // Take a snapshot for visual diffing
-    cy.percySnapshot('Masthead | profile menu has 2 items', {
-      widths: [1280],
-    });
   });
 
   it('should open the search bar on click', () => {

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead.e2e.js
@@ -43,13 +43,6 @@ describe('dds-masthead | default (desktop)', () => {
         const url = $link.prop('href');
         expect(url).not.to.be.empty;
       });
-
-    cy.screenshot();
-    // Take a snapshot for visual diffing
-    // TODO: click states currently not working in percy for web components
-    // cy.percySnapshot('dds-masthead | IBM logo', {
-    //   widths: [1280],
-    // });
   });
 
   it('should load menu item with selected state', () => {
@@ -67,13 +60,6 @@ describe('dds-masthead | default (desktop)', () => {
 
   it('should render 4 menu items', () => {
     cy.get('dds-megamenu-top-nav-menu').should('have.length', 4);
-
-    cy.screenshot();
-    // Take a snapshot for visual diffing
-    // TODO: click states currently not working in percy for web components
-    // cy.percySnapshot('dds-masthead | Number of menu items', {
-    //   widths: [1280],
-    // });
   });
 
   it('should load the megamenu - first nav item', () => {
@@ -152,13 +138,6 @@ describe('dds-masthead | default (desktop)', () => {
         const url = $link.prop('href');
         expect(url).not.to.be.empty;
       });
-
-    cy.screenshot();
-    // Take a snapshot for visual diffing
-    // TODO: click states currently not working in percy for web components
-    // cy.percySnapshot('dds-masthead | megamenu sublinks have urls', {
-    //   widths: [1280],
-    // });
   });
 
   it('should open the login menu', () => {
@@ -177,13 +156,6 @@ describe('dds-masthead | default (desktop)', () => {
 
   it('should have 2 menu items under the login menu', () => {
     cy.get('dds-masthead-profile-item').should('have.length', 2);
-
-    cy.screenshot();
-    // Take a snapshot for visual diffing
-    // TODO: click states currently not working in percy for web components
-    // cy.percySnapshot('dds-masthead | profile menu has 2 items', {
-    //   widths: [1280],
-    // });
   });
 
   it('should open the search bar on click', () => {


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

some e2e tests for the masthead (ie. checking if there are a certain number of menu items or if an element as a url) don't require percy snapshots or cypress screenshots. Having them would add to the number of snapshots and aren't very helpful. This PR removes those methods.

### Changelog

**Removed**

- remove percy and cy snapshots methods from certain tests.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
