### PR TITLE
chore(percy): skip cards with video in percy diffs

### DIFF
--- a/packages/web-components/src/components/carousel/__stories__/carousel.stories.ts
+++ b/packages/web-components/src/components/carousel/__stories__/carousel.stories.ts
@@ -122,6 +122,12 @@ CardsWithImages.story = {
 
 CardsWithVideos.story = {
   name: 'Cards with videos',
+  parameters: {
+    ...readme.parameters,
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export default {


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This will skip the `Carousel | Cards with Video` story in Percy diff checking, as the async data is causing false positives in reports.

### Changelog

**Changed**

- Add `percy: skip` to the `Carousel | Cards with Video` story
