### PR TITLE
chore(browserstack): remove FF on Windows testing for browserstack automate

### DIFF
--- a/packages/web-components/tests/e2e-storybook/browserstack.json
+++ b/packages/web-components/tests/e2e-storybook/browserstack.json
@@ -6,11 +6,6 @@
       "versions": ["latest"]
     },
     {
-      "browser": "firefox",
-      "os": "Windows 10",
-      "versions": ["latest"]
-    },
-    {
       "browser": "edge",
       "os": "Windows 10",
       "versions": ["latest"]


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

The Browserstack Automate testing for WC is hanging on FF Windows. Removing for now.

### Changelog

**Removed**

- FF on windows configuration from browserstack.json

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
