### PR TITLE
fix(tabs-extended): allow VO to access tab panel content

### DIFF
--- a/packages/web-components/src/components/tabs-extended-media/__stories__/tabs-extended-media.stories.react.tsx
+++ b/packages/web-components/src/components/tabs-extended-media/__stories__/tabs-extended-media.stories.react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,10 @@ import DDSImage from '@carbon/ibmdotcom-web-components/es/components-react/image
 import readme from './README.stories.react.mdx';
 import { ICON_PLACEMENT } from '../../link-with-icon/link-with-icon';
 import { MEDIA_ALIGN, MEDIA_TYPE } from '../../content-item-horizontal/defs';
-import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--001.jpg';
+import imgLg16x9a from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--001.jpg';
+import imgLg16x9b from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--002.jpg';
+import imgLg16x9c from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--003.jpg';
+import imgLg16x9d from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--004.jpg';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 import { CTA_TYPE } from '../../cta/defs';
 
@@ -65,7 +68,7 @@ export const Default = ({ parameters }) => {
       <DDSContentSectionHeading>{sectionHeading || undefined}</DDSContentSectionHeading>
       <DDSTab label="First tab">
         <DDSContentItemHorizontalMedia align={align}>
-          {type === MEDIA_TYPE.IMAGE ? <DDSImage slot="media" alt={alt || undefined} default-src={imgLg16x9}></DDSImage> : ''}
+          {type === MEDIA_TYPE.IMAGE ? <DDSImage slot="media" alt={alt || undefined} default-src={imgLg16x9a}></DDSImage> : ''}
           {type === MEDIA_TYPE.VIDEO ? (
             <DDSContentItemHorizontalMediaVideo video-id="1_9h94wo6b"></DDSContentItemHorizontalMediaVideo>
           ) : (
@@ -85,7 +88,7 @@ export const Default = ({ parameters }) => {
       </DDSTab>
       <DDSTab label="Second tab">
         <DDSContentItemHorizontalMedia align={align}>
-          {type === MEDIA_TYPE.IMAGE ? <DDSImage slot="media" alt={alt || undefined} default-src={imgLg16x9}></DDSImage> : ''}
+          {type === MEDIA_TYPE.IMAGE ? <DDSImage slot="media" alt={alt || undefined} default-src={imgLg16x9b}></DDSImage> : ''}
           {type === MEDIA_TYPE.VIDEO ? (
             <DDSContentItemHorizontalMediaVideo video-id="1_9h94wo6b"></DDSContentItemHorizontalMediaVideo>
           ) : (
@@ -105,7 +108,7 @@ export const Default = ({ parameters }) => {
       </DDSTab>
       <DDSTab label="Third tab">
         <DDSContentItemHorizontalMedia align={align}>
-          {type === MEDIA_TYPE.IMAGE ? <DDSImage slot="media" alt={alt || undefined} default-src={imgLg16x9}></DDSImage> : ''}
+          {type === MEDIA_TYPE.IMAGE ? <DDSImage slot="media" alt={alt || undefined} default-src={imgLg16x9c}></DDSImage> : ''}
           {type === MEDIA_TYPE.VIDEO ? (
             <DDSContentItemHorizontalMediaVideo video-id="1_9h94wo6b"></DDSContentItemHorizontalMediaVideo>
           ) : (
@@ -125,7 +128,7 @@ export const Default = ({ parameters }) => {
       </DDSTab>
       <DDSTab label="Fourth tab">
         <DDSContentItemHorizontalMedia align={align}>
-          {type === MEDIA_TYPE.IMAGE ? <DDSImage slot="media" alt={alt || undefined} default-src={imgLg16x9}></DDSImage> : ''}
+          {type === MEDIA_TYPE.IMAGE ? <DDSImage slot="media" alt={alt || undefined} default-src={imgLg16x9d}></DDSImage> : ''}
           {type === MEDIA_TYPE.VIDEO ? (
             <DDSContentItemHorizontalMediaVideo video-id="1_9h94wo6b"></DDSContentItemHorizontalMediaVideo>
           ) : (

--- a/packages/web-components/src/components/tabs-extended-media/__stories__/tabs-extended-media.stories.ts
+++ b/packages/web-components/src/components/tabs-extended-media/__stories__/tabs-extended-media.stories.ts
@@ -15,7 +15,10 @@ import '../index';
 
 import { ICON_PLACEMENT } from '../../../globals/defs';
 import { MEDIA_ALIGN, MEDIA_TYPE } from '../../content-item-horizontal/defs';
-import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--001.jpg';
+import imgLg16x9a from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--001.jpg';
+import imgLg16x9b from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--002.jpg';
+import imgLg16x9c from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--003.jpg';
+import imgLg16x9d from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--004.jpg';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 import { CTA_TYPE } from '../../cta/defs';
 
@@ -44,7 +47,7 @@ export const Default = ({ parameters }) => {
         <dds-content-item-horizontal-media align="${align}">
           ${type === MEDIA_TYPE.IMAGE
             ? html`
-                <dds-image slot="media" alt="${ifNonNull(alt)}" default-src="${imgLg16x9}"></dds-image>
+                <dds-image slot="media" alt="${ifNonNull(alt)}" default-src="${imgLg16x9a}"></dds-image>
               `
             : null}
           ${type === MEDIA_TYPE.VIDEO
@@ -76,7 +79,7 @@ export const Default = ({ parameters }) => {
         <dds-content-item-horizontal-media align="${align}">
           ${type === MEDIA_TYPE.IMAGE
             ? html`
-                <dds-image slot="media" alt="${ifNonNull(alt)}" default-src="${imgLg16x9}"></dds-image>
+                <dds-image slot="media" alt="${ifNonNull(alt)}" default-src="${imgLg16x9b}"></dds-image>
               `
             : null}
           ${type === MEDIA_TYPE.VIDEO
@@ -108,7 +111,7 @@ export const Default = ({ parameters }) => {
         <dds-content-item-horizontal-media align="${align}">
           ${type === MEDIA_TYPE.IMAGE
             ? html`
-                <dds-image slot="media" alt="${ifNonNull(alt)}" default-src="${imgLg16x9}"></dds-image>
+                <dds-image slot="media" alt="${ifNonNull(alt)}" default-src="${imgLg16x9c}"></dds-image>
               `
             : null}
           ${type === MEDIA_TYPE.VIDEO
@@ -140,7 +143,7 @@ export const Default = ({ parameters }) => {
         <dds-content-item-horizontal-media align="${align}">
           ${type === MEDIA_TYPE.IMAGE
             ? html`
-                <dds-image slot="media" alt="${ifNonNull(alt)}" default-src="${imgLg16x9}"></dds-image>
+                <dds-image slot="media" alt="${ifNonNull(alt)}" default-src="${imgLg16x9d}"></dds-image>
               `
             : null}
           ${type === MEDIA_TYPE.VIDEO

--- a/packages/web-components/src/components/tabs-extended/tab.ts
+++ b/packages/web-components/src/components/tabs-extended/tab.ts
@@ -42,6 +42,9 @@ class DDSTab extends StableSelectorMixin(LitElement) {
   /**
    * Defines the index of the tab relative to other tabs.
    */
+  @property({ reflect: true })
+  index: Number = 0;
+
   @state()
   private _index: Number = 0;
 
@@ -50,6 +53,7 @@ class DDSTab extends StableSelectorMixin(LitElement) {
    */
   setIndex(index: Number) {
     this._index = index;
+    this.index = index;
   }
 
   render() {

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -66,12 +66,15 @@ class DDSTabsExtended extends StableSelectorMixin(LitElement) {
 
   private _setPanelFocus(index: number) {
     this._activeTab = index;
-    const newTabPanel = this.querySelector(`dds-tab[index="${index}"]`).shadowRoot?.querySelector(`[role="tabpanel"]`);
     const newTabLink = this.shadowRoot?.querySelector(`
     [role="tablist"] li[role="tab"]:nth-child(${index + 1}) .bx--tabs__nav-link`);
+    const newTabPanel = this.querySelector(`dds-tab[index="${index}"]`)?.shadowRoot?.querySelector(`[role="tabpanel"]`);
+
+    if (newTabLink instanceof HTMLElement) {
+      newTabLink.blur();
+    }
 
     if (newTabPanel instanceof HTMLElement) {
-      newTabLink.blur();
       setTimeout(() => {
         newTabPanel.focus();
       }, 0);


### PR DESCRIPTION
### Related Ticket(s)

[[Tabs extended media]: React wrapper – not able to access other tabs with VO instructions](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/8139)

### Description

The problems described in the ticket appeared to apply to not just the React wrapper but the original web components as well, so I addressed them as a whole.

Test the following in both the original web components and in the React wrapper:
1. Tabs extended
    1. Vertical
    2. Horizontal
2. Tabs extended - with media

Original issue in quotes:

> I am not able to select the second, third or fourth tab in Tabs extended or Tabs extended – with media using the keyboard and voice over on Desktop
>
> VO instructs the user to press control + option + space to select a tab and it doesn't work, I see no changes in the selected state (all tabs content are the same).

To aid in testing, I updated the stories to have different images in each of the tabs, so now when you click on or select a tab you can visually tell when it has changed.

Previously, when a tab was clicked, the keyboard/VO focus would remain on the tab. I changed the focus to go to the tab panel contents instead of the tab when the tab is clicked or selected by keyboard or in VO. This allows the user to access the tab panel content.

However, unfortunately, I was not able to find a way to get Chrome (or Firefox) to respect the VO `control + option + space`. There are differences between these browsers and Safari in how they interpret VO commands and keyboard presses. The VO commands all work as expected in Safari.

A workaround for Chrome and Firefox is to switch from using pure VO keyboard commands and just use the plain navigation arrows, which have already been mostly set up for use. Doing so, when you are on a tab and press `enter` or `space` or (if on the horizontal variation) the `down arrow`, you will be taken to the tab panel content.

> VO is also reading out the tabs as first tab: "1 of 8"; second tab "3 of 8", which seems a bit strange? Is that the expected behavior and it's indicating a tab has two sections, the heading and the content?

This does not appear to be an issue anymore, at least when in the Storybook previews. It is possible that when on a page with multiple tab sections that the screen reader might get confused, but I haven't tested that.

#### Followup

I think the VO and keyboard navigation might need some more followup and discussion to further refine the experience. For example:

1. When reaching the end of the tabs list, should it re-cycle through the tabs or continue into the selected content?
2. When reaching the end of the tab panel content, should it go back up to the tabs list or continue down the page?
3. If it goes up to the tabs list, should it go to its own tab first?
4. How should the keyboard navigation adjust to a vertical versus horizontal alignment (for `tabs-extended`)?


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
