### PR TITLE
fix(search-with-typeahead): fixed mobile focus bug

### DIFF
--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -110,7 +110,9 @@ class DDSSearchWithTypeahead extends HostListenerMixin(StableSelectorMixin(BXDro
    * Handles `click` event on the close button.
    */
   private async _handleClickCloseButton() {
-    this._closeButtonNode?.classList.add(`${prefix}--header__search--hide`);
+    if (this.leadspaceSearch) {
+      this._closeButtonNode?.classList.add(`${prefix}--header__search--hide`);
+    }
     this._handleUserInitiatedToggleActiveState(false);
   }
 
@@ -247,6 +249,17 @@ class DDSSearchWithTypeahead extends HostListenerMixin(StableSelectorMixin(BXDro
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   protected _handleFocusOut(event: FocusEvent) {
     super._handleFocusOut(event);
+    const logo = document.querySelector('dds-masthead-logo');
+    const profile = document.querySelector('dds-masthead-global-bar');
+
+    const focusedOnMasthead = event.relatedTarget ? event.relatedTarget === logo && event.relatedTarget === profile : true;
+    if (
+      focusedOnMasthead &&
+      !(event.currentTarget as HTMLElement).contains(event.relatedTarget as HTMLElement) &&
+      !this.searchOpenOnload
+    ) {
+      this._handleUserInitiatedToggleActiveState(false, false);
+    }
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)
#7587

### Description
Ensured that, in mobile, clicking on the close search button the component renders properly, as well as making sure to retain the fixes for #6321.

### Changelog
**Changed**
- added some additional checks for handling focus out in search with typeahead

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
