### PR TITLE
fix(background-media): add check for default-src

### DIFF
--- a/packages/web-components/src/components/background-media/background-media.ts
+++ b/packages/web-components/src/components/background-media/background-media.ts
@@ -167,6 +167,10 @@ class DDSBackgroundMedia extends DDSImage {
     if (this.parentElement instanceof DDSLeadSpace) {
       this.gradientHidden = true;
     }
+
+    if (this.hasAttribute('default-src')) {
+      this.containsOnlyImages = true;
+    }
   }
 
   render() {


### PR DESCRIPTION
### Related Ticket(s)

#8308 [[Lead space search - with image]: Image background not appearing](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/8308)

### Description

The original ticket pointed out that in the "React wrapper - an image should appear inside the `Lead space search - with image`, but no image appears in the background." While investigating, I found that the `Card section offset` was also missing its background image.

This happened because of some changes in the `Background media` component.

The fix should really be credited to @IgnacioBecerra as he was the one who finally tracked down the problem. :) 


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
