### PR TITLE
fix(ExpressiveModal): render react story correctly

### DIFF
--- a/packages/react/src/components/ExpressiveModal/__stories__/ExpressiveModal.stories.js
+++ b/packages/react/src/components/ExpressiveModal/__stories__/ExpressiveModal.stories.js
@@ -38,35 +38,31 @@ function StoryContent({ title, paragraph, button }) {
   );
 }
 
+const props = {
+  ExpressiveModal: () => ({
+    open: boolean('Toggle modal', true),
+  }),
+  Other: () => ({
+    title: text('Title (placeholder)', 'Lorem ipsum dolor sit amet'),
+    paragraph: text(
+      'Paragraph (placeholder)',
+      'Quisque felis odio, egestas vel tempus iaculis, interdum vel eros. Phasellus pharetra, purus et pretium posuere, ipsum risus pulvinar leo, non rutrum tortor risus vitae quam. Nulla sed nibh felis. Maecenas nec tincidunt eros. Fusce sollicitudin sit amet quam eu fringilla. Donec tincidunt ut nisi vitae pharetra. Curabitur imperdiet ante sit amet mi laoreet, vitae facilisis ante convallis. Aenean quis dapibus augue. Sed nisl dui, scelerisque et augue eget, pharetra commodo elit. In venenatis sapien eu nisl congue suscipit.'
+    ),
+    button: text('Button (placeholder)', 'Lorem ipsum dolor'),
+  }),
+};
+
 export default {
   title: 'Components/Expressive modal',
   parameters: {
     ...readme.parameters,
     'carbon-theme': { disabled: true },
-    knobs: {
-      ExpressiveModal: ({ groupId }) => ({
-        open: boolean('Toggle modal', true, groupId),
-      }),
-      Other: ({ groupId }) => ({
-        title: text(
-          'Title (placeholder)',
-          'Lorem ipsum dolor sit amet',
-          groupId
-        ),
-        paragraph: text(
-          'Paragraph (placeholder)',
-          'Quisque felis odio, egestas vel tempus iaculis, interdum vel eros. Phasellus pharetra, purus et pretium posuere, ipsum risus pulvinar leo, non rutrum tortor risus vitae quam. Nulla sed nibh felis. Maecenas nec tincidunt eros. Fusce sollicitudin sit amet quam eu fringilla. Donec tincidunt ut nisi vitae pharetra. Curabitur imperdiet ante sit amet mi laoreet, vitae facilisis ante convallis. Aenean quis dapibus augue. Sed nisl dui, scelerisque et augue eget, pharetra commodo elit. In venenatis sapien eu nisl congue suscipit.',
-          groupId
-        ),
-        button: text('Button (placeholder)', 'Lorem ipsum dolor', groupId),
-      }),
-    },
   },
 };
 
-export const Default = ({ parameters }) => {
-  const { open } = parameters?.props?.ExpressiveModal ?? {};
-  const { title, paragraph, button } = parameters?.props?.Other ?? {};
+export const Default = () => {
+  const { open } = props?.ExpressiveModal() ?? {};
+  const { title, paragraph, button } = props?.Other() ?? {};
   return (
     <ExpressiveModal open={open} className="bx--modal--expressive">
       <ModalBody>
@@ -76,9 +72,9 @@ export const Default = ({ parameters }) => {
   );
 };
 
-export const Expanded = ({ parameters }) => {
-  const { open } = parameters?.props?.ExpressiveModal ?? {};
-  const { title, paragraph, button } = parameters?.props?.Other ?? {};
+export const Expanded = () => {
+  const { open } = props?.ExpressiveModal() ?? {};
+  const { title, paragraph, button } = props?.Other() ?? {};
   return (
     <ExpressiveModal
       open={open}


### PR DESCRIPTION
### Related Ticket(s)

#9124

### Description

This PR updates the ExpressiveModal story props so that the components render properly again

<img width="914" alt="image" src="https://user-images.githubusercontent.com/8265238/180238199-42549886-2436-4dde-8dee-92faf2e6dc72.png">

<img width="1582" alt="image" src="https://user-images.githubusercontent.com/8265238/180238239-4fd5c065-3d7a-4db9-a1ec-2bcc08f91d09.png">


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
