### PR TITLE
chore(dependabot): add config and update dependabot offline mirror flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    versioning-strategy: increase

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -15,9 +15,6 @@ jobs:
         node-version: ['14.x']
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          token: ${{secrets.MERGE_ACTION}}
       - uses: fregante/setup-git-user@v1
       - name: Use Node.js
         uses: actions/setup-node@v2
@@ -28,6 +25,7 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'dependencies')
         run: |
           yarn
+          git checkout -b ${{github.event.pull_request.head.ref}}
           git add -A
           if [[ ! -z $(git status -s) ]] ; then
             git commit -m "chore(yarn): update yarn offline mirror"

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -15,16 +15,14 @@ jobs:
         node-version: ['14.x']
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
       - uses: fregante/setup-git-user@v1
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - name: Get branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: get_branch
       - name: Update yarn offline mirror
         if: contains(github.event.pull_request.labels.*.name, 'dependencies')
         run: |
@@ -32,5 +30,5 @@ jobs:
           git add -A
           if [[ ! -z $(git status -s) ]] ; then
             git commit -m "chore(yarn): update yarn offline mirror"
-            git push origin ${{ steps.get_branch.outputs.branch }}
+            git push origin ${{github.event.pull_request.head.ref}}
           fi

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -8,26 +8,24 @@ concurrency:
 
 jobs:
   update-offline-mirror:
-    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom' && contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14.x']
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{secrets.MERGE_ACTION}}
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
       - name: Update yarn offline mirror
-        if: contains(github.event.pull_request.labels.*.name, 'dependencies')
         run: |
           git config --global user.email ${{ secrets.BOT_EMAIL }}
           git config --global user.name ${{ secrets.BOT_NAME }}
-          git config --global github.token ${{ secrets.MERGE_ACTION }}
-
-          git checkout -b ${{github.event.pull_request.head.ref}}
 
           yarn
           git add -A

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -15,8 +15,6 @@ jobs:
         node-version: ['14.x']
     steps:
       - uses: actions/checkout@v2
-        with:
-          token: ${{secrets.MERGE_ACTION}}
       - uses: fregante/setup-git-user@v1
       - name: Use Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -15,7 +15,6 @@ jobs:
         node-version: ['14.x']
     steps:
       - uses: actions/checkout@v2
-      - uses: fregante/setup-git-user@v1
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
@@ -24,8 +23,13 @@ jobs:
       - name: Update yarn offline mirror
         if: contains(github.event.pull_request.labels.*.name, 'dependencies')
         run: |
-          yarn
+          git config --global user.email ${{ secrets.BOT_EMAIL }}
+          git config --global user.name ${{ secrets.BOT_NAME }}
+          git config --global github.token ${{ secrets.MERGE_ACTION }}
+
           git checkout -b ${{github.event.pull_request.head.ref}}
+
+          yarn
           git add -A
           if [[ ! -z $(git status -s) ]] ; then
             git commit -m "chore(yarn): update yarn offline mirror"

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{secrets.GH_TOKEN}}
+          token: ${{secrets.MERGE_ACTION}}
       - uses: fregante/setup-git-user@v1
       - name: Use Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.pull_request.head.ref}}
+          token: ${{secrets.MERGE_ACTION}}
       - uses: fregante/setup-git-user@v1
       - name: Use Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -14,15 +14,25 @@ jobs:
       matrix:
         node-version: ['14.x']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GH_TOKEN}}
       - uses: fregante/setup-git-user@v1
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - name: Get branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: get_branch
       - name: Update yarn offline mirror
         if: contains(github.event.pull_request.labels.*.name, 'dependencies')
         run: |
           yarn
           git add -A
-          if [[ ! -z $(git status -s) ]] ; then git commit -m "chore(yarn): update yarn offline mirror" && git push; fi
+          if [[ ! -z $(git status -s) ]] ; then
+            git commit -m "chore(yarn): update yarn offline mirror"
+            git push origin ${{ steps.get_branch.outputs.branch }}
+          fi


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This introduces a dependabot configuration for the repo (should have added one awhile ago).

Let me know if you think the versioning strategy is too aggressive. It would be good for the dev dependencies if it has problems upgrading but we'd probably have to keep an eye on the ones that would cause any breaking changes.

### Changelog

**New**

- `dependabot.yml` config in `.github`

**Changed**

- fixes to the dependabot offline mirror management workflow