### PR TITLE
feat(masthead-v2): consolidate Cloud auth methods with profileAPI & update docs

### DIFF
--- a/packages/services-store/src/actions/__tests__/profileAPI.test.ts
+++ b/packages/services-store/src/actions/__tests__/profileAPI.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,7 +11,7 @@ import configureMockStore from 'redux-mock-store';
 import { AnyAction } from 'redux';
 import thunk, { ThunkDispatch } from 'redux-thunk';
 import ProfileAPI from '@carbon/ibmdotcom-services/es/services/Profile/Profile.js';
-import { UNAUTHENTICATED_STATUS, PROFILE_API_ACTION, ProfileAPIState } from '../../types/profileAPI';
+import { UNAUTHENTICATED_STATUS, PROFILE_API_ACTION, ProfileAPIState, MASTHEAD_AUTH_METHOD } from '../../types/profileAPI';
 import convertValue from '../../../tests/utils/convert-value';
 import { loadUserStatus, setUserStatus } from '../profileAPI';
 
@@ -37,7 +37,7 @@ describe('Redux actions for `ProfileAPI`', () => {
   it('dispatches the action to get user authentication status', async () => {
     ProfileAPI.getUserStatus.mockResolvedValue({ user: UNAUTHENTICATED_STATUS });
     const store = mockStore();
-    await store.dispatch(loadUserStatus());
+    await store.dispatch(loadUserStatus(MASTHEAD_AUTH_METHOD.DEFAULT));
     expect(convertValue(store.getActions())).toEqual([
       {
         type: PROFILE_API_ACTION.SET_REQUEST_USER_STATUS_IN_PROGRESS,
@@ -55,7 +55,7 @@ describe('Redux actions for `ProfileAPI`', () => {
     const store = mockStore();
     let caught;
     try {
-      await store.dispatch(loadUserStatus());
+      await store.dispatch(loadUserStatus(MASTHEAD_AUTH_METHOD.DEFAULT));
     } catch (error) {
       caught = error;
     }

--- a/packages/services-store/src/actions/profileAPI.ts
+++ b/packages/services-store/src/actions/profileAPI.ts
@@ -9,7 +9,7 @@
 
 import { ThunkAction } from 'redux-thunk';
 import ProfileAPI from '@carbon/ibmdotcom-services/es/services/Profile/Profile.js';
-import { UserStatus, PROFILE_API_ACTION, ProfileAPIState } from '../types/profileAPI';
+import { UserStatus, PROFILE_API_ACTION, ProfileAPIState, MASTHEAD_AUTH_METHOD } from '../types/profileAPI';
 
 /**
  * @param error An error from the JSONP call for user authentication status.
@@ -60,10 +60,10 @@ export function loadUserStatus(
   return async dispatch => {
     let promiseStatus: Promise<UserStatus>;
     switch (authMethod) {
-      case 'cookie':
+      case MASTHEAD_AUTH_METHOD.COOKIE:
         promiseStatus = ProfileAPI.checkCloudCookie();
         break;
-      case 'docs-api':
+      case MASTHEAD_AUTH_METHOD.DOCS_API:
         promiseStatus = ProfileAPI.checkCloudDocsAPI();
         break;
       default:

--- a/packages/services-store/src/actions/profileAPI.ts
+++ b/packages/services-store/src/actions/profileAPI.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -54,9 +54,22 @@ export type ProfileAPIActions =
 /**
  * @returns A Redux action that sends a REST call for user authentication status.
  */
-export function loadUserStatus(): ThunkAction<Promise<UserStatus>, { profileAPI: ProfileAPIState }, void, ProfileAPIActions> {
+export function loadUserStatus(
+  authMethod: string
+): ThunkAction<Promise<UserStatus>, { profileAPI: ProfileAPIState }, void, ProfileAPIActions> {
   return async dispatch => {
-    const promiseStatus: Promise<UserStatus> = ProfileAPI.getUserStatus();
+    let promiseStatus: Promise<UserStatus>;
+    switch (authMethod) {
+      case 'cookie':
+        promiseStatus = ProfileAPI.checkCloudCookie();
+        break;
+      case 'docs-api':
+        promiseStatus = ProfileAPI.checkCloudDocsAPI();
+        break;
+      default:
+        promiseStatus = ProfileAPI.getUserStatus();
+    }
+
     dispatch(setRequestUserStatusInProgress(promiseStatus));
     try {
       dispatch(setUserStatus(await promiseStatus));

--- a/packages/services-store/src/actions/profileAPI.ts
+++ b/packages/services-store/src/actions/profileAPI.ts
@@ -55,7 +55,7 @@ export type ProfileAPIActions =
  * @returns A Redux action that sends a REST call for user authentication status.
  */
 export function loadUserStatus(
-  authMethod: string
+  authMethod: MASTHEAD_AUTH_METHOD
 ): ThunkAction<Promise<UserStatus>, { profileAPI: ProfileAPIState }, void, ProfileAPIActions> {
   return async dispatch => {
     let promiseStatus: Promise<UserStatus>;

--- a/packages/services-store/src/types/profileAPI.ts
+++ b/packages/services-store/src/types/profileAPI.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -23,6 +23,11 @@ export interface UserStatus {
 export const UNAUTHENTICATED_STATUS = 'Unauthenticated';
 
 /**
+ * Cloud Unauthenticated user status
+ */
+export const CLOUD_UNAUTHENTICATED_STATUS = 'anonymous';
+
+/**
  * The Redux action ID for `ProfileAPI`.
  */
 export enum PROFILE_API_ACTION {
@@ -39,6 +44,15 @@ export enum PROFILE_API_ACTION {
    * One to set the given user authentication status.
    */
   SET_USER_STATUS = 'SET_USER_STATUS',
+}
+
+/**
+ * Authentication status types.
+ */
+export enum MASTHEAD_AUTH_METHOD {
+  DEFAULT = 'profile-api',
+  COOKIE = 'cookie',
+  DOCS_API = 'docs-api',
 }
 
 /**

--- a/packages/services/src/services/Profile/Profile.js
+++ b/packages/services/src/services/Profile/Profile.js
@@ -78,7 +78,7 @@ class ProfileAPI {
   static checkCloudCookie() {
     const cloudLogin = Cookies.get(_cookieName);
 
-    console.log('Cloud Cookie', cloudLogin);
+    //console.log('Cloud Cookie', cloudLogin);
 
     return { user: cloudLogin === '1' ? 'authenticated' : 'anonymous' };
   }

--- a/packages/services/src/services/Profile/Profile.js
+++ b/packages/services/src/services/Profile/Profile.js
@@ -78,8 +78,6 @@ class ProfileAPI {
   static checkCloudCookie() {
     const cloudLogin = Cookies.get(_cookieName);
 
-    //console.log('Cloud Cookie', cloudLogin);
-
     return { user: cloudLogin === '1' ? 'authenticated' : 'anonymous' };
   }
 

--- a/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
@@ -2,8 +2,6 @@ import { Preview, Props, Description, Story } from '@storybook/addon-docs/blocks
 import contributing from '../../../../../../docs/contributing-license.md';
 import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 
-
-
 # Masthead
 
 > The masthead component is a required navigational pattern for IBM.com that
@@ -23,22 +21,59 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 [![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/masthead-l1)
 
 ## Getting Started
+
 ##### Note: Masthead uses the Carbon White theme by design. Using other themes will not change the Masthead color scheme.
 
 ### JS (via import)
 
-```javascript
+````javascript
 import '@carbon/ibmdotcom-web-components/es/components/masthead/masthead-container.js';
-```
-
-<Description markdown={`${cdnJs({ components: ['masthead'] })}`} />
-
+```<Description markdown={`\${cdnJs({ components: ['masthead'] })}`} />
 <Description markdown={`${cdnCss()}`} />
 
 ### HTML
 
 ```html
 <dds-masthead-container></dds-masthead-container>
+````
+
+#### Adopting Masthead v2 with new data endpoint
+
+###### JS (via CDN):
+
+```html
+// Alpha tag using changes from the feature branch (feat/masthead-v2)
+<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/alpha/masthead.min.js"></script>
+```
+
+###### Markup:
+
+```html
+<dds-masthead-container
+  data-endpoint="/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2"
+  auth-method="profile-api"
+  has-contact="false"
+></dds-masthead-container>
+```
+
+#### Adopting Masthead v2 with Cloud data endpoint
+
+###### JS (via CDN):
+
+```html
+// Alpha tag using changes from the feature branch (feat/masthead-v2)
+<script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/alpha/masthead.min.js"></script>
+```
+
+###### Markup:
+
+```html
+<dds-masthead-container
+  data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead"
+  platform="Cloud"
+  auth-method="cookie"
+  has-contact="true"
+></dds-masthead-container>
 ```
 
 #### Setting Platform
@@ -59,9 +94,9 @@ This property has to be set via javascript.
 ```
 
 ```javascript
-const singleUrl = "https://www.example.com";
+const singleUrl = 'https://www.example.com';
 
-document.getElementById("masthead-container").platformUrl = singleUrl;
+document.getElementById('masthead-container').platformUrl = singleUrl;
 ```
 
 ###### Setting multiple platform URLs with an object:
@@ -81,7 +116,7 @@ const urlObject = {
   },
 };
 
-document.getElementById("masthead-container").platformUrl = urlObject;
+document.getElementById('masthead-container').platformUrl = urlObject;
 ```
 
 ```html
@@ -121,16 +156,26 @@ To set a custom endpoint for the translation service to fetch from, set either t
 ```
 
 ### Setting the active menu item
+
 The active menu item receives a unique style treatment to indicate where the current page is within the navigation hierarchy.
 
 ##### Manually
+
 Manually set the active item by using the `selected-menu-item` property. See [the Props table](#props).
 
 ##### Automatically
+
 The first menu item whose `href` value matches the browser window's current URL will automatically be marked active if the `selected-menu-item` property has not been set.
 
 If no other menu items are marked active and the optional `platformUrl` property has been set, the platform link will be marked active.
 
+### Understanding the different authentication method types
+
+The `<dds-masthead-container>` and `<dds-masthead-composite>` components both expose the `auth-method` property which allows the adopters to define the authentication method based on their content ecosystems and renders the ultity menu items (located on the top right-hand area) based on the defined auth method. See below for more context on each available value.
+
+- `auth-method="profile-api"` - The default authentication method used on the global masthead to display links to the MyIBM profile.
+- `auth-method="cookie"` - This authentication method checks for the cookie name value return from the `cloud.ibm.com` console application (eg. `com.ibm.cloud.iam.LoggedIn.prod`) and see if it returns `1` or `0`. This method is designed and intended for "Cloud" web segment usage only.
+- `auth-method="docs-api"` - This authentication method checks against the console API user login response. This method is designed and intended for Cloud Docs (https://cloud.ibm.com) team usage only.
 
 ## Using custom search with typeahead API
 
@@ -145,18 +190,14 @@ First, add the `custom-typeahead-api` attribute into the masthead and set it to 
 As an example, we will be using the IBM Docs API to fetch the data, retrieving an array of result suggestions.
 
 ```javascript
-  async function customTypeaheadApiFunction(searchVal) {
-    return fetch(
-      `https://ibmdocs-dev.mybluemix.net/docs/api/v1/suggest?query=${searchVal}&lang=en&categories=&limit=6`
-    )
-      .then((response) => response.json())
-      .then((data) => {
-        let searchResults = [
-          data.hints,
-        ];
-        return searchResults;
-      });
-  }
+async function customTypeaheadApiFunction(searchVal) {
+  return fetch(`https://ibmdocs-dev.mybluemix.net/docs/api/v1/suggest?query=${searchVal}&lang=en&categories=&limit=6`)
+    .then(response => response.json())
+    .then(data => {
+      let searchResults = [data.hints];
+      return searchResults;
+    });
+}
 ```
 
 To query the current masthead search input, we need to create an event listener to listen for the `dds-search-with-typeahead-input` event.
@@ -164,10 +205,10 @@ Once captured, we need to call our asynchronous function to fetch the custom API
 a new custom event `dds-custom-typeahead-api-results` needs to be dispatched containing the results for the component to render the search suggestions.
 
 ```javascript
-  document.addEventListener('dds-search-with-typeahead-input', async (e) => { 
-    const results = await customTypeaheadApiFunction(e.detail.value);
-    document.dispatchEvent(new CustomEvent('dds-custom-typeahead-api-results', { detail: results}));
-  })
+document.addEventListener('dds-search-with-typeahead-input', async e => {
+  const results = await customTypeaheadApiFunction(e.detail.value);
+  document.dispatchEvent(new CustomEvent('dds-custom-typeahead-api-results', { detail: results }));
+});
 ```
 
 ### Grouped Search
@@ -178,33 +219,32 @@ As before, create a function that fetches the query and make sure to include a J
 and the array of retrieved section suggestions in `items`. In the example below, the section `Product pages` is added to the
 results array.
 
-
 ```javascript
-  async function customTypeaheadApiFunction(searchVal) {
-    return fetch(
-      `https://ibmdocs-dev.mybluemix.net/docs/api/v1/suggest?query=${searchVal}&lang=en&categories=&limit=6`
-    )
-      .then((response) => response.json())
-      .then((data) => {
-        let searchResults = [
-          data.hints,
+async function customTypeaheadApiFunction(searchVal) {
+  return fetch(`https://ibmdocs-dev.mybluemix.net/docs/api/v1/suggest?query=${searchVal}&lang=en&categories=&limit=6`)
+    .then(response => response.json())
+    .then(data => {
+      let searchResults = [
+        data.hints,
 
-          // optional category results fetched from API
-          {
-            title: "Product pages",
-            items: data.products
-          }
-        ];
-        return searchResults;
-      });
-  }
+        // optional category results fetched from API
+        {
+          title: 'Product pages',
+          items: data.products,
+        },
+      ];
+      return searchResults;
+    });
+}
 ```
 
-As mentioned above, the two events `dds-search-with-typeahead-input` and `dds-custom-typeahead-api-results` must be handled for 
+As mentioned above, the two events `dds-search-with-typeahead-input` and `dds-custom-typeahead-api-results` must be handled for
 suggestions to be rendered -- the same code for the event listener can be reused.
 
 #### Note
+
 The API results must match the following structure:
+
 ```javascript
 [
   ['result 1', 'result 2', 'result 3'],
@@ -218,6 +258,7 @@ The API results must match the following structure:
   }
 ]
 ```
+
 Note that only the first array element is necessary to render the basic search suggestions, the following JSON objects are optional Grouped sections.
 
 ## Props
@@ -242,11 +283,10 @@ See [our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/t
 | `<dds-masthead-menu-button>`                                                              | `data-autoid="dds--masthead__hamburger"`                                 | Interactive |
 | `<dds-top-nav-name>`                                                                      | `data-autoid="dds--masthead__platform-name"`                             | Interactive |
 | `<dds-top-nav>`                                                                           | `data-autoid="dds--masthead__l0-nav"`                                    | Component   |
-| `<dds-top-nav-menu trigger-content="${item}">` and `<dds-top-nav-item title="${item}">`   | `data-autoid="dds--masthead__l0-nav--nav${item}"`                       | Interactive |
+| `<dds-top-nav-menu trigger-content="${item}">` and `<dds-top-nav-item title="${item}">`   | `data-autoid="dds--masthead__l0-nav--nav${item}"`                        | Interactive |
 | `<dds-top-nav-menu-item title="${item}">`                                                 | `data-autoid="dds--masthead__l0-nav--subnav-col${item}-item${item}"`     | Interactive |
 | `<dds-left-nav>`                                                                          | `data-autoid="dds--masthead__l0-sidenav"`                                | Component   |
-| `<dds-left-nav-menu trigger-content="${item}">` and `<dds-left-nav-item title="${item}">` | `data-autoid="dds--masthead__l0-sidenav--nav${item}"`                   | Interactive |
+| `<dds-left-nav-menu trigger-content="${item}">` and `<dds-left-nav-item title="${item}">` | `data-autoid="dds--masthead__l0-sidenav--nav${item}"`                    | Interactive |
 | `<dds-left-nav-menu-item title="${item}">`                                                | `data-autoid="dds--masthead__l0-sidenav--subnav-col${item}-item${item}"` | Interactive |
-
 
 <Description markdown={contributing} />

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -116,7 +116,7 @@ export const Default = ({ parameters }) => {
   `;
 };
 
-export const WithV2Data = ({ parameters }) => {
+export const withV2Data = ({ parameters }) => {
   const { customProfileLogin, hasProfile, hasSearch, searchPlaceholder, userStatus, navLinks, hasContact } =
     parameters?.props?.MastheadComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
@@ -155,7 +155,11 @@ export const WithV2Data = ({ parameters }) => {
   `;
 };
 
-export const WithCloudData = ({ parameters }) => {
+withV2Data.story = {
+  name: 'With v2 Data',
+};
+
+export const withCloudData = ({ parameters }) => {
   const { customProfileLogin, hasSearch, selectedMenuItem, searchPlaceholder, navLinks } =
     parameters?.props?.MastheadComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -17,16 +17,13 @@ import DDSLeftNav from '../left-nav';
 import '../masthead-container';
 import styles from './masthead.stories.scss';
 import { mastheadLinks as links, mastheadL1Data, logoData } from './links';
-import { UNAUTHENTICATED_STATUS } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI';
+import {
+  UNAUTHENTICATED_STATUS,
+  MASTHEAD_AUTH_METHOD,
+} from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI';
 import { authenticatedProfileItems, unauthenticatedProfileItems } from './profile-items';
 import { DDS_CUSTOM_PROFILE_LOGIN } from '../../../globals/internal/feature-flags';
 import readme from './README.stories.mdx';
-
-const endpoints = {
-  default: null,
-  'masthead v2': '/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2',
-  'cloud masthead': '/common/carbon-for-ibm-dotcom/translations/cloud-masthead',
-};
 
 const userStatuses = {
   authenticated: 'test.user@ibm.com',
@@ -70,7 +67,6 @@ async function customTypeaheadApiFunction(searchVal) {
 
 export const Default = ({ parameters }) => {
   const {
-    endpoint,
     customProfileLogin,
     platform,
     hasProfile,
@@ -79,6 +75,7 @@ export const Default = ({ parameters }) => {
     searchPlaceholder,
     userStatus,
     navLinks,
+    authMethod,
   } = parameters?.props?.MastheadComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
@@ -99,11 +96,11 @@ export const Default = ({ parameters }) => {
             .navLinks="${navLinks}"
             .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
             custom-profile-login="${customProfileLogin}"
+            auth-method="${MASTHEAD_AUTH_METHOD.DEFAULT}"
           ></dds-masthead-composite>
         `
       : html`
           <dds-masthead-container
-            data-endpoint="${ifNonNull(endpoint)}"
             platform="${ifNonNull(platform)}"
             .platformUrl="${ifNonNull(platformData.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
@@ -113,6 +110,85 @@ export const Default = ({ parameters }) => {
             has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             custom-profile-login="${customProfileLogin}"
+            auth-method="${authMethod}"
+          ></dds-masthead-container>
+        `}
+  `;
+};
+
+export const WithV2Data = ({ parameters }) => {
+  const { customProfileLogin, hasProfile, hasSearch, searchPlaceholder, userStatus, navLinks, hasContact } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
+  return html`
+    <style>
+      ${styles}
+    </style>
+    ${useMock
+      ? html`
+          <dds-masthead-composite
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            has-profile="${hasProfile}"
+            ?has-search="${hasSearch}"
+            .navLinks="${navLinks}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+            custom-profile-login="${customProfileLogin}"
+            auth-method="${MASTHEAD_AUTH_METHOD.DEFAULT}"
+            has-contact="${hasContact}"
+          ></dds-masthead-composite>
+        `
+      : html`
+          <dds-masthead-container
+            data-endpoint="/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2"
+            user-status="${ifNonNull(userStatus)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+            .navLinks="${navLinks}"
+            has-profile="${hasProfile}"
+            ?has-search="${hasSearch}"
+            custom-profile-login="${customProfileLogin}"
+            auth-method="${MASTHEAD_AUTH_METHOD.DEFAULT}"
+            has-contact="${hasContact}"
+          ></dds-masthead-container>
+        `}
+  `;
+};
+
+export const WithCloudData = ({ parameters }) => {
+  const { customProfileLogin, hasSearch, selectedMenuItem, searchPlaceholder, navLinks } =
+    parameters?.props?.MastheadComposite ?? {};
+  const { useMock } = parameters?.props?.Other ?? {};
+  return html`
+    <style>
+      ${styles}
+    </style>
+    ${useMock
+      ? html`
+          <dds-masthead-composite
+            platform="Cloud"
+            .platformUrl="${ifNonNull(platformData.url)}"
+            selected-menu-item="${ifNonNull(selectedMenuItem)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+            .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
+            ?has-search="${hasSearch}"
+            .navLinks="${navLinks}"
+            .unauthenticatedProfileItems="${ifNonNull(unauthenticatedProfileItems)}"
+            custom-profile-login="${customProfileLogin}"
+            auth-method="${MASTHEAD_AUTH_METHOD.COOKIE}"
+          ></dds-masthead-composite>
+        `
+      : html`
+          <dds-masthead-container
+            data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead"
+            platform="Cloud"
+            .platformUrl="${ifNonNull(platformData.url)}"
+            selected-menu-item="${ifNonNull(selectedMenuItem)}"
+            searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+            .navLinks="${navLinks}"
+            ?has-search="${hasSearch}"
+            custom-profile-login="${customProfileLogin}"
+            auth-method="${MASTHEAD_AUTH_METHOD.COOKIE}"
           ></dds-masthead-container>
         `}
   `;
@@ -451,9 +527,9 @@ export default {
     knobs: {
       escapeHTML: false,
       MastheadComposite: ({ groupId }) => ({
-        endpoint: select('Masthead data (data-endpoint)', endpoints, endpoints.default, groupId),
         hasProfile: select('show the profile functionality (has-profile)', ['true', 'false'], 'true', groupId),
         hasSearch: boolean('show the search functionality (has-search)', true, groupId),
+        hasContact: select('Contact us button visibility (has-contact)', ['true', 'false'], 'true', groupId),
         searchPlaceholder: textNullable('search placeholder (searchPlaceholder)', 'Search all of IBM', groupId),
         selectedMenuItem: textNullable('selected menu item (selected-menu-item)', 'Consulting & Services', groupId),
         userStatus: select('The user authenticated status (user-status)', userStatuses, userStatuses.unauthenticated, groupId),

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -29,6 +29,7 @@ import {
   MastheadProfileItem,
 } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI.d';
 import { UNAUTHENTICATED_STATUS } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/cloudAccountAuthAPI';
+import { MASTHEAD_AUTH_METHOD } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI';
 import styles from './cloud-masthead.scss';
 import DDSMastheadComposite, { NAV_ITEMS_RENDER_TARGET } from '../masthead-composite';
 
@@ -77,7 +78,7 @@ class DDSCloudMastheadComposite extends DDSMastheadComposite {
    * The selected authentication method, either 'cookie' or 'api'.
    */
   @property({ attribute: 'auth-method' })
-  authMethod = 'cookie';
+  authMethod = MASTHEAD_AUTH_METHOD.COOKIE;
 
   /**
    * The user authentication status.

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -912,7 +912,7 @@ class DDSMastheadComposite extends LitElement {
   hasContact = 'true';
 
   /**
-   * The selected authentication method, either profile-api (default), 'cookie', 'docs-api'.
+   * The selected authentication method, either `profile-api` (default), `cookie`, or `docs-api`.
    */
   @property({ attribute: 'auth-method' })
   authMethod = MASTHEAD_AUTH_METHOD.DEFAULT;

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -25,7 +25,11 @@ import {
   MastheadProfileItem,
   Translation,
 } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI.d';
-import { UNAUTHENTICATED_STATUS } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI';
+import {
+  UNAUTHENTICATED_STATUS,
+  CLOUD_UNAUTHENTICATED_STATUS,
+  MASTHEAD_AUTH_METHOD,
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI';
 import { MEGAMENU_RIGHT_NAVIGATION_STYLE_SCHEME } from './megamenu-right-navigation';
 import { DDS_CUSTOM_PROFILE_LOGIN } from '../../globals/internal/feature-flags';
 import './masthead';
@@ -902,22 +906,22 @@ class DDSMastheadComposite extends LitElement {
   searchPlaceholder?: string;
 
   /**
-   * The user authentication status.
-   */
-  @property({ attribute: 'user-status' })
-  userStatus = UNAUTHENTICATED_STATUS;
-
-  /**
    * `true` if Contact us should be shown.
    */
   @property({ type: String, reflect: true, attribute: 'has-contact' })
   hasContact = 'true';
 
   /**
-   * The selected authentication method, either 'cookie' or 'api'.
+   * The selected authentication method, either profile-api (default), 'cookie', 'docs-api'.
    */
   @property({ attribute: 'auth-method' })
-  authMethod = 'profile-api';
+  authMethod = MASTHEAD_AUTH_METHOD.DEFAULT;
+
+  /**
+   * The user authentication status.
+   */
+  @property({ attribute: 'user-status' })
+  userStatus = this.authMethod === MASTHEAD_AUTH_METHOD.DEFAULT ? UNAUTHENTICATED_STATUS : CLOUD_UNAUTHENTICATED_STATUS;
 
   createRenderRoot() {
     // We render child elements of `<dds-masthead-container>` by ourselves
@@ -979,7 +983,7 @@ class DDSMastheadComposite extends LitElement {
       l1Data,
       hasContact,
     } = this;
-    const authenticated = userStatus !== UNAUTHENTICATED_STATUS;
+    const authenticated = userStatus !== UNAUTHENTICATED_STATUS && userStatus !== CLOUD_UNAUTHENTICATED_STATUS;
 
     const ctaButtons = authenticated ? authenticatedCtaButtons : unauthenticatedCtaButtons;
 


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9291

### Description
- This PR consolidates the Cloud authentication methods and ensures that we deliver the right utility menu items based on the value defined in the auth-method prop/attribute.
- Add different storybook previews per masthead endpoint (eg, `with V2 Data`, `with Cloud Data`), since the endpoint knob does not update the source string of the endpoint consistently.

### Changelog

**Changed**

- Move Cloud auth methods/functions into the Profile services within the `@carbon/ibmdotcom-services` package and adjust `@carbon/ibmdotcom-services-store`
- Add `has-contact` knob to show adopters that they can optionally add/remove `contact` CTA/button.

**To do**

- [x] Update the `docs` tab to include info about the different auth method types (eg.  `profile-api`, `cookie`, and `docs-api` ). Will pick this up tomorrow morning.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
