### PR TITLE
test(footer): add e2e test for default footer

### DIFF
--- a/packages/react/tests/e2e-storybook/cypress/integration/Footer/Footer.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/Footer/Footer.e2e.js
@@ -10,6 +10,14 @@ import settings from 'carbon-components/es/globals/js/settings';
 const { prefix } = settings;
 
 /**
+ * Sets the correct path (default Footer)
+ *
+ * @type {string}
+ * @private
+ */
+ const _pathDefault = '/iframe.html?id=components-footer--default';
+
+/**
  * Sets the correct path (Short language only)
  *
  * @type {string}
@@ -18,6 +26,86 @@ const { prefix } = settings;
 
 const _pathShortLanguageOnly =
   '/iframe.html?id=components-footer--short-language-only';
+
+describe('Footer | default (desktop)', () => {
+  beforeEach(() => {
+    cy.visit(`/${_pathDefault}`);
+    cy.viewport(1280, 780);
+  });
+
+  it('should have interactable url for IBM logo', () => {
+    cy.get('[data-autoid="dds--footer-logo__link"]').then($link => {
+      const url = $link.prop('href');
+      expect(url).not.to.be.empty;
+    });
+  });
+
+  it('should load locale modal', () => {
+    const localeButton = cy.get(
+      `[data-autoid="dds--locale-btn"]`
+    );
+    localeButton.click();
+
+    cy.screenshot();
+  });
+
+  it('should load the Americas region with its languages and locations', () => {
+    const localeButton = cy.get(
+      `[data-autoid="dds--locale-btn"]`
+    );
+    localeButton.click();
+
+    cy.get('[data-region="am"]').click();
+
+    cy.get('.bx--locale-modal__locales').should('have.length', 35);
+
+    cy.screenshot();
+
+    // Take a snapshot for visual diffing
+    cy.percySnapshot('Footer | Americas region selected', {
+      widths: [1280],
+    });
+  });
+
+  it('should be able to search with keywords for locations and languages', () => {
+    const localeButton = cy.get(
+      `[data-autoid="dds--locale-btn"]`
+    );
+    localeButton.click();
+
+    cy.get('[data-region="am"]').click();
+    cy.get('[data-autoid="dds--locale-modal__filter"]').type('mexico', {
+      force: true,
+    });
+
+    cy.get('.bx--locale-modal__locales:not(.bx--locale-modal__locales-hidden) > div').first().then( e => {
+      expect(e.text()).to.equal('Mexico');
+    });
+
+    cy.screenshot();
+
+    // Take a snapshot for visual diffing
+    cy.percySnapshot('Footer | Mexico locale found', {
+      widths: [1280],
+    });
+  });
+
+  it('should load all the 38 navigation links', () => {
+    cy.get(`[data-autoid="dds--footer-nav-group__link"]`).should('have.length', 38);
+    cy.screenshot();
+  });
+
+  it('should load all 4 interactable legal links', () => {
+    cy.get(`[data-autoid^='dds--footer-legal-nav__']`).should('have.length', 4);
+
+    cy.get(`[data-autoid^='dds--footer-legal-nav__']`)
+    .each($link => {
+      const url = $link.prop('href');
+      expect(url).not.to.be.empty;
+    });
+  });
+
+});
 
 describe('Footer | Short language only (desktop)', () => {
   beforeEach(() => {

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/footer/footer.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/footer/footer.e2e.js
@@ -10,6 +10,14 @@ import settings from 'carbon-components/es/globals/js/settings';
 const { prefix } = settings;
 
 /**
+ * Sets the correct path (default Footer)
+ *
+ * @type {string}
+ * @private
+ */
+ const _pathDefault = '/iframe.html?id=components-footer--default';
+
+/**
  * Sets the correct path (Short language only)
  *
  * @type {string}
@@ -17,6 +25,97 @@ const { prefix } = settings;
  */
 
 const _pathShortLanguageOnly = '/iframe.html?id=components-footer--short-language-only';
+
+describe('dds-dds-footer | default (desktop)', () => {
+  beforeEach(() => {
+    cy.visit(`/${_pathDefault}`);
+    cy.viewport(1280, 780);
+  });
+
+  it('should have interactable url for IBM logo', () => {
+    cy.get('[data-autoid="dds--footer-logo"]').then($link => {
+      const url = $link.prop('href');
+      expect(url).not.to.be.empty;
+    });
+  });
+
+  it('should load locale modal', () => {
+    const localeButton = cy.get(
+      `[data-autoid="dds--locale-btn"]`
+    );
+    localeButton.click();
+
+    cy.screenshot();
+  });
+
+  it('should load the Americas region with its languages and locations', () => {
+    const localeButton = cy.get(
+      `[data-autoid="dds--locale-btn"]`
+    );
+    localeButton.click();
+
+    cy.get('dds-region-item[name="Americas"]').click();
+
+    cy.get(`dds-locale-item[region='Americas']`).should('have.length', 35);
+
+    cy.screenshot();
+
+    // Take a snapshot for visual diffing
+    cy.percySnapshot('dds-footer | Americas region selected', {
+      widths: [1280],
+    });
+  });
+
+  it('should be able to search with keywords for locations and languages', () => {
+    const localeButton = cy.get(
+      `[data-autoid="dds--locale-btn"]`
+    );
+    localeButton.click();
+
+    cy.get('[name="Americas"]').click();
+
+    cy.get('dds-locale-search').shadow()
+    .find('.bx--search-input').type('ca', {
+      force: true,
+    });
+
+    cy.get('dds-locale-item:not([hidden])').invoke('attr', 'country').should('eq', 'Canada');
+
+    cy.screenshot();
+
+    // Take a snapshot for visual diffing
+    cy.percySnapshot('dds-footer | Filtering locales', {
+      widths: [1280],
+    });
+  });
+
+  it('should load all the 38 interactable navigation links', () => {
+    cy.get(`dds-footer-nav-item`).should('have.length', 38);
+
+  cy.get('dds-footer-nav-item')
+    .shadow()
+    .find('a')
+    .each($link => {
+      const url = $link.prop('href');
+      expect(url).not.to.be.empty;
+    });
+
+    cy.screenshot();
+  });
+
+  it('should load all 4 interactable legal links', () => {
+    cy.get(`dds-legal-nav-item`).should('have.length', 4);
+
+    cy.get('dds-legal-nav-item')
+    .shadow()
+    .find('a')
+    .each($link => {
+      const url = $link.prop('href');
+      expect(url).not.to.be.empty;
+    });
+  });
+
+});
 
 describe('dds-footer | Short language only (desktop)', () => {
   beforeEach(() => {


### PR DESCRIPTION
### Related Ticket(s)
#7422

### Description
Created the e2e tests for the default Footer desktop for both React and Web Components

### Changelog

**New**

- new default e2e tests in React and web components

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
