### PR TITLE
fix(footer): language selector styles

### DIFF
--- a/packages/styles/scss/components/footer/_language-selector.scss
+++ b/packages/styles/scss/components/footer/_language-selector.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -43,6 +43,14 @@
         width: 100%;
         height: $spacing-09;
         margin-right: 0;
+
+        .#{$prefix}--list-box__menu-icon {
+          right: 0.75rem;
+        }
+
+        .#{$prefix}--list-box__selection {
+          right: 2.25rem;
+        }
 
         .#{$prefix}--list-box__field {
           height: inherit;

--- a/packages/web-components/src/components/footer/footer.scss
+++ b/packages/web-components/src/components/footer/footer.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2022
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -290,6 +290,14 @@
 }
 
 :host(#{$dds-prefix}-language-selector-desktop) {
+  .#{$prefix}--list-box__menu-icon {
+    right: 0.75rem;
+  }
+
+  .#{$prefix}--list-box__selection {
+    right: 2.25rem;
+  }
+
   @include carbon--breakpoint-down('lg') {
     display: none;
   }


### PR DESCRIPTION
### Related Ticket(s)

#7329 
### Description

adjusted icons slightly to the right in language selector for the footer to align with styles
### Changelog

**New**

- adjust buttons slightly to the right

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
