### PR TITLE
fix(feature-section): react wrapper img alt not being used in story

### DIFF
--- a/packages/web-components/src/components/feature-section/__stories__/feature-section.stories.react.tsx
+++ b/packages/web-components/src/components/feature-section/__stories__/feature-section.stories.react.tsx
@@ -45,10 +45,10 @@ const types = {
 };
 
 export const Default = args => {
-  const { eyebrow, heading, copy, href, ctaType, mediaAlign, defaultSrc } = args?.FeatureSection ?? {};
+  const { alt, eyebrow, heading, copy, href, ctaType, mediaAlign, defaultSrc } = args?.FeatureSection ?? {};
   return (
     <DDSFeatureSection media-alignment={mediaAlign}>
-      <DDSImage slot="image" default-src={defaultSrc}>
+      <DDSImage slot="image" default-src={defaultSrc} alt={alt}>
         <DDSImageItem media="(min-width: 1584px)" srcset={imgXlg1x1}></DDSImageItem>
         <DDSImageItem media="(min-width: 1056px)" srcset={imgLg1x1}></DDSImageItem>
         <DDSImageItem media="(min-width: 672px)" srcset={imgMd4x3}></DDSImageItem>


### PR DESCRIPTION
### Related Ticket(s)

[Feature section]: VO does not read out image #8131

### Description

`alt` prop wasn't being passed in for `feature-section` React wrapper. React wrapper story should now read the image alt text in VO

https://user-images.githubusercontent.com/54281166/194951646-dedc2c33-9911-445e-9bdd-4f7a54c5a23a.mov

### Changelog

**Changed**

- pass in `alt` to image in `feature-section` React wrapper story

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
