### PR TITLE
fix(content-block): fix cta alignment for mobile viewport

### DIFF
--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -237,9 +237,6 @@
 
     @include carbon--breakpoint('sm') {
       .#{$prefix}--card__CTA {
-        // @include hang;
-        // padding-left: 0;
-        // padding-right: 0;
         margin-left: -($carbon--spacing-05);
       }
     }

--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -233,10 +233,13 @@
   .#{$prefix}--content-block__cta-col {
     @include carbon--make-col-ready;
 
-    max-width: calc(320px + $carbon--layout-05);
+    max-width: calc(320px + #{$carbon--layout-05});
 
     @include carbon--breakpoint('sm') {
       .#{$prefix}--card__CTA {
+        // @include hang;
+        // padding-left: 0;
+        // padding-right: 0;
         margin-left: -($carbon--spacing-05);
       }
     }
@@ -246,7 +249,7 @@
 
       padding-left: $carbon--spacing-05;
       padding-right: $carbon--spacing-05;
-      max-width: calc(320px + $carbon--layout-05);
+      max-width: calc(320px + #{$carbon--layout-05});
     }
   }
 }

--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -233,11 +233,12 @@
   .#{$prefix}--content-block__cta-col {
     @include carbon--make-col-ready;
 
-    max-width: calc(320px + 1rem);
+    max-width: calc(320px + $carbon--layout-05);
 
     @include carbon--breakpoint('sm') {
-      padding-left: 0;
-      padding-right: 0;
+      .#{$prefix}--card__CTA {
+        margin-left: -($carbon--spacing-05);
+      }
     }
 
     @include carbon--breakpoint('md') {
@@ -245,7 +246,7 @@
 
       padding-left: $carbon--spacing-05;
       padding-right: $carbon--spacing-05;
-      max-width: calc(320px + 1rem);
+      max-width: calc(320px + $carbon--layout-05);
     }
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

#8331 

### Description

Content block CTA should align to the left of the viewport in mobile only when `cta-type=card`.

before:
![image](https://user-images.githubusercontent.com/909118/194092497-d82c6c21-3436-42a3-a6b7-a631cefeb6f9.png)

after:
![image](https://user-images.githubusercontent.com/909118/194092583-23bc015b-0fba-4875-be0a-cec4fcf8c4e1.png)


### Changelog

**Changed**

- update `content-block` CTA alignment for mobile viewport

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
