### PR TITLE
fix(StickyHeader): fix masthead-l1 logic for Masthead v2

### DIFF
--- a/packages/web-components/src/components/masthead/masthead.ts
+++ b/packages/web-components/src/components/masthead/masthead.ts
@@ -31,6 +31,19 @@ class DDSMasthead extends StableSelectorMixin(LitElement) {
     StickyHeader.global.masthead = this;
   }
 
+  /**
+   * Re-initializes masthead component with StickyHeader class in case of L1 addition/removal.
+   */
+  handleL1Change({ target }) {
+    const L1Navs = (target as HTMLSlotElement)
+      .assignedElements()
+      .filter(element => element.tagName.toLowerCase() === `${ddsPrefix}-masthead-l1`);
+
+    if (L1Navs.length) {
+      StickyHeader.global.masthead = this;
+    }
+  }
+
   render() {
     return html`
       <div class="${prefix}--masthead__l0">
@@ -45,7 +58,7 @@ class DDSMasthead extends StableSelectorMixin(LitElement) {
           <slot name="profile"></slot>
         </div>
       </div>
-      <slot name="masthead-l1"></slot>
+      <slot name="masthead-l1" @slotchange=${this.handleL1Change}></slot>
     `;
   }
 


### PR DESCRIPTION
### Related Ticket(s)
[DCMS-6277](https://jsw.ibm.com/browse/DCMS-6277)

### Description

This PR helps fix an otherwise undocumented issue where adding/removing an L1 menu after the masthead's `firstUpdated` callback prevents the global `StickyHeader` utility class from having knowledge of L1 menus.

This was discovered during Drupal ingestion of the v2 Mastheadwork, since they're pulling L1 data in separately from the masthead component.

### Changelog

**Changed**

- Updated logic to fortify the masthead/StickyHeader combination
