### PR TITLE
fix(pricing-table): enable video CTA in pricing table header cell

### DIFF
--- a/packages/web-components/src/components/pricing-table/__stories__/pricing-table.stories.ts
+++ b/packages/web-components/src/components/pricing-table/__stories__/pricing-table.stories.ts
@@ -58,11 +58,7 @@ const renderHeaderCell = (iterator: number): TemplateResult => {
             <bx-list-item>consectetur retention adispiscing elit sed do eiusm Eiusmod tempor</bx-list-item>
           </bx-unordered-list>
         </dds-pricing-table-header-cell-description>
-        <dds-pricing-table-header-cell-cta
-          cta-type="local"
-          href="https://www.carbondesignsystem.com/all-about-carbon/what-is-carbon/"
-          >Call to action</dds-pricing-table-header-cell-cta
-        >
+        <dds-pricing-table-header-cell-cta cta-type="video" href="1_9h94wo6b">Call to action</dds-pricing-table-header-cell-cta>
       </dds-pricing-table-header-cell>
     `,
     html`

--- a/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
@@ -23,6 +23,31 @@ class DDSPricingTableHeaderCell extends StableSelectorMixin(DDSStructuredListHea
   @property({ reflect: true })
   type: PRICING_TABLE_HEADER_CELL_TYPES = PRICING_TABLE_HEADER_CELL_TYPES.COMPLEX;
 
+  @property()
+  private _ctaType?: String;
+
+  private _handleCTASlotChange = ({ target }) => {
+    const cta = target.assignedNodes()[0];
+
+    if (cta) {
+      this._ctaType = cta.getAttribute('cta-type').toLowerCase();
+    }
+  };
+
+  renderCTASlot() {
+    const { _ctaType: ctaType } = this;
+
+    return ctaType === 'video'
+      ? html`
+          <dds-video-cta-container>
+            <slot name="cta" @slotchange=${this._handleCTASlotChange}></slot>
+          </dds-video-cta-container>
+        `
+      : html`
+          <slot name="cta" @slotchange=${this._handleCTASlotChange}></slot>
+        `;
+  }
+
   render() {
     const { type } = this;
     const { tagWrapperSelector } = this.constructor as typeof DDSPricingTableHeaderCell;
@@ -45,7 +70,7 @@ class DDSPricingTableHeaderCell extends StableSelectorMixin(DDSStructuredListHea
               </div>
             </div>
             <div>
-              <slot name="cta"></slot>
+              ${this.renderCTASlot()}
             </div>
           </div>
         `


### PR DESCRIPTION
### Related Ticket(s)

Fixes #9050

### Description

Adds an internal property of `ctaType` to the pricing-table-header-cell. When this value is set to 'video' by a slotchange event, the slot is wrapped in a `<dds-video-cta-container>` element to allow the popup video player.

### Changelog

**Changed**

- fixes an issue where `video` CTAs didn't open popup player