### PR TITLE
chore(masthead-v2): update automerge target

### DIFF
--- a/.github/workflows/automerge-mastheadv2.yml
+++ b/.github/workflows/automerge-mastheadv2.yml
@@ -16,11 +16,11 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - uses: actions/checkout@v2
-      - name: Merge to feat/masthead-v2
+      - name: Merge to feat/masthead-v2-dev
         uses: devmasx/merge-branch@1.4.0
         with:
           type: now
-          target_branch: 'feat/masthead-v2'
+          target_branch: 'feat/masthead-v2-dev'
         env:
           GITHUB_TOKEN: ${{secrets.MERGE_ACTION}}
       - uses: act10ns/slack@v1


### PR DESCRIPTION
### Related Ticket(s)

Related to #9459 

### Description

To avoid volatility in masthead v2 now that it's on prod environments, we'd like to move active development to the `feat/masthead-v2-dev` branch. This includes the automerge workflow that keeps the masthead v2 work up to date with `main`.

### Changelog

**Changed**

- update automerge workflow name & target
