### PR TITLE
fix(quote): update max breakpoint corner bracket position

### DIFF
--- a/packages/react/src/components/CalloutQuote/__stories__/CalloutQuote.stories.js
+++ b/packages/react/src/components/CalloutQuote/__stories__/CalloutQuote.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,6 +16,7 @@ const types = {
   doubleAngle: 'doubleAngle',
   singleAngle: 'singleAngle',
   lowHighReversedDoubleCurved: 'lowHighReversedDoubleCurved',
+  cornerBracket: 'cornerBracket',
 };
 
 export default {

--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -78,6 +78,10 @@
     @include carbon--breakpoint('lg') {
       left: -1rem;
     }
+
+    @include carbon--breakpoint('max') {
+      left: -2rem;
+    }
   }
 
   .#{$prefix}--quote__source {

--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -20,7 +20,7 @@
     @include hang;
 
     .#{$prefix}--link-with-icon__container {
-      padding-left: 1rem;
+      padding-left: $spacing-05;
       max-width: 80%;
     }
   }
@@ -39,10 +39,10 @@
     @include carbon--font-family('serif');
 
     word-break: break-word;
-    padding: 0 2rem $carbon--layout-03 2rem;
+    padding: 0 $spacing-07 $carbon--layout-03 $spacing-07;
 
     @include carbon--breakpoint('md') {
-      padding-bottom: $carbon--layout-04;
+      padding-bottom: $spacing-09;
       @include carbon--type-style('quotation-02', true);
     }
   }
@@ -72,15 +72,15 @@
     }
 
     @include carbon--breakpoint('md') {
-      left: -0.5rem;
+      left: calc(-1 * #{$spacing-03});
     }
 
     @include carbon--breakpoint('lg') {
-      left: -1rem;
+      left: calc(-1 * #{$spacing-05});
     }
 
     @include carbon--breakpoint('max') {
-      left: -2rem;
+      left: calc(-1 * #{$spacing-07});
     }
   }
 
@@ -92,41 +92,41 @@
     }
 
     max-width: 80%;
-    padding-bottom: $carbon--layout-04;
+    padding-bottom: $spacing-09;
   }
 
   :host(#{$dds-prefix}-quote-source-heading),
   .#{$prefix}--quote__source-heading {
-    padding-left: 1rem;
+    padding-left: $spacing-05;
     @include carbon--type-style(expressive-heading-02, true);
   }
 
   :host(#{$dds-prefix}-quote-source-copy),
   .#{$prefix}--quote__source-body {
-    padding-left: 1rem;
+    padding-left: $spacing-05;
     @include carbon--type-style(body-long-02, true);
   }
 
   :host(#{$dds-prefix}-quote-source-bottom-copy),
   .#{$prefix}--quote__source-optional-copy {
-    padding-left: 1rem;
+    padding-left: $spacing-05;
     @include carbon--type-style(body-long-02, true);
   }
 
   .#{$prefix}--quote__mark-closing {
-    margin-left: -0.25rem;
+    margin-left: calc(-1 * #{$spacing-02});
 
     @include carbon--breakpoint('md') {
-      margin-left: -0.5rem;
+      margin-left: calc(-1 * #{$spacing-03});
     }
   }
 
   :host(#{$dds-prefix}-quote) .#{$prefix}--quote__footer {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-left: $spacing-05;
+    padding-right: $spacing-05;
 
     ::slotted(#{$dds-prefix}-link-with-icon) {
-      margin-left: 1rem;
+      margin-left: $spacing-05;
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

#8690 

### Description

This PR updates the Quote and Callout Quote corner bracket placement at the `max` breakpoint in both the `web-components` and `react` packages. The other quote variants should be unchanged at all breakpoints

![image](https://user-images.githubusercontent.com/8265238/170091907-f6aac5f1-f2f5-4700-9135-a6d78ba08f30.png)

![image](https://user-images.githubusercontent.com/8265238/170091981-d0981298-35a1-40b0-aed7-da7885df10f3.png)


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
