### PR TITLE
fix(masthead): fixes megamenu item styles (#9066)

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -148,12 +148,6 @@
       padding-bottom: 0;
     }
 
-    ::slotted(#{$dds-prefix}-megamenu-category-group)
-      .#{$prefix}--masthead__megamenu__category-group-shield,
-    .#{$prefix}--masthead__megamenu__category-group-shield {
-      margin-left: -1rem;
-    }
-
     .#{$prefix}--masthead__megamenu--hasHighlights {
       column-count: 3;
     }
@@ -170,7 +164,7 @@
 
   :host(#{$dds-prefix}-megamenu-category-group),
   .#{$prefix}--masthead__megamenu__category-group {
-    display: inline;
+    display: block;
 
     .#{$prefix}--masthead__megamenu__category-group-content {
       width: 100%;


### PR DESCRIPTION
### Related Ticket(s)

#9065 

### Description

Cherry-pick of the megamenu item styles fix into patch release branch:
Megamenu child items are being displayed in one, long, single column. This fixes that.

### Changelog

**Removed**

- `.bx--masthead__megamenu__category-group-shield` as child to `::slotted` selector

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->

### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

{{Add a human-readable description / detail summary of what the PR is changing and any details around how and why}}

{{If applicable, include a screenshot indicating an example or examples of what the PR is changing in the application}}

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
