### PR TITLE
fix(tabs-extended): ensure attributes are parsed as bools

### DIFF
--- a/packages/web-components/src/components/tabs-extended/tab.ts
+++ b/packages/web-components/src/components/tabs-extended/tab.ts
@@ -30,14 +30,14 @@ class DDSTab extends StableSelectorMixin(LitElement) {
   /**
    * Defines the disabled state of the tab.
    */
-  @property({ reflect: true })
-  disabled: Boolean = false;
+  @property({ reflect: true, type: Boolean })
+  disabled: boolean = false;
 
   /**
    * Defines the selected state of the tab.
    */
-  @property({ reflect: true })
-  selected: Boolean = false;
+  @property({ reflect: true, type: Boolean })
+  selected: boolean = false;
 
   /**
    * Defines the index of the tab relative to other tabs.

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -51,9 +51,7 @@ class DDSTabsExtended extends StableSelectorMixin(LitElement) {
   protected _handleSlotChange(event: Event) {
     const slottedNodes = (event.target as HTMLSlotElement).assignedNodes({ flatten: true });
     this._tabItems = slottedNodes.filter(node => node instanceof DDSTab) as DDSTab[];
-    this._tabItems.forEach((tab, index) => {
-      this._activeTab = (tab as DDSTab).selected ? index : this._activeTab;
-    });
+    this._activeTab = this._tabItems.findIndex(tab => (tab as DDSTab).selected);
   }
 
   private _handleClick(index, e) {
@@ -169,7 +167,7 @@ class DDSTabsExtended extends StableSelectorMixin(LitElement) {
     return html`
       <ul class="${prefix}--accordion">
         ${tabs.map((tab, index) => {
-          const disabled = (tab as DDSTab).disabled && true;
+          const { disabled } = tab as DDSTab;
           const active = index === this._activeTab;
           const label = (tab as DDSTab).getAttribute('label');
           const classes = classMap({
@@ -209,7 +207,7 @@ class DDSTabsExtended extends StableSelectorMixin(LitElement) {
       <div class="${prefix}--tabs">
         <ul class="${prefix}--tabs__nav ${prefix}--tabs__nav--hidden" role="tablist" @keydown="${this._handleTabListKeyDown}">
           ${tabs.map((tab, index) => {
-            const disabled = (tab as DDSTab).disabled && true;
+            const { disabled } = tab as DDSTab;
             const active = index === this._activeTab;
             const label = (tab as DDSTab).getAttribute('label');
             const classes = classMap({


### PR DESCRIPTION
### Related Ticket(s)

Resolves  #8751

### Description

There were cases where certain boolean attributes were being parsed as strings (e.g. `"false"`). Since non-empty strings are truthy, the value `"false"` was treated as `true`, and this caused any new tabs injected into the DOM to be  disabled.

This has been fixed by declaring to Lit Element that these attributes should be reflected as booleans. This tells Lit Element to convert the strings `"true"` and `"false"` to the booleans `true` and `false`, respectively.

### Changelog

**Changed**

- Declare `boolean` type for `DDSTab`'s boolean reactive properties.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
