### PR TITLE
chore(github-actions): prevent actions from running on forks

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   automerge:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -6,7 +6,8 @@ on:
     types: [opened,closed,synchronize]
 
 jobs:
-  CLAssistant:
+  DCOssistant:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-latest
     steps:
       - name: "DCO Assistant"

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   update-offline-mirror:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   react:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -46,6 +47,7 @@ jobs:
           cf-manifest: manifest-canary.yml
           deploy-dir: packages/react
   react-experimental:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -86,6 +88,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   react-rtl:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -126,6 +129,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -165,6 +169,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components-rtl:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -205,6 +210,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components-experimental:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -245,6 +251,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components-react:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -284,6 +291,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   services:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -323,6 +331,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   utilities:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   react:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -46,6 +47,7 @@ jobs:
           cf-manifest: manifest-staging.yml
           deploy-dir: packages/react
   react-rtl:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -86,6 +88,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -125,6 +128,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   web-components-rtl:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   react-storybook:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -40,6 +41,7 @@ jobs:
         run: yarn visual-snapshot
         working-directory: packages/react
   react-storybook-e2e:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -66,6 +68,7 @@ jobs:
         run: yarn build-storybook && yarn test:e2e-storybook:test
         working-directory: packages/react
   web-components:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   publish:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   publish:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   publish:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -11,7 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  react:
+  preflight:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/snapshot-update.yml
+++ b/.github/workflows/snapshot-update.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   react:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-20.04
     strategy:
       matrix:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This minor update will prevent unnecessary github actions to run on forks if actions are enabled.

Another minor thing is renaming some of the jobs to more proper names.

### Changelog

**Changed**

- Added restriction for most github workflows to only run on `carbon-design-system/carbon-for-ibm-dotcom`
- Renamed `release-preflight / react` to `release-preflight / preflight`
- Renamed `DCO Assistant / CLAAssistant` to `DCO Assistant / DCOAssistant`
