### PR TITLE
fix(logo-grid): adding bottom margin to logo-grid-item, resolves #9005

### DIFF
--- a/packages/styles/scss/components/logo-grid/_logo-grid.scss
+++ b/packages/styles/scss/components/logo-grid/_logo-grid.scss
@@ -129,7 +129,9 @@
     display: flex;
     align-items: stretch;
     justify-content: center;
-
+    @include carbon--breakpoint('sm') {
+      margin-bottom: $carbon--spacing-07;
+    }
     picture,
     img {
       width: 100%;


### PR DESCRIPTION
### Related Ticket(s)

fix #9005 

### Description

Adding spacing under each grid in small screen

### Changelog


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
