### PR TITLE
fix(card-in-card): ensure that the card image is clickable

### DIFF
--- a/packages/web-components/src/components/card-in-card/card-in-card.ts
+++ b/packages/web-components/src/components/card-in-card/card-in-card.ts
@@ -49,8 +49,14 @@ class DDSCardInCard extends StableSelectorMixin(DDSCardCTA) {
       linkNode.classList.add(`${prefix}--card-in-card`);
     }
 
-    if (this.querySelector(`${ddsPrefix}-card-in-card-image`)) {
-      (this.querySelector(`${ddsPrefix}-card-in-card-image`) as HTMLElement).onclick = () =>
+    const cardInCardImage = this.querySelector(`${ddsPrefix}-card-in-card-image`);
+    const cardInCardImageVideo = this.parentElement
+      .querySelector(`${ddsPrefix}-card-in-card`)
+      ?.shadowRoot?.querySelector('dds-card-in-card-image');
+
+    // fires the card cta footer when card image is clicked
+    if (cardInCardImage || cardInCardImageVideo) {
+      (cardInCardImage || (cardInCardImageVideo as HTMLElement)).onclick = () =>
         this.querySelector(`${ddsPrefix}-card-cta-footer`)
           ?.shadowRoot?.querySelector(`a`)
           ?.click();

--- a/packages/web-components/src/components/card-in-card/card-in-card.ts
+++ b/packages/web-components/src/components/card-in-card/card-in-card.ts
@@ -51,7 +51,7 @@ class DDSCardInCard extends StableSelectorMixin(DDSCardCTA) {
 
     const cardInCardImage = this.querySelector(`${ddsPrefix}-card-in-card-image`);
     const cardInCardImageVideo = this.parentElement
-      .querySelector(`${ddsPrefix}-card-in-card`)
+      ?.querySelector(`${ddsPrefix}-card-in-card`)
       ?.shadowRoot?.querySelector('dds-card-in-card-image');
 
     // fires the card cta footer when card image is clicked


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/8300

### Description

- This PR addresses the issue where the card image within the `<dds-card-in-card>` is not clickable.
- See the issue for more detail - https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/8300

### Changelog

**New**

- Add a new variable declaration for checking for `<dds-card-in-card-image>` that's wrapped under `<dds-video-cta-container>`.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
