### PR TITLE
chore(gh-actions): add timeout to e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,6 +18,7 @@ jobs:
         node-version: [ 14.x ]
         browser: [ chromium, firefox ]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -53,6 +54,7 @@ jobs:
         node-version: [ 14.x ]
         browser: [ chromium, firefox ]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js


### PR DESCRIPTION
### Description

This adds a timeout to the `e2e-tests` GitHub jobs for both React and web components. These jobs can hang for hours and clog the pipeline. At a quick glance, these jobs can finish as quickly as 14 minutes to as long as 35 minutes (or longer, depending on the amount of jobs in the queue). Initial timeout value is set to 60, which can be adjusted as needed.

### Changelog

**New**

- add `timeout-minutes` to end-to-end Github jobs

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
