### PR TITLE
chore: remove sass `/` division deprecation warnings

### DIFF
--- a/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
+++ b/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -42,10 +42,10 @@
 
   :host(#{$dds-prefix}-content-group-cards-item),
   .#{$prefix}--content-group-cards-item__col {
-    margin-top: $carbon--grid-gutter--condensed / 2;
-    margin-bottom: $carbon--grid-gutter--condensed / 2;
-    padding-left: $carbon--grid-gutter--condensed / 2;
-    padding-right: $carbon--grid-gutter--condensed / 2;
+    margin-top: calc($carbon--grid-gutter--condensed / 2);
+    margin-bottom: calc($carbon--grid-gutter--condensed / 2);
+    padding-left: calc($carbon--grid-gutter--condensed / 2);
+    padding-right: calc($carbon--grid-gutter--condensed / 2);
 
     &:focus {
       outline: none;
@@ -53,7 +53,7 @@
   }
 
   :host(#{$dds-prefix}-content-group-cards-item) {
-    padding: $carbon--grid-gutter--condensed / 2;
+    padding: calc($carbon--grid-gutter--condensed / 2);
     background: none;
   }
 }

--- a/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
+++ b/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,7 +18,8 @@
   $modal: '.#{$prefix}--modal';
   $button-size: carbon--rem(48px);
   $icon-size: carbon--rem(20px);
-  $offset-close-icon: $carbon--spacing-07 - (($button-size - $icon-size) / 2);
+  $offset-close-icon: $carbon--spacing-07 -
+    calc(($button-size - $icon-size) / 2);
 
   :host(#{$dds-prefix}-expressive-modal),
   #{$modal}--expressive {

--- a/packages/styles/scss/globals/utils/_aspect-ratio.scss
+++ b/packages/styles/scss/globals/utils/_aspect-ratio.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,6 +14,6 @@
 //
 // @return percentage of height vs width
 @function aspect-ratio($width, $height) {
-  $ratio: $height / $width * 100%;
+  $ratio: calc($height / $width) * 100%;
   @return $ratio;
 }

--- a/packages/styles/scss/globals/utils/_hang.scss
+++ b/packages/styles/scss/globals/utils/_hang.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,6 +7,6 @@
 
 // mixin to hang into the gutters of the grid
 @mixin hang() {
-  margin-left: -($carbon--grid-gutter / 2);
-  margin-right: -($carbon--grid-gutter / 2);
+  margin-left: -(calc($carbon--grid-gutter / 2));
+  margin-right: -(calc($carbon--grid-gutter / 2));
 }


### PR DESCRIPTION
### Description

This PR changes the deprecated `/` division operator to `calc` in our Sass files. This cleans up the deprecation warning in our test scripts

### Changelog

**Changed**

- `/` CSS division to `calc()`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
