### PR TITLE
docs(table-of-contents): add dynamic copy knobs

### DIFF
--- a/packages/react/src/components/LinkList/__stories__/LinkList.stories.js
+++ b/packages/react/src/components/LinkList/__stories__/LinkList.stories.js
@@ -239,7 +239,7 @@ EndOfSection.story = {
     knobs: {
       LinkList: ({ groupId }) => ({
         heading: text('Heading (heading):', 'Tutorials', groupId),
-        items: items,
+        items,
       }),
     },
     propsSet: {

--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -105,6 +105,7 @@ Horizontal.story = {
   name: 'Horizontal',
   parameters: {
     ...readme.parameters,
+    knobs: null,
     percy: {
       skip: true,
     },

--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -126,3 +126,28 @@ WithHeadingContent.story = {
     },
   },
 };
+
+export const Horizontal = () => (
+  <p>
+    This component is maintained in{' '}
+    <code>@carbon/ibmdotcom-web-components</code> library with a{' '}
+    <a
+      className="bx--link"
+      target="_blank"
+      href="https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-table-of-contents--horizontal">
+      React wrapper
+    </a>
+    .
+  </p>
+);
+
+Horizontal.story = {
+  name: 'Horizontal',
+  parameters: {
+    ...readme.parameters,
+    percy: {
+      skip: true,
+    },
+    proxy: true,
+  },
+};

--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { text, boolean } from '@storybook/addon-knobs';
 import DataContent from './data/DataContent';
 import Image from '../../Image/Image';
 import imgLg1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x720--004.jpg';
@@ -73,54 +72,6 @@ export default {
   ],
   parameters: {
     ...readme.parameters,
-  },
-};
-
-export const ManuallyDefineMenuItems = ({ parameters }) => {
-  const { menuItems, menuLabel, menuRule, headingContent } =
-    parameters?.props?.TableOfContents ?? {};
-  const params = new URLSearchParams(window.location.search);
-  const themeParam = params.has('theme') ? params.get('theme') : null;
-  const theme =
-    themeParam ||
-    document.documentElement.getAttribute('storybook-carbon-theme') ||
-    'white';
-  return (
-    <TableOfContents
-      theme={theme}
-      menuItems={menuItems}
-      menuLabel={menuLabel}
-      menuRule={menuRule}
-      headingContent={headingContent}>
-      <DataContent />
-    </TableOfContents>
-  );
-};
-
-ManuallyDefineMenuItems.story = {
-  name: 'Manually define menu items',
-  parameters: {
-    knobs: {
-      TableOfContents: ({ groupId }) => ({
-        menuLabel: text('Menu label (menuLabel)', 'Jump to', groupId),
-        menuRule: boolean('Optional Rule (menuRule)', false, groupId),
-      }),
-    },
-  },
-};
-
-export const DynamicItems = ({ parameters }) => (
-  <ManuallyDefineMenuItems parameters={parameters} />
-);
-
-DynamicItems.story = {
-  name: 'Dynamic items',
-  parameters: {
-    knobs: {
-      TableOfContents: ({ groupId }) => ({
-        menuLabel: text('Menu label (menuLabel)', 'Jump to', groupId),
-      }),
-    },
   },
 };
 

--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import DataContent from './data/DataContent';
+import { boolean, number, text } from '@storybook/addon-knobs';
+import DataContent, { headings, LOREM } from './data/DataContent';
 import LinkList from '../../LinkList/LinkList';
 import React from 'react';
 import readme from '../README.stories.mdx';
@@ -13,7 +14,8 @@ import styles from './TableOfContents.stories.scss';
 import TableOfContents from '../TableOfContents';
 
 export const Default = ({ parameters }) => {
-  const { withHeadingContent } = parameters?.props?.Other ?? {};
+  const { numberOfItems: menuItems, withHeadingContent } =
+    parameters?.props?.Other ?? {};
   const headingItems = [
     {
       type: 'local',
@@ -44,8 +46,8 @@ export const Default = ({ parameters }) => {
     <>
       <TableOfContents
         headingContent={withHeadingContent && headingContent}
-        menuRule={withHeadingContent}>
-        <DataContent />
+        menuRule={!!headingContent}>
+        <DataContent items={menuItems} />
       </TableOfContents>
     </>
   );
@@ -63,6 +65,25 @@ export default {
   ],
   parameters: {
     ...readme.parameters,
+    knobs: {
+      Other: ({ groupId }) => ({
+        withHeadingContent: boolean('With heading content', false, groupId),
+        numberOfItems: Array.from({
+          length: number('Number of items', 5, { min: 4, max: 8 }, groupId),
+        }).map((_, i) => ({
+          heading: text(
+            `Section ${i + 1} heading`,
+            headings[i % headings.length],
+            groupId
+          ),
+          copy: text(
+            `Section ${i + 1} copy`,
+            `${LOREM}\n`.repeat(3).trim(),
+            groupId
+          ),
+        })),
+      }),
+    },
   },
 };
 

--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -6,9 +6,7 @@
  */
 
 import DataContent from './data/DataContent';
-import Image from '../../Image/Image';
-import imgLg1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x720--004.jpg';
-import imgLg4x3 from '../../../../../storybook-images/assets/720/fpo--4x3--720x540--004.jpg';
+import LinkList from '../../LinkList/LinkList';
 import React from 'react';
 import readme from '../README.stories.mdx';
 import styles from './TableOfContents.stories.scss';
@@ -16,19 +14,31 @@ import TableOfContents from '../TableOfContents';
 
 export const Default = ({ parameters }) => {
   const { withHeadingContent } = parameters?.props?.Other ?? {};
+  const headingItems = [
+    {
+      type: 'local',
+      copy: 'DevOps',
+      cta: {
+        href: 'https://github.com/carbon-design-system/carbon-web-components',
+      },
+    },
+    {
+      type: 'local',
+      copy: 'Automation',
+      cta: {
+        href: 'https://github.com/carbon-design-system/carbon-web-components',
+      },
+    },
+    {
+      type: 'local',
+      copy: 'Development',
+      cta: {
+        href: 'https://github.com/carbon-design-system/carbon-web-components',
+      },
+    },
+  ];
   const headingContent = (
-    <Image
-      sources={sources}
-      defaultSrc={defaultSrc}
-      alt={alt}
-      longDescription={longDescription}
-      style={{
-        height: '200px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    />
+    <LinkList style="vertical" iconPlacement="left" items={headingItems} />
   );
   return (
     <>
@@ -40,25 +50,6 @@ export const Default = ({ parameters }) => {
     </>
   );
 };
-
-const sources = [
-  {
-    src: imgLg4x3,
-    breakpoint: 400,
-  },
-  {
-    src: imgLg4x3,
-    breakpoint: 672,
-  },
-  {
-    src: imgLg1x1,
-    breakpoint: 1056,
-  },
-];
-
-const defaultSrc = imgLg1x1;
-const alt = 'Lorem Ipsum';
-const longDescription = 'Lorem Ipsum Dolor';
 
 export default {
   title: 'Components|Table of contents',

--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { boolean, number, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import DataContent, { headings, LOREM } from './data/DataContent';
 import LinkList from '../../LinkList/LinkList';
 import React from 'react';
@@ -69,7 +69,7 @@ export default {
       Other: ({ groupId }) => ({
         withHeadingContent: boolean('With heading content', false, groupId),
         numberOfItems: Array.from({
-          length: number('Number of items', 5, { min: 4, max: 8 }, groupId),
+          length: select('Number of items', [5, 6, 7, 8], 5, groupId),
         }).map((_, i) => ({
           heading: text(
             `Section ${i + 1} heading`,

--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -15,6 +15,33 @@ import readme from '../README.stories.mdx';
 import styles from './TableOfContents.stories.scss';
 import TableOfContents from '../TableOfContents';
 
+export const Default = ({ parameters }) => {
+  const { withHeadingContent } = parameters?.props?.Other ?? {};
+  const headingContent = (
+    <Image
+      sources={sources}
+      defaultSrc={defaultSrc}
+      alt={alt}
+      longDescription={longDescription}
+      style={{
+        height: '200px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    />
+  );
+  return (
+    <>
+      <TableOfContents
+        headingContent={withHeadingContent && headingContent}
+        menuRule={withHeadingContent}>
+        <DataContent />
+      </TableOfContents>
+    </>
+  );
+};
+
 const sources = [
   {
     src: imgLg4x3,
@@ -92,36 +119,6 @@ DynamicItems.story = {
     knobs: {
       TableOfContents: ({ groupId }) => ({
         menuLabel: text('Menu label (menuLabel)', 'Jump to', groupId),
-      }),
-    },
-  },
-};
-
-export const WithHeadingContent = ({ parameters }) => (
-  <ManuallyDefineMenuItems parameters={parameters} />
-);
-
-WithHeadingContent.story = {
-  name: 'With heading content',
-  parameters: {
-    knobs: {
-      TableOfContents: ({ groupId }) => ({
-        menuLabel: text('Menu label (menuLabel)', 'Jump to', groupId),
-        menuRule: boolean('Optional Rule (menuRule)', false, groupId),
-        headingContent: (
-          <Image
-            sources={sources}
-            defaultSrc={defaultSrc}
-            alt={alt}
-            longDescription={longDescription}
-            style={{
-              height: '200px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          />
-        ),
       }),
     },
   },

--- a/packages/react/src/components/TableOfContents/__stories__/data/DataContent.js
+++ b/packages/react/src/components/TableOfContents/__stories__/data/DataContent.js
@@ -1,210 +1,50 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
+import { PropTypes } from 'prop-types';
 import React from 'react';
-const DataContent = () => (
+
+export const headings = [
+  'Forward thinkers',
+  'Innovation and transformation',
+  'Client success stories',
+  'Iconic moments in IBM history',
+  'Trust and responsibility',
+  'Connect with IBM',
+];
+
+// eslint-disable-next-line max-len
+export const LOREM = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
+nisl.`;
+
+const generateCopySections = n => [...Array(n)].map(() => <p>{LOREM}</p>);
+
+const DataContent = ({ items }) => (
   <div className="dds-react-demo--table-of-contents">
-    <a data-title="Cras molestie condimentum" name="8">
-      <h3>Cras molestie condimentum</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <a data-title="Praesent fermentum sodales" name="7">
-      <h3>Praesent fermentum sodales</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <a data-title="Nulla tristique lacinia" name="2">
-      <h3>Nulla tristique lacinia</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <a data-title="Morbi id nibh metus" name="3">
-      <h3>Morbi id nibh metus</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <a data-title="Integer non scelerisque" name="14">
-      <h3>Integer non scelerisque</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie
-      condimentum consectetur. Nulla tristique lacinia elit, at elementum dui
-      gravida non. Mauris et nisl semper, elementum quam non, lacinia purus.
-      Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque
-      facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis
-      scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et
-      ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam
-      vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien
-      pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-    </p>
+    {items?.map(({ heading, copy }, i) => (
+      <>
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+        <a data-title={heading} name={i}>
+          <h3>{heading}</h3>
+        </a>
+        {copy
+          ? copy.split('\n').map(section => <p>{section}</p>)
+          : generateCopySections(3)}
+      </>
+    ))}
   </div>
 );
+
+DataContent.propTypes = {
+  /**
+   * Array of table of contents items
+   */
+  items: PropTypes.array,
+};
 
 export default DataContent;

--- a/packages/react/tests/e2e-storybook/cypress/integration/TableOfContents/TableOfContents.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/TableOfContents/TableOfContents.e2e.js
@@ -12,11 +12,7 @@
  * @private
  */
 const _paths = {
-  manual_default:
-    'iframe.html?id=components-table-of-contents--manually-define-menu-items',
-  dynamic_default: 'iframe.html?id=components-table-of-contents--dynamic-items',
-  heading_content:
-    'iframe.html?id=components-table-of-contents--with-heading-content',
+  default: 'iframe.html?id=components-table-of-contents--default',
 };
 
 /**
@@ -234,10 +230,10 @@ const _tests = {
   },
 };
 
-describe('TableOfContents | manually defined (desktop)', () => {
+describe('TableOfContents | default (desktop)', () => {
   beforeEach(() => {
     cy.viewport(1280, 720);
-    cy.visit(`/${_paths.manual_default}`);
+    cy.visit(`/${_paths.default}`);
   });
 
   it(
@@ -256,98 +252,10 @@ describe('TableOfContents | manually defined (desktop)', () => {
   it('should render correctly in all themes', _tests.all.screenshotThemes);
 });
 
-describe('TableOfContents | dynamically defined (desktop)', () => {
-  beforeEach(() => {
-    cy.viewport(1280, 720);
-    cy.visit(`/${_paths.dynamic_default}`);
-  });
-
-  it(
-    'should load table of contents sidebar with links',
-    _tests.desktop.checkRender
-  );
-  it(
-    'should navigate content to selected section',
-    _tests.desktop.checkLinkFunctionality
-  );
-  xit('should update current section on scroll', _tests.desktop.checkScrollSpy);
-  it(
-    'should remain visible on page throughout scroll',
-    _tests.desktop.checkStickyNav
-  );
-  it('should render correctly in all themes', _tests.all.screenshotThemes);
-});
-
-describe('TableOfContents | with heading content (desktop)', () => {
-  beforeEach(() => {
-    cy.viewport(1280, 720);
-    cy.visit(`/${_paths.heading_content}`);
-  });
-
-  it(
-    'should load table of contents horizontal bar with links',
-    _tests.desktop.checkRender
-  );
-  it(
-    'should navigate content to selected section',
-    _tests.desktop.checkLinkFunctionality
-  );
-  xit('should update current section on scroll', _tests.desktop.checkScrollSpy);
-  it(
-    'should remain visible on page throughout scroll',
-    _tests.desktop.checkStickyNav
-  );
-  it('should render correctly in all themes', _tests.all.screenshotThemes);
-});
-
-describe('TableOfContents | manually defined (mobile)', () => {
+describe('TableOfContents | default (mobile)', () => {
   beforeEach(() => {
     cy.viewport(320, 720);
-    cy.visit(`/${_paths.manual_default}`);
-  });
-
-  it(
-    'should load table of contents sidebar with links',
-    _tests.mobile.checkRender
-  );
-  it(
-    'should navigate content to selected section',
-    _tests.mobile.checkLinkFunctionality
-  );
-  xit('should update current section on scroll', _tests.mobile.checkScrollSpy);
-  it(
-    'should remain visible on page throughout scroll',
-    _tests.mobile.checkStickyNav
-  );
-  it('should render correctly in all themes', _tests.all.screenshotThemes);
-});
-
-describe('TableOfContents | dynamically defined (mobile)', () => {
-  beforeEach(() => {
-    cy.viewport(320, 720);
-    cy.visit(`/${_paths.dynamic_default}`);
-  });
-
-  it(
-    'should load table of contents sidebar with links',
-    _tests.mobile.checkRender
-  );
-  it(
-    'should navigate content to selected section',
-    _tests.mobile.checkLinkFunctionality
-  );
-  xit('should update current section on scroll', _tests.mobile.checkScrollSpy);
-  it(
-    'should remain visible on page throughout scroll',
-    _tests.mobile.checkStickyNav
-  );
-  it('should render correctly in all themes', _tests.all.screenshotThemes);
-});
-
-describe('TableOfContents | with heading content (mobile)', () => {
-  beforeEach(() => {
-    cy.viewport(320, 720);
-    cy.visit(`/${_paths.heading_content}`);
+    cy.visit(`/${_paths.default}`);
   });
 
   it(

--- a/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
@@ -205,6 +205,15 @@ $hover-transition-timing: 95ms;
         display: none;
       }
     }
+
+    > .#{$prefix}--link-list {
+      padding-top: 0;
+      padding-bottom: $spacing-05;
+    }
+
+    hr[data-autoid='#{$dds-prefix}--hr'] {
+      margin-top: 0;
+    }
   }
 
   .#{$prefix}--tableofcontents__contents {

--- a/packages/web-components/src/components/table-of-contents/__stories__/content.ts
+++ b/packages/web-components/src/components/table-of-contents/__stories__/content.ts
@@ -9,200 +9,47 @@
 
 import { html } from 'lit-element';
 
-const content = contentClass => html`
+export const headings = [
+  'Forward thinkers',
+  'Innovation and transformation',
+  'Client success stories',
+  'Iconic moments in IBM history',
+  'Trust and responsibility',
+  'Connect with IBM',
+];
+
+// eslint-disable-next-line max-len
+export const LOREM = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
+nisl.`;
+
+const generateCopySections = n =>
+  [...Array(n)].map(
+    () =>
+      html`
+        <p>${LOREM}</p>
+      `
+  );
+
+const content = ({ contentClass, items }) => html`
   <div class="${contentClass} dds-ce-demo--table-of-contents">
-    <a name="8">
-      <h3>
-        Forward thinkers
-      </h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <a name="7">
-      <h3>
-        Innovation and transformation
-      </h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <a name="2">
-      <h3>
-        Client success stories
-      </h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <a name="3">
-      <h3>
-        Iconic moments in IBM history
-      </h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <a name="14">
-      <h3>
-        Trust and responsibility
-      </h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <a name="15">
-      <h3>
-        Connect with IBM
-      </h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
+    ${items.map(
+      ({ heading, copy }, i) =>
+        html`
+          <a name="${i}">
+            <h3>
+              ${heading}
+            </h3>
+          </a>
+          ${copy
+            ? copy.split('\n').map(
+                section =>
+                  html`
+                    <p>${section}</p>
+                  `
+              )
+            : generateCopySections(3)}
+        `
+    )}
   </div>
 `;
 

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
@@ -15,6 +15,7 @@ import DDSHorizontalRule from '@carbon/ibmdotcom-web-components/es/components-re
 import DDSImage from '@carbon/ibmdotcom-web-components/es/components-react/image/image';
 import DDSImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item';
 import { boolean } from '@storybook/addon-knobs';
+// @ts-ignore
 import DDSTableOfContents from '@carbon/ibmdotcom-web-components/es/components-react/table-of-contents/table-of-contents';
 import content from './wrapper-content';
 import readme from './README.stories.react.mdx';

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
@@ -12,19 +12,19 @@ import React from 'react';
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
 import DDSHorizontalRule from '@carbon/ibmdotcom-web-components/es/components-react/horizontal-rule/horizontal-rule';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, number, text } from '@storybook/addon-knobs';
 // @ts-ignore
 import DDSTableOfContents from '@carbon/ibmdotcom-web-components/es/components-react/table-of-contents/table-of-contents';
 import DDSLinkList from '@carbon/ibmdotcom-web-components/es/components-react/link-list/link-list';
 import DDSLinkListItem from '@carbon/ibmdotcom-web-components/es/components-react/link-list/link-list-item';
 import ArrowLeft20 from '@carbon/icons-react/es/arrow--left/20.js';
-import content from './wrapper-content';
+import content, { headings, LOREM } from './wrapper-content';
 import readme from './README.stories.react.mdx';
 import styles from './table-of-contents.stories.scss';
 import { ICON_PLACEMENT } from '../../../globals/defs';
 
 export const Default = ({ parameters }) => {
-  const { withHeadingContent } = parameters?.props?.Other ?? {};
+  const { numberOfItems: items, withHeadingContent } = parameters?.props?.Other ?? {};
   return (
     <>
       <DDSTableOfContents>
@@ -50,16 +50,17 @@ export const Default = ({ parameters }) => {
             <DDSHorizontalRule slot="menu-rule"></DDSHorizontalRule>
           </>
         )}
-        {content()}
+        {content({ items })}
       </DDSTableOfContents>
     </>
   );
 };
 
-export const Horizontal = () => {
+export const Horizontal = ({ parameters }) => {
+  const { numberOfItems: items } = parameters?.props?.Other ?? {};
   return (
     <>
-      <DDSTableOfContents layout={'horizontal'}>{content()}</DDSTableOfContents>
+      <DDSTableOfContents layout={'horizontal'}>{content({ items })}</DDSTableOfContents>
     </>
   );
 };
@@ -84,6 +85,12 @@ export default {
     knobs: {
       Other: ({ groupId }) => ({
         withHeadingContent: boolean('With heading content', false, groupId),
+        numberOfItems: Array.from({
+          length: number('Number of items', 5, { min: 4, max: 8 }, groupId),
+        }).map((_, i) => ({
+          heading: text(`Section ${i + 1} heading`, headings[i % headings.length], groupId),
+          copy: text(`Section ${i + 1} copy`, `${LOREM}\n`.repeat(3).trim(), groupId),
+        })),
       }),
     },
   },

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
@@ -25,40 +25,25 @@ import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720
 import imgLg1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x720--001.jpg';
 import imgXlg16x9 from '../../../../../storybook-images/assets/1312/fpo--16x9--1312x738--001.jpg';
 
-export const Default = () => {
-  return (
-    <>
-      <DDSTableOfContents>{content()}</DDSTableOfContents>
-    </>
-  );
-};
-
-export const WithHeadingContent = ({ parameters }) => {
-  const { menuRule } = parameters?.props?.Other ?? {};
+export const Default = ({ parameters }) => {
+  const { withHeadingContent } = parameters?.props?.Other ?? {};
   return (
     <>
       <DDSTableOfContents>
-        <DDSImage slot="heading" alt="Alt text" default-src={imgLg1x1}>
-          <DDSImageItem media="(min-width: 1056px)" srcset={imgXlg16x9}></DDSImageItem>
-          <DDSImageItem media="(min-width: 672px)" srcset={imgLg16x9}></DDSImageItem>
-          <DDSImageItem media="(min-width: 400px)" srcset={imgMd16x9}></DDSImageItem>
-        </DDSImage>
-        {!menuRule ? null : <DDSHorizontalRule slot="menu-rule"></DDSHorizontalRule>}
+        {withHeadingContent && (
+          <>
+            <DDSImage slot="heading" alt="Alt text" default-src={imgLg1x1}>
+              <DDSImageItem media="(min-width: 1056px)" srcset={imgXlg16x9}></DDSImageItem>
+              <DDSImageItem media="(min-width: 672px)" srcset={imgLg16x9}></DDSImageItem>
+              <DDSImageItem media="(min-width: 400px)" srcset={imgMd16x9}></DDSImageItem>
+            </DDSImage>
+            <DDSHorizontalRule slot="menu-rule"></DDSHorizontalRule>
+          </>
+        )}
         {content()}
       </DDSTableOfContents>
     </>
   );
-};
-
-WithHeadingContent.story = {
-  name: 'With heading content',
-  parameters: {
-    knobs: {
-      Other: () => ({
-        menuRule: boolean('Put a horizontal rule', false),
-      }),
-    },
-  },
 };
 
 export const Horizontal = () => {
@@ -86,5 +71,10 @@ export default {
   parameters: {
     ...readme.parameters,
     hasStoryPadding: true,
+    knobs: {
+      Other: ({ groupId }) => ({
+        withHeadingContent: boolean('With heading content', false, groupId),
+      }),
+    },
   },
 };

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
@@ -12,18 +12,16 @@ import React from 'react';
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
 import DDSHorizontalRule from '@carbon/ibmdotcom-web-components/es/components-react/horizontal-rule/horizontal-rule';
-import DDSImage from '@carbon/ibmdotcom-web-components/es/components-react/image/image';
-import DDSImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item';
 import { boolean } from '@storybook/addon-knobs';
 // @ts-ignore
 import DDSTableOfContents from '@carbon/ibmdotcom-web-components/es/components-react/table-of-contents/table-of-contents';
+import DDSLinkList from '@carbon/ibmdotcom-web-components/es/components-react/link-list/link-list';
+import DDSLinkListItem from '@carbon/ibmdotcom-web-components/es/components-react/link-list/link-list-item';
+import ArrowLeft20 from '@carbon/icons-react/es/arrow--left/20.js';
 import content from './wrapper-content';
 import readme from './README.stories.react.mdx';
 import styles from './table-of-contents.stories.scss';
-import imgMd16x9 from '../../../../../storybook-images/assets/480/fpo--16x9--480x270--005.jpg';
-import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--001.jpg';
-import imgLg1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x720--001.jpg';
-import imgXlg16x9 from '../../../../../storybook-images/assets/1312/fpo--16x9--1312x738--001.jpg';
+import { ICON_PLACEMENT } from '../../../globals/defs';
 
 export const Default = ({ parameters }) => {
   const { withHeadingContent } = parameters?.props?.Other ?? {};
@@ -32,11 +30,23 @@ export const Default = ({ parameters }) => {
       <DDSTableOfContents>
         {withHeadingContent && (
           <>
-            <DDSImage slot="heading" alt="Alt text" default-src={imgLg1x1}>
-              <DDSImageItem media="(min-width: 1056px)" srcset={imgXlg16x9}></DDSImageItem>
-              <DDSImageItem media="(min-width: 672px)" srcset={imgLg16x9}></DDSImageItem>
-              <DDSImageItem media="(min-width: 400px)" srcset={imgMd16x9}></DDSImageItem>
-            </DDSImage>
+            <DDSLinkList slot="heading" type="vertical">
+              <DDSLinkListItem
+                iconPlacement={ICON_PLACEMENT.LEFT}
+                href="https://github.com/carbon-design-system/carbon-web-components">
+                DevOps <ArrowLeft20 slot="icon" />
+              </DDSLinkListItem>
+              <DDSLinkListItem
+                iconPlacement={ICON_PLACEMENT.LEFT}
+                href="https://github.com/carbon-design-system/carbon-web-components">
+                Automation <ArrowLeft20 slot="icon" />
+              </DDSLinkListItem>
+              <DDSLinkListItem
+                iconPlacement={ICON_PLACEMENT.LEFT}
+                href="https://github.com/carbon-design-system/carbon-web-components">
+                Development <ArrowLeft20 slot="icon" />
+              </DDSLinkListItem>
+            </DDSLinkList>
             <DDSHorizontalRule slot="menu-rule"></DDSHorizontalRule>
           </>
         )}

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
 import DDSHorizontalRule from '@carbon/ibmdotcom-web-components/es/components-react/horizontal-rule/horizontal-rule';
-import { boolean, number, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 // @ts-ignore
 import DDSTableOfContents from '@carbon/ibmdotcom-web-components/es/components-react/table-of-contents/table-of-contents';
 import DDSLinkList from '@carbon/ibmdotcom-web-components/es/components-react/link-list/link-list';
@@ -86,7 +86,7 @@ export default {
       Other: ({ groupId }) => ({
         withHeadingContent: boolean('With heading content', false, groupId),
         numberOfItems: Array.from({
-          length: number('Number of items', 5, { min: 4, max: 8 }, groupId),
+          length: select('Number of items', [5, 6, 7, 8], 5, groupId),
         }).map((_, i) => ({
           heading: text(`Section ${i + 1} heading`, headings[i % headings.length], groupId),
           copy: text(`Section ${i + 1} copy`, `${LOREM}\n`.repeat(3).trim(), groupId),

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.react.tsx
@@ -65,6 +65,22 @@ export const Horizontal = ({ parameters }) => {
   );
 };
 
+Horizontal.story = {
+  name: 'Horizontal',
+  parameters: {
+    knobs: {
+      Other: ({ groupId }) => ({
+        numberOfItems: Array.from({
+          length: select('Number of items', [5, 6, 7, 8], 5, groupId),
+        }).map((_, i) => ({
+          heading: text(`Section ${i + 1} heading`, headings[i % headings.length], groupId),
+          copy: text(`Section ${i + 1} copy`, `${LOREM}\n`.repeat(3).trim(), groupId),
+        })),
+      }),
+    },
+  },
+};
+
 export default {
   title: 'Components/Table of contents',
   decorators: [

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.ts
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.ts
@@ -9,7 +9,7 @@
 
 import { nothing } from 'lit-html';
 import { html } from 'lit-element';
-import { boolean, number, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import ArrowLeft20 from 'carbon-web-components/es/icons/arrow--left/20.js';
 import '../table-of-contents';
 import '../../horizontal-rule/horizontal-rule';
@@ -87,7 +87,7 @@ export default {
       Other: ({ groupId }) => ({
         withHeadingContent: boolean('With heading content', false, groupId),
         numberOfItems: Array.from({
-          length: number('Number of items', 5, { min: 4, max: 8 }, groupId),
+          length: select('Number of items', [5, 6, 7, 8], 5, groupId),
         }).map((_, i) => ({
           heading: text(`Section ${i + 1} heading`, headings[i % headings.length], groupId),
           copy: text(`Section ${i + 1} copy`, `${LOREM}\n`.repeat(3).trim(), groupId),

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.ts
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.ts
@@ -10,17 +10,16 @@
 import { nothing } from 'lit-html';
 import { html } from 'lit-element';
 import { boolean } from '@storybook/addon-knobs';
+import ArrowLeft20 from 'carbon-web-components/es/icons/arrow--left/20.js';
 import '../table-of-contents';
 import '../../horizontal-rule/horizontal-rule';
 import '../../image/image';
+import '../../link-list/link-list';
 import content from './content';
 import styles from './table-of-contents.stories.scss';
 import readme from './README.stories.mdx';
-import imgMd16x9 from '../../../../../storybook-images/assets/480/fpo--16x9--480x270--005.jpg';
-import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--001.jpg';
-import imgLg1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x720--001.jpg';
-import imgXlg16x9 from '../../../../../storybook-images/assets/1312/fpo--16x9--1312x738--001.jpg';
 import { TOC_TYPES } from '../defs';
+import { ICON_PLACEMENT } from '../../../globals/defs';
 
 export const Default = ({ parameters }) => {
   const { withHeadingContent } = parameters?.props?.Other ?? {};
@@ -28,11 +27,26 @@ export const Default = ({ parameters }) => {
     <dds-table-of-contents>
       ${withHeadingContent
         ? html`
-            <dds-image slot="heading" alt="Alt text" default-src="${imgLg1x1}">
-              <dds-image-item media="(min-width: 1056px)" srcset="${imgXlg16x9}"> </dds-image-item>
-              <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}"> </dds-image-item>
-              <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}"> </dds-image-item>
-            </dds-image>
+            <dds-link-list type="vertical" slot="heading">
+              <dds-link-list-item
+                icon-placement="${ICON_PLACEMENT.LEFT}"
+                href="https://github.com/carbon-design-system/carbon-web-components"
+              >
+                DevOps${ArrowLeft20({ slot: 'icon' })}
+              </dds-link-list-item>
+              <dds-link-list-item
+                icon-placement="${ICON_PLACEMENT.LEFT}"
+                href="https://github.com/carbon-design-system/carbon-web-components"
+              >
+                Automation${ArrowLeft20({ slot: 'icon' })}
+              </dds-link-list-item>
+              <dds-link-list-item
+                icon-placement="${ICON_PLACEMENT.LEFT}"
+                href="https://github.com/carbon-design-system/carbon-web-components"
+              >
+                Development${ArrowLeft20({ slot: 'icon' })}
+              </dds-link-list-item>
+            </dds-link-list>
             <dds-hr slot="menu-rule"></dds-hr>
           `
         : nothing}

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.ts
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.ts
@@ -9,20 +9,20 @@
 
 import { nothing } from 'lit-html';
 import { html } from 'lit-element';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, number, text } from '@storybook/addon-knobs';
 import ArrowLeft20 from 'carbon-web-components/es/icons/arrow--left/20.js';
 import '../table-of-contents';
 import '../../horizontal-rule/horizontal-rule';
 import '../../image/image';
 import '../../link-list/link-list';
-import content from './content';
+import content, { headings, LOREM } from './content';
 import styles from './table-of-contents.stories.scss';
 import readme from './README.stories.mdx';
 import { TOC_TYPES } from '../defs';
 import { ICON_PLACEMENT } from '../../../globals/defs';
 
 export const Default = ({ parameters }) => {
-  const { withHeadingContent } = parameters?.props?.Other ?? {};
+  const { numberOfItems: items, withHeadingContent } = parameters?.props?.Other ?? {};
   return html`
     <dds-table-of-contents>
       ${withHeadingContent
@@ -50,20 +50,23 @@ export const Default = ({ parameters }) => {
             <dds-hr slot="menu-rule"></dds-hr>
           `
         : nothing}
-      ${content('bx--tableofcontents__contents')}
+      ${content({ contentClass: 'bx--tableofcontents__contents', items })}
     </dds-table-of-contents>
   `;
 };
 
-export const Horizontal = () => html`
-  <dds-table-of-contents toc-layout="${TOC_TYPES.HORIZONTAL}">
-    <div class="bx--row">
-      <div class="bx--col-lg-12">
-        ${content('bx--tableofcontents-horizontal__contents')}
+export const Horizontal = ({ parameters }) => {
+  const { numberOfItems: items } = parameters?.props?.Other ?? {};
+  return html`
+    <dds-table-of-contents toc-layout="${TOC_TYPES.HORIZONTAL}">
+      <div class="bx--row">
+        <div class="bx--col-lg-12">
+          ${content({ contentClass: 'bx--tableofcontents-horizontal__contents', items })}
+        </div>
       </div>
-    </div>
-  </dds-table-of-contents>
-`;
+    </dds-table-of-contents>
+  `;
+};
 
 export default {
   title: 'Components/Table of contents',
@@ -81,8 +84,14 @@ export default {
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {
-      Other: () => ({
-        withHeadingContent: boolean('With heading content', false),
+      Other: ({ groupId }) => ({
+        withHeadingContent: boolean('With heading content', false, groupId),
+        numberOfItems: Array.from({
+          length: number('Number of items', 5, { min: 4, max: 8 }, groupId),
+        }).map((_, i) => ({
+          heading: text(`Section ${i + 1} heading`, headings[i % headings.length], groupId),
+          copy: text(`Section ${i + 1} copy`, `${LOREM}\n`.repeat(3).trim(), groupId),
+        })),
       }),
     },
   },

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.ts
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.ts
@@ -22,40 +22,23 @@ import imgLg1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x7
 import imgXlg16x9 from '../../../../../storybook-images/assets/1312/fpo--16x9--1312x738--001.jpg';
 import { TOC_TYPES } from '../defs';
 
-export const Default = () => html`
-  <dds-table-of-contents>
-    ${content('bx--tableofcontents__contents')}
-  </dds-table-of-contents>
-`;
-
-export const WithHeadingContent = ({ parameters }) => {
-  const { menuRule } = parameters?.props?.Other ?? {};
+export const Default = ({ parameters }) => {
+  const { withHeadingContent } = parameters?.props?.Other ?? {};
   return html`
     <dds-table-of-contents>
-      <dds-image slot="heading" alt="Alt text" default-src="${imgLg1x1}">
-        <dds-image-item media="(min-width: 1056px)" srcset="${imgXlg16x9}"> </dds-image-item>
-        <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}"> </dds-image-item>
-        <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}"> </dds-image-item>
-      </dds-image>
-      ${!menuRule
-        ? nothing
-        : html`
+      ${withHeadingContent
+        ? html`
+            <dds-image slot="heading" alt="Alt text" default-src="${imgLg1x1}">
+              <dds-image-item media="(min-width: 1056px)" srcset="${imgXlg16x9}"> </dds-image-item>
+              <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}"> </dds-image-item>
+              <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}"> </dds-image-item>
+            </dds-image>
             <dds-hr slot="menu-rule"></dds-hr>
-          `}
+          `
+        : nothing}
       ${content('bx--tableofcontents__contents')}
     </dds-table-of-contents>
   `;
-};
-
-WithHeadingContent.story = {
-  name: 'With heading content',
-  parameters: {
-    knobs: {
-      Other: () => ({
-        menuRule: boolean('Put a horizontal rule', false),
-      }),
-    },
-  },
 };
 
 export const Horizontal = () => html`
@@ -83,5 +66,10 @@ export default {
   parameters: {
     ...readme.parameters,
     hasStoryPadding: true,
+    knobs: {
+      Other: () => ({
+        withHeadingContent: boolean('With heading content', false),
+      }),
+    },
   },
 };

--- a/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.ts
+++ b/packages/web-components/src/components/table-of-contents/__stories__/table-of-contents.stories.ts
@@ -68,6 +68,22 @@ export const Horizontal = ({ parameters }) => {
   `;
 };
 
+Horizontal.story = {
+  name: 'Horizontal',
+  parameters: {
+    knobs: {
+      Other: ({ groupId }) => ({
+        numberOfItems: Array.from({
+          length: select('Number of items', [5, 6, 7, 8], 5, groupId),
+        }).map((_, i) => ({
+          heading: text(`Section ${i + 1} heading`, headings[i % headings.length], groupId),
+          copy: text(`Section ${i + 1} copy`, `${LOREM}\n`.repeat(3).trim(), groupId),
+        })),
+      }),
+    },
+  },
+};
+
 export default {
   title: 'Components/Table of contents',
   decorators: [

--- a/packages/web-components/src/components/table-of-contents/__stories__/wrapper-content.tsx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/wrapper-content.tsx
@@ -10,191 +10,33 @@
 // @ts-nocheck
 import React from 'react';
 
-/* eslint-disable jsx-a11y/anchor-is-valid */
-const content = () => (
+export const headings = [
+  'Forward thinkers',
+  'Innovation and transformation',
+  'Client success stories',
+  'Iconic moments in IBM history',
+  'Trust and responsibility',
+  'Connect with IBM',
+];
+
+// eslint-disable-next-line max-len
+export const LOREM = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
+nisl.`;
+
+const generateCopySections = (n: Number) => [...Array(n)].map(() => <p>{LOREM}</p>);
+
+const content = ({ items }: { items: Array }) => (
   <div className="bx--tableofcontents__contents dds-ce-demo--table-of-contents">
-    <a name="8">
-      <h3>Forward thinkers</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <a name="7">
-      <h3>Innovation and transformation</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <a name="2">
-      <h3>Client success stories</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <a name="3">
-      <h3>Iconic moments in IBM history</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <a name="14">
-      <h3>Trust and responsibility</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <a name="15">
-      <h3>Connect with IBM</h3>
-    </a>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia
-      elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien
-      volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis.
-      Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in
-      faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non
-      vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque
-      nisl.
-    </p>
+    {items?.map(({ heading, copy }, i: Number) => (
+      <>
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+        <a name={i}>
+          <h3>{heading}</h3>
+        </a>
+        {copy ? copy.split('\n').map((section: String) => <p>{section}</p>) : generateCopySections(3)}
+      </>
+    ))}
   </div>
 );
-/* eslint-enable jsx-a11y/anchor-is-valid */
 
 export default content;

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/table-of-contents/table-of-contents.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/table-of-contents/table-of-contents.e2e.js
@@ -13,7 +13,6 @@
  */
 const _paths = {
   default: 'iframe.html?id=components-table-of-contents--default',
-  heading: 'iframe.html?id=components-table-of-contents--with-heading-content',
   horizontal: 'iframe.html?id=components-table-of-contents--horizontal',
 };
 
@@ -240,19 +239,6 @@ describe('dds-table-of-contents | default (desktop)', () => {
   it('should render correctly in all themes', _tests.all.screenshotThemes);
 });
 
-describe('dds-table-of-contents | with heading content (desktop)', () => {
-  beforeEach(() => {
-    cy.viewport(1280, 720);
-    cy.visit(`/${_paths.heading}`);
-  });
-
-  it('should load table of contents sidebar with links', _tests.desktop.checkRender);
-  it('should navigate content to selected section', _tests.desktop.checkLinkFunctionality);
-  xit('should update current section on scroll', _tests.desktop.checkScrollSpy);
-  it('should remain visible on page throughout scroll', _tests.desktop.checkStickyNav);
-  it('should render correctly in all themes', _tests.all.screenshotThemes);
-});
-
 describe('dds-table-of-contents | horizontal (desktop)', () => {
   beforeEach(() => {
     cy.viewport(1280, 720);
@@ -270,19 +256,6 @@ describe('dds-table-of-contents | default (mobile)', () => {
   beforeEach(() => {
     cy.viewport(320, 720);
     cy.visit(`/${_paths.default}`);
-  });
-
-  it('should load table of contents sidebar with links', _tests.mobile.checkRender);
-  it('should navigate content to selected section', _tests.mobile.checkLinkFunctionality);
-  xit('should update current section on scroll', _tests.mobile.checkScrollSpy);
-  it('should remain visible on page throughout scroll', _tests.mobile.checkStickyNav);
-  it('should render correctly in all themes', _tests.all.screenshotThemes);
-});
-
-describe('dds-table-of-contents | with heading content (mobile)', () => {
-  beforeEach(() => {
-    cy.viewport(320, 720);
-    cy.visit(`/${_paths.heading}`);
   });
 
   it('should load table of contents sidebar with links', _tests.mobile.checkRender);


### PR DESCRIPTION
### Related Ticket(s)

#5644

### Description

This PR updates the web components, React wrapper, and React storybook Table of Contents stories according to match the expected content described in #5644:

* only "Default" (vertical) and "Horizontal" stories remain
* "With heading content" knob in default story toggles a link list header instead of an image
![image](https://user-images.githubusercontent.com/8265238/142069983-473b9645-1fff-4861-bfa6-980c10ce1d4a.png)

* the number of items is limited from 4-8 and the copy can be customized. This does not work properly in the web components storybook UI so you will need to view the story in a separate tab. This will work in the React storybook after #7687 is merged

### Changelog

**New**

- dynamic content knobs (the table of contents component does not update when its child elements change though, need to view story in new tab for updates)
- "Horizontal" story in React
- "Default" story in React

**Changed**

- "Default" story in web components and react wrapper

**Removed**

- obsolete React stories
- "With heading content" stories in all storybooks

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
