### PR TITLE
test(footer): add e2e tests for footer - micro language only

### DIFF
--- a/packages/react/tests/e2e-storybook/cypress/integration/Footer/Footer.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/Footer/Footer.e2e.js
@@ -15,9 +15,17 @@ const { prefix } = settings;
  * @type {string}
  * @private
  */
-
 const _pathShortLanguageOnly =
   '/iframe.html?id=components-footer--short-language-only';
+
+/**
+ * Sets the correct path (Micro language only)
+ *
+ * @type {string}
+ * @private
+ */
+const _pathMicroLanguageOnly =
+  '/iframe.html?id=components-footer--micro-language-only';
 
 describe('Footer | Short language only (desktop)', () => {
   beforeEach(() => {
@@ -69,6 +77,46 @@ describe('Footer | Short language only (desktop)', () => {
   });
 });
 
+describe('Footer | Micro language only (desktop)', () => {
+  beforeEach(() => {
+    cy.visit(`/${_pathMicroLanguageOnly}`);
+    cy.viewport(1280, 780);
+  });
+
+  it('should load language selector dropdown', () => {
+    cy.get(`[data-autoid="dds--language-selector"]`).click();
+
+    cy.screenshot();
+    cy.percySnapshot(
+      'Footer | Micro language only (desktop language selector)',
+      {
+        widths: [1280],
+      }
+    );
+  });
+
+  it('should be able to select a language from combo box', () => {
+    cy.get(`[data-autoid="dds--language-selector"]`).click();
+    cy.get(`[data-autoid="dds--footer"]`)
+      .find(
+        `.${prefix}--list-box__menu > .${prefix}--list-box__menu-item:nth-of-type(1) .${prefix}--list-box__menu-item__option`
+      )
+      .click();
+    cy.get(`[data-autoid="dds--language-selector"]`).should(
+      'have.value',
+      'Arabic / عربية'
+    );
+
+    cy.screenshot();
+    cy.percySnapshot(
+      'Footer | Micro language only (desktop language selector)',
+      {
+        widths: [1280],
+      }
+    );
+  });
+});
+
 describe('Footer | Short language only (mobile)', () => {
   beforeEach(() => {
     cy.visit(`/${_pathShortLanguageOnly}`);
@@ -90,6 +138,34 @@ describe('Footer | Short language only (mobile)', () => {
     cy.screenshot();
     cy.percySnapshot(
       'Footer | Short language only (desktop language selector)',
+      {
+        widths: [320],
+      }
+    );
+  });
+});
+
+describe('Footer | Micro language only (mobile)', () => {
+  beforeEach(() => {
+    cy.visit(`/${_pathMicroLanguageOnly}`);
+    cy.viewport(320, 780);
+  });
+
+  it('should load language selector and be interactive', () => {
+    cy.get('[data-autoid="dds--language-selector__select"]').should(
+      'have.length',
+      1
+    );
+
+    const languageSelector = cy.get(
+      '[data-autoid="dds--language-selector__select"]'
+    );
+    languageSelector.select('Arabic / عربية');
+    languageSelector.should('have.value', 'ar');
+
+    cy.screenshot();
+    cy.percySnapshot(
+      'Footer | Micro language only (desktop language selector)',
       {
         widths: [320],
       }

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/footer/footer.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/footer/footer.e2e.js
@@ -15,8 +15,15 @@ const { prefix } = settings;
  * @type {string}
  * @private
  */
-
 const _pathShortLanguageOnly = '/iframe.html?id=components-footer--short-language-only';
+
+/**
+ * Sets the correct path (Micro language only)
+ *
+ * @type {string}
+ * @private
+ */
+const _pathMicroLanguageOnly = '/iframe.html?id=components-footer--micro-language-only';
 
 describe('dds-footer | Short language only (desktop)', () => {
   beforeEach(() => {
@@ -56,6 +63,32 @@ describe('dds-footer | Short language only (desktop)', () => {
   });
 });
 
+describe('dds-footer | Micro language only (desktop)', () => {
+  beforeEach(() => {
+    cy.visit(`/${_pathMicroLanguageOnly}`);
+    cy.viewport(1280, 780);
+  });
+
+  it('should load language selector dropdown and be interactive', () => {
+    cy.get('dds-language-selector-desktop').should('have.length', 1);
+    cy.get('dds-language-selector-desktop')
+      .shadow()
+      .find(`div.${prefix}--dropdown`)
+      .click();
+    cy.get('dds-language-selector-desktop')
+      .find(`${prefix}-combo-box-item[value="Arabic / عربية"]`)
+      .click();
+    cy.get('dds-language-selector-desktop').should('have.value', 'Arabic / عربية');
+
+    cy.screenshot();
+    // Take a snapshot for visual diffing
+    // TODO: click states currently not working in percy for web components
+    // cy.percySnapshot('dds-footer | Micro language only (desktop language selector)', {
+    //   widths: [1280],
+    // });
+  });
+});
+
 describe('dds-footer | Short language only (mobile)', () => {
   beforeEach(() => {
     cy.visit(`/${_pathShortLanguageOnly}`);
@@ -76,6 +109,31 @@ describe('dds-footer | Short language only (mobile)', () => {
     // Take a snapshot for visual diffing
     // TODO: click states currently not working in percy for web components
     // cy.percySnapshot('dds-footer | Short language only (desktop language selector)', {
+    //   widths: [320],
+    // });
+  });
+});
+
+describe('dds-footer | Micro language only (mobile)', () => {
+  beforeEach(() => {
+    cy.visit(`/${_pathMicroLanguageOnly}`);
+    cy.viewport(320, 780);
+  });
+
+  it('should load language selector dropdown and be interactive', () => {
+    cy.get('dds-language-selector-mobile').should('have.length', 1);
+    cy.get('dds-language-selector-mobile')
+      .shadow()
+      .find(`select.${prefix}--select-input`)
+      .select('Arabic / عربية');
+    cy.get('dds-language-selector-mobile')
+      .shadow()
+      .find(`select.${prefix}--select-input`)
+      .should('have.value', 'Arabic / عربية');
+
+    // Take a snapshot for visual diffing
+    // TODO: click states currently not working in percy for web components
+    // cy.percySnapshot('dds-footer | Micro language only (desktop language selector)', {
     //   widths: [320],
     // });
   });


### PR DESCRIPTION
### Related Ticket(s)

#7427

### Description

This PR adds e2e tests on the micro language only footer variant for the following scenarios:

a. Check language selector (dropdown) is available and clickable
b. Click on language selector, drop down opens and user must be able to select language/geoFooter

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
