### PR TITLE
fix(Masthead): add optional chaining to root.location to remove error in NextJS when rendering server-side

### DIFF
--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -31,7 +31,7 @@ const MastheadL1 = ({ navigationL1, ...rest }) => {
 
   const mastheadL1Links = navigationL1.map((link, index) => {
     const selectedUrlItem =
-      childLinkChecker && childLinkChecker(link, root.location.href);
+      childLinkChecker && childLinkChecker(link, root.location?.href);
     const autoid = `${stablePrefix}--masthead-${rest.navType}__l1-nav${index}`;
     const selected = rest.selectedMenuItem
       ? link.titleEnglish === rest.selectedMenuItem

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -48,7 +48,7 @@ const MastheadLeftNav = ({
       key = '',
       parentItemUrl = '',
     }) => {
-      const currentUrlPath = root.location.href;
+      const currentUrlPath = root.location?.href;
       if (!matchFound) {
         if (parentItemUrl === currentUrlPath) {
           selectedItems.level0 = `${key}`;

--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -36,7 +36,7 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
    */
   const mastheadLinks = navigation.map((link, i) => {
     const selectedUrlItem =
-      childLinkChecker && childLinkChecker(link, root.location.href);
+      childLinkChecker && childLinkChecker(link, root.location?.href);
     const autoid = `${stablePrefix}--masthead-${topNavProps.navType}__l0-nav${i}`;
     const selected = topNavProps.selectedMenuItem
       ? link.titleEnglish === topNavProps.selectedMenuItem

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -482,7 +482,7 @@ class DDSMastheadComposite extends LitElement {
     target: NAV_ITEMS_RENDER_TARGET;
     hasL1: boolean;
   }) {
-    const currentUrlPath = root.location.href;
+    const currentUrlPath = root.location?.href;
     const hasChildLink = this._childLinkChecker();
     const { navLinks, l1Data } = this;
     let menu: MastheadLink[] | undefined = navLinks;


### PR DESCRIPTION
### Related Ticket(s)

DotcomShell component L1 not working #7678

### Description

When setting up DotcomShell with L1 in NextJS template, adopter is running into an error specifically with ` const currentUrlPath = root.location.href;`. Seems like NextJS is trying to load it server-side and throws an error that `root.location` is undefined. Adding optional chaining resolves this issue.

### Changelog

**Changed**

- add optional chaining to `currentUrlPath`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
