### PR TITLE
fix(carousel): add null check for carousel same height method

### DIFF
--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -193,7 +193,7 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
 
     this._childItemHeadings.forEach(e => {
       // add tag group height to heading to the cards lacking tag group
-      if (e && !e.nextElementSibling.matches((this.constructor as typeof DDSCardGroup).selectorItemTagGroup)) {
+      if (e && !e.nextElementSibling?.matches((this.constructor as typeof DDSCardGroup).selectorItemTagGroup)) {
         e.style.marginBottom = `${tagGroupHeight + headingBottomMargin}px`;
       }
     });

--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -349,7 +349,7 @@ class DDSCarousel extends HostListenerMixin(StableSelectorMixin(LitElement)) {
 
     this._childItemHeadings.forEach(e => {
       // add tag group height to heading to the cards lacking tag group
-      if (e && !e.nextElementSibling.matches((this.constructor as typeof DDSCarousel).selectorItemTagGroup)) {
+      if (e && !e.nextElementSibling?.matches((this.constructor as typeof DDSCarousel).selectorItemTagGroup)) {
         e.style.marginBottom = `${tagGroupHeight + headingBottomMargin}px`;
       }
     });


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

We were occasionally getting exception errors on a NextJS page that loaded in the carousel, which seems to be stemming from the internal `_setSameHeight` method:

![image](https://user-images.githubusercontent.com/1641214/143896734-aaae8378-12d7-4eb9-b0bf-60a6d196d950.png)

![image](https://user-images.githubusercontent.com/1641214/143896748-324bcb47-4054-408f-8450-de54ecb636e7.png)

![image](https://user-images.githubusercontent.com/1641214/143896851-c84274b8-29e2-4137-bcd1-e11a2031c21b.png)

Adding a null check in this method will hopefully fix the issues here.

### Changelog

**Changed**

- Added optional chaining in `_setSameHeight` method in `carousel.ts`
