### PR TITLE
chore(dotcomshell): update `card-group` component example

### DIFF
--- a/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
@@ -87,9 +87,9 @@ const cardGroupItems = html`
     <dds-image slot="image" alt="Image alt text" default-src="${imgXlg4x3}"> </dds-image>
     <dds-card-eyebrow>Topic</dds-card-eyebrow>
     <dds-card-heading>Natural Language Processing.</dds-card-heading>
-    <dds-card-footer slot="footer">
+    <dds-card-cta-footer slot="footer">
       ${ArrowRight20({ slot: 'icon' })}
-    </dds-card-footer>
+    </dds-card-cta-footer>
   </dds-card-group-item>
 `;
 


### PR DESCRIPTION
### Related Ticket(s)

#7766 

### Description

Update `card-group` example with latest markup.

### Changelog

**Changed**

- change `dds-card-footer` to `dds-card-cta-footer`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
