### PR TITLE
feat(pictogram-item): Allow for changing of Pictogram color

### DIFF
--- a/packages/styles/scss/components/pictogram-item/_pictogram-item.scss
+++ b/packages/styles/scss/components/pictogram-item/_pictogram-item.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -56,6 +56,12 @@
       margin-top: $carbon--spacing-07;
       height: 80px;
       width: 80px;
+    }
+
+    &[color='blue'] {
+      .#{$prefix}--pictogram-item__pictogram {
+        color: $link-01;
+      }
     }
   }
 }

--- a/packages/web-components/src/components/pictogram-item/__stories__/pictogram-item.stories.ts
+++ b/packages/web-components/src/components/pictogram-item/__stories__/pictogram-item.stories.ts
@@ -48,6 +48,7 @@ const Pattern = html`
     focusable="false"
     preserveAspectRatio="xMidYMid meet"
     xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
     data-autoid="dds--pictogram-item__pictogram"
     aria-label="Pictogram description"
     width="64"
@@ -92,6 +93,7 @@ const Touch = html`
     focusable="false"
     preserveAspectRatio="xMidYMid meet"
     xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
     data-autoid="dds--pictogram-item__pictogram"
     aria-label="Pictogram description"
     width="64"
@@ -146,8 +148,8 @@ const pictograms = {
 };
 
 const pictogramColors = {
-  'Black (default)': COLOR_OPTIONS.DEFAULT,
-  'Blue 50': COLOR_OPTIONS.BLUE,
+  'Text color (default)': COLOR_OPTIONS.DEFAULT,
+  Blue: COLOR_OPTIONS.BLUE,
 };
 
 export const Default = ({ parameters }) => {
@@ -196,7 +198,7 @@ export default {
           src: selectPictogram(select('Pictogram (required)', pictograms, pictograms.Desktop, groupId)),
           'aria-label': textNullable('Aria-label:', 'Pictogram description', groupId),
         },
-        pictogramColor: select('Pictogram color:', pictogramColors, pictogramColors.black, groupId),
+        pictogramColor: select('Pictogram color:', pictogramColors, COLOR_OPTIONS.DEFAULT, groupId),
       }),
     },
     propsSet: {
@@ -213,7 +215,7 @@ export default {
             src: pictograms.Desktop,
             'aria-label': 'Pictogram description',
           },
-          pictogramColor: pictogramColors.black,
+          pictogramColor: COLOR_OPTIONS.DEFAULT,
         },
       },
     },

--- a/packages/web-components/src/components/pictogram-item/__stories__/pictogram-item.stories.ts
+++ b/packages/web-components/src/components/pictogram-item/__stories__/pictogram-item.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,6 +12,7 @@ import '../index';
 import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 import { select } from '@storybook/addon-knobs';
 import styles from './pictogram-item.stories.scss';
+import { COLOR_OPTIONS } from '../defs';
 import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 
@@ -144,10 +145,15 @@ const pictograms = {
   Pattern: 'Pattern',
 };
 
+const pictogramColors = {
+  'Black (default)': COLOR_OPTIONS.DEFAULT,
+  'Blue 50': COLOR_OPTIONS.BLUE,
+};
+
 export const Default = ({ parameters }) => {
-  const { heading, copy, href, linkCopy, pictogram } = parameters?.props?.PictogramItem ?? {};
+  const { heading, copy, href, linkCopy, pictogram, pictogramColor } = parameters?.props?.PictogramItem ?? {};
   return html`
-    <dds-pictogram-item>
+    <dds-pictogram-item color="${pictogramColor}">
       ${pictogram?.src}
       <dds-content-item-heading>${heading}</dds-content-item-heading>
       <dds-content-item-copy>${copy}</dds-content-item-copy>
@@ -190,6 +196,7 @@ export default {
           src: selectPictogram(select('Pictogram (required)', pictograms, pictograms.Desktop, groupId)),
           'aria-label': textNullable('Aria-label:', 'Pictogram description', groupId),
         },
+        pictogramColor: select('Pictogram color:', pictogramColors, pictogramColors.black, groupId),
       }),
     },
     propsSet: {
@@ -206,6 +213,7 @@ export default {
             src: pictograms.Desktop,
             'aria-label': 'Pictogram description',
           },
+          pictogramColor: pictogramColors.black,
         },
       },
     },

--- a/packages/web-components/src/components/pictogram-item/defs.ts
+++ b/packages/web-components/src/components/pictogram-item/defs.ts
@@ -12,12 +12,12 @@
  */
 export enum COLOR_OPTIONS {
   /**
-   * Defaults to black.
+   * Defaults to component text color.
    */
   DEFAULT = '',
 
   /**
-   * Blue 50 - $link-01
+   * Blue - $link-01
    */
   BLUE = 'blue',
 }

--- a/packages/web-components/src/components/pictogram-item/defs.ts
+++ b/packages/web-components/src/components/pictogram-item/defs.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pictogram colors.
+ */
+export enum COLOR_OPTIONS {
+  /**
+   * Defaults to black.
+   */
+  DEFAULT = '',
+
+  /**
+   * Blue 50 - $link-01
+   */
+  BLUE = 'blue',
+}

--- a/packages/web-components/src/components/pictogram-item/pictogram-item.ts
+++ b/packages/web-components/src/components/pictogram-item/pictogram-item.ts
@@ -7,9 +7,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { customElement, html } from 'lit-element';
+import { property, customElement, html } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
+import { COLOR_OPTIONS } from './defs';
 import DDSContentItem from '../content-item/content-item';
 import styles from './pictogram-item.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
@@ -27,6 +28,14 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  */
 @customElement(`${ddsPrefix}-pictogram-item`)
 class DDSPictogramItem extends StableSelectorMixin(DDSContentItem) {
+  /**
+   * The pictogram color.
+   *
+   * Color scheme options are: "Black (Default)" and "Blue 50"
+   */
+  @property({ attribute: 'color', reflect: true })
+  colorOption = COLOR_OPTIONS.DEFAULT;
+
   render() {
     return html`
       <div class="${prefix}--pictogram-item__row">


### PR DESCRIPTION
### Related Ticket(s)

#8603: [Pictogram Item]: Allow for changing of Pictogram color

### Description

Expose a pictogram-color color prop/attribute that allows Content Editors to pick and choose from the following options.
- Black (Default)
- Blue 50

#### To test

1. Open the component at `/?path=/story/components-pictogram-item--default`
2. In the "Knobs" tab, the last knob should be "Pictogram color"
3. Select "Blue 50" and check that the pictogram SVG changes to blue

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
