### PR TITLE
fix(e2e): adding wait times for React storybook e2e percy snapshots

### DIFF
--- a/packages/react/tests/e2e-storybook/cypress/integration/CardSectionImages/CardSectionImages.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/CardSectionImages/CardSectionImages.e2e.js
@@ -72,12 +72,16 @@ describe('dds-card-section-images | default (desktop)', () => {
         );
       });
 
+    cy.wait(3000);
+
     cy.takeSnapshots();
   });
 
   it('should load correctly in all themes', () => {
     cy.visit(`/${_pathDefault}`);
     cy.viewport(1280, 780);
+
+    cy.wait(3000);
 
     cy.carbonThemesScreenshot();
   });
@@ -137,12 +141,16 @@ describe('dds-card-section-images | default (mobile)', () => {
         );
       });
 
+    cy.wait(3000);
+
     cy.takeSnapshots('mobile');
   });
 
   it('should load correctly in all themes', () => {
     cy.visit(`/${_pathDefault}`);
     cy.viewport(320, 780);
+
+    cy.wait(3000);
 
     cy.carbonThemesScreenshot(
       {},

--- a/packages/react/tests/e2e-storybook/cypress/integration/CardSectionSimple/CardSectionSimple.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/CardSectionSimple/CardSectionSimple.e2e.js
@@ -64,6 +64,8 @@ const _tests = {
     });
   },
   checkThemes: () => {
+    cy.wait(3000);
+
     cy.carbonThemesScreenshot();
   },
 };

--- a/packages/react/tests/e2e-storybook/cypress/integration/TableOfContents/TableOfContents.e2e.js
+++ b/packages/react/tests/e2e-storybook/cypress/integration/TableOfContents/TableOfContents.e2e.js
@@ -123,6 +123,8 @@ const _tests = {
           .then(sidebar => {
             expect(sidebar.offset().top).to.be.greaterThan(0);
             if (pos === 'bottom') {
+              cy.wait(3000);
+
               cy.takeSnapshots(
                 'desktop',
                 {},
@@ -182,6 +184,8 @@ const _tests = {
               section.offset().top === 0 || window.scrollY === maxScrollVal;
             expect(sectionScrolledTo).to.be.true;
             if (i === 1) {
+              cy.wait(3000);
+
               cy.takeSnapshots(
                 'mobile',
                 {},
@@ -219,6 +223,8 @@ const _tests = {
           .then(mobileNav => {
             expect(mobileNav.offset().top).to.be.greaterThan(-1);
             if (pos === 'bottom') {
+              cy.wait(3000);
+
               cy.takeSnapshots(
                 'mobile',
                 {},


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Noticing consistent false positives happening around snapshots in Percy that involve motion/height calculation. This adds some wait time to see if this helps at all.

### Changelog

**Changed**

- Added `cy.wait()` to various React e2e tests
