### PR TITLE
feat(image/with-caption): add wrapper stories and codesandbox

### DIFF
--- a/packages/web-components/examples/codesandbox/components-react/image-with-caption/.gitignore
+++ b/packages/web-components/examples/codesandbox/components-react/image-with-caption/.gitignore
@@ -1,0 +1,2 @@
+/build
+/node_modules

--- a/packages/web-components/examples/codesandbox/components-react/image-with-caption/index.html
+++ b/packages/web-components/examples/codesandbox/components-react/image-with-caption/index.html
@@ -1,0 +1,24 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>carbon-web-components example with React</title>
+  </head>
+  <body>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+    <div id="root"></div>
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/packages/web-components/examples/codesandbox/components-react/image-with-caption/package.json
+++ b/packages/web-components/examples/codesandbox/components-react/image-with-caption/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "ibmdotcom-web-components-react-image-with-caption-example",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sample project for getting started with the Web Components from Carbon for IBM.com with React.",
+  "license": "Apache-2",
+  "scripts": {
+    "start": "webpack serve"
+  },
+  "dependencies": {
+    "@carbon/ibmdotcom-web-components": "latest",
+    "@carbon/icons-react": "~10.22.0",
+    "carbon-components": "~10.23.0",
+    "lit-element": "^2.5.1",
+    "lit-html": "^1.4.1",
+    "lodash-es": "^4.17.0",
+    "prop-types": "^15.7.0",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
+    "react-redux": "^7.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0",
+    "@babel/preset-react": "^7.10.0",
+    "@types/lodash-es": "^4.17.0",
+    "@types/react": "^16.9.0",
+    "babel-loader": "^8.2.0",
+    "css-loader": "^4.3.0",
+    "html-webpack-plugin": "^4.5.0",
+    "style-loader": "^2.0.0",
+    "webpack": "^4.0.0",
+    "webpack-cli": "^4.0.0",
+    "webpack-dev-server": "^3.11.0"
+  }
+}

--- a/packages/web-components/examples/codesandbox/components-react/image-with-caption/sandbox.config.json
+++ b/packages/web-components/examples/codesandbox/components-react/image-with-caption/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}

--- a/packages/web-components/examples/codesandbox/components-react/image-with-caption/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/image-with-caption/src/index.css
@@ -1,0 +1,43 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+html,
+body {
+  margin: 0;
+}
+
+body {
+  padding: 2rem;
+}
+
+/* Minimum setting to use IBM Plex font */
+@font-face {
+  font-weight: 400;
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  src: local('IBM Plex Sans'), local('IBMPlexSans'),
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
+  font-display: auto;
+}
+
+@font-face {
+  font-weight: 600;
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
+  font-display: auto;
+}
+
+/* From: https://github.com/carbon-design-system/carbon/blob/v10.22.0/packages/type/scss/_reset.scss#L31-L32 */
+body {
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}

--- a/packages/web-components/examples/codesandbox/components-react/image-with-caption/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/image-with-caption/src/index.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render } from 'react-dom';
+import DDSImageWithCaption from '@carbon/ibmdotcom-web-components/es/components-react/image-with-caption/image-with-caption.js';
+import DDSImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item.js';
+import './index.css';
+
+const App = () => (
+  <DDSImageWithCaption alt="Image alt text" heading="this is a heading" copy="lorum ipsum" lightbox>
+    <DDSImageItem
+      media="(min-wiidth:672px)"
+      srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616"></DDSImageItem>
+    <DDSImageItem
+      media="(min-wiidth:400px)"
+      srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616"></DDSImageItem>
+    <DDSImageItem
+      media="(min-wiidth:320px)"
+      srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616"></DDSImageItem>
+  </DDSImageWithCaption>
+);
+
+render(<App />, document.getElementById('root'));

