### PR TITLE
chore(github-actions): avoid duplicate ci-checks on non-forks

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -1,6 +1,10 @@
 name: ci-check
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master, release/* ]
+  pull_request:
+    branches: [ master, release/* ]
 
 concurrency:
   group: ci-check-${{ github.ref }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,10 @@
 name: e2e-tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master, release/* ]
+  pull_request:
+    branches: [ master, release/* ]
 
 concurrency:
   group: e2e-tests-${{ github.ref }}


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This PR will add restrictions for non-forked PRs so that ci-checks will not run twice.

### Changelog

**Changed**

- restrict github action event triggers for `ci-check`
