### PR TITLE
fix(link-list): remove unneeded vertical padding

### DIFF
--- a/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
@@ -439,6 +439,11 @@ $hover-transition-timing: 95ms;
       }
     }
   }
+
+  .#{$prefix}--tableofcontents .#{$prefix}--link-list {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 }
 
 @include exports('tableofcontents') {


### PR DESCRIPTION
### Related Ticket(s)

related #5644
unblocks #7676

### Description

This removes the vertical padding on the vertical React LinkList to match the spec, overriding changes in #1688 and #2452

### Changelog

**Removed**

- vertical React Link List padding

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
