### PR TITLE
fix(Masthead): use `window` or `global` object

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -148,7 +148,7 @@ const Masthead = ({
     [`${prefix}--masthead__header--search-active`]: isSearchActive,
   });
 
-  const [scrollOffset, setScrollOffset] = useState(window.scrollY);
+  const [scrollOffset, setScrollOffset] = useState(root.scrollY);
 
   useEffect(() => {
     /**


### PR DESCRIPTION
### Related Ticket(s)

#7707
#6391

### Description

This PR updates a `window` object reference to `root` to avoid NPE issues when server side rendering the React Masthead

### Changelog

**Changed**

- React Masthead `window` object reference to `root`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
