### PR TITLE
chore(deps): update allowlist for DCO assistant

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -20,7 +20,7 @@ jobs:
           path-to-signatures: 'dco-signatures.json'
           path-to-document: 'https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md'
           branch: 'main'
-          allowlist: ibmdotcom-bot,dependabot[bot],kodiakhq[bot],renovate-bot
+          allowlist: ibmdotcom-bot,dependabot[bot],kodiakhq[bot],renovate[bot]
           remote-organization-name: carbon-design-system
           remote-repository-name: carbon-dco
           create-file-commit-message: 'chore: create file to store dco signatures'


### PR DESCRIPTION
### Description

This updates the `renovate` bot username in the DCO Assistant `allowlist`. The incorrect name is preventing the GitHub action from passing.

### Changelog

**Changed**

- change `renovate-bot` to `renovate[bot]`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
