### PR TITLE
chore(docs): adding to CDN artifact documentation in storybook docs

### DIFF
--- a/packages/web-components/src/globals/internal/storybook-cdn.ts
+++ b/packages/web-components/src/globals/internal/storybook-cdn.ts
@@ -65,9 +65,11 @@ ${_renderScript(components, 'tag/v1/latest')}
 ${_renderScript(components, 'tag/v1/next')}
 \`\`\`
 
-> NOTE: The latest/next tags are moving versions. While beneficial to
-> always stay on the most recent version, it is recommended to choose a specific
-> version and properly test your application when upgrading to a newer version.
+> NOTE: The \`latest\`/\`next\` tags are moving versions.
+>
+> The \`latest\` tag is only updated every Friday at 6pm EST after a release. When \`latest\`/\`next\` tags are updated, Akamai caches can take up to 24 hours to clear, which could result in instability during that time. It is highly recommended to instead use a specific version and to properly test your application when upgrading to a newer version.
+>
+> Please ensure only one version of artifacts is used at a time, having multiple versions will cause rendering issues.
 
 #### Right-to-left (RTL) versions
 


### PR DESCRIPTION
### Related Ticket(s)

[Documentation]: Update storybook and website documentation about using tagged versions of Carbon for IBM.com #9138

### Description

Add more specific information about CDN tagged versions in Storybook Docs tab for all web components.

<img width="1028" alt="Screen Shot 2022-07-26 at 12 46 25 PM" src="https://user-images.githubusercontent.com/54281166/181098920-70a46d90-ad40-4dbb-9316-661b11eb152c.png">

### Changelog

**Changed**

- edit language in the `storybook-cdn` file that renders in all component storybook docs

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
