### PR TITLE
fix(github-actions): fix to dco workflow name

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -6,7 +6,7 @@ on:
     types: [opened,closed,synchronize]
 
 jobs:
-  DCOssistant:
+  DCOAssistant:
     if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

I misspelled `DCOAssistant` in a previous PR (https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/7618)

### Changelog

**Changed**

- `dco.yml`
