### PR TITLE
fix(storybook): dotcomshell/lightbox missing imports

### DIFF
--- a/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
@@ -25,6 +25,7 @@ import '../../../quote/index';
 import '../../../cta-block/index';
 import '../../../callout-quote/index';
 import '../../../callout-with-media/index';
+import '../../../table-of-contents/index';
 
 import imgSm16x9 from '../../../../../../storybook-images/assets/320/fpo--16x9--320x180--002.jpg';
 import imgMd16x9 from '../../../../../../storybook-images/assets/480/fpo--16x9--480x270--002.jpg';

--- a/packages/web-components/src/components/lightbox-media-viewer/__stories__/lightbox-media-viewer.stories.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/__stories__/lightbox-media-viewer.stories.ts
@@ -14,6 +14,8 @@ import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.j
 import 'carbon-web-components/es/components/modal/modal-close-button.js';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 import '../index';
+import '../../carousel/index';
+import '../../expressive-modal/index';
 import styles from './lightbox-media-viewer.stories.scss';
 import readme from './README.stories.mdx';
 


### PR DESCRIPTION
### Related Ticket(s)

#9420 

### Description

Storybook bug where stories are missing all of the component imports and displaying wrong. This updates dotcomshell stories to include a table-of-contents import and lightbox-media-viewer to include importing the carousel
### Changelog

**New**

- add missing component import to stories

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
