### PR TITLE
docs(storybook): add button-cta documentation in CTA readme and update masthead's platform url documentation

### DIFF
--- a/packages/web-components/examples/codesandbox/components/cta-button/.babelrc
+++ b/packages/web-components/examples/codesandbox/components/cta-button/.babelrc
@@ -1,0 +1,22 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "modules": false,
+        "targets": [
+          "last 1 version",
+          "Firefox ESR",
+          "not opera > 0",
+          "not op_mini > 0",
+          "not op_mob > 0",
+          "not android > 0",
+          "not edge > 0",
+          "not ie > 0",
+          "not ie_mob > 0"
+        ]
+      }
+    ]
+  ],
+  "plugins": [["@babel/plugin-transform-runtime", { "version": "7.3.0" }]]
+}

--- a/packages/web-components/examples/codesandbox/components/cta-button/.gitignore
+++ b/packages/web-components/examples/codesandbox/components/cta-button/.gitignore
@@ -1,0 +1,2 @@
+/build
+/node_modules

--- a/packages/web-components/examples/codesandbox/components/cta-button/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-button/cdn.html
@@ -1,0 +1,48 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+  <head>
+    <title>@carbon/ibmdotcom-web-components example</title>
+    <meta charset="UTF-8" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"
+    />
+    <style type="text/css">
+      /* Suppress custom element until styles are loaded */
+      dds-card-cta:not(:defined) {
+        display: none;
+      }
+    </style>
+    <script
+      type="module"
+      src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button-cta.min.js"
+    ></script>
+  </head>
+  <body>
+    <div class="bx--grid">
+      <div class="bx--row">
+        <div class="bx--col-sm-4 bx--col-lg-12">
+          <dds-button-cta
+            cta-type="local"
+            kind="tertiary"
+            href="https://www.example.com"
+          >
+            Button CTA Copy
+          </dds-button-cta>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/packages/web-components/examples/codesandbox/components/cta-button/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-button/index.html
@@ -1,0 +1,45 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+  <head>
+    <title>@carbon/ibmdotcom-web-components example</title>
+    <meta charset="UTF-8" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"
+    />
+    <style type="text/css">
+      /* Suppress custom element until styles are loaded */
+      dds-card-cta:not(:defined) {
+        display: none;
+      }
+    </style>
+    <script src="src/index.js"></script>
+  </head>
+  <body>
+    <div class="bx--grid">
+      <div class="bx--row">
+        <div class="bx--col-sm-4 bx--col-lg-12">
+          <dds-button-cta
+            cta-type="local"
+            kind="tertiary"
+            href="https://www.example.com"
+          >
+            Button CTA Copy
+          </dds-button-cta>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/packages/web-components/examples/codesandbox/components/cta-button/package.json
+++ b/packages/web-components/examples/codesandbox/components/cta-button/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ibmdotcom-web-components-card-cta-example",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sample project for getting started with the Web Components from Carbon for IBM.com.",
+  "license": "Apache-2",
+  "main": "index.html",
+  "scripts": {
+    "clean": "rimraf node_modules dist .cache",
+    "start": "parcel index.html --port=9000 --no-hmr",
+    "build": "parcel build *.html --no-minify --public-url ./"
+  },
+  "dependencies": {
+    "@carbon/ibmdotcom-web-components": "canary"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0-0",
+    "parcel-bundler": "1.12.3",
+    "rimraf": "^3.0.2"
+  }
+}

--- a/packages/web-components/examples/codesandbox/components/cta-button/sandbox.config.json
+++ b/packages/web-components/examples/codesandbox/components/cta-button/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}

--- a/packages/web-components/examples/codesandbox/components/cta-button/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/cta-button/src/index.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import "@carbon/ibmdotcom-web-components/es/components/cta/button-cta.js";
+import '@carbon/ibmdotcom-web-components/es/components/cta/button-cta.js';

--- a/packages/web-components/examples/codesandbox/components/cta-button/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/cta-button/src/index.js
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import "@carbon/ibmdotcom-web-components/es/components/cta/button-cta.js";

--- a/packages/web-components/src/components/cta/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/cta/__stories__/README.stories.mdx
@@ -22,10 +22,10 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 `<dds-text-cta>` is the most basic version of CTA, presented as a simple link.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta/text)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-text)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta/text)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-text)
 
 ### JS (via import)
 
@@ -49,15 +49,45 @@ import '@carbon/ibmdotcom-web-components/es/components/cta/text-cta.js';
 
 <Props of="dds-text-cta" />
 
