### PR TITLE
test(link-with-icon): add e2e tests

### DIFF
--- a/packages/react/tests/e2e-storybook/cypress/integration/LinkWithIcon/Default.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/LinkWithIcon/Default.e2e.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+/**
+ * Defines the component path.
+ *
+ * @type {string}
+ * @private
+ */
+const _path = '/iframe.html?id=components-link-with-icon--default';
+
+/**
+ * Defines the component selector.
+ *
+ * @type {string}
+ * @private
+ */
+const _selector = '[data-autoid="dds--link-with-icon"]';
+
+/**
+ * Collection of test scenarios.
+ *
+ * @type {Array<function>}
+ * @private
+ */
+const _tests = [
+  () => {
+    it('should render link text', () => {
+      cy.visit(_path)
+        .get(_selector)
+        .should('not.be.empty');
+    });
+  },
+  () => {
+    it('should have a clickable link', () => {
+      cy.visit(_path)
+        .get(_selector)
+        .find('a')
+        .should($link => {
+          expect($link.prop('href')).not.to.be.empty;
+        });
+    });
+  },
+  () => {
+    it('should not be clickable when disabled', () => {
+      cy.visit(`${_path}&knob-Disabled%20(disabled):_LinkWithIcon=true`)
+        .get(_selector)
+        .find('a')
+        .should('have.length', 0);
+    });
+  },
+  () => {
+    it('should optionally allow visited styles', () => {
+      cy.visit(
+        `${_path}&knob-Allow%20visited%20styles%20(visited):_LinkWithIcon=true`
+      )
+        .get(_selector)
+        .find('a')
+        .should('have.class', 'bx--link--visited');
+    });
+  },
+  () => {
+    it('should check icon placements', () => {
+      ['left', 'right'].forEach(placement => {
+        cy.visit(
+          `${_path}&knob-Icon%20placement%20(iconPlacement):_LinkWithIcon=${placement}`
+        )
+          .get(_selector)
+          .find('a')
+          .should($link => {
+            const svgPosition = $link.find('svg')[0].getBoundingClientRect();
+            const textPosition = $link.find('span')[0].getBoundingClientRect();
+
+            if (placement === 'left') {
+              expect(svgPosition.left).to.be.lt(textPosition.left);
+            } else {
+              expect(svgPosition.left).to.be.gt(textPosition.left);
+            }
+          });
+      });
+    });
+  },
+  () => {
+    it('should render correctly in all themes', () => {
+      cy.visit(_path).carbonThemesScreenshot({
+        capture: 'viewport',
+      });
+    });
+  },
+];
+
+describe('dds-link-with-icon | default (desktop)', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 780);
+  });
+
+  _tests.forEach(test => test());
+});
+
+describe('dds-link-with-icon | default (mobile)', () => {
+  beforeEach(() => {
+    cy.viewport(325, 720);
+  });
+
+  _tests.forEach(test => test());
+});

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/link-with-icon/default.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/link-with-icon/default.e2e.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+/**
+ * Defines the component path.
+ *
+ * @type {string}
+ * @private
+ */
+const _path = '/iframe.html?id=components-link-with-icon--default';
+
+/**
+ * Defines the component selector.
+ *
+ * @type {string}
+ * @private
+ */
+const _selector = '[data-autoid="dds--link-with-icon"]';
+
+/**
+ * Collection of test scenarios.
+ *
+ * @type {Array<function>}
+ * @private
+ */
+const _tests = [
+  () => {
+    it('should render customizable link text', () => {
+      let defaultCopy, customCopyOutput;
+      const customCopyInput = 'Consectetur adipiscing elit.';
+
+      cy.visit(_path)
+        .get(_selector)
+        .then(([copy]) => {
+          defaultCopy = copy.innerText.trim();
+        })
+        .visit(`${_path}&knob-Link%20text%20(unnamed%20slot)_LinkWithIcon=${customCopyInput}`)
+        .get(_selector)
+        .should(([copy]) => {
+          customCopyOutput = copy.innerText.trim();
+
+          expect(customCopyOutput).to.be.eq(customCopyInput);
+          expect(customCopyOutput).to.not.eq(defaultCopy);
+        });
+    });
+  },
+  () => {
+    it('should have a customizable and clickable link', () => {
+      let defaultHref, customHrefOutput;
+      const customHrefInput = 'https://www.example.com/foo';
+
+      cy.visit(_path)
+        .get(_selector)
+        .shadow()
+        .find('a')
+        .should($link => {
+          defaultHref = $link.prop('href');
+
+          expect($link.prop('href')).not.to.be.empty;
+        })
+        .visit(`${_path}&knob-Link%20href%20(href)_LinkWithIcon=${customHrefInput}`)
+        .get(_selector)
+        .shadow()
+        .find('a')
+        .should($link => {
+          customHrefOutput = $link.prop('href');
+
+          expect(customHrefOutput).to.be.eq(customHrefInput);
+          expect(customHrefOutput).to.not.eq(defaultHref);
+        });
+    });
+  },
+  () => {
+    it('should not be clickable when disabled', () => {
+      cy.visit(`${_path}&knob-Disabled%20(disabled)_LinkWithIcon=true`)
+        .get(_selector)
+        .shadow()
+        .find('a')
+        .should('have.length', 0);
+    });
+  },
+  () => {
+    it('should check icon placements', () => {
+      ['left', 'right'].forEach(placement => {
+        let $svg;
+        cy.visit(`${_path}&knob-Icon%20Position%20(icon-placement):_LinkWithIcon=${placement}`)
+          .get(_selector)
+          .then($elem => {
+            $svg = $elem.find('svg');
+          })
+          .shadow()
+          .find('a')
+          .should($link => {
+            const svgPosition = $svg[0].getBoundingClientRect();
+            const textPosition = $link.find('span')[0].getBoundingClientRect();
+
+            if (placement === 'left') {
+              expect(svgPosition.left).to.be.lt(textPosition.left);
+            } else {
+              expect(svgPosition.left).to.be.gt(textPosition.left);
+            }
+          });
+      });
+    });
+  },
+  () => {
+    it('should render correctly in all themes', () => {
+      cy.visit(_path).carbonThemesScreenshot({
+        capture: 'viewport',
+      });
+    });
+  },
+];
+
+describe('dds-link-with-icon | default (desktop)', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 780);
+  });
+
+  _tests.forEach(test => test());
+});
+
+describe('dds-link-with-icon | default (mobile)', () => {
+  beforeEach(() => {
+    cy.viewport(325, 720);
+  });
+
+  _tests.forEach(test => test());
+});


### PR DESCRIPTION
### Related Ticket(s)

Resolves #7841

### Description

Adds e2e test coverage for the `Link with Icon` component in both the `react` and `web-components` packages.

### Changelog

**New**

- Adds e2e-storybook tests for `dds-link-with-icon` web component
- Adds e2e-storybook tests for `LinkWithIcon` React component

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
