### PR TITLE
fix(masthead): add optional chaining

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -218,7 +218,7 @@ const Masthead = ({
           tocBoundingClient.top + lastScrollPosition - window.scrollY;
 
         if (
-          tableOfContents.getRootNode().host.getAttribute('toc-layout') ===
+          tableOfContents?.getRootNode()?.host?.getAttribute('toc-layout') ===
           'horizontal'
         ) {
           tableOfContents.style.top = `${stickyRef.current.offsetHeight}px`;


### PR DESCRIPTION
### Related Ticket(s)
None.

### Description
This PR ensures that the Masthead only checks for the horizontal ToC if the `getRootNode` exists. In other words, it ensures no errors happen when checking for it as can be seen happening in the NextJS page.

### Changelog

**Changed**

- added optional chaining for the React wrapper ToC

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
