### PR TITLE
docs(masthead): add missing sandbox dependency

### DIFF
--- a/packages/web-components/examples/codesandbox/components/masthead/package.json
+++ b/packages/web-components/examples/codesandbox/components/masthead/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0-0",
     "carbon-components": "^10.36.0",
+    "lit-element": "^2.5.1",
     "parcel-bundler": "1.12.3",
     "rimraf": "^3.0.2",
     "sass": "^1.32.13"

--- a/packages/web-components/examples/codesandbox/components/masthead/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/masthead/src/index.js
@@ -10,6 +10,13 @@
 import '@carbon/ibmdotcom-web-components/es/components/masthead/masthead-container.js';
 import './index.scss';
 
+/**
+ * the `lit-element` package is not required in `package.json`, but is included
+ * in this example for CodeSandbox compatibility
+ *
+ * https://github.com/codesandbox/codesandbox-client/issues/4456
+ */
+
 window.digitalData = {
   page: {
     pageInfo: {


### PR DESCRIPTION
### Related Ticket(s)

#7847

### Description

This PR adds a missing dependency to the masthead sandbox example so that it displays without any build errors

The working sandbox should be viewable at https://codesandbox.io/s/github/emyarod/carbon-for-ibm-dotcom/tree/7847-docs/masthead-sandbox-example/packages/web-components/examples/codesandbox/components/masthead

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
