### PR TITLE
fix(github-actions): update dependabot name for dco allowlist

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -19,7 +19,7 @@ jobs:
           path-to-signatures: 'dco-signatures.json'
           path-to-document: 'https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md'
           branch: 'main'
-          allowlist: ibmdotcom-bot,dependabot,kodiakhq[bot]
+          allowlist: ibmdotcom-bot,dependabot[bot],kodiakhq[bot]
           remote-organization-name: carbon-design-system
           remote-repository-name: carbon-dco
           create-file-commit-message: 'chore: create file to store dco signatures'


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The name for the `dependabot` name needed the appended `[bot]` in order to be added properly to the `allowlist` for the `DCO Assistant` workflow.

### Changelog

**Changed**

- Updated name for `dependabot` in `dco` workflow
