### PR TITLE
fix(rollup): fix to named exports declaration for marked dependency

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         node-version: [ 14.x ]
-        browser: [ chromium, firefox ]
+        browser: [ chromium ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/packages/web-components/tools/get-rollup-config.js
+++ b/packages/web-components/tools/get-rollup-config.js
@@ -152,7 +152,7 @@ function getRollupConfig({ mode = 'development', dir = 'ltr', folders = ['dotcom
         sourceMap: true,
         namedExports: {
           'redux-logger/dist/redux-logger.js': ['createLogger'],
-          'marked/lib/marked.umd.js': ['marked'],
+          '../utilities/node_modules/marked/lib/marked.umd.js': ['marked'],
         },
       }),
       ibmdotcomIcon(),


### PR DESCRIPTION
### Related Ticket(s)

Refs https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/8383

### Description

The namedExport declaration specific to `marked` needed to be very specific in order for the commonjs plugin in rollup to register the import correctly. This will hopefully be the fix.

### Changelog

**Changed**

- Updated `namedExports` declaration in rollup config for web components
