### PR TITLE
fix(content-item-horizontal): remove invalid selector

### DIFF
--- a/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
@@ -284,10 +284,6 @@
   :host(#{$dds-prefix}-content-item-horizontal-copy) ::slotted(:not([slot])),
   .#{$prefix}--content-item-horizontal__item--copy {
     margin-bottom: $carbon--spacing-06;
-
-    p {
-      color: $text-01;
-    }
   }
 
   :host(#{$dds-prefix}-content-item-horizontal-thumbnail-copy)


### PR DESCRIPTION
### Description

Removes an unused and invalid selector that can cause build issues in bundlers.

### Changelog

**Removed**

- unused styles for `p` selector

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
