### PR TITLE
chore(support): update fireline roster for sprint 24

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -3,7 +3,7 @@ description:
   Something isn't working as expected? Here is the right place to report.
 title: '[YOUR TITLE]: Brief description'
 assignees:
-  - jeffchew,ljcarot,shixiedesign,RobertaJHahn,photodow,andysherman2121,annawen1
+  - jeffchew,ljcarot,shixiedesign,RobertaJHahn,RichKummer,kennylam,BrunnoM7
 labels: ['bug']
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/contribution_request.yaml
+++ b/.github/ISSUE_TEMPLATE/contribution_request.yaml
@@ -3,7 +3,7 @@ description:
   Contribute things large and small — code, design, ideas, and guidance.
 title: '[YOUR TITLE]: Brief description'
 assignees:
-  - jeffchew,ljcarot,shixiedesign,RobertaJHahn,photodow,andysherman2121,annawen1
+  - jeffchew,ljcarot,shixiedesign,RobertaJHahn,RichKummer,kennylam,BrunnoM7
 labels: ['contribution']
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -3,7 +3,7 @@ description:
   Suggest a new idea for the project.
 title: '[YOUR TITLE]: Brief description'
 assignees:
-  - jeffchew,ljcarot,shixiedesign,RobertaJHahn,photodow,andysherman2121,annawen1
+  - jeffchew,ljcarot,shixiedesign,RobertaJHahn,RichKummer,kennylam,BrunnoM7
 labels: ['Feature request']
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -3,7 +3,7 @@ description:
   Usage question or discussion about Carbon for IBM.com.
 title: '[YOUR TITLE]: Brief description'
 assignees:
-  - jeffchew,ljcarot,shixiedesign,RobertaJHahn,photodow,andysherman2121,annawen1
+  - jeffchew,ljcarot,shixiedesign,RobertaJHahn,RichKummer,kennylam,BrunnoM7
 labels: ['question']
 body:
   - type: markdown


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This will update the fireline support roster for sprint 24.

### Changelog

**Changed**

- Updated issue templates
