### PR TITLE
fix(image-with-caption): revert caption requirement

### DIFF
--- a/packages/react/src/components/ImageWithCaption/ImageWithCaption.js
+++ b/packages/react/src/components/ImageWithCaption/ImageWithCaption.js
@@ -95,7 +95,7 @@ ImageWithCaption.propTypes = {
   /**
    * Caption text.
    */
-  heading: PropTypes.string.isRequired,
+  heading: PropTypes.string,
 
   /**
    * More detailed description of the image.

--- a/packages/web-components/src/components/image-with-caption/image-with-caption.ts
+++ b/packages/web-components/src/components/image-with-caption/image-with-caption.ts
@@ -78,7 +78,7 @@ class DDSImageWithCaption extends StableSelectorMixin(ModalRenderMixin(FocusMixi
    * The heading.
    */
   @property({ reflect: true })
-  heading = 'this is a required caption';
+  heading = '';
 
   @property({ attribute: 'launch-lightbox-button-assistive-text' })
   launchLightboxButtonAssistiveText = 'launch light box media viewer';

--- a/packages/web-components/tests/snapshots/dds-image-with-caption.md
+++ b/packages/web-components/tests/snapshots/dds-image-with-caption.md
@@ -14,7 +14,6 @@
   </slot>
 </dds-image>
 <p class="bx--image__caption">
-  this is a required caption
 </p>
 
 ```


### PR DESCRIPTION
This reverts commit 335a02bd06652e7acadd6a6ff6579a05b210a4a3.

### Related Ticket(s)

#6871
#7257

related Slack thread https://cognitive-app.slack.com/archives/C2PLX8GQ6/p1638980498318300

### Description

This PR removes the default value and reverts the required caption in the image with caption component

### Changelog

**New**

- {{new thing}}

**Changed**

- `heading` requirement in ImageWithCaption

**Removed**

- default image-with-caption `heading` value

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
