### PR TITLE
fix(table-of-contents): add scroll behavior to react with toc wrapper

### DIFF
--- a/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
+++ b/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
@@ -64,6 +64,26 @@ export const Default = ({ parameters }) => {
   );
 };
 
+export const WithHorizontalTOC = ({ parameters }) => {
+  const { mastheadProps, footerProps } = parameters?.props?.DotcomShell ?? {};
+  return (
+    <DotcomShell mastheadProps={mastheadProps} footerProps={footerProps}>
+      <main id="main-content">
+        <div style={{ paddingTop: '6rem' }}>
+          <Content withHorizontalTOC={true} withL1={!!mastheadProps.mastheadL1Data} />
+        </div>
+      </main>
+    </DotcomShell>
+  );
+};
+
+WithHorizontalTOC.story = {
+  name: 'With ToC horizontal',
+  parameters: {
+    ...readme.parameters,
+  },
+};
+
 export const DefaultLanguageOnly = ({ parameters }) => (
   <Default parameters={parameters} />
 );

--- a/packages/react/src/components/DotcomShell/__stories__/data/content.js
+++ b/packages/react/src/components/DotcomShell/__stories__/data/content.js
@@ -35,21 +35,39 @@ import logoMicrosoft from '../../../../../../storybook-images/assets/logos/logo-
 import logoRabobank from '../../../../../../storybook-images/assets/logos/logo-rabobank.png';
 import logoUsBank from '../../../../../../storybook-images/assets/logos/logo-usbank.png';
 
+import DDSTableOfContents from '@carbon/ibmdotcom-web-components/es/components-react/table-of-contents/table-of-contents';
+
 import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
- * DDS patterns template
+ * Function to conditionally render horizontal or default ToC
  *
- * @returns {*} JSX for Learn template
+ * @returns {*} JSX for ToC components
  */
-const Content = ({ withL1 }) => (
-  <>
-    <TableOfContents
+const renderTableOfContents = (withHorizontalTOC, withL1) => {
+  if(withHorizontalTOC) {
+    return (<DDSTableOfContents
+      layout='horizontal'
       menuLabel="Jump to"
       theme="white"
       stickyOffset={withL1 ? '96' : '48'}>
-      <a name="section-1" data-title="Lorem ipsum dolor sit amet" />
+      {innerContent()}
+    </DDSTableOfContents>)
+  }
+  return (<DDSTableOfContents>
+    {innerContent()}
+  </DDSTableOfContents>)
+}
+
+/**
+ * DDS components
+ *
+ * @returns {*} JSX for the inner components
+ */
+const innerContent = () => (
+  <>
+  <a name="section-1" data-title="Lorem ipsum dolor sit amet" />
       <LeadSpaceBlock
         title="Lorem ipsum dolor sit amet"
         copy="Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
@@ -382,7 +400,17 @@ const Content = ({ withL1 }) => (
           },
         }}
       />
-    </TableOfContents>
+  </>
+)
+
+/**
+ * DDS patterns template
+ *
+ * @returns {*} JSX for Learn template
+ */
+const Content = ({ withHorizontalTOC, withL1 }) => (
+  <>
+  {renderTableOfContents(withHorizontalTOC, withL1)}
     <div className="bx--grid" style={{ backgroundColor: '#f4f4f4' }}>
       <div className="bx--row">
         <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
@@ -431,6 +459,11 @@ const Content = ({ withL1 }) => (
 );
 
 Content.propTypes = {
+  /**
+   * `true` if content is rendered with a horizontal TOC
+   */
+  withHorizontalTOC: PropTypes.bool,
+
   /**
    * `true` if content is rendered with an L1 on the page
    */

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -158,11 +158,15 @@ const Masthead = ({
   });
 
   const [scrollOffset, setScrollOffset] = useState(root.scrollY);
+  const [tableOfContents, setTableOfContents] = useState(null)
 
   useEffect(() => {
-    const tableOfContents = document.querySelector(
+    setTableOfContents(document.querySelector(
       '.bx--tableofcontents__sidebar'
-    );
+    ) ?? document.querySelector('dds-table-of-contents')?.shadowRoot.querySelector('.bx--tableofcontents__navbar'));
+  })
+
+  useEffect(() => {
     let lastScrollPosition = 0;
 
     /**
@@ -185,8 +189,7 @@ const Masthead = ({
          */
       } else if (
         tableOfContents != null &&
-        stickyRef.current !== null &&
-        window.innerWidth < gridBreakpoint
+        stickyRef.current !== null
       ) {
         const tocBoundingClient = tableOfContents.getBoundingClientRect();
         stickyRef.current.style.transition = `none`;
@@ -196,19 +199,25 @@ const Masthead = ({
         );
         const tocPosition =
           tocBoundingClient.top + lastScrollPosition - window.scrollY;
-        tableOfContents.style.top = `${Math.max(
-          Math.min(tocPosition, stickyRef.current.offsetHeight),
-          0
-        )}px`;
 
-        if (tableOfContents.style.top === '0px') {
-          stickyRef.current.style.top = `-${stickyRef.current.offsetHeight}px`;
-        } else if (
-          tableOfContents.style.top === `${stickyRef.current.offsetHeight}px`
-        ) {
-          stickyRef.current.style.top = '0';
-        } else {
-          stickyRef.current.style.top = `${mastheadTop}px`;
+        if(tableOfContents.getRootNode().host.getAttribute('toc-layout') === 'horizontal') {
+          tableOfContents.style.top = `${stickyRef.current.offsetHeight}px`;
+
+        } else if(window.innerWidth < gridBreakpoint) {
+          tableOfContents.style.top = `${Math.max(
+            Math.min(tocPosition, stickyRef.current.offsetHeight),
+            0
+          )}px`;
+
+          if (tableOfContents.style.top === '0px') {
+            stickyRef.current.style.top = `-${stickyRef.current.offsetHeight}px`;
+          } else if (
+            tableOfContents.style.top === `${stickyRef.current.offsetHeight}px`
+          ) {
+            stickyRef.current.style.top = '0';
+          } else {
+            stickyRef.current.style.top = `${mastheadTop}px`;
+          }
         }
 
         lastScrollPosition = window.scrollY;
@@ -218,7 +227,7 @@ const Masthead = ({
     return () => {
       root.removeEventListener('scroll', () => handleScroll);
     };
-  }, [scrollOffset]);
+  }, [scrollOffset, tableOfContents]);
 
   if (navigation) {
     switch (typeof navigation) {


### PR DESCRIPTION
### Related Ticket(s)
#7641

### Description
This PR ensures that the React version of the Masthead can handle the Horizontal TOC that is only present in the React wrapper version.

This also adds a Horizontal TOC story to the Dotcom Shell so it's similar to the Web Components version. However, this might be removed if the ci-checks dont pass as we've seen before when trying to use React wrappers in the React Storybook.

### Changelog

**New**

- Horizontal TOC story for React Dotcom shell

**Changed**

- scrolling logic in the React masthead


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
