### PR TITLE
fix(feature-section): responsive card styles

### DIFF
--- a/packages/web-components/src/components/feature-section/feature-section.scss
+++ b/packages/web-components/src/components/feature-section/feature-section.scss
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,4 +13,14 @@
 :host(#{$dds-prefix}-feature-section) {
   display: block;
   outline: none;
+
+  &[media-alignment='left'] {
+    .#{$prefix}--card-link,
+    ::slotted(#{$dds-prefix}-feature-section-card-link) {
+      @include carbon--breakpoint-down('lg') {
+        position: relative;
+        right: 0;
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

#8103 

### Description

Update mobile styles when feature section `media-alignment=left`

### Changelog

**Changed**

- add responsive styles for `sm`/`md` breakpoints

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
