### PR TITLE
chore: update cla document path

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,14 +17,14 @@ jobs:
           PERSONAL_ACCESS_TOKEN : ${{ secrets.BOT_TOKEN_CLA }}
         with:
           path-to-signatures: 'cla.json'
-          path-to-document: 'https://github.com/carbon-design-system/carbon-for-ibm-dotcom-cla/blob/master/CLA.md'
+          path-to-document: 'https://github.com/carbon-design-system/carbon-for-ibm-dotcom-cla/blob/main/CLA.md'
           branch: 'main'
           allowlist: ibmdotcom-bot,dependabot,kodiakhq[bot]
           remote-organization-name: carbon-design-system
           remote-repository-name: carbon-for-ibm-dotcom-cla
           create-file-commit-message: 'chore(cla): creating file for storing CLA signatures'
           signed-commit-message: 'chore(cla): $contributorName has signed the CLA in #$pullRequestNo'
-          custom-notsigned-prcomment: 'Thank you for your contribution! Please review and sign our [Contributor License Agreement](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-cla/blob/master/CLA.md) before we can review and merge your pull request. To sign, enter a comment in this pull request with the following message:'
+          custom-notsigned-prcomment: 'Thank you for your contribution! Please review and sign our [Contributor License Agreement](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-cla/blob/main/CLA.md) before we can review and merge your pull request. To sign, enter a comment in this pull request with the following message:'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-allsigned-prcomment: 'All Contributors have signed the CLA.'
           lock-pullrequest-aftermerge: false


### PR DESCRIPTION
This PR updates the CLA workflow to point to the `main` branch

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
