### PR TITLE
chore(csb): fixes `content-block` CDN url

### DIFF
--- a/packages/web-components/examples/codesandbox/components/content-block/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block/cdn.html
@@ -18,7 +18,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-cta-link.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-link-cta.min.js"></script>
 </head>
 <body>
 <div class="bx--grid">


### PR DESCRIPTION
### Description

Fixes incorrect CDN url for `content-block` Codesandbox example

### Changelog

**Changed**

- fix CDN url


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
