### PR TITLE
fix(card-group): prevent extra top "borders" in Safari

### DIFF
--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -175,6 +175,16 @@
   // Add Grid Mode Narrow (16px gutter) style.
   :host(#{$dds-prefix}-card-group)[grid-mode='narrow'],
   .#{$prefix}--card-group--narrow {
+    @include carbon--breakpoint('sm') {
+      padding-top: $carbon--spacing-03;
+      gap: $carbon--spacing-03;
+    }
+
+    @include carbon--breakpoint('md') {
+      padding-top: $carbon--spacing-05;
+      gap: $carbon--spacing-05;
+    }
+
     @include carbon--breakpoint('lg') {
       grid-template-columns: repeat(
         3,
@@ -182,20 +192,11 @@
       );
     }
 
-    @include carbon--breakpoint('sm') {
-      column-gap: $carbon--spacing-05;
-    }
-
     ::slotted(#{$dds-prefix}-card-group-item),
     ::slotted(#{$dds-prefix}-card-group-card-link-item),
     .#{$prefix}--card-group__cards__col {
       border: 0;
-      background-color: inherit;
-      padding: $carbon--spacing-03 0 0 0;
-
-      @include carbon--breakpoint('md') {
-        padding: $carbon--spacing-05 0 0 0;
-      }
+      padding: 0;
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

Resolves https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7541

### Description

Once again, Safari doesn't handle web component selector specificity correctly, or at least in the same way as other major browsers. In this case, a background color on `<dds-card-group-item>` elements was not being overridden, and those element's `padding-top` made a chunk of the dark gray background visible.

I side-stepped this issue by modifying the way we create even spacing between grid items. Instead of only setting a `column-gap` value, we now use the full `gap` property for internal spacing and set a `padding-top` on the `<dds-card-group>` to create external spacing above the card group.

### Changelog

**Changed**

- Refactor `card-group` internal and external spacing to prevent Safari bug.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
