### PR TITLE
chore(leadspace-search): add subheading knob

### DIFF
--- a/packages/web-components/src/components/leadspace-with-search/__stories__/leadspace-with-search.stories.ts
+++ b/packages/web-components/src/components/leadspace-with-search/__stories__/leadspace-with-search.stories.ts
@@ -41,7 +41,7 @@ export const Default = args => {
   const subheadingComponent = document.querySelector('dds-leadspace-with-search-content-heading');
 
   if (subheadingComponent) {
-    document.querySelector('dds-leadspace-with-search-content-heading')!.shadowRoot!.innerHTML = subheading;
+    subheadingComponent!.shadowRoot!.innerHTML = subheading;
   }
   return html`
     <dds-leadspace-with-search adjacent-theme="${theme}">
@@ -65,7 +65,7 @@ export const WithImage = args => {
   const subheadingComponent = document.querySelector('dds-leadspace-with-search-content-heading');
 
   if (subheadingComponent) {
-    document.querySelector('dds-leadspace-with-search-content-heading')!.shadowRoot!.innerHTML = subheading;
+    subheadingComponent!.shadowRoot!.innerHTML = subheading;
   }
 
   return html`

--- a/packages/web-components/src/components/leadspace-with-search/__stories__/leadspace-with-search.stories.ts
+++ b/packages/web-components/src/components/leadspace-with-search/__stories__/leadspace-with-search.stories.ts
@@ -38,6 +38,11 @@ observer.observe(htmlElement, { attributes: true });
 export const Default = args => {
   const { theme, heading, subheading, paragraph } = args?.LeadspaceWithSearch ?? {};
   const secondTheme = theme.split('-')[2];
+  const subheadingComponent = document.querySelector('dds-leadspace-with-search-content-heading');
+
+  if (subheadingComponent) {
+    document.querySelector('dds-leadspace-with-search-content-heading')!.shadowRoot!.innerHTML = subheading;
+  }
   return html`
     <dds-leadspace-with-search adjacent-theme="${theme}">
       <dds-leadspace-with-search-heading>${heading}</dds-leadspace-with-search-heading>
@@ -56,6 +61,13 @@ export const Default = args => {
 export const WithImage = args => {
   const { theme, heading, subheading, paragraph } = args?.LeadspaceWithSearch ?? {};
   const secondTheme = theme.split('-')[2];
+
+  const subheadingComponent = document.querySelector('dds-leadspace-with-search-content-heading');
+
+  if (subheadingComponent) {
+    document.querySelector('dds-leadspace-with-search-content-heading')!.shadowRoot!.innerHTML = subheading;
+  }
+
   return html`
     <dds-leadspace-with-search adjacent-theme="${theme}">
       <dds-background-media gradient-direction="left-to-right" mobile-position="bottom" default-src="${image}" slot="image">
@@ -108,7 +120,7 @@ export default {
     knobs: {
       LeadspaceWithSearch: () => ({
         heading: text('Heading:', 'Find a product'),
-        subheading: 'Innovate like a startup, scale for the enterprise',
+        subheading: text('Subheading', 'Innovate like a startup, scale for the enterprise'),
         paragraph: text('Paragraph:', ''),
         theme: select(`Adjacent theme`, adjacentThemes, adjacentThemes.Monotheme) ?? 0,
       }),


### PR DESCRIPTION
### Related Ticket(s)
#8793

### Description
The current Storybook lacked a knob to modify the subheading in Leadspace with search, this ensures the knob works. 

### Changelog

**New**

- new subheading knob and logic to ensure it works

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
