### PR TITLE
fix(plex): replace `gstatic` font references with akamai

### DIFF
--- a/packages/react/.storybook/manager-head.html
+++ b/packages/react/.storybook/manager-head.html
@@ -46,7 +46,7 @@ LICENSE file in the root directory of this source tree.
     font-family: 'IBM Plex Sans';
     font-style: normal;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff)
+      url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff)
         format('woff');
     font-display: auto;
   }
@@ -56,7 +56,7 @@ LICENSE file in the root directory of this source tree.
     font-family: 'IBM Plex Sans';
     font-style: normal;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff)
+      url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff)
         format('woff');
     font-display: auto;
   }

--- a/packages/web-components/.storybook/manager-head.html
+++ b/packages/web-components/.storybook/manager-head.html
@@ -30,7 +30,8 @@ LICENSE file in the root directory of this source tree.
     font-family: 'IBM Plex Sans';
     font-style: normal;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+      url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff)
+        format('woff');
     font-display: auto;
   }
 
@@ -39,7 +40,8 @@ LICENSE file in the root directory of this source tree.
     font-family: 'IBM Plex Sans';
     font-style: normal;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+      url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff)
+        format('woff');
     font-display: auto;
   }
 </style>

--- a/packages/web-components/.storybook/react/manager-head.html
+++ b/packages/web-components/.storybook/react/manager-head.html
@@ -26,7 +26,8 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     src: local('IBM Plex Sans'), local('IBMPlexSans'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+      url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff)
+        format('woff');
     font-display: auto;
   }
 
@@ -35,7 +36,8 @@
     font-family: 'IBM Plex Sans';
     font-style: normal;
     src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-      url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+      url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff)
+        format('woff');
     font-display: auto;
   }
 </style>

--- a/packages/web-components/examples/codesandbox/components-react/card-group/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/card-group/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/card-in-card/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/card-in-card/src/index.css
@@ -27,7 +27,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -36,6 +36,6 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }

--- a/packages/web-components/examples/codesandbox/components-react/card-link/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/card-link/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/card-section-offset/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/card-section-offset/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/card/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/card/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/carousel/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/carousel/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/content-group-banner/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/content-group-banner/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/content-item-horizontal/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/content-item-horizontal/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/cta-section/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/cta-section/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/feature-section/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/feature-section/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/filter-panel/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/filter-panel/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/leadspace-with-search/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/leadspace-with-search/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/leadspace/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/leadspace/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/leaving-ibm/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/leaving-ibm/src/index.css
@@ -18,7 +18,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -27,7 +27,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/search-with-typeahead/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/search-with-typeahead/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/table-of-contents/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/table-of-contents/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/tabs-extended-media/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/tabs-extended-media/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/tabs-extended/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/tabs-extended/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/tag-group/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/tag-group/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/tag-link/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/tag-link/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/components-react/universal-banner/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/universal-banner/src/index.css
@@ -22,7 +22,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -31,7 +31,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-handlebars/index.hbs
+++ b/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-handlebars/index.hbs
@@ -35,7 +35,7 @@ LICENSE file in the root directory of this source tree.
         font-family: 'IBM Plex Sans';
         font-style: normal;
         src:
-          local('IBM Plex Sans'), local('IBMPlexSans'), url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+          local('IBM Plex Sans'), local('IBMPlexSans'), url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
         font-display: auto;
       }
 
@@ -43,7 +43,7 @@ LICENSE file in the root directory of this source tree.
         font-weight: 600;
         font-family: 'IBM Plex Sans';
         font-style: normal;
-        src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'), url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+        src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'), url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
         font-display: auto;
       }
 

--- a/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl/index.hbs
+++ b/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl/index.hbs
@@ -40,7 +40,7 @@ LICENSE file in the root directory of this source tree.
         font-family: 'IBM Plex Sans';
         font-style: normal;
         src:
-          local('IBM Plex Sans'), local('IBMPlexSans'), url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+          local('IBM Plex Sans'), local('IBMPlexSans'), url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
         font-display: auto;
       }
 
@@ -48,7 +48,7 @@ LICENSE file in the root directory of this source tree.
         font-weight: 600;
         font-family: 'IBM Plex Sans';
         font-style: normal;
-        src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'), url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+        src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'), url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
         font-display: auto;
       }
 

--- a/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn/index.html
+++ b/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn/index.html
@@ -26,7 +26,7 @@ LICENSE file in the root directory of this source tree.
         font-family: 'IBM Plex Sans';
         font-style: normal;
         src: local('IBM Plex Sans'), local('IBMPlexSans'),
-          url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+          url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
         font-display: auto;
       }
 
@@ -35,7 +35,7 @@ LICENSE file in the root directory of this source tree.
         font-family: 'IBM Plex Sans';
         font-style: normal;
         src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-          url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+          url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
         font-display: auto;
       }
 

--- a/packages/web-components/examples/codesandbox/usage/react-ssr/src/index.css
+++ b/packages/web-components/examples/codesandbox/usage/react-ssr/src/index.css
@@ -18,7 +18,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans'), local('IBMPlexSans'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
   font-display: auto;
 }
 
@@ -27,7 +27,7 @@ body {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-    url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
   font-display: auto;
 }
 

--- a/packages/web-components/examples/codesandbox/usage/webpack-basic/index.html
+++ b/packages/web-components/examples/codesandbox/usage/webpack-basic/index.html
@@ -24,7 +24,7 @@ LICENSE file in the root directory of this source tree.
         font-family: 'IBM Plex Sans';
         font-style: normal;
         src: local('IBM Plex Sans'), local('IBMPlexSans'),
-          url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+          url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
         font-display: auto;
       }
 
@@ -33,7 +33,7 @@ LICENSE file in the root directory of this source tree.
         font-family: 'IBM Plex Sans';
         font-style: normal;
         src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-          url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+          url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
         font-display: auto;
       }
 

--- a/packages/web-components/examples/codesandbox/usage/webpack-rtl/index.hbs
+++ b/packages/web-components/examples/codesandbox/usage/webpack-rtl/index.hbs
@@ -38,7 +38,7 @@ LICENSE file in the root directory of this source tree.
         font-family: 'IBM Plex Sans';
         font-style: normal;
         src:
-          local('IBM Plex Sans'), local('IBMPlexSans'), url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format('woff');
+          local('IBM Plex Sans'), local('IBMPlexSans'), url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
         font-display: auto;
       }
 
@@ -46,7 +46,7 @@ LICENSE file in the root directory of this source tree.
         font-weight: 600;
         font-family: 'IBM Plex Sans';
         font-style: normal;
-        src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'), url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
+        src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'), url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
         font-display: auto;
       }
 


### PR DESCRIPTION
### Related Ticket(s)

#8501 

### Description

This replaces all font references in the library to use the IBM Akamai CDN rather than Google Fonts server (`gstatic`). This is necessary in order to GDPR compliance issues with fonts hosted on Google Fonts.

### Changelog

**Changed**

- update all instances of `gstatic` external font references to IBM Akamai.


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