+## `<dds-button-cta>`
+
+`<dds-button-cta>` is a version of CTA presented as a button.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-button)
+> example implementation.
+
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-button)
+
+### JS (via import)
+
+```javascript
+import '@carbon/ibmdotcom-web-components/es/components/cta/button-cta.js';
+```
+
+<Description markdown={`${cdnJs({ components: ['button-cta'] })}`} />
+
+### HTML
+
+```html
+<dds-button-cta cta-type="local" kind="tertiary" href="https://www.example.com">
+  Button CTA Copy
+</dds-button-cta>
+```
+
+### Props
+
+<Props of="dds-button-cta" />
+
 ## `<dds-card-cta>`
 
 `<dds-card-cta>` is a version of CTA presented as a card.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta/card)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta/card)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-card)
 
 ### JS (via import)
 
@@ -84,10 +114,10 @@ import '@carbon/ibmdotcom-web-components/es/components/cta/card-cta.js';
 `<dds-card-link-cta>` is a version of CTA presented as a card.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta/card)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta/card)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-card)
 
 ### JS (via import)
 
@@ -116,10 +146,10 @@ import '@carbon/ibmdotcom-web-components/es/components/cta/card-link-cta.js';
 `<dds-feature-cta>` is a version of CTA presented as a feature card.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta/feature)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-feature)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta/feature)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-feature)
 
 ### JS (via import)
 
@@ -171,9 +201,9 @@ import '@carbon/ibmdotcom-web-components/es/components/image/image.js';
 
 ## Using a video player
 
-The `<dds-video-cta-container>` component lets you integrate `<dds-text-cta>`/`<dds-card-cta>`/`<dds-feature-cta>` with video player quickly.
+The `<dds-video-cta-container>` component lets you integrate `<dds-text-cta>`/`<dds-button-cta>`/`<dds-card-cta>`/`<dds-feature-cta>` with video player quickly.
 Only one `<dds-cta-container>` has to be put in application.
-Ensure that `<dds-cta-container>` contains all `<dds-text-cta>`/`<dds-card-cta>`/`<dds-feature-cta>`:
+Ensure that `<dds-cta-container>` contains all `<dds-text-cta>`/`<dds-button-cta>`/`<dds-card-cta>`/`<dds-feature-cta>`:
 
 ### JS (via import)
 

--- a/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
@@ -50,11 +50,18 @@ import '@carbon/ibmdotcom-web-components/es/components/masthead/masthead-contain
 #### Setting Platform URL
 
 The `platformUrl` property accepts a single URL as string or an object with a specific URL for each locale.
+This property has to be set via javascript.
 
 ###### Setting a single platform URL:
 
 ```html
-<dds-masthead-container platform="Lorem Ipsum" .platformUrl="${`https://www.example.com`}"></dds-masthead-container>
+<dds-masthead-container platform="Lorem Ipsum" id="masthead-container"></dds-masthead-container>
+```
+
+```javascript
+const singleUrl = "https://www.example.com";
+
+document.getElementById("masthead-container").platformUrl = singleUrl;
 ```
 
 ###### Setting multiple platform URLs with an object:
@@ -73,10 +80,12 @@ const urlObject = {
     url: 'https://www.example.com/es-mx/sample',
   },
 };
+
+document.getElementById("masthead-container").platformUrl = urlObject;
 ```
 
 ```html
-<dds-masthead-container platform="Lorem Ipsum" .platformUrl=${urlObject}></dds-masthead-container>
+<dds-masthead-container platform="Lorem Ipsum" id="masthead-container"></dds-masthead-container>
 ```
 
 #### Custom Navigation

--- a/packages/web-components/tests/e2e/cypress/integration/cta-button/cta-button.cdn.e2e.js
+++ b/packages/web-components/tests/e2e/cypress/integration/cta-button/cta-button.cdn.e2e.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+describe('dds-button-cta (cdn)', () => {
+  it('should load the default dds-button-cta example (cdn)', () => {
+    cy.visit('/cta-button/cdn.html');
+
+    // Take a snapshot for visual diffing
+    cy.percySnapshot('dds-button-cta | cdn | default');
+  });
+});

--- a/packages/web-components/tests/e2e/cypress/integration/cta-button/cta-button.e2e.js
+++ b/packages/web-components/tests/e2e/cypress/integration/cta-button/cta-button.e2e.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+describe('dds-button-cta', () => {
+  it('should load the default dds-button-cta example', () => {
+    cy.visit('/cta-button');
+
+    // Take a snapshot for visual diffing
+    cy.percySnapshot('dds-button-cta | default');
+  });
+});


### PR DESCRIPTION
### Related Ticket(s)

[Masthead]: Update platform url documentation #8002

### Description

Add documentation for button-cta:
- add `button-cta` codesandbox
- add code snippet for adopter to get started in cta readme

Updated masthead's documentation on how to set up `platformUrl`. Current example shows how it works within `lit-html` template which most adopters are not using. Change documentation to show how to set up with javascript instead.

### Changelog

**New**

- created codesandbox example for `button-cta`

**Changed**

- fix codesandbox example links for cta components in cta readme

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
