### PR TITLE
fix(footer): change cypress intercept for translation to use raw data

### DIFF
--- a/packages/react/tests/e2e-storybook/cypress/fixtures/translations-raw.json
+++ b/packages/react/tests/e2e-storybook/cypress/fixtures/translations-raw.json
@@ -1,0 +1,1567 @@
+{
+  "mastheadNav": {
+    "links": [
+      {
+        "title": "Products & Solutions",
+        "titleEnglish": "Products & Solutions",
+        "url": "",
+        "hasMenu": true,
+        "hasMegapanel": true,
+        "menuSections": [
+          {
+            "heading": "The essentials",
+            "menuItems": [
+              {
+                "title": "Hybrid Cloud",
+                "titleEnglish": "Hybrid Cloud",
+                "url": "",
+                "highlighted": true,
+                "megapanelContent": {
+                  "headingTitle": "Hybrid Cloud",
+                  "headingUrl": "",
+                  "description": "Blend cloud and on-premises resources for flexibility and balance",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "What is Hybrid Cloud?",
+                        "titleEnglish": "What is Hybrid Cloud?",
+                        "highlightedLink": true,
+                        "url": "https://www.ibm.com/cloud/learn/hybrid-cloud?lnk=hpmps_ess"
+                      },
+                      {
+                        "title": "Hybrid Cloud solutions",
+                        "titleEnglish": "Hybrid Cloud solutions",
+                        "highlightedLink": true,
+                        "url": "https://www.ibm.com/cloud/go-hybrid?lnk=hpmps_ess"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Artificial intelligence",
+                "titleEnglish": "Artificial intelligence",
+                "url": "",
+                "highlighted": true,
+                "megapanelContent": {
+                  "headingTitle": "Artificial intelligence",
+                  "headingUrl": "",
+                  "description": "Unlock the value in your organization with Watson",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "What is AI?",
+                        "titleEnglish": "What is AI?",
+                        "highlightedLink": true,
+                        "url": "https://www.ibm.com/cloud/learn/what-is-artificial-intelligence?mhsrc=ibmsearch_a&mhq=what%20is%20AI%3F"
+                      },
+                      {
+                        "title": "AI solutions",
+                        "titleEnglish": "AI solutions",
+                        "highlightedLink": true,
+                        "url": "https://www.ibm.com/cloud/ai?lnk=hpmps_ess"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Top products & platforms",
+                "titleEnglish": "Top products & platforms",
+                "url": "https://www.ibm.com/products?lnk=hpmps_bupr",
+                "megapanelContent": {
+                  "headingTitle": "Top products & platforms",
+                  "headingUrl": "https://www.ibm.com/products?lnk=hpmps_bupr",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Aspera",
+                        "titleEnglish": "Aspera",
+                        "url": "https://www.ibm.com/products/aspera?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "Cognos",
+                        "titleEnglish": "Cognos",
+                        "url": "https://www.ibm.com/products/cognos-analytics?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "Db2",
+                        "titleEnglish": "Db2",
+                        "url": "https://www.ibm.com/analytics/db2?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "IBM Cloud",
+                        "titleEnglish": "IBM Cloud",
+                        "url": "https://www.ibm.com/cloud?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "IBM Cloud Paks",
+                        "titleEnglish": "IBM Cloud Paks",
+                        "url": "https://www.ibm.com/cloud/paks?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "IBM Sterling",
+                        "titleEnglish": "IBM Sterling",
+                        "url": "https://www.ibm.com/supply-chain/sterling?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "IBM Storage",
+                        "titleEnglish": "IBM Storage",
+                        "url": "https://www.ibm.com/it-infrastructure/storage/?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "IBM Z",
+                        "titleEnglish": "IBM Z",
+                        "url": "https://www.ibm.com/it-infrastructure/z?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "Red Hat OpenShift",
+                        "titleEnglish": "Red Hat OpenShift",
+                        "url": "https://www.ibm.com/cloud/openshift?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "SPSS Statistics",
+                        "titleEnglish": "SPSS Statistics",
+                        "url": "https://www.ibm.com/products/spss-statistics?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "Watson",
+                        "titleEnglish": "Watson",
+                        "url": "https://www.ibm.com/watson?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "WebSphere",
+                        "titleEnglish": "WebSphere",
+                        "url": "https://www.ibm.com/cloud/websphere-application-server?lnk=hpmps_bupr"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Solutions",
+                "titleEnglish": "Solutions",
+                "url": "",
+                "megapanelContent": {
+                  "headingTitle": "Solutions",
+                  "headingUrl": "",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Artificial intelligence",
+                        "titleEnglish": "Artificial intelligence",
+                        "url": "https://www.ibm.com/cloud/ai?lnk=hpmps_buai"
+                      },
+                      {
+                        "title": "Automation",
+                        "titleEnglish": "Business automation",
+                        "url": "https://www.ibm.com/cloud/automation?lnk=hpmps_buau"
+                      },
+                      {
+                        "title": "Blockchain",
+                        "titleEnglish": "Blockchain",
+                        "url": "https://www.ibm.com/blockchain?lnk=hpmps_bubc"
+                      },
+                      {
+                        "title": "Business operations",
+                        "titleEnglish": "Business operations",
+                        "url": "https://www.ibm.com/business-operations?lnk=hpmps_buop"
+                      },
+                      {
+                        "title": "Cloud computing",
+                        "titleEnglish": "Cloud computing",
+                        "url": "https://www.ibm.com/cloud?lnk=hpmps_bucl"
+                      },
+                      {
+                        "title": "Data & Analytics",
+                        "titleEnglish": "Data & Analytics",
+                        "url": "https://www.ibm.com/analytics?lnk=hpmps_buda"
+                      },
+                      {
+                        "title": "Hybrid Cloud",
+                        "titleEnglish": "Hybrid Cloud",
+                        "url": "https://www.ibm.com/cloud/hybrid?lnk=hpmps_bucl"
+                      },
+                      {
+                        "title": "IT infrastructure",
+                        "titleEnglish": "IT infrastructure",
+                        "url": "https://www.ibm.com/it-infrastructure?lnk=hpmps_buit"
+                      },
+                      {
+                        "title": "Quantum computing",
+                        "titleEnglish": "Quantum computing",
+                        "url": "https://www.ibm.com/quantum-computing/?lnk=hpmps_qc"
+                      },
+                      {
+                        "title": "Security",
+                        "titleEnglish": "Security",
+                        "url": "https://www.ibm.com/security?lnk=hpmps_buse"
+                      },
+                      {
+                        "title": "Supply chain",
+                        "titleEnglish": "Supply chain",
+                        "url": "https://www.ibm.com/supply-chain?lnk=hpmps_busc"
+                      },
+                      {
+                        "title": "COVID-19 solutions",
+                        "titleEnglish": "COVID-19 solutions",
+                        "url": "https://www.ibm.com/impact/covid-19/business-solutions?lnk=hpmps_buco"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Industries",
+                "titleEnglish": "Industries",
+                "url": "https://www.ibm.com/industries?lnk=hpmps_buin",
+                "megapanelContent": {
+                  "headingTitle": "Industries",
+                  "headingUrl": "https://www.ibm.com/industries?lnk=hpmps_buin",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Aerospace & defense",
+                        "titleEnglish": "Aerospace & defense",
+                        "url": "https://www.ibm.com/industries/aerospace-defense?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Automotive",
+                        "titleEnglish": "Automotive",
+                        "url": "https://www.ibm.com/industries/automotive?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Banking & financial markets",
+                        "titleEnglish": "Banking & financial markets",
+                        "url": "https://www.ibm.com/industries/banking-financial-markets?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Education",
+                        "titleEnglish": "Education",
+                        "url": "https://www.ibm.com/industries/education?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Electronics",
+                        "titleEnglish": "Electronics",
+                        "url": "https://www.ibm.com/industries/electronics?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Energy & utilities",
+                        "titleEnglish": "Energy & utilities",
+                        "url": "https://www.ibm.com/industries/energy?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Government",
+                        "titleEnglish": "Government",
+                        "url": "https://www.ibm.com/industries/government?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Healthcare",
+                        "titleEnglish": "Healthcare",
+                        "url": "https://www.ibm.com/industries/healthcare?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Insurance",
+                        "titleEnglish": "Insurance",
+                        "url": "https://www.ibm.com/industries/insurance?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Life sciences",
+                        "titleEnglish": "Life sciences",
+                        "url": "https://www.ibm.com/industries/lifesciences?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "View all Industries",
+                        "titleEnglish": "View all Industries",
+                        "url": "https://www.ibm.com/industries?lnk=hpmps_buin#2546397"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "View all products",
+                "titleEnglish": "View all products",
+                "url": "https://www.ibm.com/products?lnk=hpmps_buall",
+                "megaPanelViewAll": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Consulting & Services",
+        "titleEnglish": "Consulting & Services",
+        "url": "",
+        "hasMenu": true,
+        "hasMegapanel": true,
+        "menuSections": [
+          {
+            "heading": "",
+            "menuItems": [
+              {
+                "title": "IBM Consulting",
+                "titleEnglish": "IBM Consulting",
+                "url": "https://www.ibm.com/consulting?lnk=hpmco&lnk2=link",
+                "megapanelContent": {
+                  "headingTitle": "IBM Consulting",
+                  "headingUrl": "https://www.ibm.com/consulting?lnk=hpmco&lnk2=link",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Strategy Consulting",
+                        "titleEnglish": "Strategy Consulting",
+                        "url": "https://www.ibm.com/consulting/strategy?lnk=hpmco_bust&lnk2=learn"
+                      },
+                      {
+                        "title": "Experience Consulting",
+                        "titleEnglish": "Experience Consulting",
+                        "url": "https://www.ibm.com/consulting/experience?lnk=hpmco_buex&lnk2=learn"
+                      },
+                      {
+                        "title": "Operations Consulting",
+                        "titleEnglish": "Operations Consulting",
+                        "url": "https://www.ibm.com/consulting/operations?lnk=hpmco_buop&lnk2=learn"
+                      },
+                      {
+                        "title": "Technology Consulting",
+                        "titleEnglish": "Technology Consulting",
+                        "url": "https://www.ibm.com/consulting/technology?lnk=hpmco_bute&lnk2=learn"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/79a6c3cde7dd0665/original/megamenu-pictogram-business-process-service.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Business consulting services",
+                "titleEnglish": "Business process services",
+                "url": "https://www.ibm.com/services/business?lnk=hpmsc_bups",
+                "megapanelContent": {
+                  "headingTitle": "Business consulting services",
+                  "headingUrl": "https://www.ibm.com/services/business?lnk=hpmsc_bups",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Artificial intelligence services",
+                        "titleEnglish": "Artificial intelligence services",
+                        "url": "https://www.ibm.com/services/artificial-intelligence?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Automation",
+                        "titleEnglish": "Automation",
+                        "url": "https://www.ibm.com/cloud/automation/services?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Big data & data platform",
+                        "titleEnglish": "Big data & data platform",
+                        "url": "https://www.ibm.com/services/big-data-services?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Business process outsourcing",
+                        "titleEnglish": "Business process outsourcing",
+                        "url": "https://www.ibm.com/services/process/outsourcing?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Edge consulting",
+                        "titleEnglish": "Edge consulting",
+                        "url": "https://www.ibm.com/services/process/edge-services?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Finance consulting and outsourcing services",
+                        "titleEnglish": "Finance transformation",
+                        "url": "https://www.ibm.com/services/process/finance-consulting?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Operations consulting",
+                        "titleEnglish": "IoT consulting",
+                        "url": "https://www.ibm.com/services/process/operations-consulting?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Procurement consulting and managed services",
+                        "titleEnglish": "Procurement & strategic sourcing",
+                        "url": "https://www.ibm.com/services/process/procurement-consulting?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Risk management consulting services",
+                        "titleEnglish": "Risk consulting & fraud management",
+                        "url": "https://www.ibm.com/services/process/risk-management?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Supply chain consulting services",
+                        "titleEnglish": "Supply chain",
+                        "url": "https://www.ibm.com/services/process/supply-chain?lnk=hpmsc_bups"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/79a6c3cde7dd0665/original/megamenu-pictogram-business-process-service.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Design & business strategy",
+                "titleEnglish": "Design & business strategy",
+                "url": "https://www.ibm.com/services/ibmix/?lnk=hpmsc_budbs",
+                "megapanelContent": {
+                  "headingTitle": "Design & business strategy",
+                  "headingUrl": "https://www.ibm.com/services/ibmix/?lnk=hpmsc_bubs",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Customer experience consulting",
+                        "titleEnglish": "Experience strategy",
+                        "url": "https://www.ibm.com/services/customer-experience-consulting?lnk=hpmsc_bubs"
+                      },
+                      {
+                        "title": "E-commerce consulting",
+                        "titleEnglish": "Digital strategy",
+                        "url": "https://www.ibm.com/services/ecommerce?lnk=hpmsc_bubs"
+                      },
+                      {
+                        "title": "Marketing consulting",
+                        "titleEnglish": "Marketing platforms",
+                        "url": "https://www.ibm.com/services/marketing-consulting?lnk=hpmsc_bubs"
+                      },
+                      {
+                        "title": "Salesforce consulting",
+                        "titleEnglish": "Salesforce consulting",
+                        "url": "https://www.ibm.com/services/salesforce?lnk=hpmsc_bubs"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/1b7522c50ea39ca/original/megamenu-pictogram-design-business-strategy.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Hybrid multicloud services",
+                "titleEnglish": "Hybrid multicloud services",
+                "url": "https://www.ibm.com/cloud/services?lnk=hpmsc_bups"
+              },
+              {
+                "title": "Talent management services",
+                "titleEnglish": "Talent & transformation",
+                "url": "https://www.ibm.com/services/talent-management?lnk=hpmsc_buta",
+                "megapanelContent": {
+                  "headingTitle": "Talent management services",
+                  "headingUrl": "https://www.ibm.com/services/talent-management?lnk=hpmsc_buta",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "HR transformation services",
+                        "titleEnglish": "HR transformation",
+                        "url": "https://www.ibm.com/services/talent-management/hr-transformation?lnk=hpmsc_buta"
+                      },
+                      {
+                        "title": "Talent acquisition services",
+                        "titleEnglish": "Talent acquisition",
+                        "url": "https://www.ibm.com/services/talent-management/talent-acquisition?lnk=hpmsc_buta"
+                      },
+                      {
+                        "title": "Talent development services",
+                        "titleEnglish": "Talent development",
+                        "url": "https://www.ibm.com/services/talent-management/talent-development?lnk=hpmsc_buta"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/69e350b141e12bd5/original/megamenu-pictogram-talent-and-transformation.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Application services",
+                "titleEnglish": "Application services",
+                "url": "https://www.ibm.com/services/applications?lnk=hpmsc_buas",
+                "megapanelContent": {
+                  "headingTitle": "Application services",
+                  "headingUrl": "https://www.ibm.com/services/applications?lnk=hpmsc_buas",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Application Modernization",
+                        "titleEnglish": "Application Modernization",
+                        "url": "https://www.ibm.com/services/cloud/modernize-applications?lnk=hpmsc_buas"
+                      },
+                      {
+                        "title": "Enterprise applications strategy",
+                        "titleEnglish": "Enterprise applications strategy",
+                        "url": "https://www.ibm.com/services/applications/enterprise?lnk=hpmsc_buas"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/2b7c180c68557dcb/original/megamenu-pictogram-application-services.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "IBM Garage",
+                "titleEnglish": "IBM Garages",
+                "url": "https://www.ibm.com/garage?lnk=hpmsc_buas"
+              },
+              {
+                "title": "Security services",
+                "titleEnglish": "Security services",
+                "url": "https://www.ibm.com/security/services?lnk=hpmsc_buse",
+                "megapanelContent": {
+                  "headingTitle": "Security services",
+                  "headingUrl": "https://www.ibm.com/security/services?lnk=hpmsc_buse",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Application security",
+                        "titleEnglish": "Application security",
+                        "url": "https://www.ibm.com/security/services/application-security-services?lnk=hpmsc_buse"
+                      },
+                      {
+                        "title": "Cloud security",
+                        "titleEnglish": "Cloud security",
+                        "url": "https://www.ibm.com/security/services/cloud-security-services?lnk=hpmsc_buse"
+                      },
+                      {
+                        "title": "Data security",
+                        "titleEnglish": "Data security",
+                        "url": "https://www.ibm.com/security/services/data-security?lnk=hpmsc_buse"
+                      },
+                      {
+                        "title": "Identity & access management",
+                        "titleEnglish": "Identity & access management",
+                        "url": "https://www.ibm.com/security/services/identity-access-management?lnk=hpmsc_buse"
+                      },
+                      {
+                        "title": "Managed security",
+                        "titleEnglish": "Managed security",
+                        "url": "https://www.ibm.com/security/services/managed-security-services?lnk=hpmsc_buse"
+                      },
+                      {
+                        "title": "Security governance",
+                        "titleEnglish": "Security governance",
+                        "url": "https://www.ibm.com/security/services/security-governance?lnk=hpmsc_buse"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/6ecec25a8489cf82/original/megamenu-pictogram-security-services.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Technology Support Services",
+                "titleEnglish": "Services for tech support",
+                "url": "https://www.ibm.com/services/technology-support?lnk=hpmsc_busv",
+                "megapanelContent": {
+                  "headingTitle": "Technology Support Services",
+                  "headingUrl": "https://www.ibm.com/services/technology-support?lnk=hpmsc_busv",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Open source",
+                        "titleEnglish": "Open source",
+                        "url": "https://www.ibm.com/services/technology-support/open-source?lnk=hpmsc_busv"
+                      },
+                      {
+                        "title": "Third party & multivendor",
+                        "titleEnglish": "Third party & multivendor",
+                        "url": "https://www.ibm.com/services/technology-support/multivendor-it?lnk=hpmsc_busv"
+                      },
+                      {
+                        "title": "IBM warranties and maintenance",
+                        "titleEnglish": "IBM warranties and maintenance",
+                        "url": "https://www.ibm.com/services/technology-support/hardware-software?lnk=hpmsc_busv"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/7056e2b83b04133e/original/megamenu-pictogram-services-for-tech-support.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Flexible payment plans",
+                "titleEnglish": "Flexible payment plans",
+                "url": "https://www.ibm.com/financing?lnk=hpmsc_bufi"
+              },
+              {
+                "title": "View all services",
+                "titleEnglish": "View all services",
+                "url": "https://www.ibm.com/services?lnk=hpmsc_buall",
+                "megaPanelViewAll": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Learn & Support",
+        "titleEnglish": "Learn & Support",
+        "url": "",
+        "hasMenu": true,
+        "hasMegapanel": true,
+        "menuSections": [
+          {
+            "heading": "",
+            "menuItems": [
+              {
+                "title": "What is...",
+                "titleEnglish": "What is...",
+                "url": "https://www.ibm.com/cloud/learn?lnk=hpmls_buwi",
+                "megapanelContent": {
+                  "headingTitle": "What is...",
+                  "headingUrl": "https://www.ibm.com/cloud/learn?lnk=hpmls_buwi",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Artificial intelligence",
+                        "titleEnglish": "Artificial intelligence",
+                        "url": "https://www.ibm.com/cloud/learn/what-is-artificial-intelligence?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Automation",
+                        "titleEnglish": "Automation",
+                        "url": "https://www.ibm.com/topics/automation?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Blockchain",
+                        "titleEnglish": "Blockchain",
+                        "url": "https://www.ibm.com/topics/what-is-blockchain?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Business intelligence",
+                        "titleEnglish": "Business intelligence",
+                        "url": "https://www.ibm.com/topics/business-intelligence?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Chatbots",
+                        "titleEnglish": "Chatbots",
+                        "url": "https://www.ibm.com/cloud/learn/chatbots-explained?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Cloud computing",
+                        "titleEnglish": "Cloud computing",
+                        "url": "https://www.ibm.com/cloud/learn/cloud-computing?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Containerization",
+                        "titleEnglish": "Containerization",
+                        "url": "https://www.ibm.com/cloud/container-service?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Cybersecurity",
+                        "titleEnglish": "Cybersecurity",
+                        "url": "https://www.ibm.com/topics/cybersecurity?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Databases",
+                        "titleEnglish": "Databases",
+                        "url": "https://www.ibm.com/cloud/learn/database?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "DevOps",
+                        "titleEnglish": "DevOps",
+                        "url": "https://www.ibm.com/cloud/learn/devops-a-complete-guide?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Hybrid Cloud",
+                        "titleEnglish": "Hybrid Cloud",
+                        "url": "https://www.ibm.com/cloud/learn/hybrid-cloud?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Kubernetes",
+                        "titleEnglish": "Kubernetes",
+                        "url": "https://www.ibm.com/cloud/learn/kubernetes?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Quantum computing",
+                        "titleEnglish": "Quantum computing",
+                        "url": "https://www.ibm.com/quantum-computing/learn/what-is-quantum-computing?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Supply chain",
+                        "titleEnglish": "Supply chain",
+                        "url": "https://www.ibm.com/topics/supply-chain-management?lnk=hpmls_buwi"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/581adf40f2b008ec/original/megamenu-pictogram-what-is-_.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Training",
+                "titleEnglish": "Training",
+                "url": "https://www.ibm.com/training/?lnk=hpmls_butr",
+                "megapanelContent": {
+                  "headingTitle": "Training",
+                  "headingUrl": "https://www.ibm.com/training/?lnk=hpmls_butr",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Courses",
+                        "titleEnglish": "Courses",
+                        "url": "https://www.ibm.com/training/search?q=course&lnk=hpmls_butr"
+                      },
+                      {
+                        "title": "Learning journeys",
+                        "titleEnglish": "Learning journeys",
+                        "url": "https://www.ibm.com/training/journeys?lnk=hpmls_butr"
+                      },
+                      {
+                        "title": "Professional certifications",
+                        "titleEnglish": "Professional certifications",
+                        "url": "https://www.ibm.com/certify?lnk=hpmls_butr"
+                      },
+                      {
+                        "title": "Digital learning subscriptions",
+                        "titleEnglish": "Digital learning subscriptions",
+                        "url": "https://www.ibm.com/training/subscriptions?lnk=hpmls_butr"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/5540e5627aeb2568/original/megamenu-pictogram-training.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Developer education",
+                "titleEnglish": "Developer education",
+                "url": "https://developer.ibm.com/?lnk=hpmls_bude",
+                "megapanelContent": {
+                  "headingTitle": "Developer education",
+                  "headingUrl": "https://developer.ibm.com/?lnk=hpmls_bude",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Code patterns",
+                        "titleEnglish": "Code patterns",
+                        "url": "https://developer.ibm.com/patterns/?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Developer community",
+                        "titleEnglish": "Developer community",
+                        "url": "https://developer.ibm.com/community/?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Developer events",
+                        "titleEnglish": "Developer events",
+                        "url": "https://developer.ibm.com/events/?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Open Source @ IBM",
+                        "titleEnglish": "Open Source @ IBM",
+                        "url": "https://ibm.com/opensource?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Technical articles",
+                        "titleEnglish": "Technical articles",
+                        "url": "https://developer.ibm.com/articles?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Tutorials",
+                        "titleEnglish": "Tutorials",
+                        "url": "https://developer.ibm.com/tutorials/?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Videos",
+                        "titleEnglish": "Videos",
+                        "url": "https://developer.ibm.com/videos?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "View more Developer education",
+                        "titleEnglish": "View more Developer education",
+                        "url": "https://developer.ibm.com/?lnk=hpmls_bude"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/1e651d0f7b539774/original/megamenu-pictogram-developer-education.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Documentation",
+                "titleEnglish": "Documentation",
+                "url": "https://www.ibm.com/docs/en?lnk=hpmls_budc",
+                "megapanelContent": {
+                  "headingTitle": "Documentation",
+                  "headingUrl": "https://www.ibm.com/docs/en?lnk=hpmls_budc",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "All product documentation",
+                        "titleEnglish": "All product documentation",
+                        "url": "https://www.ibm.com/docs/en?lnk=hpmls_budc"
+                      },
+                      {
+                        "title": "For products on IBM Cloud",
+                        "titleEnglish": "For products on IBM Cloud",
+                        "url": "https://cloud.ibm.com/docs?lnk=hpmls_budc"
+                      },
+                      {
+                        "title": "For use cases — IBM Redbooks",
+                        "titleEnglish": "For use cases — IBM Redbooks",
+                        "url": "https://www.redbooks.ibm.com/?lnk=hpmls_budc"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/49d529fab45bb565/original/megamenu-pictogram-documentation.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Community",
+                "titleEnglish": "Community",
+                "url": "",
+                "megapanelContent": {
+                  "headingTitle": "Community",
+                  "headingUrl": "",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "IBM Developer",
+                        "titleEnglish": "IBM Developer",
+                        "url": "https://developer.ibm.com/?lnk=hpmls_buco"
+                      },
+                      {
+                        "title": "IBM Community",
+                        "titleEnglish": "IBM Community",
+                        "url": "https://community.ibm.com/community/user/home?lnk=hpmls_buco"
+                      },
+                      {
+                        "title": "Support forums",
+                        "titleEnglish": "Support forums",
+                        "url": "https://www.ibm.com/mysupport/s/forumshome?lnk=hpmls_buco"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Resources",
+                "titleEnglish": "Resources",
+                "url": "https://www.ibm.com/blogs/?lnk=hpmls_bure",
+                "megapanelContent": {
+                  "headingTitle": "Resources",
+                  "headingUrl": "https://www.ibm.com/blogs/?lnk=hpmls_bure",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Blogs & thought leadership",
+                        "titleEnglish": "Blogs & thought leadership",
+                        "url": "https://www.ibm.com/blogs/?lnk=hpmls_bure"
+                      },
+                      {
+                        "title": "Case studies & client stories",
+                        "titleEnglish": "Case studies & client stories",
+                        "url": "https://www.ibm.com/case-studies?lnk=hpmls_bure"
+                      },
+                      {
+                        "title": "Upcoming events & webinars",
+                        "titleEnglish": "Upcoming events & webinars",
+                        "url": "https://www.ibm.com/events?lnk=hpmls_bure"
+                      },
+                      {
+                        "title": "IBM Institute for Business Value",
+                        "titleEnglish": "IBM Institute for Business Value",
+                        "url": "https://www.ibm.com/thought-leadership/institute-business-value?lnk=hpmls_bure"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/164ef3660bad78a8/original/megamenu-pictogram-resources.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Support",
+                "titleEnglish": "Support",
+                "url": "https://www.ibm.com/mysupport?lnk=hpmls_busu",
+                "megapanelContent": {
+                  "headingTitle": "Support",
+                  "headingUrl": "https://www.ibm.com/mysupport?lnk=hpmls_busu",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Download fixes, updates & drivers",
+                        "titleEnglish": "Download fixes, updates & drivers",
+                        "url": "https://www.ibm.com/support/fixcentral/?lnk=hpmls_busu"
+                      },
+                      {
+                        "title": "Download licensed software - Passport Advantage",
+                        "titleEnglish": "Download licensed software - Passport Advantage",
+                        "url": "https://www.ibm.com/software/passportadvantage/pao_customer.html?lnk=hpmls_busu"
+                      },
+                      {
+                        "title": "View your cases",
+                        "titleEnglish": "View your cases",
+                        "url": "https://www.ibm.com/mysupport/s/my-cases?lnk=hpmls_busu"
+                      },
+                      {
+                        "title": "Open a case",
+                        "titleEnglish": "Open a case",
+                        "url": "https://www.ibm.com/mysupport/s/redirecttoopencasepage?lnk=hpmls_busu"
+                      },
+                      {
+                        "title": "View available support plans",
+                        "titleEnglish": "View available support plans",
+                        "url": "https://www.ibm.com/support/offerings?lnk=hpmls_busu"
+                      },
+                      {
+                        "title": "View more on Support",
+                        "titleEnglish": "View more on Support",
+                        "url": "https://www.ibm.com/mysupport?lnk=hpmls_busu&lnk2=all"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/5b1abed637b01b55/original/megamenu-pictogram-support.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Cloud platform support",
+                "titleEnglish": "Cloud platform support",
+                "url": "https://www.ibm.com/cloud/support?lnk=hpmls_bucl"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Explore more",
+        "titleEnglish": "Explore more",
+        "url": "",
+        "hasMenu": true,
+        "hasMegapanel": true,
+        "menuSections": [
+          {
+            "heading": "",
+            "menuItems": [
+              {
+                "title": "Partner with us",
+                "titleEnglish": "Partners",
+                "url": "https://www.ibm.com/partners?lnk=hpmex_bupa",
+                "megapanelContent": {
+                  "headingTitle": "Partner with us",
+                  "headingUrl": "https://www.ibm.com/partners?lnk=hpmex_bupa",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "PartnerWorld",
+                        "titleEnglish": "Partner with us — PartnerWorld",
+                        "url": "https://www.ibm.com/partnerworld/public?lnk=hpmex_bupa"
+                      },
+                      {
+                        "title": "Our strategic partnerships",
+                        "titleEnglish": "Our strategic partnerships",
+                        "url": "https://www.ibm.com/alliances?lnk=hpmex_bupa"
+                      },
+                      {
+                        "title": "Flexible payment plans",
+                        "titleEnglish": "Flexible payment plans",
+                        "url": "https://www.ibm.com/partnerworld/financing?lnk=hpmex_bupa"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/4075a8633a1137d/original/megamenu-pictogram-partners.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "IBM Research",
+                "titleEnglish": "IBM Research",
+                "url": "https://www.research.ibm.com/?lnk=hpmex_bure",
+                "megapanelContent": {
+                  "headingTitle": "IBM Research",
+                  "headingUrl": "https://www.research.ibm.com/?lnk=hpmex_bure",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Research areas",
+                        "titleEnglish": "Research areas",
+                        "url": "https://www.research.ibm.com/?lnk=hpmex_bure"
+                      },
+                      {
+                        "title": "Researcher directory",
+                        "titleEnglish": "Researcher directory",
+                        "url": "https://researcher.watson.ibm.com/researcher/people.php?lnk=hpmex_bure"
+                      },
+                      {
+                        "title": "Patents",
+                        "titleEnglish": "Patents",
+                        "url": "https://www.research.ibm.com/patents/?lnk=hpmex_bure"
+                      },
+                      {
+                        "title": "Work with us",
+                        "titleEnglish": "Work with us",
+                        "url": "https://www.research.ibm.com/frontiers/?lnk=hpmex_bure"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/5e05b0b234bc3846/original/megamenu-pictogram-ibm-research.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "About IBM",
+                "titleEnglish": "About IBM",
+                "url": "https://www.ibm.com/about?lnk=hpmex_buab",
+                "megapanelContent": {
+                  "headingTitle": "About IBM",
+                  "headingUrl": "https://www.ibm.com/about?lnk=hpmex_buab",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Annual report",
+                        "titleEnglish": "Annual report",
+                        "url": "https://www.ibm.com/annualreport/?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Career opportunities",
+                        "titleEnglish": "Career opportunities",
+                        "url": "https://www.ibm.com/employment/?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Corporate social responsibility",
+                        "titleEnglish": "Corporate social responsibility",
+                        "url": "https://www.ibm.org?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Diversity & inclusion",
+                        "titleEnglish": "Diversity & inclusion",
+                        "url": "https://www.ibm.com/employment/inclusion/?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Investor relations",
+                        "titleEnglish": "Investor relations",
+                        "url": "https://www.ibm.com/investor/?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "News & announcements",
+                        "titleEnglish": "News & announcements",
+                        "url": "https://newsroom.ibm.com?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Thought leadership",
+                        "titleEnglish": "Thought leadership",
+                        "url": "https://www.ibm.com/thought-leadership/?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Security, privacy & trust",
+                        "titleEnglish": "Security, privacy & trust",
+                        "url": "https://www.ibm.com/trust?lnk=hpmex_buab"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/220eb8ea8345a4d6/original/megamenu-pictogram-about-ibm.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "COVID-19",
+                "titleEnglish": "COVID-19",
+                "url": "https://www.ibm.com/impact/covid-19?lnk=hpmex_buco",
+                "megapanelContent": {
+                  "headingTitle": "COVID-19",
+                  "headingUrl": "https://www.ibm.com/impact/covid-19?lnk=hpmex_buco",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Business solutions",
+                        "titleEnglish": "Business solutions",
+                        "url": "https://www.ibm.com/impact/covid-19/business-solutions?lnk=hpmex_buco"
+                      },
+                      {
+                        "title": "Action guide",
+                        "titleEnglish": "Action guide",
+                        "url": "https://www.ibm.com/thought-leadership/institute-business-value/report/covid-19-action-guide?lnk=hpmex_buco"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "masthead": {
+    "search": {
+      "btnSearchClosed": "Open IBM search field",
+      "btnSearchOpen": "Search all of IBM",
+      "btnClose": "Close IBM search field",
+      "placeHolderText": "Search all of IBM"
+    },
+    "profileMenu": {
+      "signedout": {
+        "iconLabel": "User Profile",
+        "links": [
+          {
+            "title": "My IBM",
+            "url": "https://myibm.ibm.com/?lnk=mmi"
+          },
+          {
+            "title": "Log in",
+            "url": "https://login.ibm.com/oidc/endpoint/default/authorize?redirect_uri=https%3A%2F%2Fmyibm.ibm.com%2FOIDCHandler.html&response_type=token&client_id=v18LoginProdCI&scope=openid&state=https%3A%2F%2Fwww.ibm.com&nonce=8675309"
+          }
+        ]
+      },
+      "signedin": {
+        "iconLabel": "User Profile: Logged in",
+        "links": [
+          {
+            "title": "My IBM",
+            "url": "https://myibm.ibm.com/?lnk=mmi"
+          },
+          {
+            "title": "Profile",
+            "url": "https://myibm.ibm.com/profile/?lnk=mmi"
+          },
+          {
+            "title": "Billing",
+            "url": "https://myibm.ibm.com/billing/?lnk=mmi"
+          },
+          {
+            "title": "Log out",
+            "url": "https://myibm.ibm.com/pkmslogout?filename=accountRedir.html"
+          }
+        ]
+      }
+    }
+  },
+  "profileMenu": {
+    "signedout": [
+      {
+        "title": "My IBM",
+        "url": "https://myibm.ibm.com/?lnk=mmi"
+      },
+      {
+        "id": "signin",
+        "title": "Log in",
+        "url": "https://login.ibm.com/oidc/endpoint/default/authorize?redirect_uri=https%3A%2F%2Fmyibm.ibm.com%2FOIDCHandler.html&response_type=token&client_id=v18LoginProdCI&scope=openid&state=https%3A%2F%2Fwww.ibm.com&nonce=8675309"
+      }
+    ],
+    "signedin": [
+      {
+        "title": "My IBM",
+        "url": "https://myibm.ibm.com/?lnk=mmi"
+      },
+      {
+        "title": "Profile",
+        "url": "https://myibm.ibm.com/profile/?lnk=mmi"
+      },
+      {
+        "title": "Billing",
+        "url": "https://myibm.ibm.com/billing/?lnk=mmi"
+      },
+      {
+        "id": "signout",
+        "title": "Log out",
+        "url": "https://myibm.ibm.com/pkmslogout?filename=accountRedir.html"
+      }
+    ]
+  },
+  "marketplace": {
+    "title": "Products",
+    "url": ""
+  },
+  "footerMenu": [
+    {
+      "title": "Products & Solutions",
+      "links": [
+        {
+          "title": "Top products & platforms",
+          "url": "https://www.ibm.com/products?lnk=fps"
+        },
+        {
+          "title": "Industries",
+          "url": "https://www.ibm.com/industries?lnk=fps"
+        },
+        {
+          "title": "Artificial intelligence",
+          "url": "https://ibm.com/cloud/ai?lnk=fps"
+        },
+        {
+          "title": "Blockchain",
+          "url": "https://www.ibm.com/blockchain?lnk=fps"
+        },
+        {
+          "title": "Business operations",
+          "url": "https://www.ibm.com/business-operations?lnk=fps"
+        },
+        {
+          "title": "Cloud computing",
+          "url": "https://www.ibm.com/cloud?lnk=fps"
+        },
+        {
+          "title": "Data & Analytics",
+          "url": "https://www.ibm.com/analytics?lnk=fps"
+        },
+        {
+          "title": "Hybrid cloud",
+          "url": "https://www.ibm.com/cloud/hybrid?lnk=fps"
+        },
+        {
+          "title": "IT infrastructure",
+          "url": "https://www.ibm.com/it-infrastructure?lnk=fps"
+        },
+        {
+          "title": "Security",
+          "url": "https://www.ibm.com/security?lnk=fps"
+        },
+        {
+          "title": "Supply chain",
+          "url": "https://www.ibm.com/supply-chain?lnk=fps"
+        }
+      ]
+    },
+    {
+      "title": "Learn about",
+      "links": [
+        {
+          "title": "What is Hybrid Cloud?",
+          "url": "https://www.ibm.com/cloud/learn/hybrid-cloud?lnk=fle"
+        },
+        {
+          "title": "What is Artificial intelligence?",
+          "url": "https://www.ibm.com/cloud/learn/what-is-artificial-intelligence?lnk=fle"
+        },
+        {
+          "title": "What is Cloud Computing?",
+          "url": "https://www.ibm.com/cloud/learn/cloud-computing?lnk=fle"
+        },
+        {
+          "title": "What is Kubernetes?",
+          "url": "https://www.ibm.com/cloud/learn/kubernetes?lnk=fle"
+        },
+        {
+          "title": "What are Containers?",
+          "url": "https://www.ibm.com/cloud/learn/containers?lnk=fle"
+        },
+        {
+          "title": "What is DevOps?",
+          "url": "https://www.ibm.com/cloud/learn/devops-a-complete-guide?lnk=fle"
+        },
+        {
+          "title": "What is Machine Learning?",
+          "url": "https://www.ibm.com/cloud/learn/machine-learning?lnk=fle"
+        }
+      ]
+    },
+    {
+      "title": "Popular links",
+      "links": [
+        {
+          "title": "IBM Consulting",
+          "url": "https://www.ibm.com/consulting?lnk=fco"
+        },
+        {
+          "title": "Communities",
+          "url": "https://community.ibm.com/community/user/home?lnk=fpo"
+        },
+        {
+          "title": "Developer education",
+          "url": "https://developer.ibm.com/?lnk=fpo"
+        },
+        {
+          "title": "Support - Download fixes, updates & drivers",
+          "url": "https://www.ibm.com/support/fixcentral/?lnk=fpo"
+        },
+        {
+          "title": "IBM Research",
+          "url": "https://www.research.ibm.com/?lnk=fpo"
+        },
+        {
+          "title": "Partner with us - PartnerWorld",
+          "url": "https://www.ibm.com/partnerworld/public?lnk=fpo"
+        },
+        {
+          "title": "Training - Courses",
+          "url": "https://www.ibm.com/training/search?q=course&lnk=fpo"
+        },
+        {
+          "title": "Upcoming events & webinars",
+          "url": "https://www.ibm.com/events/?lnk=fpo"
+        }
+      ]
+    },
+    {
+      "title": "About IBM",
+      "links": [
+        {
+          "title": "Annual report",
+          "url": "https://www.ibm.com/annualreport/?lnk=fab"
+        },
+        {
+          "title": "Career opportunities",
+          "url": "https://www.ibm.com/employment/?lnk=fab"
+        },
+        {
+          "title": "Corporate social responsibility",
+          "url": "https://www.ibm.org/?lnk=fab"
+        },
+        {
+          "title": "Diversity & inclusion",
+          "url": "https://www.ibm.com/employment/inclusion/?lnk=fab"
+        },
+        {
+          "title": "Investor relations",
+          "url": "https://www.ibm.com/investor/?lnk=fab"
+        },
+        {
+          "title": "News & announcements",
+          "url": "https://newsroom.ibm.com/?lnk=fab"
+        },
+        {
+          "title": "Thought leadership",
+          "url": "https://www.ibm.com/thought-leadership/?lnk=fab"
+        },
+        {
+          "title": "Security, privacy & trust",
+          "url": "https://www.ibm.com/trust?lnk=fab"
+        },
+        {
+          "title": "About IBM",
+          "url": "https://www.ibm.com/about?lnk=fab"
+        }
+      ]
+    }
+  ],
+  "footerThin": [
+    {
+      "title": "Contact IBM",
+      "titleEnglish": "Contact IBM",
+      "url": "https://www.ibm.com/contact/us/en/?lnk=flg-cont-usen"
+    },
+    {
+      "title": "Privacy",
+      "titleEnglish": "Privacy",
+      "url": "https://www.ibm.com/privacy/us/en/?lnk=flg-priv-usen"
+    },
+    {
+      "title": "Terms of use",
+      "titleEnglish": "Terms of use",
+      "url": "https://www.ibm.com/us-en/legal?lnk=flg-tous-usen"
+    },
+    {
+      "title": "Accessibility",
+      "titleEnglish": "Accessibility",
+      "url": "https://www.ibm.com/accessibility/us/en/?lnk=flg-acce-usen"
+    }
+  ],
+  "localeSelector": {
+    "localVersions": "Localized versions of this page",
+    "homepages": "Worldwide ibm.com home pages"
+  },
+  "socialFollow": {
+    "title": "Follow IBM",
+    "links": [
+      {
+        "linkClass": "ibm-linkedin-encircled-link",
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/company/ibm"
+      },
+      {
+        "linkClass": "ibm-twitter-encircled-link",
+        "title": "Twitter",
+        "url": "https://www.twitter.com/ibm"
+      },
+      {
+        "linkClass": "ibm-instagram-encircled-link",
+        "title": "Instagram",
+        "url": "https://www.instagram.com/ibm"
+      }
+    ]
+  },
+  "socialSharing": [
+    {
+      "id": "facebook",
+      "title": "Facebook",
+      "url": "https://www.facebook.com/sharer.php?u=%{URL}&t=%{TITLE}"
+    },
+    {
+      "id": "twitter",
+      "title": "Twitter",
+      "url": "https://twitter.com/?status=%{URL}%20-%20%{TITLE}"
+    },
+    {
+      "id": "linkedin",
+      "title": "Linked In",
+      "url": "https://www.linkedin.com/shareArticle?mini=true&url=%{URL}&title=%{TITLE}"
+    }
+  ],
+  "leaving": {
+    "LEAVING001": "Leaving the IBM Web site",
+    "LEAVING002": "You are now leaving IBM.com and going to an external 3rd party site. Unless otherwise stated, the 3rd party's site Terms and Privacy Policy will apply, and may differ from IBM's.",
+    "LEAVING003": "You are headed to",
+    "LEAVING004": "Notice"
+  },
+  "misc": {
+    "backtotop": "Back to top",
+    "cancelText": "Cancel",
+    "close": "Close",
+    "cookiePrefs": "Cookie preferences",
+    "continueText": "Continue",
+    "editProfile": "Edit profile",
+    "emailThisPage": "E-mail this page",
+    "feedback": "Feedback",
+    "mpScopedSearh": "Products",
+    "withinMp": "Products",
+    "next": "Next",
+    "noresults": "No results found",
+    "prev": "Previous",
+    "resultsNav": "Use down and up arrow keys to navigate through the results.",
+    "search": "Search",
+    "selectCountry": "Select a country/region",
+    "sharePage": "Share this page",
+    "signin": "Sign in",
+    "signout": "Sign out",
+    "sitenav": "Site navigation",
+    "welcomeback": "Welcome back"
+  }
+}

--- a/packages/react/tests/e2e-storybook/cypress/support/index.js
+++ b/packages/react/tests/e2e-storybook/cypress/support/index.js
@@ -20,7 +20,7 @@ beforeEach(() => {
   // Mock the translation file
   cy.intercept(
     'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/translations/masthead-footer/usen.json',
-    { fixture: 'translation.json' }
+    { fixture: 'translation-raw.json' }
   );
 
   // Mock the user status

--- a/packages/web-components/tests/e2e-storybook/cypress/fixtures/translations-raw.json
+++ b/packages/web-components/tests/e2e-storybook/cypress/fixtures/translations-raw.json
@@ -1,0 +1,1567 @@
+{
+  "mastheadNav": {
+    "links": [
+      {
+        "title": "Products & Solutions",
+        "titleEnglish": "Products & Solutions",
+        "url": "",
+        "hasMenu": true,
+        "hasMegapanel": true,
+        "menuSections": [
+          {
+            "heading": "The essentials",
+            "menuItems": [
+              {
+                "title": "Hybrid Cloud",
+                "titleEnglish": "Hybrid Cloud",
+                "url": "",
+                "highlighted": true,
+                "megapanelContent": {
+                  "headingTitle": "Hybrid Cloud",
+                  "headingUrl": "",
+                  "description": "Blend cloud and on-premises resources for flexibility and balance",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "What is Hybrid Cloud?",
+                        "titleEnglish": "What is Hybrid Cloud?",
+                        "highlightedLink": true,
+                        "url": "https://www.ibm.com/cloud/learn/hybrid-cloud?lnk=hpmps_ess"
+                      },
+                      {
+                        "title": "Hybrid Cloud solutions",
+                        "titleEnglish": "Hybrid Cloud solutions",
+                        "highlightedLink": true,
+                        "url": "https://www.ibm.com/cloud/go-hybrid?lnk=hpmps_ess"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Artificial intelligence",
+                "titleEnglish": "Artificial intelligence",
+                "url": "",
+                "highlighted": true,
+                "megapanelContent": {
+                  "headingTitle": "Artificial intelligence",
+                  "headingUrl": "",
+                  "description": "Unlock the value in your organization with Watson",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "What is AI?",
+                        "titleEnglish": "What is AI?",
+                        "highlightedLink": true,
+                        "url": "https://www.ibm.com/cloud/learn/what-is-artificial-intelligence?mhsrc=ibmsearch_a&mhq=what%20is%20AI%3F"
+                      },
+                      {
+                        "title": "AI solutions",
+                        "titleEnglish": "AI solutions",
+                        "highlightedLink": true,
+                        "url": "https://www.ibm.com/cloud/ai?lnk=hpmps_ess"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Top products & platforms",
+                "titleEnglish": "Top products & platforms",
+                "url": "https://www.ibm.com/products?lnk=hpmps_bupr",
+                "megapanelContent": {
+                  "headingTitle": "Top products & platforms",
+                  "headingUrl": "https://www.ibm.com/products?lnk=hpmps_bupr",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Aspera",
+                        "titleEnglish": "Aspera",
+                        "url": "https://www.ibm.com/products/aspera?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "Cognos",
+                        "titleEnglish": "Cognos",
+                        "url": "https://www.ibm.com/products/cognos-analytics?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "Db2",
+                        "titleEnglish": "Db2",
+                        "url": "https://www.ibm.com/analytics/db2?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "IBM Cloud",
+                        "titleEnglish": "IBM Cloud",
+                        "url": "https://www.ibm.com/cloud?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "IBM Cloud Paks",
+                        "titleEnglish": "IBM Cloud Paks",
+                        "url": "https://www.ibm.com/cloud/paks?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "IBM Sterling",
+                        "titleEnglish": "IBM Sterling",
+                        "url": "https://www.ibm.com/supply-chain/sterling?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "IBM Storage",
+                        "titleEnglish": "IBM Storage",
+                        "url": "https://www.ibm.com/it-infrastructure/storage/?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "IBM Z",
+                        "titleEnglish": "IBM Z",
+                        "url": "https://www.ibm.com/it-infrastructure/z?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "Red Hat OpenShift",
+                        "titleEnglish": "Red Hat OpenShift",
+                        "url": "https://www.ibm.com/cloud/openshift?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "SPSS Statistics",
+                        "titleEnglish": "SPSS Statistics",
+                        "url": "https://www.ibm.com/products/spss-statistics?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "Watson",
+                        "titleEnglish": "Watson",
+                        "url": "https://www.ibm.com/watson?lnk=hpmps_bupr"
+                      },
+                      {
+                        "title": "WebSphere",
+                        "titleEnglish": "WebSphere",
+                        "url": "https://www.ibm.com/cloud/websphere-application-server?lnk=hpmps_bupr"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Solutions",
+                "titleEnglish": "Solutions",
+                "url": "",
+                "megapanelContent": {
+                  "headingTitle": "Solutions",
+                  "headingUrl": "",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Artificial intelligence",
+                        "titleEnglish": "Artificial intelligence",
+                        "url": "https://www.ibm.com/cloud/ai?lnk=hpmps_buai"
+                      },
+                      {
+                        "title": "Automation",
+                        "titleEnglish": "Business automation",
+                        "url": "https://www.ibm.com/cloud/automation?lnk=hpmps_buau"
+                      },
+                      {
+                        "title": "Blockchain",
+                        "titleEnglish": "Blockchain",
+                        "url": "https://www.ibm.com/blockchain?lnk=hpmps_bubc"
+                      },
+                      {
+                        "title": "Business operations",
+                        "titleEnglish": "Business operations",
+                        "url": "https://www.ibm.com/business-operations?lnk=hpmps_buop"
+                      },
+                      {
+                        "title": "Cloud computing",
+                        "titleEnglish": "Cloud computing",
+                        "url": "https://www.ibm.com/cloud?lnk=hpmps_bucl"
+                      },
+                      {
+                        "title": "Data & Analytics",
+                        "titleEnglish": "Data & Analytics",
+                        "url": "https://www.ibm.com/analytics?lnk=hpmps_buda"
+                      },
+                      {
+                        "title": "Hybrid Cloud",
+                        "titleEnglish": "Hybrid Cloud",
+                        "url": "https://www.ibm.com/cloud/hybrid?lnk=hpmps_bucl"
+                      },
+                      {
+                        "title": "IT infrastructure",
+                        "titleEnglish": "IT infrastructure",
+                        "url": "https://www.ibm.com/it-infrastructure?lnk=hpmps_buit"
+                      },
+                      {
+                        "title": "Quantum computing",
+                        "titleEnglish": "Quantum computing",
+                        "url": "https://www.ibm.com/quantum-computing/?lnk=hpmps_qc"
+                      },
+                      {
+                        "title": "Security",
+                        "titleEnglish": "Security",
+                        "url": "https://www.ibm.com/security?lnk=hpmps_buse"
+                      },
+                      {
+                        "title": "Supply chain",
+                        "titleEnglish": "Supply chain",
+                        "url": "https://www.ibm.com/supply-chain?lnk=hpmps_busc"
+                      },
+                      {
+                        "title": "COVID-19 solutions",
+                        "titleEnglish": "COVID-19 solutions",
+                        "url": "https://www.ibm.com/impact/covid-19/business-solutions?lnk=hpmps_buco"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Industries",
+                "titleEnglish": "Industries",
+                "url": "https://www.ibm.com/industries?lnk=hpmps_buin",
+                "megapanelContent": {
+                  "headingTitle": "Industries",
+                  "headingUrl": "https://www.ibm.com/industries?lnk=hpmps_buin",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Aerospace & defense",
+                        "titleEnglish": "Aerospace & defense",
+                        "url": "https://www.ibm.com/industries/aerospace-defense?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Automotive",
+                        "titleEnglish": "Automotive",
+                        "url": "https://www.ibm.com/industries/automotive?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Banking & financial markets",
+                        "titleEnglish": "Banking & financial markets",
+                        "url": "https://www.ibm.com/industries/banking-financial-markets?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Education",
+                        "titleEnglish": "Education",
+                        "url": "https://www.ibm.com/industries/education?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Electronics",
+                        "titleEnglish": "Electronics",
+                        "url": "https://www.ibm.com/industries/electronics?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Energy & utilities",
+                        "titleEnglish": "Energy & utilities",
+                        "url": "https://www.ibm.com/industries/energy?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Government",
+                        "titleEnglish": "Government",
+                        "url": "https://www.ibm.com/industries/government?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Healthcare",
+                        "titleEnglish": "Healthcare",
+                        "url": "https://www.ibm.com/industries/healthcare?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Insurance",
+                        "titleEnglish": "Insurance",
+                        "url": "https://www.ibm.com/industries/insurance?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "Life sciences",
+                        "titleEnglish": "Life sciences",
+                        "url": "https://www.ibm.com/industries/lifesciences?lnk=hpmps_buin"
+                      },
+                      {
+                        "title": "View all Industries",
+                        "titleEnglish": "View all Industries",
+                        "url": "https://www.ibm.com/industries?lnk=hpmps_buin#2546397"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "View all products",
+                "titleEnglish": "View all products",
+                "url": "https://www.ibm.com/products?lnk=hpmps_buall",
+                "megaPanelViewAll": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Consulting & Services",
+        "titleEnglish": "Consulting & Services",
+        "url": "",
+        "hasMenu": true,
+        "hasMegapanel": true,
+        "menuSections": [
+          {
+            "heading": "",
+            "menuItems": [
+              {
+                "title": "IBM Consulting",
+                "titleEnglish": "IBM Consulting",
+                "url": "https://www.ibm.com/consulting?lnk=hpmco&lnk2=link",
+                "megapanelContent": {
+                  "headingTitle": "IBM Consulting",
+                  "headingUrl": "https://www.ibm.com/consulting?lnk=hpmco&lnk2=link",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Strategy Consulting",
+                        "titleEnglish": "Strategy Consulting",
+                        "url": "https://www.ibm.com/consulting/strategy?lnk=hpmco_bust&lnk2=learn"
+                      },
+                      {
+                        "title": "Experience Consulting",
+                        "titleEnglish": "Experience Consulting",
+                        "url": "https://www.ibm.com/consulting/experience?lnk=hpmco_buex&lnk2=learn"
+                      },
+                      {
+                        "title": "Operations Consulting",
+                        "titleEnglish": "Operations Consulting",
+                        "url": "https://www.ibm.com/consulting/operations?lnk=hpmco_buop&lnk2=learn"
+                      },
+                      {
+                        "title": "Technology Consulting",
+                        "titleEnglish": "Technology Consulting",
+                        "url": "https://www.ibm.com/consulting/technology?lnk=hpmco_bute&lnk2=learn"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/79a6c3cde7dd0665/original/megamenu-pictogram-business-process-service.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Business consulting services",
+                "titleEnglish": "Business process services",
+                "url": "https://www.ibm.com/services/business?lnk=hpmsc_bups",
+                "megapanelContent": {
+                  "headingTitle": "Business consulting services",
+                  "headingUrl": "https://www.ibm.com/services/business?lnk=hpmsc_bups",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Artificial intelligence services",
+                        "titleEnglish": "Artificial intelligence services",
+                        "url": "https://www.ibm.com/services/artificial-intelligence?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Automation",
+                        "titleEnglish": "Automation",
+                        "url": "https://www.ibm.com/cloud/automation/services?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Big data & data platform",
+                        "titleEnglish": "Big data & data platform",
+                        "url": "https://www.ibm.com/services/big-data-services?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Business process outsourcing",
+                        "titleEnglish": "Business process outsourcing",
+                        "url": "https://www.ibm.com/services/process/outsourcing?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Edge consulting",
+                        "titleEnglish": "Edge consulting",
+                        "url": "https://www.ibm.com/services/process/edge-services?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Finance consulting and outsourcing services",
+                        "titleEnglish": "Finance transformation",
+                        "url": "https://www.ibm.com/services/process/finance-consulting?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Operations consulting",
+                        "titleEnglish": "IoT consulting",
+                        "url": "https://www.ibm.com/services/process/operations-consulting?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Procurement consulting and managed services",
+                        "titleEnglish": "Procurement & strategic sourcing",
+                        "url": "https://www.ibm.com/services/process/procurement-consulting?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Risk management consulting services",
+                        "titleEnglish": "Risk consulting & fraud management",
+                        "url": "https://www.ibm.com/services/process/risk-management?lnk=hpmsc_bups"
+                      },
+                      {
+                        "title": "Supply chain consulting services",
+                        "titleEnglish": "Supply chain",
+                        "url": "https://www.ibm.com/services/process/supply-chain?lnk=hpmsc_bups"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/79a6c3cde7dd0665/original/megamenu-pictogram-business-process-service.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Design & business strategy",
+                "titleEnglish": "Design & business strategy",
+                "url": "https://www.ibm.com/services/ibmix/?lnk=hpmsc_budbs",
+                "megapanelContent": {
+                  "headingTitle": "Design & business strategy",
+                  "headingUrl": "https://www.ibm.com/services/ibmix/?lnk=hpmsc_bubs",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Customer experience consulting",
+                        "titleEnglish": "Experience strategy",
+                        "url": "https://www.ibm.com/services/customer-experience-consulting?lnk=hpmsc_bubs"
+                      },
+                      {
+                        "title": "E-commerce consulting",
+                        "titleEnglish": "Digital strategy",
+                        "url": "https://www.ibm.com/services/ecommerce?lnk=hpmsc_bubs"
+                      },
+                      {
+                        "title": "Marketing consulting",
+                        "titleEnglish": "Marketing platforms",
+                        "url": "https://www.ibm.com/services/marketing-consulting?lnk=hpmsc_bubs"
+                      },
+                      {
+                        "title": "Salesforce consulting",
+                        "titleEnglish": "Salesforce consulting",
+                        "url": "https://www.ibm.com/services/salesforce?lnk=hpmsc_bubs"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/1b7522c50ea39ca/original/megamenu-pictogram-design-business-strategy.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Hybrid multicloud services",
+                "titleEnglish": "Hybrid multicloud services",
+                "url": "https://www.ibm.com/cloud/services?lnk=hpmsc_bups"
+              },
+              {
+                "title": "Talent management services",
+                "titleEnglish": "Talent & transformation",
+                "url": "https://www.ibm.com/services/talent-management?lnk=hpmsc_buta",
+                "megapanelContent": {
+                  "headingTitle": "Talent management services",
+                  "headingUrl": "https://www.ibm.com/services/talent-management?lnk=hpmsc_buta",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "HR transformation services",
+                        "titleEnglish": "HR transformation",
+                        "url": "https://www.ibm.com/services/talent-management/hr-transformation?lnk=hpmsc_buta"
+                      },
+                      {
+                        "title": "Talent acquisition services",
+                        "titleEnglish": "Talent acquisition",
+                        "url": "https://www.ibm.com/services/talent-management/talent-acquisition?lnk=hpmsc_buta"
+                      },
+                      {
+                        "title": "Talent development services",
+                        "titleEnglish": "Talent development",
+                        "url": "https://www.ibm.com/services/talent-management/talent-development?lnk=hpmsc_buta"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/69e350b141e12bd5/original/megamenu-pictogram-talent-and-transformation.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Application services",
+                "titleEnglish": "Application services",
+                "url": "https://www.ibm.com/services/applications?lnk=hpmsc_buas",
+                "megapanelContent": {
+                  "headingTitle": "Application services",
+                  "headingUrl": "https://www.ibm.com/services/applications?lnk=hpmsc_buas",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Application Modernization",
+                        "titleEnglish": "Application Modernization",
+                        "url": "https://www.ibm.com/services/cloud/modernize-applications?lnk=hpmsc_buas"
+                      },
+                      {
+                        "title": "Enterprise applications strategy",
+                        "titleEnglish": "Enterprise applications strategy",
+                        "url": "https://www.ibm.com/services/applications/enterprise?lnk=hpmsc_buas"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/2b7c180c68557dcb/original/megamenu-pictogram-application-services.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "IBM Garage",
+                "titleEnglish": "IBM Garages",
+                "url": "https://www.ibm.com/garage?lnk=hpmsc_buas"
+              },
+              {
+                "title": "Security services",
+                "titleEnglish": "Security services",
+                "url": "https://www.ibm.com/security/services?lnk=hpmsc_buse",
+                "megapanelContent": {
+                  "headingTitle": "Security services",
+                  "headingUrl": "https://www.ibm.com/security/services?lnk=hpmsc_buse",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Application security",
+                        "titleEnglish": "Application security",
+                        "url": "https://www.ibm.com/security/services/application-security-services?lnk=hpmsc_buse"
+                      },
+                      {
+                        "title": "Cloud security",
+                        "titleEnglish": "Cloud security",
+                        "url": "https://www.ibm.com/security/services/cloud-security-services?lnk=hpmsc_buse"
+                      },
+                      {
+                        "title": "Data security",
+                        "titleEnglish": "Data security",
+                        "url": "https://www.ibm.com/security/services/data-security?lnk=hpmsc_buse"
+                      },
+                      {
+                        "title": "Identity & access management",
+                        "titleEnglish": "Identity & access management",
+                        "url": "https://www.ibm.com/security/services/identity-access-management?lnk=hpmsc_buse"
+                      },
+                      {
+                        "title": "Managed security",
+                        "titleEnglish": "Managed security",
+                        "url": "https://www.ibm.com/security/services/managed-security-services?lnk=hpmsc_buse"
+                      },
+                      {
+                        "title": "Security governance",
+                        "titleEnglish": "Security governance",
+                        "url": "https://www.ibm.com/security/services/security-governance?lnk=hpmsc_buse"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/6ecec25a8489cf82/original/megamenu-pictogram-security-services.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Technology Support Services",
+                "titleEnglish": "Services for tech support",
+                "url": "https://www.ibm.com/services/technology-support?lnk=hpmsc_busv",
+                "megapanelContent": {
+                  "headingTitle": "Technology Support Services",
+                  "headingUrl": "https://www.ibm.com/services/technology-support?lnk=hpmsc_busv",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Open source",
+                        "titleEnglish": "Open source",
+                        "url": "https://www.ibm.com/services/technology-support/open-source?lnk=hpmsc_busv"
+                      },
+                      {
+                        "title": "Third party & multivendor",
+                        "titleEnglish": "Third party & multivendor",
+                        "url": "https://www.ibm.com/services/technology-support/multivendor-it?lnk=hpmsc_busv"
+                      },
+                      {
+                        "title": "IBM warranties and maintenance",
+                        "titleEnglish": "IBM warranties and maintenance",
+                        "url": "https://www.ibm.com/services/technology-support/hardware-software?lnk=hpmsc_busv"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/7056e2b83b04133e/original/megamenu-pictogram-services-for-tech-support.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Flexible payment plans",
+                "titleEnglish": "Flexible payment plans",
+                "url": "https://www.ibm.com/financing?lnk=hpmsc_bufi"
+              },
+              {
+                "title": "View all services",
+                "titleEnglish": "View all services",
+                "url": "https://www.ibm.com/services?lnk=hpmsc_buall",
+                "megaPanelViewAll": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Learn & Support",
+        "titleEnglish": "Learn & Support",
+        "url": "",
+        "hasMenu": true,
+        "hasMegapanel": true,
+        "menuSections": [
+          {
+            "heading": "",
+            "menuItems": [
+              {
+                "title": "What is...",
+                "titleEnglish": "What is...",
+                "url": "https://www.ibm.com/cloud/learn?lnk=hpmls_buwi",
+                "megapanelContent": {
+                  "headingTitle": "What is...",
+                  "headingUrl": "https://www.ibm.com/cloud/learn?lnk=hpmls_buwi",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Artificial intelligence",
+                        "titleEnglish": "Artificial intelligence",
+                        "url": "https://www.ibm.com/cloud/learn/what-is-artificial-intelligence?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Automation",
+                        "titleEnglish": "Automation",
+                        "url": "https://www.ibm.com/topics/automation?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Blockchain",
+                        "titleEnglish": "Blockchain",
+                        "url": "https://www.ibm.com/topics/what-is-blockchain?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Business intelligence",
+                        "titleEnglish": "Business intelligence",
+                        "url": "https://www.ibm.com/topics/business-intelligence?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Chatbots",
+                        "titleEnglish": "Chatbots",
+                        "url": "https://www.ibm.com/cloud/learn/chatbots-explained?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Cloud computing",
+                        "titleEnglish": "Cloud computing",
+                        "url": "https://www.ibm.com/cloud/learn/cloud-computing?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Containerization",
+                        "titleEnglish": "Containerization",
+                        "url": "https://www.ibm.com/cloud/container-service?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Cybersecurity",
+                        "titleEnglish": "Cybersecurity",
+                        "url": "https://www.ibm.com/topics/cybersecurity?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Databases",
+                        "titleEnglish": "Databases",
+                        "url": "https://www.ibm.com/cloud/learn/database?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "DevOps",
+                        "titleEnglish": "DevOps",
+                        "url": "https://www.ibm.com/cloud/learn/devops-a-complete-guide?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Hybrid Cloud",
+                        "titleEnglish": "Hybrid Cloud",
+                        "url": "https://www.ibm.com/cloud/learn/hybrid-cloud?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Kubernetes",
+                        "titleEnglish": "Kubernetes",
+                        "url": "https://www.ibm.com/cloud/learn/kubernetes?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Quantum computing",
+                        "titleEnglish": "Quantum computing",
+                        "url": "https://www.ibm.com/quantum-computing/learn/what-is-quantum-computing?lnk=hpmls_buwi"
+                      },
+                      {
+                        "title": "Supply chain",
+                        "titleEnglish": "Supply chain",
+                        "url": "https://www.ibm.com/topics/supply-chain-management?lnk=hpmls_buwi"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/581adf40f2b008ec/original/megamenu-pictogram-what-is-_.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Training",
+                "titleEnglish": "Training",
+                "url": "https://www.ibm.com/training/?lnk=hpmls_butr",
+                "megapanelContent": {
+                  "headingTitle": "Training",
+                  "headingUrl": "https://www.ibm.com/training/?lnk=hpmls_butr",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Courses",
+                        "titleEnglish": "Courses",
+                        "url": "https://www.ibm.com/training/search?q=course&lnk=hpmls_butr"
+                      },
+                      {
+                        "title": "Learning journeys",
+                        "titleEnglish": "Learning journeys",
+                        "url": "https://www.ibm.com/training/journeys?lnk=hpmls_butr"
+                      },
+                      {
+                        "title": "Professional certifications",
+                        "titleEnglish": "Professional certifications",
+                        "url": "https://www.ibm.com/certify?lnk=hpmls_butr"
+                      },
+                      {
+                        "title": "Digital learning subscriptions",
+                        "titleEnglish": "Digital learning subscriptions",
+                        "url": "https://www.ibm.com/training/subscriptions?lnk=hpmls_butr"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/5540e5627aeb2568/original/megamenu-pictogram-training.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Developer education",
+                "titleEnglish": "Developer education",
+                "url": "https://developer.ibm.com/?lnk=hpmls_bude",
+                "megapanelContent": {
+                  "headingTitle": "Developer education",
+                  "headingUrl": "https://developer.ibm.com/?lnk=hpmls_bude",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Code patterns",
+                        "titleEnglish": "Code patterns",
+                        "url": "https://developer.ibm.com/patterns/?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Developer community",
+                        "titleEnglish": "Developer community",
+                        "url": "https://developer.ibm.com/community/?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Developer events",
+                        "titleEnglish": "Developer events",
+                        "url": "https://developer.ibm.com/events/?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Open Source @ IBM",
+                        "titleEnglish": "Open Source @ IBM",
+                        "url": "https://ibm.com/opensource?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Technical articles",
+                        "titleEnglish": "Technical articles",
+                        "url": "https://developer.ibm.com/articles?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Tutorials",
+                        "titleEnglish": "Tutorials",
+                        "url": "https://developer.ibm.com/tutorials/?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "Videos",
+                        "titleEnglish": "Videos",
+                        "url": "https://developer.ibm.com/videos?lnk=hpmls_bude"
+                      },
+                      {
+                        "title": "View more Developer education",
+                        "titleEnglish": "View more Developer education",
+                        "url": "https://developer.ibm.com/?lnk=hpmls_bude"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/1e651d0f7b539774/original/megamenu-pictogram-developer-education.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Documentation",
+                "titleEnglish": "Documentation",
+                "url": "https://www.ibm.com/docs/en?lnk=hpmls_budc",
+                "megapanelContent": {
+                  "headingTitle": "Documentation",
+                  "headingUrl": "https://www.ibm.com/docs/en?lnk=hpmls_budc",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "All product documentation",
+                        "titleEnglish": "All product documentation",
+                        "url": "https://www.ibm.com/docs/en?lnk=hpmls_budc"
+                      },
+                      {
+                        "title": "For products on IBM Cloud",
+                        "titleEnglish": "For products on IBM Cloud",
+                        "url": "https://cloud.ibm.com/docs?lnk=hpmls_budc"
+                      },
+                      {
+                        "title": "For use cases — IBM Redbooks",
+                        "titleEnglish": "For use cases — IBM Redbooks",
+                        "url": "https://www.redbooks.ibm.com/?lnk=hpmls_budc"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/49d529fab45bb565/original/megamenu-pictogram-documentation.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Community",
+                "titleEnglish": "Community",
+                "url": "",
+                "megapanelContent": {
+                  "headingTitle": "Community",
+                  "headingUrl": "",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "IBM Developer",
+                        "titleEnglish": "IBM Developer",
+                        "url": "https://developer.ibm.com/?lnk=hpmls_buco"
+                      },
+                      {
+                        "title": "IBM Community",
+                        "titleEnglish": "IBM Community",
+                        "url": "https://community.ibm.com/community/user/home?lnk=hpmls_buco"
+                      },
+                      {
+                        "title": "Support forums",
+                        "titleEnglish": "Support forums",
+                        "url": "https://www.ibm.com/mysupport/s/forumshome?lnk=hpmls_buco"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Resources",
+                "titleEnglish": "Resources",
+                "url": "https://www.ibm.com/blogs/?lnk=hpmls_bure",
+                "megapanelContent": {
+                  "headingTitle": "Resources",
+                  "headingUrl": "https://www.ibm.com/blogs/?lnk=hpmls_bure",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Blogs & thought leadership",
+                        "titleEnglish": "Blogs & thought leadership",
+                        "url": "https://www.ibm.com/blogs/?lnk=hpmls_bure"
+                      },
+                      {
+                        "title": "Case studies & client stories",
+                        "titleEnglish": "Case studies & client stories",
+                        "url": "https://www.ibm.com/case-studies?lnk=hpmls_bure"
+                      },
+                      {
+                        "title": "Upcoming events & webinars",
+                        "titleEnglish": "Upcoming events & webinars",
+                        "url": "https://www.ibm.com/events?lnk=hpmls_bure"
+                      },
+                      {
+                        "title": "IBM Institute for Business Value",
+                        "titleEnglish": "IBM Institute for Business Value",
+                        "url": "https://www.ibm.com/thought-leadership/institute-business-value?lnk=hpmls_bure"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/164ef3660bad78a8/original/megamenu-pictogram-resources.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Support",
+                "titleEnglish": "Support",
+                "url": "https://www.ibm.com/mysupport?lnk=hpmls_busu",
+                "megapanelContent": {
+                  "headingTitle": "Support",
+                  "headingUrl": "https://www.ibm.com/mysupport?lnk=hpmls_busu",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Download fixes, updates & drivers",
+                        "titleEnglish": "Download fixes, updates & drivers",
+                        "url": "https://www.ibm.com/support/fixcentral/?lnk=hpmls_busu"
+                      },
+                      {
+                        "title": "Download licensed software - Passport Advantage",
+                        "titleEnglish": "Download licensed software - Passport Advantage",
+                        "url": "https://www.ibm.com/software/passportadvantage/pao_customer.html?lnk=hpmls_busu"
+                      },
+                      {
+                        "title": "View your cases",
+                        "titleEnglish": "View your cases",
+                        "url": "https://www.ibm.com/mysupport/s/my-cases?lnk=hpmls_busu"
+                      },
+                      {
+                        "title": "Open a case",
+                        "titleEnglish": "Open a case",
+                        "url": "https://www.ibm.com/mysupport/s/redirecttoopencasepage?lnk=hpmls_busu"
+                      },
+                      {
+                        "title": "View available support plans",
+                        "titleEnglish": "View available support plans",
+                        "url": "https://www.ibm.com/support/offerings?lnk=hpmls_busu"
+                      },
+                      {
+                        "title": "View more on Support",
+                        "titleEnglish": "View more on Support",
+                        "url": "https://www.ibm.com/mysupport?lnk=hpmls_busu&lnk2=all"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/5b1abed637b01b55/original/megamenu-pictogram-support.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "Cloud platform support",
+                "titleEnglish": "Cloud platform support",
+                "url": "https://www.ibm.com/cloud/support?lnk=hpmls_bucl"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Explore more",
+        "titleEnglish": "Explore more",
+        "url": "",
+        "hasMenu": true,
+        "hasMegapanel": true,
+        "menuSections": [
+          {
+            "heading": "",
+            "menuItems": [
+              {
+                "title": "Partner with us",
+                "titleEnglish": "Partners",
+                "url": "https://www.ibm.com/partners?lnk=hpmex_bupa",
+                "megapanelContent": {
+                  "headingTitle": "Partner with us",
+                  "headingUrl": "https://www.ibm.com/partners?lnk=hpmex_bupa",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "PartnerWorld",
+                        "titleEnglish": "Partner with us — PartnerWorld",
+                        "url": "https://www.ibm.com/partnerworld/public?lnk=hpmex_bupa"
+                      },
+                      {
+                        "title": "Our strategic partnerships",
+                        "titleEnglish": "Our strategic partnerships",
+                        "url": "https://www.ibm.com/alliances?lnk=hpmex_bupa"
+                      },
+                      {
+                        "title": "Flexible payment plans",
+                        "titleEnglish": "Flexible payment plans",
+                        "url": "https://www.ibm.com/partnerworld/financing?lnk=hpmex_bupa"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/4075a8633a1137d/original/megamenu-pictogram-partners.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "IBM Research",
+                "titleEnglish": "IBM Research",
+                "url": "https://www.research.ibm.com/?lnk=hpmex_bure",
+                "megapanelContent": {
+                  "headingTitle": "IBM Research",
+                  "headingUrl": "https://www.research.ibm.com/?lnk=hpmex_bure",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Research areas",
+                        "titleEnglish": "Research areas",
+                        "url": "https://www.research.ibm.com/?lnk=hpmex_bure"
+                      },
+                      {
+                        "title": "Researcher directory",
+                        "titleEnglish": "Researcher directory",
+                        "url": "https://researcher.watson.ibm.com/researcher/people.php?lnk=hpmex_bure"
+                      },
+                      {
+                        "title": "Patents",
+                        "titleEnglish": "Patents",
+                        "url": "https://www.research.ibm.com/patents/?lnk=hpmex_bure"
+                      },
+                      {
+                        "title": "Work with us",
+                        "titleEnglish": "Work with us",
+                        "url": "https://www.research.ibm.com/frontiers/?lnk=hpmex_bure"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/5e05b0b234bc3846/original/megamenu-pictogram-ibm-research.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "About IBM",
+                "titleEnglish": "About IBM",
+                "url": "https://www.ibm.com/about?lnk=hpmex_buab",
+                "megapanelContent": {
+                  "headingTitle": "About IBM",
+                  "headingUrl": "https://www.ibm.com/about?lnk=hpmex_buab",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Annual report",
+                        "titleEnglish": "Annual report",
+                        "url": "https://www.ibm.com/annualreport/?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Career opportunities",
+                        "titleEnglish": "Career opportunities",
+                        "url": "https://www.ibm.com/employment/?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Corporate social responsibility",
+                        "titleEnglish": "Corporate social responsibility",
+                        "url": "https://www.ibm.org?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Diversity & inclusion",
+                        "titleEnglish": "Diversity & inclusion",
+                        "url": "https://www.ibm.com/employment/inclusion/?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Investor relations",
+                        "titleEnglish": "Investor relations",
+                        "url": "https://www.ibm.com/investor/?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "News & announcements",
+                        "titleEnglish": "News & announcements",
+                        "url": "https://newsroom.ibm.com?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Thought leadership",
+                        "titleEnglish": "Thought leadership",
+                        "url": "https://www.ibm.com/thought-leadership/?lnk=hpmex_buab"
+                      },
+                      {
+                        "title": "Security, privacy & trust",
+                        "titleEnglish": "Security, privacy & trust",
+                        "url": "https://www.ibm.com/trust?lnk=hpmex_buab"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "https://1.dam.s81c.com/m/220eb8ea8345a4d6/original/megamenu-pictogram-about-ibm.png",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              },
+              {
+                "title": "COVID-19",
+                "titleEnglish": "COVID-19",
+                "url": "https://www.ibm.com/impact/covid-19?lnk=hpmex_buco",
+                "megapanelContent": {
+                  "headingTitle": "COVID-19",
+                  "headingUrl": "https://www.ibm.com/impact/covid-19?lnk=hpmex_buco",
+                  "description": "",
+                  "quickLinks": {
+                    "title": "",
+                    "links": [
+                      {
+                        "title": "Business solutions",
+                        "titleEnglish": "Business solutions",
+                        "url": "https://www.ibm.com/impact/covid-19/business-solutions?lnk=hpmex_buco"
+                      },
+                      {
+                        "title": "Action guide",
+                        "titleEnglish": "Action guide",
+                        "url": "https://www.ibm.com/thought-leadership/institute-business-value/report/covid-19-action-guide?lnk=hpmex_buco"
+                      }
+                    ]
+                  },
+                  "feature": {
+                    "heading": "",
+                    "imageUrl": "",
+                    "linkTitle": "",
+                    "linkUrl": ""
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "masthead": {
+    "search": {
+      "btnSearchClosed": "Open IBM search field",
+      "btnSearchOpen": "Search all of IBM",
+      "btnClose": "Close IBM search field",
+      "placeHolderText": "Search all of IBM"
+    },
+    "profileMenu": {
+      "signedout": {
+        "iconLabel": "User Profile",
+        "links": [
+          {
+            "title": "My IBM",
+            "url": "https://myibm.ibm.com/?lnk=mmi"
+          },
+          {
+            "title": "Log in",
+            "url": "https://login.ibm.com/oidc/endpoint/default/authorize?redirect_uri=https%3A%2F%2Fmyibm.ibm.com%2FOIDCHandler.html&response_type=token&client_id=v18LoginProdCI&scope=openid&state=https%3A%2F%2Fwww.ibm.com&nonce=8675309"
+          }
+        ]
+      },
+      "signedin": {
+        "iconLabel": "User Profile: Logged in",
+        "links": [
+          {
+            "title": "My IBM",
+            "url": "https://myibm.ibm.com/?lnk=mmi"
+          },
+          {
+            "title": "Profile",
+            "url": "https://myibm.ibm.com/profile/?lnk=mmi"
+          },
+          {
+            "title": "Billing",
+            "url": "https://myibm.ibm.com/billing/?lnk=mmi"
+          },
+          {
+            "title": "Log out",
+            "url": "https://myibm.ibm.com/pkmslogout?filename=accountRedir.html"
+          }
+        ]
+      }
+    }
+  },
+  "profileMenu": {
+    "signedout": [
+      {
+        "title": "My IBM",
+        "url": "https://myibm.ibm.com/?lnk=mmi"
+      },
+      {
+        "id": "signin",
+        "title": "Log in",
+        "url": "https://login.ibm.com/oidc/endpoint/default/authorize?redirect_uri=https%3A%2F%2Fmyibm.ibm.com%2FOIDCHandler.html&response_type=token&client_id=v18LoginProdCI&scope=openid&state=https%3A%2F%2Fwww.ibm.com&nonce=8675309"
+      }
+    ],
+    "signedin": [
+      {
+        "title": "My IBM",
+        "url": "https://myibm.ibm.com/?lnk=mmi"
+      },
+      {
+        "title": "Profile",
+        "url": "https://myibm.ibm.com/profile/?lnk=mmi"
+      },
+      {
+        "title": "Billing",
+        "url": "https://myibm.ibm.com/billing/?lnk=mmi"
+      },
+      {
+        "id": "signout",
+        "title": "Log out",
+        "url": "https://myibm.ibm.com/pkmslogout?filename=accountRedir.html"
+      }
+    ]
+  },
+  "marketplace": {
+    "title": "Products",
+    "url": ""
+  },
+  "footerMenu": [
+    {
+      "title": "Products & Solutions",
+      "links": [
+        {
+          "title": "Top products & platforms",
+          "url": "https://www.ibm.com/products?lnk=fps"
+        },
+        {
+          "title": "Industries",
+          "url": "https://www.ibm.com/industries?lnk=fps"
+        },
+        {
+          "title": "Artificial intelligence",
+          "url": "https://ibm.com/cloud/ai?lnk=fps"
+        },
+        {
+          "title": "Blockchain",
+          "url": "https://www.ibm.com/blockchain?lnk=fps"
+        },
+        {
+          "title": "Business operations",
+          "url": "https://www.ibm.com/business-operations?lnk=fps"
+        },
+        {
+          "title": "Cloud computing",
+          "url": "https://www.ibm.com/cloud?lnk=fps"
+        },
+        {
+          "title": "Data & Analytics",
+          "url": "https://www.ibm.com/analytics?lnk=fps"
+        },
+        {
+          "title": "Hybrid cloud",
+          "url": "https://www.ibm.com/cloud/hybrid?lnk=fps"
+        },
+        {
+          "title": "IT infrastructure",
+          "url": "https://www.ibm.com/it-infrastructure?lnk=fps"
+        },
+        {
+          "title": "Security",
+          "url": "https://www.ibm.com/security?lnk=fps"
+        },
+        {
+          "title": "Supply chain",
+          "url": "https://www.ibm.com/supply-chain?lnk=fps"
+        }
+      ]
+    },
+    {
+      "title": "Learn about",
+      "links": [
+        {
+          "title": "What is Hybrid Cloud?",
+          "url": "https://www.ibm.com/cloud/learn/hybrid-cloud?lnk=fle"
+        },
+        {
+          "title": "What is Artificial intelligence?",
+          "url": "https://www.ibm.com/cloud/learn/what-is-artificial-intelligence?lnk=fle"
+        },
+        {
+          "title": "What is Cloud Computing?",
+          "url": "https://www.ibm.com/cloud/learn/cloud-computing?lnk=fle"
+        },
+        {
+          "title": "What is Kubernetes?",
+          "url": "https://www.ibm.com/cloud/learn/kubernetes?lnk=fle"
+        },
+        {
+          "title": "What are Containers?",
+          "url": "https://www.ibm.com/cloud/learn/containers?lnk=fle"
+        },
+        {
+          "title": "What is DevOps?",
+          "url": "https://www.ibm.com/cloud/learn/devops-a-complete-guide?lnk=fle"
+        },
+        {
+          "title": "What is Machine Learning?",
+          "url": "https://www.ibm.com/cloud/learn/machine-learning?lnk=fle"
+        }
+      ]
+    },
+    {
+      "title": "Popular links",
+      "links": [
+        {
+          "title": "IBM Consulting",
+          "url": "https://www.ibm.com/consulting?lnk=fco"
+        },
+        {
+          "title": "Communities",
+          "url": "https://community.ibm.com/community/user/home?lnk=fpo"
+        },
+        {
+          "title": "Developer education",
+          "url": "https://developer.ibm.com/?lnk=fpo"
+        },
+        {
+          "title": "Support - Download fixes, updates & drivers",
+          "url": "https://www.ibm.com/support/fixcentral/?lnk=fpo"
+        },
+        {
+          "title": "IBM Research",
+          "url": "https://www.research.ibm.com/?lnk=fpo"
+        },
+        {
+          "title": "Partner with us - PartnerWorld",
+          "url": "https://www.ibm.com/partnerworld/public?lnk=fpo"
+        },
+        {
+          "title": "Training - Courses",
+          "url": "https://www.ibm.com/training/search?q=course&lnk=fpo"
+        },
+        {
+          "title": "Upcoming events & webinars",
+          "url": "https://www.ibm.com/events/?lnk=fpo"
+        }
+      ]
+    },
+    {
+      "title": "About IBM",
+      "links": [
+        {
+          "title": "Annual report",
+          "url": "https://www.ibm.com/annualreport/?lnk=fab"
+        },
+        {
+          "title": "Career opportunities",
+          "url": "https://www.ibm.com/employment/?lnk=fab"
+        },
+        {
+          "title": "Corporate social responsibility",
+          "url": "https://www.ibm.org/?lnk=fab"
+        },
+        {
+          "title": "Diversity & inclusion",
+          "url": "https://www.ibm.com/employment/inclusion/?lnk=fab"
+        },
+        {
+          "title": "Investor relations",
+          "url": "https://www.ibm.com/investor/?lnk=fab"
+        },
+        {
+          "title": "News & announcements",
+          "url": "https://newsroom.ibm.com/?lnk=fab"
+        },
+        {
+          "title": "Thought leadership",
+          "url": "https://www.ibm.com/thought-leadership/?lnk=fab"
+        },
+        {
+          "title": "Security, privacy & trust",
+          "url": "https://www.ibm.com/trust?lnk=fab"
+        },
+        {
+          "title": "About IBM",
+          "url": "https://www.ibm.com/about?lnk=fab"
+        }
+      ]
+    }
+  ],
+  "footerThin": [
+    {
+      "title": "Contact IBM",
+      "titleEnglish": "Contact IBM",
+      "url": "https://www.ibm.com/contact/us/en/?lnk=flg-cont-usen"
+    },
+    {
+      "title": "Privacy",
+      "titleEnglish": "Privacy",
+      "url": "https://www.ibm.com/privacy/us/en/?lnk=flg-priv-usen"
+    },
+    {
+      "title": "Terms of use",
+      "titleEnglish": "Terms of use",
+      "url": "https://www.ibm.com/us-en/legal?lnk=flg-tous-usen"
+    },
+    {
+      "title": "Accessibility",
+      "titleEnglish": "Accessibility",
+      "url": "https://www.ibm.com/accessibility/us/en/?lnk=flg-acce-usen"
+    }
+  ],
+  "localeSelector": {
+    "localVersions": "Localized versions of this page",
+    "homepages": "Worldwide ibm.com home pages"
+  },
+  "socialFollow": {
+    "title": "Follow IBM",
+    "links": [
+      {
+        "linkClass": "ibm-linkedin-encircled-link",
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/company/ibm"
+      },
+      {
+        "linkClass": "ibm-twitter-encircled-link",
+        "title": "Twitter",
+        "url": "https://www.twitter.com/ibm"
+      },
+      {
+        "linkClass": "ibm-instagram-encircled-link",
+        "title": "Instagram",
+        "url": "https://www.instagram.com/ibm"
+      }
+    ]
+  },
+  "socialSharing": [
+    {
+      "id": "facebook",
+      "title": "Facebook",
+      "url": "https://www.facebook.com/sharer.php?u=%{URL}&t=%{TITLE}"
+    },
+    {
+      "id": "twitter",
+      "title": "Twitter",
+      "url": "https://twitter.com/?status=%{URL}%20-%20%{TITLE}"
+    },
+    {
+      "id": "linkedin",
+      "title": "Linked In",
+      "url": "https://www.linkedin.com/shareArticle?mini=true&url=%{URL}&title=%{TITLE}"
+    }
+  ],
+  "leaving": {
+    "LEAVING001": "Leaving the IBM Web site",
+    "LEAVING002": "You are now leaving IBM.com and going to an external 3rd party site. Unless otherwise stated, the 3rd party's site Terms and Privacy Policy will apply, and may differ from IBM's.",
+    "LEAVING003": "You are headed to",
+    "LEAVING004": "Notice"
+  },
+  "misc": {
+    "backtotop": "Back to top",
+    "cancelText": "Cancel",
+    "close": "Close",
+    "cookiePrefs": "Cookie preferences",
+    "continueText": "Continue",
+    "editProfile": "Edit profile",
+    "emailThisPage": "E-mail this page",
+    "feedback": "Feedback",
+    "mpScopedSearh": "Products",
+    "withinMp": "Products",
+    "next": "Next",
+    "noresults": "No results found",
+    "prev": "Previous",
+    "resultsNav": "Use down and up arrow keys to navigate through the results.",
+    "search": "Search",
+    "selectCountry": "Select a country/region",
+    "sharePage": "Share this page",
+    "signin": "Sign in",
+    "signout": "Sign out",
+    "sitenav": "Site navigation",
+    "welcomeback": "Welcome back"
+  }
+}

--- a/packages/web-components/tests/e2e-storybook/cypress/support/index.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/support/index.js
@@ -27,7 +27,7 @@ beforeEach(() => {
 
   // Mock the translation file
   cy.intercept('https://1.www.s81c.com/common/carbon-for-ibm-dotcom/translations/masthead-footer/usen.json', {
-    fixture: 'translation.json',
+    fixture: 'translation-raw.json',
   });
 
   // Mock the user status


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This is a followup to the cypress e2e tests for Footer. In some cases the sessionStorage isn't being used and the `cy.intercept` is caught instead. In this case, it should use the raw response from the translation repo.

### Changelog

**Changed**

- Changed fixture for translation API to use raw response data
