### PR TITLE
fix(card-in-card): implement md breakpoints redesign enhancement

### DIFF
--- a/packages/styles/scss/components/card-in-card/_card-in-card.scss
+++ b/packages/styles/scss/components/card-in-card/_card-in-card.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -48,11 +48,15 @@
       height: auto;
       padding: $carbon--spacing-05;
 
-      @include carbon--breakpoint('lg') {
-        width: 33.33%;
+      @include carbon--breakpoint('md') {
+        width: 50%;
         position: absolute;
         bottom: 0;
         right: 0;
+      }
+
+      @include carbon--breakpoint('lg') {
+        width: 33.33%;
       }
 
       .#{$prefix}--card__eyebrow,
@@ -90,6 +94,14 @@
 
     ::slotted(svg[slot='icon']) {
       @extend .#{$prefix}--image__icon;
+
+      @include carbon--breakpoint('md') {
+        right: calc(75% - #{$carbon--spacing-07});
+      }
+
+      @include carbon--breakpoint('lg') {
+        right: calc(50% - #{$carbon--spacing-04});
+      }
     }
 
     &::before {
@@ -121,6 +133,10 @@
     }
 
     .#{$prefix}--card__wrapper {
+      @include carbon--breakpoint('md') {
+        width: calc(50% - #{$carbon--spacing-04});
+      }
+
       @include carbon--breakpoint('lg') {
         width: calc(33.33% - #{$carbon--spacing-04});
       }

--- a/packages/styles/scss/components/image/_image.scss
+++ b/packages/styles/scss/components/image/_image.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -36,8 +36,8 @@
 
   .#{$prefix}--image__icon {
     position: absolute;
-    top: calc(50% - 32px);
-    right: calc(50% - 32px);
+    top: calc(50% - #{$carbon--spacing-07});
+    right: calc(50% - #{$carbon--spacing-07});
   }
 
   // dds-image-logo style.


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7667

### Description
- This PR implements the new design treatment for the `Card-in-Card` component within the medium breakpoints.
- See epic for more detail related to the design specs - https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7355

**Final design for `md` breakpoints:**
![68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3562653039633361363130323930306336643136643939312f30646565636636382d663662362d346534342d393831382d356438653532633065306537](https://user-images.githubusercontent.com/1815714/154358990-23d38571-76ca-41d1-8a3f-40900a35e024.png)


### Changelog

**Changed**

- Mostly styling changes within the `_card-in-card.scss` partial

![Screen Shot 2022-02-16 at 4 22 37 PM](https://user-images.githubusercontent.com/1815714/154359410-f0dcb8fc-588e-40c7-a554-333a2b620ad0.png) 
![Screen Shot 2022-02-16 at 4 22 54 PM](https://user-images.githubusercontent.com/1815714/154359416-812d5aea-9153-485f-9ff9-9cac220f2069.png)

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
