### PR TITLE
fix(tabs-extended): move aria-selected to li elem with tab role

### DIFF
--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -223,14 +223,19 @@ class DDSTabsExtended extends StableSelectorMixin(LitElement) {
               'bx--tabs__nav-item--disabled': disabled,
             });
             return html`
-              <li class="${classes}" data-target=".tab-${index}-default" role="tab" ?disabled="${disabled}">
+              <li
+                class="${classes}"
+                aria-selected="${active}"
+                data-target=".tab-${index}-default"
+                role="tab"
+                ?disabled="${disabled}"
+              >
                 <button
                   tabindex="${active ? '0' : '-1'}"
                   id="tab-link-${index}-default"
                   class="${prefix}--tabs__nav-link"
                   type="button"
                   aria-controls="tab-panel-${index}-default"
-                  aria-selected="${active}"
                   @click="${e => this._handleClick(index, e)}"
                 >
                   <div><p>${label}</p></div>


### PR DESCRIPTION
### Related Ticket(s)

[Tab Extended]: QA: Screen reader does not identify the currently selected tab #9230

### Description

Screen reader was not picking up the `aria-selected` attribute on the tab buttons. According to https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected#description, the `aria-selected` attribute should be applied to elements with the `role="tab"` attribute, which in this case is the `li` element wrapping the `button`. 

Moving the `aria-selected` attribute to the `li` should hopefully work to have the screen reader pick it up.

<img width="980" alt="Screen Shot 2022-08-22 at 11 22 52 AM" src="https://user-images.githubusercontent.com/54281166/185991903-6cfe32b6-cbe4-4dad-a4e9-e5e38fbb5bf0.png">

### Changelog

**Changed**

- move `aria-selected` to `li` element wrapping tabs-extended button

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
