### PR TITLE
feat(toc): add an event to trigger harvesting of anchor tags

### DIFF
--- a/packages/web-components/src/components/table-of-contents/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/README.stories.mdx
@@ -106,6 +106,20 @@ dds-table-of-contents::part(table) {
 }
 ```
 
+## Reharvest the table of contents
+
+Use a dispatched event to trigger a reharvesting of the anchor tags within the Table of Contents.
+
+```js
+document.dispatchEvent(
+  new CustomEvent('dds-table-of-contents-reharvest', {
+    bubbles: true,
+    cancelable: true,
+    composed: true
+  })
+);
+```
+
 ## Slots
 
 <Props of="dds-table-of-contents" />

--- a/packages/web-components/src/components/table-of-contents/table-of-contents.ts
+++ b/packages/web-components/src/components/table-of-contents/table-of-contents.ts
@@ -512,6 +512,15 @@ class DDSTableOfContents extends HostListenerMixin(StableSelectorMixin(LitElemen
     this._throttleScroll!(event);
   };
 
+  /**
+   * The trigger reharvest listener.
+   */
+  @HostListener(`document:${ddsPrefix}-table-of-contents-reharvest`)
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  private _retriggerHarvest = () => {
+    this._targets = Array.from(this.querySelectorAll('a[name]'));
+  };
+
   connectedCallback() {
     super.connectedCallback();
     this._cleanAndCreateObserverResizeMobileContainer({ create: true });


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/8216

### Description

- This PR exposes an event that triggers the harvesting of anchor tags within the Table of Contents component.
- This feature allows AEM CMS Content Authors to see their inline text changes reflected in the anchor tags area of the Table of Contents.

### Changelog

**New**

- `dds-table-of-contents-reharvest` custom event.


https://user-images.githubusercontent.com/1815714/154524031-c537f882-ff0b-46ec-a971-a99c0c463039.mov



<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
