### PR TITLE
fix(masthead): remove unnecessary aria-label

### DIFF
--- a/packages/web-components/src/components/masthead/top-nav.ts
+++ b/packages/web-components/src/components/masthead/top-nav.ts
@@ -473,7 +473,7 @@ class DDSTopNav extends StableSelectorMixin(HostListenerMixin(BXHeaderNav)) {
                 </div>
                 <div class="${ddsPrefix}-ce--header__nav-content-container">
                   <div class="${prefix}--header__nav-content" style="right: -${currentScrollPosition}px">
-                    <nav part="nav" aria-label="nav-rtl" class="${prefix}--header__nav">
+                    <nav part="nav" class="${prefix}--header__nav">
                       <div class="${prefix}--sub-content-right"></div>
                       <div part="menubar" class="${prefix}--header__menu-bar" aria-label="${ifNonNull(this.menuBarLabel)}">
                         <slot @slotchange=${handleSlotChange} @keydown="${handleOnKeyDown}"></slot>
@@ -510,7 +510,7 @@ class DDSTopNav extends StableSelectorMixin(HostListenerMixin(BXHeaderNav)) {
                 </div>
                 <div class="${ddsPrefix}-ce--header__nav-content-container">
                   <div class="${prefix}--header__nav-content" style="left: -${currentScrollPosition}px">
-                    <nav part="nav" aria-label="nav-ltr" class="${prefix}--header__nav">
+                    <nav part="nav" class="${prefix}--header__nav">
                       <div class="${prefix}--sub-content-left"></div>
                       <div part="menubar" class="${prefix}--header__menu-bar" aria-label="${ifNonNull(this.menuBarLabel)}">
                         <slot @slotchange=${handleSlotChange} @keydown="${handleOnKeyDown}"></slot>


### PR DESCRIPTION
### Related Ticket(s)

[Masthead]: Screen reader announces the landmark label as "Nav LTR" which is not meaningful #8853

### Description

the `top-nav` aria-label is unnecessary and should be removed to not confused the user.

### Changelog

**Removed**

- `aria-label` from `top-nav`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
