### PR TITLE
fix(link-list): align icon to top when wrapping multiple lines

### DIFF
--- a/packages/styles/scss/components/link-list/_link-list.scss
+++ b/packages/styles/scss/components/link-list/_link-list.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,6 +30,11 @@
 
       svg {
         margin-right: 0;
+
+        @include carbon--breakpoint-down('md') {
+          align-self: start;
+          margin-top: 1px; /* keeps icon centered when text is a single line */
+        }
       }
     }
 
@@ -179,7 +184,9 @@
       }
 
       svg {
+        align-self: start;
         margin-left: $carbon--spacing-07;
+        margin-top: 1px; /* keeps icon centered when text is a single line */
       }
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

#6874 
### Description

Align icon in Link list to the top when text wraps multiple lines
<img width="256" alt="Screen Shot 2022-05-12 at 1 38 03 PM" src="https://user-images.githubusercontent.com/20210594/168163793-01e9644c-741f-4968-a02c-509dc6627472.png">

### Changelog

**New**

- added align-self: center to svgs and 1px top magin to keep it centered with the text

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
