### PR TITLE
fix(search-with-typeahead): remove focusout code

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-global-bar.ts
+++ b/packages/web-components/src/components/masthead/masthead-global-bar.ts
@@ -39,7 +39,9 @@ class DDSMastheadGlobalBar extends FocusMixin(HostListenerMixin(StableSelectorMi
   @HostListener('parentRoot:eventToggleSearch')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleSearchToggle = (event: Event) => {
-    this._hasSearchActive = (event as CustomEvent).detail.active;
+    if ((event as CustomEvent).detail.active !== undefined) {
+      this._hasSearchActive = (event as CustomEvent).detail.active;
+    }
   };
 
   /**

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -249,17 +249,6 @@ class DDSSearchWithTypeahead extends HostListenerMixin(StableSelectorMixin(BXDro
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   protected _handleFocusOut(event: FocusEvent) {
     super._handleFocusOut(event);
-    const logo = document.querySelector('dds-masthead-logo');
-    const profile = document.querySelector('dds-masthead-global-bar');
-
-    const focusedOnMasthead = event.relatedTarget ? event.relatedTarget === logo && event.relatedTarget === profile : true;
-    if (
-      focusedOnMasthead &&
-      !(event.currentTarget as HTMLElement).contains(event.relatedTarget as HTMLElement) &&
-      !this.searchOpenOnload
-    ) {
-      this._handleUserInitiatedToggleActiveState(false, false);
-    }
   }
 
   /**

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -110,7 +110,9 @@ class DDSSearchWithTypeahead extends HostListenerMixin(StableSelectorMixin(BXDro
    * Handles `click` event on the close button.
    */
   private async _handleClickCloseButton() {
-    this._closeButtonNode?.classList.add(`${prefix}--header__search--hide`);
+    if (this.leadspaceSearch) {
+      this._closeButtonNode?.classList.add(`${prefix}--header__search--hide`);
+    }
     this._handleUserInitiatedToggleActiveState(false);
   }
 
@@ -247,6 +249,17 @@ class DDSSearchWithTypeahead extends HostListenerMixin(StableSelectorMixin(BXDro
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   protected _handleFocusOut(event: FocusEvent) {
     super._handleFocusOut(event);
+    const logo = document.querySelector('dds-masthead-logo');
+    const profile = document.querySelector('dds-masthead-global-bar');
+
+    const focusedOnMasthead = event.relatedTarget ? event.relatedTarget === logo && event.relatedTarget === profile : true;
+    if (
+      focusedOnMasthead &&
+      !(event.currentTarget as HTMLElement).contains(event.relatedTarget as HTMLElement) &&
+      !this.searchOpenOnload
+    ) {
+      this._handleUserInitiatedToggleActiveState(false, false);
+    }
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)
#7587 

### Description
Removes the `handleFocusOut` code that used to be in the `dds-masthead-search` component since it causes a cypress test to fail, as well as any search toggle related issue.

### Changelog
**Removed**

- removes `handleFocusOut` code from `dds-search-with-typeahead` so its reverted to how it was since #7200

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
