### PR TITLE
fix(leadspace): fix scrollable component

### DIFF
--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -189,7 +189,7 @@ $btn-min-width: 26;
 
     @include carbon--breakpoint(lg) {
       width: 100vw;
-      overflow-x: hidden;
+      overflow: hidden;
       position: relative;
       left: 50%;
       right: 50%;


### PR DESCRIPTION
### Related Ticket(s)
#8034

### Description
The Leadspace currently has a bug where, if the image is big enough, it can be scrolled within its own component. This means that if a user tries to scroll a bug when the cursor is on the leadspace, the leadspace will out of view. See the issue for a video with the bug.

You can see this in any Leadspace story containing an image (e.g. Leadspace Super with Image), though in the deploy previews here it will be fixed and unscrollable.

### Changelog

**Changed**

- `overflow-x` to `overflow` to account for the `y` overflow

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
