### PR TITLE
fix(snapshots): react storybook6

### DIFF
--- a/packages/react/src/components/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/components/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -113,7 +113,6 @@ const getBaseKnobs = () => {
 };
 
 /**
-
  * @returns {object} The knobs data.
  */
 const getCTAKnobs = () => {

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/storybook-docs/storybook-components.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/storybook-docs/storybook-components.e2e.js
@@ -17,18 +17,18 @@ describe('Storybook Docs | grab component list', () => {
 
     cy.get('button[id^="components-"]').each($el => {
       cy.get($el)
-      .click()
-      .then( ([copy]) => {
-        const name = copy.innerText.trim();
-        const docsPath = $el[0].nextSibling.firstChild.href;
+        .click()
+        .then(([copy]) => {
+          const name = copy.innerText.trim();
+          const docsPath = $el[0].nextSibling.firstChild.href;
 
-        if (docsPath) {
-          const url = docsPath.split('?')[1].replace('path=/story', 'path=/docs');
-          docs.push({ url, name });
-        }
-      });
-    })
-    
+          if (docsPath) {
+            const url = docsPath.split('?')[1].replace('path=/story', 'path=/docs');
+            docs.push({ url, name });
+          }
+        });
+    });
+
     cy.writeFile('tests/e2e-storybook/cypress/fixtures/components.json', docs);
   });
 });


### PR DESCRIPTION
### Related Ticket(s)

#9151 

### Description

Update snapshots for unit tests, so ci-checks pass for react.

### Changelog

**Changed**

- update snapshots and fix formating

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
