### PR TITLE
chore(github): add `publish-alpha` workflow

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -30,18 +30,6 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_API_KEY }}" >> .npmrc
       - name: Run Lerna
         run: yarn lerna publish --alpha minor --preid alpha.${{github.run_id}} --dist-tag alpha --force-publish --no-push --no-git-tag-version --yes
-      - name: Deploy NextJS Test
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          repository: carbon-design-system/carbon-for-ibm-dotcom-nextjs-test
-          token: ${{ secrets.GH_DISPATCH_TOKEN }}
-          event-type: deploy-alpha
-      - name: Deploy Web Components HTML Test
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          repository: carbon-design-system/carbon-for-ibm-dotcom-web-components-test
-          token: ${{ secrets.GH_DISPATCH_TOKEN }}
-          event-type: deploy-alpha
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,0 +1,48 @@
+name: publish-alpha (Publish Alpha release to NPM)
+
+on:
+  push:
+    branches:
+      - feat/masthead-v2
+
+concurrency:
+  group: publish-alpha-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
+    runs-on: ubuntu-20.04
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --offline
+      - name: Build project
+        run: yarn build
+      - name: Set NPM token
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_API_KEY }}" >> .npmrc
+      - name: Run Lerna
+        run: yarn lerna publish --alpha minor --preid alpha.${{github.run_id}} --dist-tag alpha --force-publish --no-push --no-git-tag-version --yes
+      - name: Deploy NextJS Test
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          repository: carbon-design-system/carbon-for-ibm-dotcom-nextjs-test
+          token: ${{ secrets.GH_DISPATCH_TOKEN }}
+          event-type: deploy-alpha
+      - name: Deploy Web Components HTML Test
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          repository: carbon-design-system/carbon-for-ibm-dotcom-web-components-test
+          token: ${{ secrets.GH_DISPATCH_TOKEN }}
+          event-type: deploy-alpha
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+        if: failure()


### PR DESCRIPTION
### Description

Adds GitHub workflow to publish `alpha` tag for NPM package from the `feat/masthead-v2` branch. This workflow can be modified to target the `c4dotcom-v2` feature branch when it is created.

### Changelog

**New**

- GH workflow `publish-alpha`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