--- a/packages/web-components/examples/codesandbox/components-react/image-with-caption/webpack.config.js
+++ b/packages/web-components/examples/codesandbox/components-react/image-with-caption/webpack.config.js
@@ -1,0 +1,47 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: ['@babel/preset-react'],
+            },
+          },
+        ],
+      },
+      {
+        test: /\.css$/,
+        sideEffects: true,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+  plugins: [
+    // Lets WebPack Dev Server serve `.html` file.
+    // If you have other means to server `.html` content, this is not needed.
+    new HtmlWebpackPlugin({
+      template: 'index.html',
+      inject: false,
+    }),
+  ],
+  output: {
+    library: 'index',
+    filename: 'index.js',
+  },
+};

--- a/packages/web-components/examples/codesandbox/components-react/image/.gitignore
+++ b/packages/web-components/examples/codesandbox/components-react/image/.gitignore
@@ -1,0 +1,2 @@
+/build
+/node_modules

--- a/packages/web-components/examples/codesandbox/components-react/image/index.html
+++ b/packages/web-components/examples/codesandbox/components-react/image/index.html
@@ -1,0 +1,24 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>carbon-web-components example with React</title>
+  </head>
+  <body>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+    <div id="root"></div>
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/packages/web-components/examples/codesandbox/components-react/image/package.json
+++ b/packages/web-components/examples/codesandbox/components-react/image/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "ibmdotcom-web-components-react-image-example",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sample project for getting started with the Web Components from Carbon for IBM.com with React.",
+  "license": "Apache-2",
+  "scripts": {
+    "start": "webpack serve"
+  },
+  "dependencies": {
+    "@carbon/ibmdotcom-web-components": "latest",
+    "@carbon/icons-react": "~10.22.0",
+    "carbon-components": "~10.23.0",
+    "lit-element": "^2.5.1",
+    "lit-html": "^1.4.1",
+    "lodash-es": "^4.17.0",
+    "prop-types": "^15.7.0",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
+    "react-redux": "^7.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0",
+    "@babel/preset-react": "^7.10.0",
+    "@types/lodash-es": "^4.17.0",
+    "@types/react": "^16.9.0",
+    "babel-loader": "^8.2.0",
+    "css-loader": "^4.3.0",
+    "html-webpack-plugin": "^4.5.0",
+    "style-loader": "^2.0.0",
+    "webpack": "^4.0.0",
+    "webpack-cli": "^4.0.0",
+    "webpack-dev-server": "^3.11.0"
+  }
+}

--- a/packages/web-components/examples/codesandbox/components-react/image/sandbox.config.json
+++ b/packages/web-components/examples/codesandbox/components-react/image/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}

--- a/packages/web-components/examples/codesandbox/components-react/image/src/index.css
+++ b/packages/web-components/examples/codesandbox/components-react/image/src/index.css
@@ -1,0 +1,43 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+html,
+body {
+  margin: 0;
+}
+
+body {
+  padding: 2rem;
+}
+
+/* Minimum setting to use IBM Plex font */
+@font-face {
+  font-weight: 400;
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  src: local('IBM Plex Sans'), local('IBMPlexSans'),
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff) format('woff');
+  font-display: auto;
+}
+
+@font-face {
+  font-weight: 600;
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
+    url(https://1www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff) format('woff');
+  font-display: auto;
+}
+
+/* From: https://github.com/carbon-design-system/carbon/blob/v10.22.0/packages/type/scss/_reset.scss#L31-L32 */
+body {
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}

--- a/packages/web-components/examples/codesandbox/components-react/image/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/image/src/index.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render } from 'react-dom';
+import DDSImage from '@carbon/ibmdotcom-web-components/es/components-react/image/image.js';
+import DDSImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item.js';
+import './index.css';
+
+const App = () => (
+  <DDSImage alt="Image alt text">
+    <DDSImageItem
+      media="(min-width:672px)"
+      srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616"></DDSImageItem>
+    <DDSImageItem
+      media="(min-width:400px)"
+      srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616"></DDSImageItem>
+    <DDSImageItem
+      media="(min-width:320px)"
+      srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616"></DDSImageItem>
+  </DDSImage>
+);
+
+render(<App />, document.getElementById('root'));

