### PR TITLE
chore(github-actions): introduce concurrency limit to workflows

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - 'release/*'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   automerge:
     runs-on: ubuntu-20.04

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -5,7 +5,7 @@ on:
       - 'release/*'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: automerge-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -3,7 +3,7 @@ name: ci-check
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ci-check-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -2,6 +2,10 @@ name: ci-check
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-packages:
     runs-on: ubuntu-20.04

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '35 16 * * 1'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ on:
     - cron: '35 16 * * 1'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: codeql-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,10 +5,6 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -3,7 +3,7 @@ name: dependabot-yarn-mirror
 on: [pull_request]
 
 concurrency:
-  group: ${{ github.ref }}
+  group: dependabot-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -2,6 +2,10 @@ name: dependabot-yarn-mirror
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-offline-mirror:
     runs-on: ubuntu-20.04

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   react:
     runs-on: ubuntu-20.04

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.ref }}
+  group: deploy-canary-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - release/*
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   react:
     runs-on: ubuntu-20.04

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -6,7 +6,7 @@ on:
       - release/*
 
 concurrency:
-  group: ${{ github.ref }}
+  group: deploy-staging-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: e2e-tests
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.ref }}
+  group: e2e-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,6 +2,10 @@ name: e2e-tests
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   storybook-web-components:
     runs-on: ubuntu-20.04

--- a/.github/workflows/percy-update-base-wc-e2e-codesandbox.yml
+++ b/.github/workflows/percy-update-base-wc-e2e-codesandbox.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   web-components:
     runs-on: ubuntu-20.04

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -6,6 +6,10 @@ on:
       - master
       - release/*
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   react-storybook:
     runs-on: ubuntu-20.04

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -7,7 +7,7 @@ on:
       - release/*
 
 concurrency:
-  group: ${{ github.ref }}
+  group: percy-update-base-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.ref }}
+  group: publish-canary-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 1 * * 1-5'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: publish-nightly-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 1 * * 1-5'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: publish-staging-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -6,6 +6,10 @@ on:
       - master
       - release/*
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   react:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -7,7 +7,7 @@ on:
       - release/*
 
 concurrency:
-  group: ${{ github.ref }}
+  group: release-preflight-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/snapshot-update.yml
+++ b/.github/workflows/snapshot-update.yml
@@ -8,7 +8,7 @@ on:
       - chore/carbon-upgrade-*
 
 concurrency:
-  group: ${{ github.ref }}
+  group: snapshot-update-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/snapshot-update.yml
+++ b/.github/workflows/snapshot-update.yml
@@ -7,6 +7,10 @@ on:
       - release/*
       - chore/carbon-upgrade-*
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   react:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Adding a new `concurrency` configuration may assist with removing redundant workflows in the queue. 

### Changelog

**Changed**

- Add `concurrency` setting for all workflows (except DCO)
