### PR TITLE
fix(cta): ensure href works again

### DIFF
--- a/packages/web-components/src/components/video-player/video-player-container.ts
+++ b/packages/web-components/src/components/video-player/video-player-container.ts
@@ -239,7 +239,7 @@ export const DDSVideoPlayerContainerMixin = <T extends Constructor<HTMLElement>>
     firstUpdated() {
       window.requestAnimationFrame(() => {
         const button = this.querySelector('dds-video-player')?.shadowRoot?.querySelector('button');
-        if (!this.getAttribute('href')) {
+        if (!this.getAttribute('href') && this.getAttribute('video-id')) {
           this.setAttribute('href', `https://mediacenter.ibm.com/id/${this.getAttribute('video-id')}`);
         }
         this.transposeAttributes(button, ['href']);


### PR DESCRIPTION
### Related Ticket(s)
None.

### Description
The TextCTA component test was failing due to the href being updated erroneously, this should fix it.

### Changelog

**Changed**

- added a `video-id` attribute check for videos before transposing the href

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
