### PR TITLE
fix(back-to-top): reset tab order on click

### DIFF
--- a/packages/web-components/src/components/back-to-top/back-to-top.ts
+++ b/packages/web-components/src/components/back-to-top/back-to-top.ts
@@ -55,6 +55,9 @@ class DDSBackToTop extends HostListenerMixin(StableSelectorMixin(LitElement)) {
    */
   private _handleOnClick() {
     this.ownerDocument!.defaultView!.scrollTo({ top: 0, behavior: 'smooth' });
+    this.ownerDocument.body.tabIndex = 0;
+    this.ownerDocument.body.focus({ preventScroll: true });
+    this.ownerDocument.body.removeAttribute('tabindex');
   }
 
   /**

--- a/packages/web-components/src/components/back-to-top/back-to-top.ts
+++ b/packages/web-components/src/components/back-to-top/back-to-top.ts
@@ -53,7 +53,6 @@ class DDSBackToTop extends HostListenerMixin(StableSelectorMixin(LitElement)) {
   /**
    * Button click scrolls to top
    */
-  // eslint-disable-next-line class-methods-use-this
   private _handleOnClick() {
     this.ownerDocument!.defaultView!.scrollTo({ top: 0, behavior: 'smooth' });
   }


### PR DESCRIPTION
### Related Ticket(s)

#8230

### Description

This PR resets the tab order after the back to top component is clicked. The first focusable element in the document should be focused after clicking the back to top component and the pressing <kbd>Tab</kbd>


https://user-images.githubusercontent.com/8265238/170094268-db4f27f6-a572-4df1-b530-3627121bc40b.mov



<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
