### PR TITLE
fix(masthead): remove aria-haspopup from profile menu for VO

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-profile.ts
+++ b/packages/web-components/src/components/masthead/masthead-profile.ts
@@ -115,7 +115,6 @@ class DDSMastheadProfile extends HostListenerMixin(FocusMixin(StableSelectorMixi
         tabindex="0"
         class="${prefix}--header__menu-item ${prefix}--header__menu-title"
         href="javascript:void 0"
-        aria-haspopup="menu"
         aria-expanded="${String(Boolean(expanded))}"
         aria-label="${ifDefined(triggerLabel)}"
         @click=${handleClick}

--- a/packages/web-components/tests/snapshots/dds-masthead-profile.md
+++ b/packages/web-components/tests/snapshots/dds-masthead-profile.md
@@ -7,7 +7,6 @@
 ```
 <a
   aria-expanded="false"
-  aria-haspopup="menu"
   aria-label="User profile"
   class="bx--header__menu-item bx--header__menu-title"
   href="javascript:void 0"
@@ -27,7 +26,6 @@
 ```
 <a
   aria-expanded="true"
-  aria-haspopup="menu"
   aria-label="User profile"
   class="bx--header__menu-item bx--header__menu-title"
   href="javascript:void 0"


### PR DESCRIPTION
### Related Ticket(s)

[Masthead]: QA: Voiceover does not announce whether the profile pop up menu is expanded or collapsed #8869

### Description

In mobile, VO doesn't tell user if the profile menu is expanded or collapsed - it currently identifies that it is a popup button when focus is on the button:

"user profile popup-button menu-popup double tap to activate picker"

however, this same is announced when the profile menu is expanded so it is not descriptive enough to alert user if the menu has been expanded or collapsed.

In researching, it seems that VO will not announce the `aria-expanded` attribute if the button element also has the `aria-haspopup` attribute. Removing the `aria-haspopup` attribute allows for VO to properly announce if the menu is expanded or not. VO then reads:

"user profile button expanded"

BEFORE:
https://user-images.githubusercontent.com/54281166/195444988-d18f97de-2bec-4aed-8873-bf0073a03d73.mov

AFTER:
https://user-images.githubusercontent.com/54281166/195445097-afefd854-800e-4d8a-bc54-e30f0e90b2a8.mov

### Changelog

**Removed**

- remove `aria-haspopup` attribute so that VO can alert user if profile menu is expanded/collapsed

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
