### PR TITLE
chore: downgrade cypress

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -180,7 +180,7 @@
     "cross-env": "^7.0.0",
     "css-loader": "^5.2.0",
     "cssnano": "^4.1.10",
-    "cypress": "^8.7.0",
+    "cypress": "^8.1.0",
     "cypress-axe": "^0.14.0",
     "cypress-wait-until": "^1.7.2",
     "del": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8942,7 +8942,7 @@ cypress-wait-until@^1.7.2:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz#7f534dd5a11c89b65359e7a0210f20d3dfc22107"
   integrity sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==
 
-cypress@^8.7.0:
+cypress@^8.1.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.7.0.tgz#2ee371f383d8f233d3425b6cc26ddeec2668b6da"
   integrity sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/8233/
https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/8147/

### Description

This PR downgrades Cypress in the `web-components` package back to v8.1.0 due to out of memory issues present in v8.2+

Firefox is also added to the browsers matrix again for end to end tests

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
