### PR TITLE
fix(cloud-masthead): remove extra spacing from masthead

### DIFF
--- a/packages/utilities/src/utilities/settings/settings.js
+++ b/packages/utilities/src/utilities/settings/settings.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,11 +11,11 @@
  * @exports ibmdotcom.settings
  * @type {object} Settings object
  * @property {string} [prefix=dds]
- * Carbon for IBM.com v1.31.0',
+ * Carbon for IBM.com v1.31.1',
  *
  */
 const settings = {
-  version: 'Carbon for IBM.com v1.31.0',
+  version: 'Carbon for IBM.com v1.31.1',
   stablePrefix: 'dds',
 };
 

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -264,7 +264,6 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
 
     // This is a temp fix until we figure out why we can't set styles to the :host(dds-cloud-masthead-container) in stylesheets
     this.style.zIndex = '900';
-    this.style.paddingTop = '48px';
   }
 
   render() {


### PR DESCRIPTION
### Related Ticket(s)

#8450 

### Description

Removes extra top spacing from `cloud-masthead`

### Changelog

**Removed**

- extra spacing from `cloud-masthead`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
