### PR TITLE
fix(static-card): react wrapper story not showing

### DIFF
--- a/packages/web-components/src/components/card/__stories__/card.stories.react.tsx
+++ b/packages/web-components/src/components/card/__stories__/card.stories.react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -159,7 +159,7 @@ Static.story = {
   parameters: {
     ...readme.parameters,
     knobs: {
-      Card: ({ groupId }) => {
+      StaticCard: ({ groupId }) => {
         const image = boolean('Add image:', false, groupId);
         const eyebrow = textNullable('Eyebrow:', 'SPSS Statistics', groupId);
         const heading = textNullable('Heading:', 'Free trial', groupId);


### PR DESCRIPTION
### Related Ticket(s)

#8105 

### Description

update storybook variable for static card. so static card renders properly 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
