### PR TITLE
test(card-section-images): yield images in card group items

### DIFF
--- a/packages/web-components/tests/e2e-storybook/cypress/integration/card-section-images/card-section-images.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/card-section-images/card-section-images.e2e.js
@@ -93,7 +93,7 @@ describe('dds-card-section-images | default (mobile)', () => {
       });
 
     cy.get('dds-card-group-item > dds-image').each($img => {
-      expect($img).to.be.visible;
+      cy.wrap($img).should('be.visible');
     });
 
     cy.get('dds-card-group-item > dds-card-eyebrow').each($eyebrow => {


### PR DESCRIPTION
### Related Ticket(s)

#7880

### Description

This PR wraps the card group item images in Cypress to ensure that they are visible before testing

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
