### PR TITLE
fix(browserstack): add `cypress-wait-until` for browserstack automate

### DIFF
--- a/packages/react/tests/e2e-storybook/browserstack.json
+++ b/packages/react/tests/e2e-storybook/browserstack.json
@@ -34,7 +34,8 @@
     "parallels": "5",
     "npm_dependencies": {
       "@percy/cypress": "^3.1.0",
-      "@percy/dom": "^1.0.0-beta.55"
+      "@percy/dom": "^1.0.0-beta.55",
+      "cypress-wait-until": "^1.7.2"
     },
     "package_config_options": {},
     "headless": true

--- a/packages/web-components/tests/e2e-storybook/browserstack.json
+++ b/packages/web-components/tests/e2e-storybook/browserstack.json
@@ -34,7 +34,8 @@
     "parallels": "5",
     "npm_dependencies": {
       "@percy/cypress": "^3.1.0",
-      "@percy/dom": "^1.0.0-beta.55"
+      "@percy/dom": "^1.0.0-beta.55",
+      "cypress-wait-until": "^1.7.2"
     },
     "package_config_options": {},
     "headless": true


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Forgot to add `cypress-wail-until` to the `browserstack.json` config file to load that dependency for the automate runs. This should fix the issues there.

### Changelog

**Changed**

- `browserstack.json` added `cypress-wait-until` as npm dependency