### PR TITLE
fix(cta-section-content-items): missing lightbox video player

### DIFF
--- a/packages/web-components/src/components/cta-section/__stories__/cta-section.stories.react.tsx
+++ b/packages/web-components/src/components/cta-section/__stories__/cta-section.stories.react.tsx
@@ -144,17 +144,20 @@ export const WithContentItems = ({ parameters }) => {
   const { contentItemType, contentItemCount } = parameters?.props?.WithContentItems ?? {};
 
   return (
-    <DDSCTASection>
-      <DDSContentSectionHeading>Related products and services</DDSContentSectionHeading>
-      <DDSCTABlock _noBorder={!border}>
-        <DDSContentBlockHeading>{heading || undefined}</DDSContentBlockHeading>
-        <DDSContentBlockCopy>{copy}</DDSContentBlockCopy>
-        <DDSTextCTA slot="action" cta-type="local" icon-placement="right" href="example.com">
-          Browse tutorials
-        </DDSTextCTA>
-        {renderItems(contentItemType, contentItemCount)}
-      </DDSCTABlock>
-    </DDSCTASection>
+    <>
+      <DDSCTASection>
+        <DDSContentSectionHeading>Related products and services</DDSContentSectionHeading>
+        <DDSCTABlock _noBorder={!border}>
+          <DDSContentBlockHeading>{heading || undefined}</DDSContentBlockHeading>
+          <DDSContentBlockCopy>{copy}</DDSContentBlockCopy>
+          <DDSTextCTA slot="action" cta-type="local" icon-placement="right" href="example.com">
+            Browse tutorials
+          </DDSTextCTA>
+          {renderItems(contentItemType, contentItemCount)}
+        </DDSCTABlock>
+      </DDSCTASection>
+      <DDSLightboxVideoPlayerContainer></DDSLightboxVideoPlayerContainer>
+    </>
   );
 };
 


### PR DESCRIPTION
### Related Ticket(s)

#8306 
### Description

missing lightbox video player - was not launching the video when switching to using the media knob
### Changelog

**New**

- add lightbox video player container to content-item story

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
