### PR TITLE
fix(masthead-e2e): update overflow test

### DIFF
--- a/packages/react/tests/e2e-storybook/cypress/integration/Masthead/Masthead.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/Masthead/Masthead.e2e.js
@@ -280,9 +280,24 @@ describe('Masthead | custom (desktop)', () => {
   });
 
   it('should scroll the L0 overflow properly', () => {
-    cy.get('.bx--header__nav-caret-right').click();
+    cy.document().then($document => {
+      $document.querySelector('head').insertAdjacentHTML(
+        'beforeend',
+        `
+      <style>
+        /* Disable CSS transitions. */
+        * { -webkit-transition: none !important; -moz-transition: none !important; -o-transition: none !important; transition: none !important; }
+        /* Disable CSS animations. */
+        * { -webkit-animation: none !important; -moz-animation: none !important; -o-animation: none !important; animation: none !important; }
+        /* Reset values on non-opaque/offscreen framer-motion components. */
+        *[style*="opacity"] { opacity: 1 !important; }
+        *[style*="transform"] { transform: none !important; }
+      </style>
+    `
+      );
+    });
 
-    cy.wait(500);
+    cy.get('.bx--header__nav-caret-right').click();
 
     cy.get('.bx--header__nav-caret-right-container').then($button => {
       expect($button).to.have.attr('hidden');

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead.e2e.js
@@ -342,12 +342,27 @@ describe('dds-masthead | custom (desktop)', () => {
   });
 
   it('should scroll the L0 overflow properly', () => {
+    cy.document().then($document => {
+      $document.querySelector('head').insertAdjacentHTML(
+        'beforeend',
+        `
+      <style>
+        /* Disable CSS transitions. */
+        * { -webkit-transition: none !important; -moz-transition: none !important; -o-transition: none !important; transition: none !important; }
+        /* Disable CSS animations. */
+        * { -webkit-animation: none !important; -moz-animation: none !important; -o-animation: none !important; animation: none !important; }
+        /* Reset values on non-opaque/offscreen framer-motion components. */
+        *[style*="opacity"] { opacity: 1 !important; }
+        *[style*="transform"] { transform: none !important; }
+      </style>
+    `
+      );
+    });
+
     cy.get('dds-top-nav')
       .shadow()
       .find('.bx--header__nav-caret-right-container > button')
       .click();
-
-    cy.wait(500);
 
     cy.get('dds-top-nav')
       .shadow()


### PR DESCRIPTION
### Related Ticket(s)

none 
### Description

Update masthead e2e overflow tests to remove animation


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
