### PR TITLE
fix(card-section-image): fix to image check in e2e tests

### DIFF
--- a/packages/web-components/tests/e2e-storybook/cypress/integration/card-section-images/card-section-images.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/card-section-images/card-section-images.e2e.js
@@ -28,12 +28,9 @@ describe('dds-card-section-images | default (desktop)', () => {
         expect(url).not.to.be.empty;
       });
 
-    cy.get('dds-card-group-item:nth-child(1) > dds-image')
-      .shadow()
-      .find('img')
-      .then($img => {
-        expect($img).to.be.visible;
-      });
+    cy.get('dds-card-group-item > dds-image').each($img => {
+      cy.wrap($img).should('be.visible');
+    });
 
     cy.get('dds-card-group-item > dds-card-eyebrow').each($eyebrow => {
       expect($eyebrow).to.be.visible;


### PR DESCRIPTION
### Related Ticket(s)

#7880 

### Description

This fixes the desktop e2e test for `dds-card-section-images` to wrap the image before testing.

### Changelog

**Changed**

- `card-section-images.e2e.js`

