### PR TITLE
docs: index compatible design kits

### DIFF
--- a/packages/styles/carbon.yml
+++ b/packages/styles/carbon.yml
@@ -5,6 +5,15 @@ library:
   description: Apply framework-agnostic styles to any IBM.com component.
   noIndex: true
   externalDocsUrl: www.ibm.com/standards/web/carbon-for-ibm-dotcom
+  designKits:
+    ibm-dotcom-white-figma:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/ibm-dotcom-white-figma
+    ibm-dotcom-g10-figma:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/ibm-dotcom-g10-figma
+    ibm-dotcom-g90-figma:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/ibm-dotcom-g90-figma
+    ibm-dotcom-g100-figma:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/ibm-dotcom-g100-figma
 assets:
   back-to-top:
     name: Back to top


### PR DESCRIPTION
### Related Ticket(s)

Related: https://github.com/carbon-design-system/carbon-platform/issues/967

### Description

The IBM.com Web Components and IBM.com React libraries have a design kits page, to view a subset of indexed design kits that are compatible with those libraries:

https://next.carbondesignsystem.com/libraries/ibmdotcom-web-components/latest/design-kits

https://next.carbondesignsystem.com/libraries/ibmdotcom-react/latest/design-kits

Because both of those libraries inherit IBM.com Styles, and `designKits` array in the schema is inheritable, this PR adds compatible design kits to the styles library.

### Changelog

**New**

- `designKits` in IBM.com Styles library index

**Changed**

- N/A

**Removed**

- N/A

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