--- a/packages/web-components/examples/codesandbox/components-react/image/webpack.config.js
+++ b/packages/web-components/examples/codesandbox/components-react/image/webpack.config.js
@@ -1,0 +1,47 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: ['@babel/preset-react'],
+            },
+          },
+        ],
+      },
+      {
+        test: /\.css$/,
+        sideEffects: true,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+  plugins: [
+    // Lets WebPack Dev Server serve `.html` file.
+    // If you have other means to server `.html` content, this is not needed.
+    new HtmlWebpackPlugin({
+      template: 'index.html',
+      inject: false,
+    }),
+  ],
+  output: {
+    library: 'index',
+    filename: 'index.js',
+  },
+};

--- a/packages/web-components/src/components/image-with-caption/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/image-with-caption/__stories__/README.stories.react.mdx
@@ -1,0 +1,53 @@
+import { Preview, Props, Description, Story } from '@storybook/addon-docs/blocks';
+import contributing from '../../../../../../docs/contributing-license.md';
+import { PropTypesRef as ImageWithCaptionProps } from '@carbon/ibmdotcom-web-components/es/components-react/image-with-caption/image-with-caption';
+
+# Image with caption
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/image-with-caption)
+> example implementation.
+
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/image-with-caption)
+
+## Getting started
+
+Here's a quick example to get you started.
+
+### JS
+
+```javascript
+import DDSImageWithCaption from '@carbon/ibmdotcom-web-components/es/components-react/image-with-caption/image-with-caption.js';
+import DDSImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item.js';
+
+function App() {
+  return (
+  <DDSImageWithCaption
+    alt="Image alt text"
+    heading="this is a heading"
+    copy="lorum ipsum"
+    lightbox>
+      <DDSImageItem media="(min-wiidth:672px)" srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616">
+      </DDSImageItem>
+      <DDSImageItem media="(min-wiidth:400px)" srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616">
+      </DDSImageItem>
+      <DDSImageItem media="(min-wiidth:320px)" srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616">
+      </DDSImageItem>
+  </DDSImageWithCaption>
+  );
+}
+```
+
+## Props of ImageWithCaption
+
+<Props of={ImageWithCaptionProps} />
+
+## Stable selectors
+
+See [our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components#stable-selectors-for-analytics-and-integratione2e-testing-in-web-components) to see how Web Components selector and `data-autoid` should be used.
+
+| Web Components selector | Compatibility selector | Description |
+| ----------------------- | ---------------------- | ----------- |
+| `<dds-image-with-caption>`        | N/A                    | Component   |
+
+<Description markdown={contributing} />

--- a/packages/web-components/src/components/image-with-caption/__stories__/image-with-caption.stories.react.tsx
+++ b/packages/web-components/src/components/image-with-caption/__stories__/image-with-caption.stories.react.tsx
@@ -1,0 +1,91 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { text, select, boolean } from '@storybook/addon-knobs';
+import React from 'react';
+// Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
+// In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
+// @ts-ignore
+import DDSImageWithCaption from '@carbon/ibmdotcom-web-components/es/components-react/image-with-caption/image-with-caption';
+import DDSImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item';
+
+import readme from './README.stories.react.mdx';
+import imgLg2x1 from '../../../../../storybook-images/assets/720/fpo--2x1--720x360--005.jpg';
+import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--005.jpg';
+import imgSm2x1 from '../../../../../storybook-images/assets/320/fpo--2x1--320x160--005.jpg';
+import imgMd2x1 from '../../../../../storybook-images/assets/480/fpo--2x1--480x240--005.jpg';
+import imgSm16x9 from '../../../../../storybook-images/assets/320/fpo--16x9--320x180--005.jpg';
+import imgMd16x9 from '../../../../../storybook-images/assets/480/fpo--16x9--480x270--005.jpg';
+
+const images = {
+  '2:1': imgLg2x1,
+  '16:9': imgLg16x9,
+};
+
+const srcsets = {
+  '2:1': [imgSm2x1, imgMd2x1, imgLg2x1],
+  '16:9': [imgSm16x9, imgMd16x9, imgLg16x9],
+};
+
+export const Default = ({ parameters }) => {
+  const { alt, defaultSrc, heading, copy, lightbox } = parameters?.props?.ImageWithCaption ?? {};
+  // TODO: See if we can fix unwanted `&` to `&amp` conversion upon changing the select knob
+  const srcset = srcsets[defaultSrc?.replace(/&amp;/, '&')];
+  return (
+    <DDSImageWithCaption
+      alt={alt || undefined}
+      defaultSrc={defaultSrc || undefined}
+      heading={heading || undefined}
+      copy={copy || undefined}
+      lightbox={lightbox}>
+      {!srcset ? (
+        undefined
+      ) : (
+        <>
+          <DDSImageItem media="(min-width: 672px)" srcset={srcset[2]} />
+          <DDSImageItem media="(min-width: 400px)" srcset={srcset[1]} />
+          <DDSImageItem media="(min-width: 320px)" srcset={srcset[0]} />
+        </>
+      )}
+    </DDSImageWithCaption>
+  );
+};
+
+Default.story = {
+  parameters: {
+    knobs: {
+      ImageWithCaption: () => ({
+        alt: text('Alt text', 'Image alt text'),
+        defaultSrc: select('Default image (default-src)', images, imgLg2x1),
+        lightbox: boolean('Lightbox (lightbox)', true),
+        copy: text('Copy (copy)', 'Lorem ipsum dolor sit amet'),
+        heading: text('Heading (heading)', 'This is a caption'),
+      }),
+    },
+  },
+};
+
+export default {
+  title: 'Components/Image with caption',
+  decorators: [
+    story => {
+      return (
+        <div className="bx--grid">
+          <div className="bx--row">
+            <div className="bx--col-sm-4 bx--col-lg-8">{story()}</div>
+          </div>
+        </div>
+      );
+    },
+  ],
+  parameters: {
+    ...readme.parameters,
+    hasStoryPadding: true,
+  },
+};

--- a/packages/web-components/src/components/image-with-caption/image-with-caption.ts
+++ b/packages/web-components/src/components/image-with-caption/image-with-caption.ts
@@ -177,4 +177,5 @@ class DDSImageWithCaption extends StableSelectorMixin(ModalRenderMixin(FocusMixi
   static styles = styles;
 }
 
+/* @__GENERATE_REACT_CUSTOM_ELEMENT_TYPE__ */
 export default DDSImageWithCaption;

--- a/packages/web-components/src/components/image/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/image/__stories__/README.stories.react.mdx
@@ -1,0 +1,50 @@
+import { Preview, Props, Description, Story } from '@storybook/addon-docs/blocks';
+import contributing from '../../../../../../docs/contributing-license.md';
+import { PropTypesRef as ImageProps } from '@carbon/ibmdotcom-web-components/es/components-react/image/image';
+
+# Image
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/image)
+> example implementation.
+
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/image)
+
+## Getting started
+
+Here's a quick example to get you started.
+
+### JS
+
+```javascript
+import DDSImage from '@carbon/ibmdotcom-web-components/es/components-react/image/image.js';
+import DDSImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item.js';
+
+function App() {
+  return (
+  <DDSImage alt="Image alt text">
+    <DDSImageItem media="(min-wiidth:672px)" srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616">
+    </DDSImageItem>
+    <DDSImageItem media="(min-wiidth:400px)" srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616">
+    </DDSImageItem>
+    <DDSImageItem media="(min-wiidth:320px)" srcset="https://fpoimg.com/672x336?text=2:1&bg_color=ee5396&text_color=161616">
+    </DDSImageItem>
+  </DDSImage>
+  );
+}
+```
+
+## Props of Image
+
+<Props of={ImageProps} />
+
+## Stable selectors
+
+See [our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components#stable-selectors-for-analytics-and-integratione2e-testing-in-web-components) to see how Web Components selector and `data-autoid` should be used.
+
+| Web Components selector | Compatibility selector | Description |
+| ----------------------- | ---------------------- | ----------- |
+| `<dds-image>`        | N/A                    | Component   |
+| `<dds-image-item>`        | N/A                    | Component   |
+
+<Description markdown={contributing} />

--- a/packages/web-components/src/components/image/__stories__/image.stories.react.tsx
+++ b/packages/web-components/src/components/image/__stories__/image.stories.react.tsx
@@ -1,0 +1,84 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { text, select, boolean } from '@storybook/addon-knobs';
+import React from 'react';
+// Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
+// In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
+// @ts-ignore
+import DDSImage from '@carbon/ibmdotcom-web-components/es/components-react/image/image';
+import DDSImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item';
+
+import readme from './README.stories.react.mdx';
+import imgLg2x1 from '../../../../../storybook-images/assets/720/fpo--2x1--720x360--005.jpg';
+import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--005.jpg';
+import imgSm2x1 from '../../../../../storybook-images/assets/320/fpo--2x1--320x160--005.jpg';
+import imgMd2x1 from '../../../../../storybook-images/assets/480/fpo--2x1--480x240--005.jpg';
+import imgSm16x9 from '../../../../../storybook-images/assets/320/fpo--16x9--320x180--005.jpg';
+import imgMd16x9 from '../../../../../storybook-images/assets/480/fpo--16x9--480x270--005.jpg';
+
+const images = {
+  '2:1': imgLg2x1,
+  '16:9': imgLg16x9,
+};
+
+const srcsets = {
+  '2:1': [imgSm2x1, imgMd2x1, imgLg2x1],
+  '16:9': [imgSm16x9, imgMd16x9, imgLg16x9],
+};
+
+export const Default = ({ parameters }) => {
+  const { alt, defaultSrc, border } = parameters?.props?.Image ?? {};
+  // TODO: See if we can fix unwanted `&` to `&amp` conversion upon changing the select knob
+  const srcset = srcsets[defaultSrc?.replace(/&amp;/, '&')];
+  return (
+    <DDSImage alt={alt || undefined} defaultSrc={defaultSrc || undefined} border={border}>
+      {!srcset ? (
+        undefined
+      ) : (
+        <>
+          <DDSImageItem media="(min-width: 672px)" srcset={srcset[2]} />
+          <DDSImageItem media="(min-width: 400px)" srcset={srcset[1]} />
+          <DDSImageItem media="(min-width: 320px)" srcset={srcset[0]} />
+        </>
+      )}
+    </DDSImage>
+  );
+};
+
+Default.story = {
+  parameters: {
+    knobs: {
+      Image: () => ({
+        alt: text('Alt text', 'Image alt text'),
+        defaultSrc: select('Default image (default-src)', images, imgLg2x1),
+        border: boolean('Border', false),
+      }),
+    },
+  },
+};
+
+export default {
+  title: 'Components/Image',
+  decorators: [
+    story => {
+      return (
+        <div className="bx--grid">
+          <div className="bx--row">
+            <div className="bx--col-sm-4 bx--col-lg-8">{story()}</div>
+          </div>
+        </div>
+      );
+    },
+  ],
+  parameters: {
+    ...readme.parameters,
+    hasStoryPadding: true,
+  },
+};


### PR DESCRIPTION
### Related Ticket(s)

#8641 #8640

### Description

Added Image and Image with Caption to storybook. Also added codesandbox examples

### Changelog

**New**

-stories, readme, codesandbox


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
