### PR TITLE
test(e2e): various false positive fixes for Masthead and Quote

### DIFF
--- a/packages/react/tests/e2e-storybook/cypress/integration/CalloutQuote/CalloutQuote.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/CalloutQuote/CalloutQuote.e2e.js
@@ -19,8 +19,10 @@ describe('CalloutQuote | default', () => {
     cy.visit(`${_path}&theme=g100`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--callout-quote"]');
-    cy.wait(500);
+    cy.get('[data-autoid="dds--callout-quote"]')
+      .shadow()
+      .find('.bx--quote__copy');
+
     cy.screenshot();
 
     // Take a snapshot for visual diffing
@@ -33,8 +35,10 @@ describe('CalloutQuote | default', () => {
     cy.visit(`${_path}&theme=g90`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--callout-quote"]');
-    cy.wait(500);
+    cy.get('[data-autoid="dds--callout-quote"]')
+      .shadow()
+      .find('.bx--quote__copy');
+
     cy.screenshot();
     // Take a snapshot for visual diffing
     cy.percySnapshot('CalloutQuote | default | g90 theme', {
@@ -46,8 +50,9 @@ describe('CalloutQuote | default', () => {
     cy.visit(`${_path}&theme=g10`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--callout-quote"]');
-    cy.wait(500);
+    cy.get('[data-autoid="dds--callout-quote"]')
+      .shadow()
+      .find('.bx--quote__copy');
     cy.screenshot();
     // Take a snapshot for visual diffing
     cy.percySnapshot('CalloutQuote | default | g10 theme', {

--- a/packages/react/tests/e2e-storybook/cypress/integration/CalloutQuote/CalloutQuote.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/CalloutQuote/CalloutQuote.e2e.js
@@ -19,9 +19,11 @@ describe('CalloutQuote | default', () => {
     cy.visit(`${_path}&theme=g100`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--callout-quote"]')
-      .shadow()
-      .find('.bx--quote__copy');
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--callout-quote"] .bx--quote__copy')
+        .then($copy => $copy.text().trim() !== '')
+    );
 
     cy.screenshot();
 
@@ -35,9 +37,11 @@ describe('CalloutQuote | default', () => {
     cy.visit(`${_path}&theme=g90`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--callout-quote"]')
-      .shadow()
-      .find('.bx--quote__copy');
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--callout-quote"] .bx--quote__copy')
+        .then($copy => $copy.text().trim() !== '')
+    );
 
     cy.screenshot();
     // Take a snapshot for visual diffing
@@ -50,9 +54,12 @@ describe('CalloutQuote | default', () => {
     cy.visit(`${_path}&theme=g10`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--callout-quote"]')
-      .shadow()
-      .find('.bx--quote__copy');
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--callout-quote"] .bx--quote__copy')
+        .then($copy => $copy.text().trim() !== '')
+    );
+
     cy.screenshot();
     // Take a snapshot for visual diffing
     cy.percySnapshot('CalloutQuote | default | g10 theme', {

--- a/packages/react/tests/e2e-storybook/cypress/integration/Footer/Footer.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/Footer/Footer.e2e.js
@@ -213,12 +213,9 @@ describe('Footer | Short language only (desktop)', () => {
 
     cy.screenshot();
     // Take a snapshot for visual diffing
-    cy.percySnapshot(
-      'Footer | Short language only (desktop language selector)',
-      {
-        widths: [1280],
-      }
-    );
+    cy.percySnapshot('Footer | Short language only | desktop dropdown', {
+      widths: [1280],
+    });
   });
 
   it('should be able to select a language from combo box', () => {
@@ -234,12 +231,9 @@ describe('Footer | Short language only (desktop)', () => {
     );
 
     cy.screenshot();
-    cy.percySnapshot(
-      'Footer | Short language only (desktop language selector)',
-      {
-        widths: [1280],
-      }
-    );
+    cy.percySnapshot('Footer | Short language only | desktop combo box', {
+      widths: [1280],
+    });
   });
 });
 
@@ -253,12 +247,9 @@ describe('Footer | Micro language only (desktop)', () => {
     cy.get(`[data-autoid="dds--language-selector"]`).click();
 
     cy.screenshot();
-    cy.percySnapshot(
-      'Footer | Micro language only (desktop language selector)',
-      {
-        widths: [1280],
-      }
-    );
+    cy.percySnapshot('Footer | Micro language only | desktop dropdown', {
+      widths: [1280],
+    });
   });
 
   it('should be able to select a language from combo box', () => {
@@ -274,12 +265,9 @@ describe('Footer | Micro language only (desktop)', () => {
     );
 
     cy.screenshot();
-    cy.percySnapshot(
-      'Footer | Micro language only (desktop language selector)',
-      {
-        widths: [1280],
-      }
-    );
+    cy.percySnapshot('Footer | Micro language only | desktop combobox', {
+      widths: [1280],
+    });
   });
 });
 
@@ -302,12 +290,9 @@ describe('Footer | Short language only (mobile)', () => {
     languageSelector.should('have.value', 'ar');
 
     cy.screenshot();
-    cy.percySnapshot(
-      'Footer | Short language only (desktop language selector)',
-      {
-        widths: [320],
-      }
-    );
+    cy.percySnapshot('Footer | Short language only | desktop interactive', {
+      widths: [320],
+    });
   });
 });
 
@@ -330,11 +315,8 @@ describe('Footer | Micro language only (mobile)', () => {
     languageSelector.should('have.value', 'ar');
 
     cy.screenshot();
-    cy.percySnapshot(
-      'Footer | Micro language only (desktop language selector)',
-      {
-        widths: [320],
-      }
-    );
+    cy.percySnapshot('Footer | Micro language only | mobile interactive', {
+      widths: [320],
+    });
   });
 });

--- a/packages/react/tests/e2e-storybook/cypress/integration/Masthead/Masthead.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/Masthead/Masthead.e2e.js
@@ -224,6 +224,12 @@ describe('Masthead | custom (desktop)', () => {
       }
     );
 
+    cy.waitUntil(() =>
+      cy
+        .get('.bx--header__nav-caret-right-container')
+        .then($elem => $elem.is(':visible'))
+    );
+
     cy.screenshot();
     // Take a snapshot for visual diffing
     cy.percySnapshot('Masthead | custom menu item with selected state', {
@@ -375,9 +381,15 @@ describe('Masthead | with L1 (desktop)', () => {
       expect($menuItem).to.have.attr('data-selected', 'true');
     });
 
+    cy.waitUntil(() =>
+      cy
+        .get('.bx--header__nav-caret-right-container')
+        .then($elem => $elem.is(':visible'))
+    );
+
     cy.screenshot();
     // Take a snapshot for visual diffing
-    cy.percySnapshot('dds-masthead | menu item with selected state', {
+    cy.percySnapshot('Masthead | L1 menu item with selected state', {
       widths: [1280],
     });
   });

--- a/packages/react/tests/e2e-storybook/cypress/integration/Masthead/Masthead.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/Masthead/Masthead.e2e.js
@@ -225,9 +225,7 @@ describe('Masthead | custom (desktop)', () => {
     );
 
     cy.waitUntil(() =>
-      cy
-        .get('.bx--header__nav-caret-right-container')
-        .then($elem => $elem.is(':visible'))
+      cy.get('.bx--header__nav-caret-right').then($elem => $elem.is(':visible'))
     );
 
     cy.screenshot();
@@ -382,9 +380,7 @@ describe('Masthead | with L1 (desktop)', () => {
     });
 
     cy.waitUntil(() =>
-      cy
-        .get('.bx--header__nav-caret-right-container')
-        .then($elem => $elem.is(':visible'))
+      cy.get('.bx--header__nav-caret-right').then($elem => $elem.is(':visible'))
     );
 
     cy.screenshot();

--- a/packages/react/tests/e2e-storybook/cypress/integration/Quote/Quote.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/Quote/Quote.e2e.js
@@ -19,8 +19,9 @@ describe('Quote | default', () => {
     cy.visit(`${_path}&theme=g100`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--quote"]');
-    cy.wait(500);
+    cy.get('[data-autoid="dds--quote"]')
+      .shadow()
+      .find('.bx--quote__copy');
 
     cy.screenshot();
 
@@ -34,8 +35,9 @@ describe('Quote | default', () => {
     cy.visit(`${_path}&theme=g90`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--quote"]');
-    cy.wait(500);
+    cy.get('[data-autoid="dds--quote"]')
+      .shadow()
+      .find('.bx--quote__copy');
 
     cy.screenshot();
     // Take a snapshot for visual diffing
@@ -48,8 +50,9 @@ describe('Quote | default', () => {
     cy.visit(`${_path}&theme=g10`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--quote"]');
-    cy.wait(500);
+    cy.get('[data-autoid="dds--quote"]')
+      .shadow()
+      .find('.bx--quote__copy');
 
     cy.screenshot();
     // Take a snapshot for visual diffing

--- a/packages/react/tests/e2e-storybook/cypress/integration/Quote/Quote.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/Quote/Quote.e2e.js
@@ -19,9 +19,11 @@ describe('Quote | default', () => {
     cy.visit(`${_path}&theme=g100`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--quote"]')
-      .shadow()
-      .find('.bx--quote__copy');
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--quote"] .bx--quote__copy')
+        .then($copy => $copy.text().trim() !== '')
+    );
 
     cy.screenshot();
 
@@ -35,9 +37,11 @@ describe('Quote | default', () => {
     cy.visit(`${_path}&theme=g90`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--quote"]')
-      .shadow()
-      .find('.bx--quote__copy');
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--quote"] .bx--quote__copy')
+        .then($copy => $copy.text().trim() !== '')
+    );
 
     cy.screenshot();
     // Take a snapshot for visual diffing
@@ -50,9 +54,11 @@ describe('Quote | default', () => {
     cy.visit(`${_path}&theme=g10`);
     cy.viewport(1280, 780);
 
-    cy.get('[data-autoid="dds--quote"]')
-      .shadow()
-      .find('.bx--quote__copy');
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--quote"] .bx--quote__copy')
+        .then($copy => $copy.text().trim() !== '')
+    );
 
     cy.screenshot();
     // Take a snapshot for visual diffing

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead.e2e.js
@@ -459,7 +459,7 @@ describe('dds-masthead | with L1 (desktop)', () => {
     cy.screenshot();
     // Take a snapshot for visual diffing
     // TODO: click states currently not working in percy for web components
-    // cy.percySnapshot('dds-masthead | custom menu item with selected state', {
+    // cy.percySnapshot('dds-masthead | l1 menu item with selected state', {
     //   widths: [1280],
     // });
   });


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

We were noticing some false positives in the percy snapshots, which is probably due to elements not properly loading before the snapshots are being taken. For the tests in `Masthead`,  `CalloutQuote`, and `Quote`, additional selector gets were added in order to ensure that the proper elements are in place before taking a snapshot.

### Changelog

**Changed**

- e2e tests for `Masthead`, `CalloutQuote`, and `Quote`
