### PR TITLE
feat(masthead-v2): add utility menu

### DIFF
--- a/packages/web-components/src/components/masthead/__stories__/cloud-masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/cloud-masthead.stories.ts
@@ -26,8 +26,8 @@ import { DDS_CLOUD_MASTHEAD } from '../../../globals/internal/feature-flags';
  * platform knob data
  */
 const platformData = {
-  name: 'IBM Cloud',
-  url: 'https://www.ibm.com/cloud',
+  name: null,
+  url: null,
 };
 
 const urlObject = {
@@ -67,7 +67,7 @@ export const Default = !DDS_CLOUD_MASTHEAD
         ${useMock
           ? html`
               <dds-cloud-masthead-composite
-                platform="Cloud"
+                platform="${ifNonNull(platformData.name)}"
                 .platformUrl="${ifNonNull(platformData.url)}"
                 selected-menu-item="${ifNonNull(selectedMenuItem)}"
                 has-contact="${hasContact}"
@@ -84,7 +84,7 @@ export const Default = !DDS_CLOUD_MASTHEAD
             `
           : html`
               <dds-cloud-masthead-container
-                platform="Cloud"
+                platform="${ifNonNull(platformData.name)}"
                 .platformUrl="${ifNonNull(urlObject)}"
                 selected-menu-item="${ifNonNull(selectedMenuItem)}"
                 has-contact="${hasContact}"

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -271,8 +271,7 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
       activateSearch,
       authenticatedProfileItems,
       authenticatedCtaButtons,
-      contactUsButton,
-      hasContact,
+      hasProfile,
       platform,
       platformUrl,
       inputTimeout,
@@ -338,61 +337,27 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
           ?open="${openSearchDropdown}"
           placeholder="${ifNonNull(searchPlaceholder)}"
         ></dds-search-with-typeahead>
-        ${authenticated
-          ? html`
-              <dds-cloud-masthead-global-bar>
-                <dds-cloud-masthead-profile>
+
+        <dds-cloud-masthead-global-bar ?has-search-active=${activateSearch}>
+          ${hasProfile === 'false'
+            ? ''
+            : html`
+                <dds-masthead-profile ?authenticated="${authenticated}">
                   ${profileItems?.map(
                     ({ title, url }) =>
                       html`
-                        <dds-cloud-button-cta href="${ifNonNull(url)}" kind="ghost">${title}</dds-cloud-button-cta>
+                        <dds-masthead-profile-item href="${ifNonNull(url)}">${title}</dds-masthead-profile-item>
                       `
                   )}
-                </dds-cloud-masthead-profile>
-                ${hasContact === 'false'
-                  ? ''
-                  : html`
-                      <dds-cloud-button-cta kind="ghost" data-ibm-contact="contact-link"
-                        ><span>${contactUsButton?.title}</span></dds-cloud-button-cta
-                      >
-                    `}
-                ${ctaButtons?.map(
-                  ({ title, url }) =>
-                    html`
-                      <dds-cloud-button-cta href="${ifNonNull(url)}" class="console" kind="ghost">${title}</dds-cloud-button-cta>
-                    `
-                )}
-              </dds-cloud-masthead-global-bar>
-            `
-          : html`
-              <dds-cloud-masthead-global-bar>
-                ${hasContact === 'false'
-                  ? ''
-                  : html`
-                      <dds-cloud-button-cta kind="ghost" data-ibm-contact="contact-link"
-                        ><span>${contactUsButton?.title}</span></dds-cloud-button-cta
-                      >
-                    `}
-                ${profileItems?.map(
-                  ({ title, url }) =>
-                    html`
-                      <dds-cloud-button-cta
-                        href="${url === 'https://cloud.ibm.com/login' && this.redirectPath
-                          ? ifNonNull(`${url}?redirect=${encodeURIComponent(this.redirectPath)}`)
-                          : ifNonNull(url)}"
-                        kind="ghost"
-                        >${title}</dds-cloud-button-cta
-                      >
-                    `
-                )}
-                ${ctaButtons?.map(
-                  ({ title, url }) =>
-                    html`
-                      <dds-cloud-button-cta href="${ifNonNull(url)}" kind="primary">${title}</dds-cloud-button-cta>
-                    `
-                )}
-              </dds-cloud-masthead-global-bar>
-            `}
+                </dds-masthead-profile>
+              `}
+          ${ctaButtons?.map(
+            ({ title, url }) =>
+              html`
+                <dds-cloud-button-cta href="${ifNonNull(url)}" kind="ghost">${title}</dds-cloud-button-cta>
+              `
+          )}
+        </dds-cloud-masthead-global-bar>
         ${!l1Data ? undefined : this._renderL1({ selectedMenuItem })}
         <dds-megamenu-overlay></dds-megamenu-overlay>
       </dds-masthead>

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
@@ -45,12 +45,8 @@
   }
 
   .#{$prefix}--btn--ghost {
-    color: $text-02;
-
-    &:hover,
-    &:focus {
-      color: $text-01;
-    }
+    color: $link-01;
+    @include carbon--type-style('body-short-02');
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

Closes #9211

### Description

This PR updates the `<cloud-masthead-composite>` to use the `dds-masthead-profile` component for the user authentication links, and updates the styles of the CTA button.

<img width="1195" alt="Screen Shot 2022-08-12 at 3 32 19 PM" src="https://user-images.githubusercontent.com/25532785/184430213-b68c8886-a355-4901-821c-5e26f0ae8dfc.png">

### Changelog

**Changed**

- Cloud Masthead's utility section updated to V2 specs