### PR TITLE
fix(storybook-react-wrapper): props not appearing

### DIFF
--- a/packages/web-components/.storybook/react/main.js
+++ b/packages/web-components/.storybook/react/main.js
@@ -166,6 +166,7 @@ module.exports = {
             ],
           },
         },
+        require.resolve('../../tools/react-docgen-custom-element-type-loader'),
       ],
     });
     return massagedConfig;

--- a/packages/web-components/src/components/button-group/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/button-group/__stories__/README.stories.react.mdx
@@ -1,6 +1,7 @@
 import { Preview, Props, Description, Story } from '@storybook/addon-docs/blocks';
 import contributing from '../../../../../../docs/contributing-license.md';
 import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-react/button-group/button-group';
+import { PropTypesRef as ButtonGroupItem } from '@carbon/ibmdotcom-web-components/es/components-react/button-group/button-group-item';
 
 # Button Group
 
@@ -40,6 +41,10 @@ function App() {
 ## Props
 
 <Props of={PropTypesRef} />
+
+## Props of DDSButtonGroupItem
+
+<Props of={ButtonGroupItem} />
 
 ## Stable selectors
 

--- a/packages/web-components/src/components/dotcom-shell/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/README.stories.react.mdx
@@ -1,6 +1,6 @@
 import { Preview, Props, Description, Story } from '@storybook/addon-docs/blocks';
 import contributing from '../../../../../../docs/contributing-license.md';
-import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-react/dotcom-shell/dotcom-shell';
+import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-react/dotcom-shell/dotcom-shell-composite';
 
 # Dotcom shell
 

--- a/packages/web-components/tools/babel-plugin-create-react-custom-element-type.js
+++ b/packages/web-components/tools/babel-plugin-create-react-custom-element-type.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,6 +14,7 @@ const { default: template } = require('@babel/template');
 const { default: traverse } = require('@babel/traverse');
 const { default: transformTemplateLiterals } = require('@babel/plugin-transform-template-literals');
 const replaceExtension = require('replace-ext');
+const fs = require('fs');
 
 const regexEvent = /^event/;
 
@@ -209,6 +210,63 @@ function createMetadataVisitor(api) {
       }
 
       const metadata = getPropertyMetadata(path);
+
+      // Checks if the current component extends a local dotcom component
+      if (context.parentDescriptorSource && !context.parentDescriptorSource.includes('carbon-web-components')) {
+        // Gets parent path at ES components/react folder
+        let parentFileName = context.parentDescriptorSource
+          .replace('..', '/es/components-react')
+          .replace('./lightbox-media-viewer-body', '/es/components-react/lightbox-media-viewer/lightbox-media-viewer-body')
+          .replace('./', '/es/components-react/cta/');
+
+        parentFileName += '.js';
+        parentFileName = context.file.opts.root + parentFileName;
+
+        // Use fs.readFile() method to read the parent file
+        fs.readFile(parentFileName, 'utf8', (_errParent, parentData) => {
+          const firstIndex = parentData.indexOf('export var propTypes') + 'export var propTypes = {'.length;
+          const secondIndex = parentData.indexOf('}', firstIndex);
+          // Gets parent props from ES folder as string
+          if (secondIndex > firstIndex + 1) {
+            let copy = parentData.slice(firstIndex, secondIndex);
+
+            const currentFileName = context.file.opts.filename
+              .replace('src/components', 'es/components-react')
+              .replace('.ts', '.js');
+
+            // Gets original component file
+            fs.readFile(currentFileName, 'utf8', (_errOriginal, originalData) => {
+              if (originalData.length && !originalData.includes(copy) && !copy.includes('.assign')) {
+                const originalSplit = originalData.split('\n');
+                const index =
+                  originalSplit.indexOf('export var propTypes = {') !== -1
+                    ? originalSplit.indexOf('export var propTypes = {')
+                    : originalSplit.indexOf('export var propTypes = {};');
+
+                // Combines parent props with original props
+                if (originalSplit[index] === 'export var propTypes = {};') {
+                  originalSplit[index] = originalSplit[index].slice(0, -2) + copy + originalSplit[index].slice(-2);
+                } else {
+                  if (copy !== '' && copy.slice(-1) !== ',') {
+                    copy += ',';
+                  }
+                  originalSplit.splice(index + 1, 0, copy);
+                }
+                const output = originalSplit.join('\n');
+
+                // Checks that nothing else was copied after the final line
+                const lastString = 'export default Component;';
+                const lastIndex = output.indexOf(lastString);
+                const finalOutput = output.slice(0, lastIndex + lastString.length);
+
+                // Outputs combined props to ES file
+                fs.writeFile(currentFileName, finalOutput, () => {});
+              }
+            });
+          }
+        });
+      }
+
       if (metadata) {
         if (
           !parentPath.isClassProperty() &&
@@ -411,14 +469,7 @@ module.exports = function generateCreateReactCustomElementType(api, { nonUpgrada
             ]);
 
         const propTypes = t.objectExpression([...buildPropTypes(declaredProps), ...buildEventsPropTypes(customEvents)]);
-        const propTypesWithParent = !context.parentDescriptorSource
-          ? propTypes
-          : t.callExpression(t.memberExpression(t.identifier('Object'), t.identifier('assign')), [
-              t.objectExpression([]),
-              t.identifier('parentPropTypes'),
-              propTypes,
-            ]);
-
+        const propTypesWithParent = propTypes;
         const body = [];
         if (!context.customElementName) {
           if (context.className) {

--- a/packages/web-components/tools/babel-plugin-create-react-custom-element-type.js
+++ b/packages/web-components/tools/babel-plugin-create-react-custom-element-type.js
@@ -236,12 +236,12 @@ function createMetadataVisitor(api) {
 
             // Gets original component file
             fs.readFile(currentFileName, 'utf8', (_errOriginal, originalData) => {
-              if (originalData.length && !originalData.includes(copy) && !copy.includes('.assign')) {
+              if (originalData?.length && !originalData?.includes(copy) && !copy?.includes('.assign')) {
                 const originalSplit = originalData.split('\n');
                 const index =
-                  originalSplit.indexOf('export var propTypes = {') !== -1
-                    ? originalSplit.indexOf('export var propTypes = {')
-                    : originalSplit.indexOf('export var propTypes = {};');
+                  originalSplit?.indexOf('export var propTypes = {') !== -1
+                    ? originalSplit?.indexOf('export var propTypes = {')
+                    : originalSplit?.indexOf('export var propTypes = {};');
 
                 // Combines parent props with original props
                 if (originalSplit[index] === 'export var propTypes = {};') {
@@ -256,7 +256,7 @@ function createMetadataVisitor(api) {
 
                 // Checks that nothing else was copied after the final line
                 const lastString = 'export default Component;';
-                const lastIndex = output.indexOf(lastString);
+                const lastIndex = output?.indexOf(lastString);
                 const finalOutput = output.slice(0, lastIndex + lastString.length);
 
                 // Outputs combined props to ES file

--- a/packages/web-components/tools/babel-plugin-create-react-custom-element-type.js
+++ b/packages/web-components/tools/babel-plugin-create-react-custom-element-type.js
@@ -224,8 +224,8 @@ function createMetadataVisitor(api) {
 
         // Use fs.readFile() method to read the parent file
         fs.readFile(parentFileName, 'utf8', (_errParent, parentData) => {
-          const firstIndex = parentData.indexOf('export var propTypes') + 'export var propTypes = {'.length;
-          const secondIndex = parentData.indexOf('}', firstIndex);
+          const firstIndex = parentData?.indexOf('export var propTypes') + 'export var propTypes = {'.length;
+          const secondIndex = parentData?.indexOf('}', firstIndex);
           // Gets parent props from ES folder as string
           if (secondIndex > firstIndex + 1) {
             let copy = parentData.slice(firstIndex, secondIndex);


### PR DESCRIPTION
### Related Ticket(s)

N/A
### Description

Components that extend other components were not showing props in the storybook `docs` tab. 

Note: the first time the react wrapper deploy preview ran it failed, but the second time it passed. not sure if it will be finnicky when running on github pages

<img width="856" alt="Screen Shot 2022-10-19 at 7 53 05 AM" src="https://user-images.githubusercontent.com/20210594/196726323-018ae0d7-9bba-4d03-b191-98787e211aa4.png">

### Changelog

**New**

- Added to `babel-create-react-custom-element-type` to check if parentProps exist and if they do copies and pastes props into current component `es` files

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
