### PR TITLE
fix(masthead): change hasProfile to accept a string instead of boolean

### DIFF
--- a/packages/web-components/src/components/masthead/__stories__/cloud-masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/cloud-masthead.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021
+ * Copyright IBM Corp. 2021, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -73,7 +73,7 @@ export const Default = !DDS_CLOUD_MASTHEAD
                 user-status="${ifNonNull(userStatus)}"
                 searchPlaceholder="${ifNonNull(searchPlaceholder)}"
                 .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
-                ?has-profile="${hasProfile}"
+                has-profile="${hasProfile}"
                 ?has-search="${hasSearch}"
                 .navLinks="${navLinks}"
                 .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
@@ -90,7 +90,7 @@ export const Default = !DDS_CLOUD_MASTHEAD
                 user-status="${ifNonNull(userStatus)}"
                 searchPlaceholder="${ifNonNull(searchPlaceholder)}"
                 .navLinks="${navLinks}"
-                ?has-profile="${hasProfile}"
+                has-profile="${hasProfile}"
                 ?has-search="${hasSearch}"
                 data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead"
               ></dds-cloud-masthead-container>

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -98,7 +98,7 @@ export const Default = ({ parameters }) => {
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             .navLinks="${navLinks}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
@@ -113,7 +113,7 @@ export const Default = ({ parameters }) => {
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .navLinks="${navLinks}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             custom-profile-login="${customProfileLogin}"
           ></dds-masthead-container>
@@ -191,7 +191,7 @@ export const WithCustomTypeahead = ({ parameters }) => {
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             .navLinks="${navLinks}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
@@ -207,7 +207,7 @@ export const WithCustomTypeahead = ({ parameters }) => {
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .navLinks="${navLinks}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             custom-profile-login="${customProfileLogin}"
             ?custom-typeahead-api=${true}
@@ -239,7 +239,7 @@ export const searchOpenOnload = ({ parameters }) => {
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
             .navLinks="${navLinks}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
             custom-profile-login="${customProfileLogin}"
@@ -254,7 +254,7 @@ export const searchOpenOnload = ({ parameters }) => {
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .navLinks="${navLinks}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             custom-profile-login="${customProfileLogin}"
           ></dds-masthead-container>
@@ -284,7 +284,7 @@ export const withPlatform = ({ parameters }) => {
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
             .navLinks="${navLinks}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
           ></dds-masthead-composite>
@@ -295,7 +295,7 @@ export const withPlatform = ({ parameters }) => {
             .platformUrl="${ifNonNull(platformData.url)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
           ></dds-masthead-composite>
         `}
@@ -307,7 +307,7 @@ withPlatform.story = {
   parameters: {
     knobs: {
       MastheadComposite: ({ groupId }) => ({
-        hasProfile: boolean('show the profile functionality (has-profile)', true, groupId),
+        hasProfile: select('show the profile functionality (has-profile)', ['true', 'false'], 'true', groupId),
         hasSearch: boolean('show the search functionality (has-search)', true, groupId),
         searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', inPercy() ? '' : 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Consulting & Services', groupId),
@@ -317,7 +317,7 @@ withPlatform.story = {
     propsSet: {
       default: {
         MastheadComposite: {
-          hasProfile: true,
+          hasProfile: 'true',
           hasSearch: true,
           searchPlaceHolder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -343,7 +343,7 @@ export const withL1 = ({ parameters }) => {
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             user-status="${ifNonNull(userStatus)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             .l1Data="${mastheadL1Data}"
             .navLinks="${navLinks}"
@@ -354,7 +354,7 @@ export const withL1 = ({ parameters }) => {
           <dds-masthead-container
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             .l1Data="${mastheadL1Data}"
             .navLinks="${navLinks}"
@@ -368,7 +368,7 @@ withL1.story = {
   parameters: {
     knobs: {
       MastheadComposite: ({ groupId }) => ({
-        hasProfile: boolean('show the profile functionality (has-profile)', true, groupId),
+        hasProfile: select('show the profile functionality (has-profile)', ['true', 'false'], 'true', groupId),
         hasSearch: boolean('show the search functionality (has-search)', true, groupId),
         searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', inPercy() ? '' : 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Products', groupId),
@@ -378,7 +378,7 @@ withL1.story = {
     propsSet: {
       default: {
         MastheadComposite: {
-          hasProfile: true,
+          hasProfile: 'true',
           hasSearch: true,
           searchPlaceholder: 'Search all of IBM',
           selectedMenuItem: 'Lorem ipsum dolor sit amet',
@@ -404,7 +404,7 @@ export const withAlternateLogoAndTooltip = ({ parameters }) => {
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             .navLinks="${navLinks}"
             .logoData="${mastheadLogo === 'alternateWithTooltip' ? logoData : null}"
@@ -418,7 +418,7 @@ export const withAlternateLogoAndTooltip = ({ parameters }) => {
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .navLinks="${navLinks}"
             .logoData="${mastheadLogo === 'alternateWithTooltip' ? logoData : null}"
-            ?has-profile="${hasProfile}"
+            has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
           ></dds-masthead-container>
         `}
@@ -430,7 +430,7 @@ withAlternateLogoAndTooltip.story = {
   parameters: {
     knobs: {
       MastheadComposite: ({ groupId }) => ({
-        hasProfile: boolean('show the profile functionality (has-profile)', true, groupId),
+        hasProfile: select('show the profile functionality (has-profile)', ['true', 'false'], 'true', groupId),
         hasSearch: boolean('show the search functionality (has-search)', true, groupId),
         searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Consulting & Services', groupId),
@@ -447,7 +447,7 @@ withAlternateLogoAndTooltip.story = {
       default: {
         MastheadComposite: {
           platform: null,
-          hasProfile: true,
+          hasProfile: 'true',
           hasSearch: true,
           searchPlaceholder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -478,7 +478,7 @@ export default {
     knobs: {
       escapeHTML: false,
       MastheadComposite: ({ groupId }) => ({
-        hasProfile: boolean('show the profile functionality (has-profile)', true, groupId),
+        hasProfile: select('show the profile functionality (has-profile)', ['true', 'false'], 'true', groupId),
         hasSearch: boolean('show the search functionality (has-search)', true, groupId),
         searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Consulting & Services', groupId),
@@ -504,7 +504,7 @@ export default {
       default: {
         MastheadComposite: {
           platform: null,
-          hasProfile: true,
+          hasProfile: 'true',
           hasSearch: true,
           searchPlaceholder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -623,8 +623,8 @@ class DDSMastheadComposite extends LitElement {
   /**
    * `true` if there is a profile.
    */
-  @property({ type: Boolean, attribute: 'has-profile' })
-  hasProfile = true;
+  @property({ type: String, reflect: true, attribute: 'has-profile' })
+  hasProfile = 'true';
 
   /**
    * `true` if there is a search.
@@ -922,8 +922,8 @@ class DDSMastheadComposite extends LitElement {
               ></dds-search-with-typeahead>
             `}
         <dds-masthead-global-bar ?has-search-active=${activateSearch}>
-          ${!hasProfile
-            ? undefined
+          ${hasProfile === 'false'
+            ? ''
             : html`
                 <dds-masthead-profile ?authenticated="${authenticated}">
                   ${profileItems?.map(


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/8017

### Description

- This PR addresses the issue for adopters using the `has-profile="false"` to optionally hide the "Profile" button.


### Changelog

**Changed**

- This PR sets the `has-profile` prop to accept a string instead of a boolean.

### Testing Instruction

- Spin up a sandbox example of the Masthead component - https://codesandbox.io/s/github/preoung/carbon-for-ibm-dotcom/tree/fix/masthead-8017/packages/web-components/examples/codesandbox/components/masthead
- Set `has-profile` attribute sets to `false`.
- Ensure that the "Profile" button is removed when the attribute is set to `false`. If the `has-profile` is not defined or set to `true`, the "Contact us" button should be set visible.
```
<dds-masthead-container
  has-contact="false"
></dds-masthead-container>
```

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
