### PR TITLE
fix(link-list): ensure icon stays on top

### DIFF
--- a/packages/styles/scss/components/link-list/_link-list.scss
+++ b/packages/styles/scss/components/link-list/_link-list.scss
@@ -84,8 +84,7 @@
 
   :host(#{$dds-prefix}-link-list-item-card-cta) {
     ::slotted(#{$dds-prefix}-card-cta-footer) {
-      @include carbon--breakpoint-down('md') {
-        align-self: center;
+      @include carbon--breakpoint-down('lg') {
         margin-top: 0;
       }
     }


### PR DESCRIPTION
### Related Ticket(s)
#8977

### Description
There was a small leftover where the Link list icon doesn't stay at the top when there is more than two lines. 

### Changelog

**Changed**

- removed `padding-top` of `card-cta-footer` when slotted within `list-list-item-card-cta` at `md` or less breakpoint

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
