### PR TITLE
fix(masthead): align react and wc mobile menu styles

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -198,18 +198,28 @@
       min-height: 3rem;
       border-bottom: 1px solid $ui-04;
       align-items: center;
+      text-decoration: none;
+
+      &:focus {
+        outline: 2px solid $focus;
+        outline-offset: -2px;
+      }
     }
 
     .#{$prefix}--side-nav__item
       .#{$prefix}--masthead__side-nav--submemu-section-title {
       height: auto;
       min-height: 3rem;
+      padding: 0;
 
       span {
         @include carbon--type-style(productive-heading-02);
 
         display: flex;
         width: 100%;
+        padding: 0.8rem 1rem;
+        color: $text-01;
+        border-bottom: 1px solid $ui-04;
       }
     }
 
@@ -291,6 +301,7 @@
 
         color: $link-01;
         display: flex;
+        border-bottom: none;
         align-items: center;
       }
 
@@ -447,7 +458,8 @@
     .#{$prefix}--side-nav__link,
   :host(dds-left-nav-menu-section)
     .#{$prefix}--masthead__side-nav--submemu-back
-    .#{$prefix}--side-nav__link,
+    .#{$prefix}--side-nav__link
+    .#{$prefix}--side-nav__link-text,
   :host(#{$dds-prefix}-left-nav-menu-item[last-highlighted])
     .#{$prefix}--side-nav__link {
     border-bottom: none;

--- a/packages/web-components/src/components/masthead/left-nav-menu-section.ts
+++ b/packages/web-components/src/components/masthead/left-nav-menu-section.ts
@@ -17,7 +17,6 @@ import ChevronDown20 from 'carbon-web-components/es/icons/chevron--down/20.js';
 import FocusMixin from 'carbon-web-components/es/globals/mixins/focus.js';
 import { selectorTabbable } from 'carbon-web-components/es/globals/settings.js';
 import { forEach } from '../../globals/internal/collection-helpers';
-import './left-nav-item';
 import styles from './masthead.scss';
 import DDSLeftNav from './left-nav';
 

--- a/packages/web-components/src/components/masthead/left-nav-menu-section.ts
+++ b/packages/web-components/src/components/masthead/left-nav-menu-section.ts
@@ -13,9 +13,11 @@ import HostListener from 'carbon-web-components/es/globals/decorators/host-liste
 import HostListenerMixin from 'carbon-web-components/es/globals/mixins/host-listener';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import ChevronLeft20 from 'carbon-web-components/es/icons/chevron--left/20.js';
+import ChevronDown20 from 'carbon-web-components/es/icons/chevron--down/20.js';
 import FocusMixin from 'carbon-web-components/es/globals/mixins/focus.js';
 import { selectorTabbable } from 'carbon-web-components/es/globals/settings.js';
 import { forEach } from '../../globals/internal/collection-helpers';
+import './left-nav-item';
 import styles from './masthead.scss';
 import DDSLeftNav from './left-nav';
 
@@ -80,6 +82,12 @@ class DDSLeftNavMenuSection extends HostListenerMixin(FocusMixin(LitElement)) {
    */
   @property()
   title = '';
+
+  /**
+   * The title url.
+   */
+  @property()
+  titleUrl = '';
 
   /**
    * Handler for the `click` event on the back button.
@@ -217,7 +225,7 @@ class DDSLeftNavMenuSection extends HostListenerMixin(FocusMixin(LitElement)) {
   }
 
   render() {
-    const { backButtonText, title, _handleClickBack: handleClickBack, showBackBtn } = this;
+    const { backButtonText, title, titleUrl, _handleClickBack: handleClickBack, showBackBtn } = this;
     return html`
       <ul>
         ${showBackBtn
@@ -229,9 +237,19 @@ class DDSLeftNavMenuSection extends HostListenerMixin(FocusMixin(LitElement)) {
               </li>
             `
           : undefined}
-        ${title
+        ${title && !titleUrl
           ? html`
               <li class="${prefix}--masthead__side-nav--submemu-title">${title}</li>
+            `
+          : undefined}
+        ${title && titleUrl
+          ? html`
+              <a class="${prefix}--masthead__side-nav--submemu-title" href=${titleUrl}>
+                <span>${title}</span>
+                <div class="${prefix}--side-nav__icon ${prefix}--side-nav__icon--small ${prefix}--side-nav__submenu-chevron">
+                  ${ChevronDown20()}
+                </div>
+              </a>
             `
           : undefined}
         <slot></slot>

--- a/packages/web-components/src/components/masthead/left-nav-menu-section.ts
+++ b/packages/web-components/src/components/masthead/left-nav-menu-section.ts
@@ -13,7 +13,7 @@ import HostListener from 'carbon-web-components/es/globals/decorators/host-liste
 import HostListenerMixin from 'carbon-web-components/es/globals/mixins/host-listener';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import ChevronLeft20 from 'carbon-web-components/es/icons/chevron--left/20.js';
-import ChevronDown20 from 'carbon-web-components/es/icons/chevron--down/20.js';
+import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20.js';
 import FocusMixin from 'carbon-web-components/es/globals/mixins/focus.js';
 import { selectorTabbable } from 'carbon-web-components/es/globals/settings.js';
 import { forEach } from '../../globals/internal/collection-helpers';
@@ -245,8 +245,8 @@ class DDSLeftNavMenuSection extends HostListenerMixin(FocusMixin(LitElement)) {
           ? html`
               <a class="${prefix}--masthead__side-nav--submemu-title" href=${titleUrl}>
                 <span>${title}</span>
-                <div class="${prefix}--side-nav__icon ${prefix}--side-nav__icon--small ${prefix}--side-nav__submenu-chevron">
-                  ${ChevronDown20()}
+                <div class="${prefix}--masthead__side-nav--submemu-section-title__icon">
+                  ${ArrowRight20()}
                 </div>
               </a>
             `

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -416,7 +416,6 @@ class DDSMastheadComposite extends LitElement {
           });
         });
 
-        console.log('elemLevel1', elem);
         if (level1Items.length !== 0) {
           menu.push(
             this._renderLeftNavMenuSections(

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -51,7 +51,6 @@ import './top-nav-menu';
 import './top-nav-menu-item';
 import './left-nav';
 import './left-nav-name';
-import './left-nav-item';
 import './left-nav-menu';
 import './left-nav-menu-section';
 import './left-nav-menu-item';
@@ -238,10 +237,11 @@ class DDSMastheadComposite extends LitElement {
    * @param isSubmenu determines whether menu section is a submenu section
    * @param showBackButton Determines whether to show back button
    * @param sectionTitle title of menu section
+   * @param sectionUrl section title url of menu section
    * @param sectionId id of menu section
    */
   // eslint-disable-next-line class-methods-use-this
-  protected _renderLeftNavMenuSections(menuItems, heading, isSubmenu, showBackButton, sectionTitle, sectionId) {
+  protected _renderLeftNavMenuSections(menuItems, heading, isSubmenu, showBackButton, sectionTitle, sectionUrl, sectionId) {
     const items = menuItems.map(elem => {
       if (elem.menu) {
         return html`
@@ -280,6 +280,7 @@ class DDSMastheadComposite extends LitElement {
         section-id="${sectionId}"
         ?is-submenu=${ifNonNull(isSubmenu)}
         title=${ifNonNull(sectionTitle)}
+        titleUrl=${ifNonNull(sectionUrl)}
         show-back-button=${ifNonNull(showBackButton)}
       >
         ${items}
@@ -399,8 +400,9 @@ class DDSMastheadComposite extends LitElement {
                 : selectedMenuItem === submenu.titleEnglish,
             });
           });
+          console.log('elemLevel2', item);
           if (level2Items.length !== 0) {
-            menu.push(this._renderLeftNavMenuSections(level2Items, null, true, true, item.title, `${i}, ${k}`));
+            menu.push(this._renderLeftNavMenuSections(level2Items, null, true, true, item.title, item.url, `${i}, ${k}`));
           }
 
           return level1Items.push({
@@ -413,9 +415,19 @@ class DDSMastheadComposite extends LitElement {
             menu: item.megapanelContent?.quickLinks?.links && item.megapanelContent?.quickLinks?.links.length !== 0,
           });
         });
+
+        console.log('elemLevel1', elem);
         if (level1Items.length !== 0) {
           menu.push(
-            this._renderLeftNavMenuSections(level1Items, elem.menuSections[0]?.heading, true, true, elem.title, `${i}, -1`)
+            this._renderLeftNavMenuSections(
+              level1Items,
+              elem.menuSections[0]?.heading,
+              true,
+              true,
+              elem.title,
+              elem.url,
+              `${i}, -1`
+            )
           );
         }
       }
@@ -434,7 +446,7 @@ class DDSMastheadComposite extends LitElement {
     });
 
     return html`
-      ${this._renderLeftNavMenuSections(level0Items, null, false, null, null, '-1, -1')} ${menu}
+      ${this._renderLeftNavMenuSections(level0Items, null, false, null, null, null, '-1, -1')} ${menu}
     `;
   }
 

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -400,7 +400,7 @@ class DDSMastheadComposite extends LitElement {
                 : selectedMenuItem === submenu.titleEnglish,
             });
           });
-          console.log('elemLevel2', item);
+
           if (level2Items.length !== 0) {
             menu.push(this._renderLeftNavMenuSections(level2Items, null, true, true, item.title, item.url, `${i}, ${k}`));
           }

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -9,8 +9,7 @@
 @import 'carbon-components/scss/components/ui-shell/side-nav';
 @import '@carbon/ibmdotcom-styles/scss/globals/vars';
 @import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead';
-// @import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead-leftnav';
-@import '../../../../styles/scss/components/masthead/_masthead-leftnav.scss';
+@import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead-leftnav';
 @import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead-top-nav-name';
 @import '@carbon/ibmdotcom-styles/scss/components/search-with-typeahead/search-with-typeahead';
 @import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead-l1';

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -9,7 +9,8 @@
 @import 'carbon-components/scss/components/ui-shell/side-nav';
 @import '@carbon/ibmdotcom-styles/scss/globals/vars';
 @import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead';
-@import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead-leftnav';
+// @import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead-leftnav';
+@import '../../../../styles/scss/components/masthead/_masthead-leftnav.scss';
 @import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead-top-nav-name';
 @import '@carbon/ibmdotcom-styles/scss/components/search-with-typeahead/search-with-typeahead';
 @import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead-l1';


### PR DESCRIPTION
### Related Ticket(s)

[Masthead] Web component and React version discrepancies #7116

### Description

There's some difference between the react and web-components mobile masthead versions:
 - the category heading arrow doesn't appear in the web components masthead
 - the category heading in react is using different color tokens
 - the horizontal rule under the category headings have different lengths
 
 This PR fixes both web-components and react styles to align.
 
 **REACT BEFORE:**
 
<img width="249" alt="Screen Shot 2021-12-31 at 12 38 00 PM" src="https://user-images.githubusercontent.com/54281166/147834691-f54af422-8fd3-4037-b01c-9513500b2424.png">

**REACT AFTER:**
<img width="251" alt="Screen Shot 2021-12-31 at 12 37 37 PM" src="https://user-images.githubusercontent.com/54281166/147834697-0fe3b3f6-7ae6-4d88-baa6-002250bb0ced.png">

**WEB COMPONENTS BEFORE:**

<img width="241" alt="Screen Shot 2021-12-30 at 3 36 02 PM" src="https://user-images.githubusercontent.com/54281166/147834803-2186342d-2895-42d2-a3d3-ab9cc82dfdc3.png">

**WEB COMPONENTS AFTER:**

<img width="257" alt="Screen Shot 2021-12-30 at 3 35 50 PM" src="https://user-images.githubusercontent.com/54281166/147834762-4d5e4396-577e-4d94-84c6-71a73e3e7759.png">

### Changelog

**New**

- check if section title has associated link, if so render with arrow icon

**Changed**

- adjust styles for the section title and back button

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
