### PR TITLE
fix(filter-panel-input-select): aria expanded

### DIFF
--- a/packages/web-components/src/components/filter-panel/filter-panel-input-select.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-input-select.ts
@@ -169,6 +169,11 @@ class DDSFilterPanelInputSelect extends FocusMixin(StableSelectorMixin(LitElemen
     if (changedProperties.has('selected')) {
       this.ariaLabel = `${this.title}, ${this.selected ? 'selected' : 'unselected'}`;
     }
+    if (this._items.length) {
+      this.shadowRoot
+        ?.querySelector(`.${prefix}--input-container__heading`)
+        ?.setAttribute('aria-expanded', String(Boolean(this.isOpen)));
+    }
   }
 
   render() {
@@ -181,7 +186,6 @@ class DDSFilterPanelInputSelect extends FocusMixin(StableSelectorMixin(LitElemen
           @click=${this._handleClickHeader}
           @keydown=${this._handleKeydown}
           aria-controls="content"
-          aria-expanded="${String(Boolean(this.isOpen))}"
           aria-label="${this.ariaLabel}"
           role="button"
         >


### PR DESCRIPTION
### Related Ticket(s)

#9391 
### Description

Removes `aria-expanded` attribute for the options within the filter panel that do not "expand/collapse". aria-expanded attribute should be present only for the elements that behave like expand/collapse e.g. Artificial intelligence, etc.

### Changelog

**Changed**

- checks which filter panel input has items and adds `aria-expanded` to only the ones with items

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
