### PR TITLE
chore(leaving-ibm): update `leaving-ibm` docs

### DIFF
--- a/packages/web-components/src/components/leaving-ibm/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/leaving-ibm/__stories__/README.stories.mdx
@@ -29,8 +29,11 @@ import '@carbon/ibmdotcom-web-components/es/components/leaving-ibm/index';
 ### HTML
 
 ```html
-<dds-leaving-ibm-container ?open="true" href="http://example.com/"> </dds-leaving-ibm-container>
+<dds-leaving-ibm-container open="true" href="http://example.com/"> </dds-leaving-ibm-container>
 ```
+
+> 💡 The modal state must be set manually by the triggering element. Alternatively, the component could be placed in a reusable function or component if multiple external links are present. 
+> See available custom events available to the modal [here](https://web-components.carbondesignsystem.com/?path=/docs/components-modal--default#bx-modal-attributes-and-properties).
 
 ## Stable selectors
 

--- a/packages/web-components/src/components/leaving-ibm/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/leaving-ibm/__stories__/README.stories.react.mdx
@@ -26,11 +26,14 @@ import DDSLeavingIbmContainer, { store } from '@carbon/ibmdotcom-web-components/
 function App() {
   return (
     <Provider store={store}>
-      <DDSLeavingIbmContainer href="https://www.carbondesignsystem.com/all-about-carbon/what-is-carbon/" open />
+      <DDSLeavingIbmContainer href="https://www.carbondesignsystem.com/all-about-carbon/what-is-carbon/" open="true" />
     </Provider>
   );
 }
 ```
+
+> 💡 The modal state must be set manually by the triggering element. Alternatively, the component could be placed in a reusable function or component if multiple external links are present. 
+> See available custom events available to the modal [here](https://web-components.carbondesignsystem.com/?path=/docs/components-modal--default#bx-modal-attributes-and-properties).
 
 ## Props
 


### PR DESCRIPTION
### Related Ticket(s)

#7738 

### Description

This updates `leaving-ibm` documentation to instruct users on what is required to trigger the modal.

### Changelog

**New**

- short instructions pointing out the need to manually set the modal state, as well as links to the modal's custom events


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
