### PR TITLE
fix(tabs-extended & table-of-contents): ensure DOM updates are handled

### DIFF
--- a/packages/web-components/src/components/table-of-contents/__stories__/content.ts
+++ b/packages/web-components/src/components/table-of-contents/__stories__/content.ts
@@ -22,7 +22,7 @@ export const headings = [
 export const LOREM = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.`;
 
 const generateCopySections = n =>
-  [...Array(n)].map(
+  Array(n).map(
     () =>
       html`
         <p>${LOREM}</p>

--- a/packages/web-components/src/components/table-of-contents/table-of-contents.ts
+++ b/packages/web-components/src/components/table-of-contents/table-of-contents.ts
@@ -305,13 +305,25 @@ class DDSTableOfContents extends HostListenerMixin(StableSelectorMixin(LitElemen
   };
 
   /**
-   * Handles `slotchange` event on the default `<slot>`.
-   *
-   * @param event The event.
+   * Watches for changes to content in the default slot.
    */
-  private _handleSlotChange(event: Event) {
+  private _contentMutationObserver = new MutationObserver(this._contentObserverCallback.bind(this));
+
+  /**
+   * Sets table of contents targets whenever any node tree mutation is observed.
+   */
+  private _contentObserverCallback() {
+    const shadowRoot = this.shadowRoot as ShadowRoot;
+    const defaultSlot = shadowRoot.querySelector(`.${prefix}--tableofcontents__content slot`) as HTMLSlotElement;
+    this._setTargets(Array.from(defaultSlot.assignedNodes()));
+  }
+
+  /**
+   * Sets targets used for generating the table of contents.
+   */
+  private _setTargets(nodes: Node[]) {
     const { selectorTarget } = this.constructor as typeof DDSTableOfContents;
-    this._targets = (event.target as HTMLSlotElement).assignedNodes().reduce((acc, node) => {
+    this._targets = nodes.reduce((acc, node) => {
       if (node.nodeType === Node.ELEMENT_NODE) {
         const elem = node as Element;
         if (elem.matches(selectorTarget)) {
@@ -321,6 +333,24 @@ class DDSTableOfContents extends HostListenerMixin(StableSelectorMixin(LitElemen
       }
       return acc;
     }, [] as HTMLAnchorElement[]);
+  }
+
+  /**
+   * Handles `slotchange` event on the default `<slot>`.
+   *
+   * @param event The event.
+   */
+  private _handleSlotChange(event: Event) {
+    // Handle changes to immediate slotted children.
+    this._setTargets((event.target as HTMLSlotElement).assignedNodes());
+
+    // Handle changes to slotted contents' children.
+    this._contentMutationObserver.disconnect();
+    (event.target as HTMLSlotElement).assignedNodes().forEach(node => {
+      if (node instanceof HTMLElement) {
+        this._contentMutationObserver.observe(node, { subtree: true, childList: true });
+      }
+    });
   }
 
   /**
@@ -554,6 +584,7 @@ class DDSTableOfContents extends HostListenerMixin(StableSelectorMixin(LitElemen
   disconnectedCallback() {
     this._cleanAndCreateObserverResizeMobileContainer();
     this._cleanAndCreateIntersectionObserverContainer();
+    this._contentMutationObserver.disconnect();
     if (this._throttleScroll) {
       this._throttleScroll.cancel();
       this._throttleScroll = null;

--- a/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.react.tsx
+++ b/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -28,7 +28,7 @@ export const Default = ({ parameters }) => {
     <DDSTabsExtended orientation={orientation || undefined}>
       <DDSTab
         label="First tab with long text that wraps multiple lines. Lorem ipsum dolor sit amet consectetur adipiscing elit"
-        selected="true">
+        selected={true}>
         <p>Content for first tab goes here.</p>
       </DDSTab>
       <DDSTab label="Second tab">
@@ -40,7 +40,7 @@ export const Default = ({ parameters }) => {
       <DDSTab label="Fourth tab">
         <p>Content for fourth tab goes here.</p>
       </DDSTab>
-      <DDSTab label="Fifth tab" disabled="true">
+      <DDSTab label="Fifth tab" disabled={true}>
         <p>Content for fifth tab goes here.</p>
       </DDSTab>
     </DDSTabsExtended>

--- a/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
+++ b/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
@@ -34,7 +34,7 @@ export const Default = ({ parameters }) => {
     <dds-tabs-extended orientation="${ifNonNull(orientation)}">
       <dds-tab
         label="First tab with long text that wraps multiple lines. Lorem ipsum dolor sit amet consectetur adipiscing elit"
-        selected="true"
+        selected
       >
         <dds-content-block-media-content>
           <dds-content-item>
@@ -64,7 +64,7 @@ export const Default = ({ parameters }) => {
       <dds-tab label="Fourth tab">
         <p>Content for fourth tab goes here.</p>
       </dds-tab>
-      <dds-tab label="Fifth tab" disabled="true">
+      <dds-tab label="Fifth tab" disabled>
         <p>Content for fifth tab goes here.</p>
       </dds-tab>
     </dds-tabs-extended>

--- a/packages/web-components/src/components/tabs-extended/tab.ts
+++ b/packages/web-components/src/components/tabs-extended/tab.ts
@@ -30,14 +30,14 @@ class DDSTab extends StableSelectorMixin(LitElement) {
   /**
    * Defines the disabled state of the tab.
    */
-  @property({ reflect: true })
-  disabled: Boolean = false;
+  @property({ reflect: true, type: Boolean })
+  disabled: boolean = false;
 
   /**
    * Defines the selected state of the tab.
    */
-  @property({ reflect: true })
-  selected: Boolean = false;
+  @property({ reflect: true, type: Boolean })
+  selected: boolean = false;
 
   /**
    * Defines the index of the tab relative to other tabs.

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -169,7 +169,7 @@ class DDSTabsExtended extends StableSelectorMixin(LitElement) {
     return html`
       <ul class="${prefix}--accordion">
         ${tabs.map((tab, index) => {
-          const disabled = (tab as DDSTab).disabled && true;
+          const { disabled } = tab as DDSTab;
           const active = index === this._activeTab;
           const label = (tab as DDSTab).getAttribute('label');
           const classes = classMap({
@@ -209,7 +209,7 @@ class DDSTabsExtended extends StableSelectorMixin(LitElement) {
       <div class="${prefix}--tabs">
         <ul class="${prefix}--tabs__nav ${prefix}--tabs__nav--hidden" role="tablist" @keydown="${this._handleTabListKeyDown}">
           ${tabs.map((tab, index) => {
-            const disabled = (tab as DDSTab).disabled && true;
+            const { disabled } = tab as DDSTab;
             const active = index === this._activeTab;
             const label = (tab as DDSTab).getAttribute('label');
             const classes = classMap({


### PR DESCRIPTION
### Related Ticket(s)

Resolves  #8751

### Description

#### DDSTabsExtended
There were cases where certain boolean attributes were being parsed as strings (e.g. `"false"`). Since non-empty strings are truthy, the value `"false"` was treated as `true`, and this caused any new tabs injected into the DOM to be  disabled.

This has been fixed by declaring to Lit Element that these attributes should be reflected as booleans. This tells Lit Element to convert the strings `"true"` and `"false"` to the booleans `true` and `false`, respectively.

#### DDSTableOfContents
The `slotchange` event that we typically use to catch updates to slotted DOM nodes has a limitation. From [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/slotchange_event):

> Note: the slotchange event doesn't fire if the children of a slotted node change — only if you change (e.g. add or delete) the actual nodes themselves.

This means the event will not fire if one of the immediate descendent DOM nodes are merely updated (e.g. have an attribute added/removed), nor will it fire if any of their children are added, removed, or modified.

Instead, we have to implement a MutationObserver to track changes to those nodes and rebuild the table of contents accordingly.

### Changelog

**Added**
- Added a MutationObserver to `DDSTableOfContents` components that rebuilds the table of contents when it sees changes to descendants of the default slot's children.

**Changed**

- Declare `boolean` type for `DDSTab`'s boolean reactive properties.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
