### PR TITLE
feat(controls): add hr, tag-group, tag-link, banner

### DIFF
--- a/packages/web-components/src/components/background-media/__stories__/background-media.stories.react.tsx
+++ b/packages/web-components/src/components/background-media/__stories__/background-media.stories.react.tsx
@@ -11,9 +11,10 @@ import React from 'react';
 // Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
+// eslint-disable-next-line max-len, prettier/prettier
 import DDSBackgroundMedia, {
   PropTypesRef,
-} from '@carbon/ibmdotcom-web-components/es/components-react/background-media/background-media'; // PropTypesRef,
+} from '@carbon/ibmdotcom-web-components/es/components-react/background-media/background-media';
 import DDSImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item';
 import DDSVideoPlayerContainer from '@carbon/ibmdotcom-web-components/es/components-react/video-player/video-player-container';
 import imgMax from '../../../../../storybook-images/assets/leadspace/leadspaceMax.jpg';

--- a/packages/web-components/src/components/background-media/__stories__/background-media.stories.react.tsx
+++ b/packages/web-components/src/components/background-media/__stories__/background-media.stories.react.tsx
@@ -11,7 +11,9 @@ import React from 'react';
 // Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import DDSBackgroundMedia from '@carbon/ibmdotcom-web-components/es/components-react/background-media/background-media';
+import DDSBackgroundMedia, {
+  PropTypesRef,
+} from '@carbon/ibmdotcom-web-components/es/components-react/background-media/background-media'; // PropTypesRef,
 import DDSImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item';
 import DDSVideoPlayerContainer from '@carbon/ibmdotcom-web-components/es/components-react/video-player/video-player-container';
 import imgMax from '../../../../../storybook-images/assets/leadspace/leadspaceMax.jpg';
@@ -26,14 +28,14 @@ const gradientDirections = {
 };
 
 export const Default = args => {
-  const { alt, opacity } = args ?? {};
+  const { alt, backgroundOpacity } = args ?? {};
   return (
     <DDSBackgroundMedia
       gradient-direction={args['gradient-direction']}
       mobile-position="bottom"
       alt={alt}
       default-src={imgMax}
-      opacity={opacity}>
+      opacity={backgroundOpacity}>
       <DDSImageItem media="(min-width: 1584px)" srcset={imgMax}>
         {' '}
       </DDSImageItem>
@@ -54,10 +56,10 @@ export const Default = args => {
 };
 
 export const WithVideo = args => {
-  const { opacity } = args ?? {};
+  const { backgroundOpacity } = args ?? {};
   return (
     <div style={{ height: '70vh' }}>
-      <DDSBackgroundMedia gradient-direction={args['gradient-direction']} mobile-position="bottom" opacity={opacity}>
+      <DDSBackgroundMedia gradient-direction={args['gradient-direction']} mobile-position="bottom" opacity={backgroundOpacity}>
         <DDSVideoPlayerContainer video-id="1_9h94wo6b" background-mode="true"></DDSVideoPlayerContainer>
       </DDSBackgroundMedia>
     </div>
@@ -65,20 +67,20 @@ export const WithVideo = args => {
 };
 
 export const WithDefaultSource = args => {
-  const { alt, opacity } = args ?? {};
+  const { alt, backgroundOpacity } = args ?? {};
   return (
     <DDSBackgroundMedia
       gradient-direction={args['gradient-direction']}
       mobile-position="bottom"
       alt={alt}
       default-src={imgMax}
-      opacity={opacity}></DDSBackgroundMedia>
+      opacity={backgroundOpacity}></DDSBackgroundMedia>
   );
 };
 
 export default {
   title: 'Components/Background media',
-  component: DDSBackgroundMedia,
+  component: PropTypesRef,
   decorators: [
     story => (
       <div className="bx--grid">
@@ -89,12 +91,12 @@ export default {
     ),
   ],
   argTypes: {
-    'gradient-direction': {
+    gradientDirection: {
       control: { type: 'radio' },
       options: gradientDirections,
       defaultValue: GRADIENT_DIRECTION.LEFT_TO_RIGHT,
     },
-    opacity: {
+    backgroundOpacity: {
       control: { type: 'range', min: 0, max: 100 },
       defaultValue: 100,
     },
@@ -103,26 +105,7 @@ export default {
         disable: true,
       },
     },
-    'default-src': {
-      table: {
-        disable: true,
-      },
-    },
-    'launch-lightbox-button-assistive-text': {
-      table: {
-        disable: true,
-      },
-    },
-    'mobile-position': {
-      table: {
-        disable: true,
-      },
-    },
-    backgroundOpacity: {
-      table: {
-        disable: true,
-      },
-    },
+
     border: {
       table: {
         disable: true,
@@ -139,11 +122,6 @@ export default {
       },
     },
     defaultSrc: {
-      table: {
-        disable: true,
-      },
-    },
-    gradientDirection: {
       table: {
         disable: true,
       },

--- a/packages/web-components/src/components/horizontal-rule/__stories__/horizontal-rule.stories.react.tsx
+++ b/packages/web-components/src/components/horizontal-rule/__stories__/horizontal-rule.stories.react.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 // Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
+// eslint-disable-next-line max-len, prettier/prettier
 import DDSHorizontalRule, {
   PropTypesRef,
 } from '@carbon/ibmdotcom-web-components/es/components-react/horizontal-rule/horizontal-rule';

--- a/packages/web-components/src/components/horizontal-rule/__stories__/horizontal-rule.stories.react.tsx
+++ b/packages/web-components/src/components/horizontal-rule/__stories__/horizontal-rule.stories.react.tsx
@@ -11,31 +11,18 @@ import React from 'react';
 // Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import DDSHorizontalRule from '@carbon/ibmdotcom-web-components/es/components-react/horizontal-rule/horizontal-rule';
+import DDSHorizontalRule, {
+  PropTypesRef,
+} from '@carbon/ibmdotcom-web-components/es/components-react/horizontal-rule/horizontal-rule';
 import readme from './README.stories.react.mdx';
 
-const types = {
-  solid: undefined,
-  dashed: 'dashed',
-};
+const types = ['solid', 'dashed'];
 
-const sizes = {
-  small: 'small',
-  medium: 'medium',
-  large: 'large',
-  fluid: undefined,
-};
+const sizes = ['small', 'medium', 'large', 'fluid'];
 
-const contrasts = {
-  'low-contrast': 'low-contrast',
-  'medium-contrast': undefined,
-  'high-contrast': 'high-contrast',
-};
+const contrasts = ['low-contrast', 'medium-contrast', 'high-contrast'];
 
-const weights = {
-  thin: undefined,
-  thick: 'thick',
-};
+const weights = ['thin', 'thick'];
 
 export const Default = args => {
   const { type, size, contrast, weight } = args ?? {};
@@ -44,7 +31,7 @@ export const Default = args => {
 
 export default {
   title: 'Components/Horizontal Rule',
-  component: DDSHorizontalRule,
+  component: PropTypesRef,
   decorators: [
     story => {
       return (
@@ -63,22 +50,22 @@ export default {
     type: {
       control: { type: 'select' },
       options: types,
-      defaultValue: types.solid,
+      defaultValue: 'solid',
     },
     size: {
       control: { type: 'select' },
       options: sizes,
-      defaultValue: sizes.fluid,
+      defaultValue: 'fluid',
     },
     contrast: {
       control: { type: 'select' },
       options: contrasts,
-      defaultValue: contrasts['medium-contrast'],
+      defaultValue: 'medium-contrast',
     },
     weight: {
       control: { type: 'select' },
       options: weights,
-      defaultValue: weights.thin,
+      defaultValue: 'thin',
     },
   },
   parameters: {

--- a/packages/web-components/src/components/horizontal-rule/__stories__/horizontal-rule.stories.ts
+++ b/packages/web-components/src/components/horizontal-rule/__stories__/horizontal-rule.stories.ts
@@ -76,10 +76,10 @@ export default {
     propsSet: {
       default: {
         HorizontalRule: {
-          type: types.solid,
-          size: sizes.fluid,
+          type: 'solid',
+          size: 'fluid',
           contrast: contrasts['medium-contrast'],
-          weight: weights.thin,
+          weight: 'weights',
         },
       },
     },

--- a/packages/web-components/src/components/horizontal-rule/__stories__/horizontal-rule.stories.ts
+++ b/packages/web-components/src/components/horizontal-rule/__stories__/horizontal-rule.stories.ts
@@ -7,7 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { select } from '@storybook/addon-knobs';
 import { html } from 'lit-element';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
 import '../horizontal-rule';
@@ -21,28 +20,13 @@ export const Default = args => {
   `;
 };
 
-const types = {
-  solid: undefined,
-  dashed: 'dashed',
-};
+const types = ['solid', 'dashed'];
 
-const sizes = {
-  small: 'small',
-  medium: 'medium',
-  large: 'large',
-  fluid: undefined,
-};
+const sizes = ['small', 'medium', 'large', 'fluid'];
 
-const contrasts = {
-  'low-contrast': 'low-contrast',
-  'medium-contrast': undefined,
-  'high-contrast': 'high-contrast',
-};
+const contrasts = ['low-contrast', 'medium-contrast', 'high-contrast'];
 
-const weights = {
-  thin: undefined,
-  thick: 'thick',
-};
+const weights = ['thin', 'thick'];
 
 export default {
   title: 'Components/Horizontal rule',
@@ -51,12 +35,12 @@ export default {
     type: {
       control: { type: 'select' },
       options: types,
-      defaultValue: types.solid,
+      defaultValue: 'solid',
     },
     size: {
       control: { type: 'select' },
       options: sizes,
-      defaultValue: sizes.fluid,
+      defaultValue: 'fluid',
     },
     contrast: {
       control: { type: 'select' },
@@ -66,7 +50,12 @@ export default {
     weight: {
       control: { type: 'select' },
       options: weights,
-      defaultValue: weights.thin,
+      defaultValue: 'thin',
+    },
+    styles: {
+      table: {
+        disable: true,
+      },
     },
   },
   decorators: [
@@ -84,14 +73,6 @@ export default {
   parameters: {
     ...readme.parameters,
     hasStoryPadding: true,
-    knobs: {
-      HorizontalRule: () => ({
-        type: select('Type (type):', types, types.solid),
-        size: select('Size (size):', sizes, sizes.fluid),
-        contrast: select('Contrast (contrast):', contrasts, contrasts['medium-contrast']),
-        weight: select('Weight (weight):', weights, weights.thin),
-      }),
-    },
     propsSet: {
       default: {
         HorizontalRule: {

--- a/packages/web-components/src/components/tag-group/__stories__/tag-group.stories.react.tsx
+++ b/packages/web-components/src/components/tag-group/__stories__/tag-group.stories.react.tsx
@@ -6,14 +6,13 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { select } from '@storybook/addon-knobs';
 import React from 'react';
 // Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
 import DDSTagLink from '@carbon/ibmdotcom-web-components/es/components-react/tag-link/tag-link';
 // @ts-ignore
-import DDSTagGroup from '@carbon/ibmdotcom-web-components/es/components-react/tag-group/tag-group';
+import DDSTagGroup, { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-react/tag-group/tag-group';
 import { Tag } from 'carbon-components-react';
 import 'carbon-web-components/es/components/tag/tag.js';
 import readme from './README.stories.react.mdx';
@@ -23,7 +22,7 @@ const tagTitles = ['Cloud', 'Blockchain', 'Supply chain', 'Watson health', 'IT I
 const tagTypeOptions = ['Tag Link', 'Carbon tag'];
 
 export const Default = args => {
-  const { tagType } = args?.TagGroup ?? {};
+  const { tagType } = args ?? {};
   return (
     <DDSTagGroup>
       {tagType === tagTypeOptions[0]
@@ -33,18 +32,9 @@ export const Default = args => {
   );
 };
 
-Default.story = {
-  parameters: {
-    knobs: {
-      TagGroup: () => ({
-        tagType: select('Tag Type:', tagTypeOptions, 'Tag Link'),
-      }),
-    },
-  },
-};
-
 export default {
   title: 'Components/Tag group',
+  component: PropTypesRef,
   decorators: [
     story => {
       return (
@@ -56,6 +46,13 @@ export default {
       );
     },
   ],
+  argTypes: {
+    tagType: {
+      control: { type: 'select' },
+      options: tagTypeOptions,
+      defaultValue: tagTypeOptions[0],
+    },
+  },
   parameters: {
     ...readme.parameters,
     hasStoryPadding: true,

--- a/packages/web-components/src/components/tag-group/__stories__/tag-group.stories.ts
+++ b/packages/web-components/src/components/tag-group/__stories__/tag-group.stories.ts
@@ -8,7 +8,6 @@
  */
 
 import { html } from 'lit-element';
-import { select } from '@storybook/addon-knobs';
 import readme from './README.stories.mdx';
 import '../index';
 import 'carbon-web-components/es/components/tag/tag.js';
@@ -18,20 +17,16 @@ const tagTitles = ['Cloud', 'Blockchain', 'Supply chain', 'Watson health', 'IT I
 const tagTypeOptions = ['Tag Link', 'Carbon tag'];
 
 export const Default = args => {
-  const { tagType } = args?.TagGroup ?? {};
+  const { tagType } = args ?? {};
   return html`
     <dds-tag-group>
       ${tagTitles.map(title =>
         tagType === tagTypeOptions[0]
           ? html`
-              <dds-tag-link href="https://example.com">
-                ${title}
-              </dds-tag-link>
+              <dds-tag-link href="https://example.com"> ${title} </dds-tag-link>
             `
           : html`
-              <bx-tag>
-                ${title}
-              </bx-tag>
+              <bx-tag> ${title} </bx-tag>
             `
       )}
     </dds-tag-group>
@@ -40,25 +35,31 @@ export const Default = args => {
 
 export default {
   title: 'Components/Tag group',
+  component: 'dds-tag-group',
   decorators: [
     story => html`
       <div class="bx--grid">
         <div class="bx--row">
-          <div class="bx--col-sm-16 bx--col-md-6">
-            ${story()}
-          </div>
+          <div class="bx--col-sm-16 bx--col-md-6">${story()}</div>
         </div>
       </div>
     `,
   ],
+  argTypes: {
+    tagType: {
+      control: { type: 'select' },
+      options: tagTypeOptions,
+      defaultValue: tagTypeOptions[0],
+    },
+    styles: {
+      table: {
+        disable: true,
+      },
+    },
+  },
   parameters: {
     ...readme.parameters,
     hasStoryPadding: true,
-    knobs: {
-      TagGroup: () => ({
-        tagType: select('Tag Type:', tagTypeOptions, 'Tag Link'),
-      }),
-    },
     propsSet: {
       default: {
         TagGroup: {

--- a/packages/web-components/src/components/tag-link/__stories__/tag-link.stories.react.tsx
+++ b/packages/web-components/src/components/tag-link/__stories__/tag-link.stories.react.tsx
@@ -7,37 +7,61 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { text } from '@storybook/addon-knobs';
 import React from 'react';
 // Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import DDSTagLink from '@carbon/ibmdotcom-web-components/es/components-react/tag-link/tag-link';
+import DDSTagLink, { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-react/tag-link/tag-link';
 import readme from './README.stories.react.mdx';
 
 export const Default = args => {
-  const { copy, href } = args?.TagLink ?? {};
+  const { copy, href } = args ?? {};
   return <DDSTagLink href={href || undefined}>{copy}</DDSTagLink>;
-};
-
-Default.story = {
-  parameters: {
-    knobs: {
-      TagLink: () => ({
-        copy: text('Tag link (copy)', 'Brand: Watson'),
-        href: text('Tag link (href)', `https://example.com`),
-      }),
-    },
-  },
 };
 
 export default {
   title: 'Components/Tag link',
+  component: PropTypesRef,
   decorators: [
     story => {
       return <div className="bx--grid">{story()}</div>;
     },
   ],
+  argTypes: {
+    href: {
+      control: 'text',
+      defaultValue: 'https://example.com',
+    },
+    copy: {
+      control: 'text',
+      defaultValue: 'Brand: Watson',
+    },
+    hreflang: {
+      table: {
+        disable: true,
+      },
+    },
+    ping: {
+      table: {
+        disable: true,
+      },
+    },
+    rel: {
+      table: {
+        disable: true,
+      },
+    },
+    target: {
+      table: {
+        disable: true,
+      },
+    },
+    linkRole: {
+      table: {
+        disable: true,
+      },
+    },
+  },
   parameters: {
     ...readme.parameters,
     hasStoryPadding: true,

--- a/packages/web-components/src/components/tag-link/__stories__/tag-link.stories.ts
+++ b/packages/web-components/src/components/tag-link/__stories__/tag-link.stories.ts
@@ -11,35 +11,71 @@ import { html } from 'lit-element';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
 import readme from './README.stories.mdx';
 import '../tag-link';
-import textNullable from '../../../../.storybook/knob-text-nullable';
 
 export const Default = args => {
-  const { copy, href } = args?.TagLink ?? {};
+  const { copy, href } = args ?? {};
   return html`
-    <dds-tag-link href=${ifNonNull(href || undefined)}>
-      ${copy}
-    </dds-tag-link>
+    <dds-tag-link href=${ifNonNull(href || undefined)}> ${copy} </dds-tag-link>
   `;
 };
 
 export default {
   title: 'Components/Tag link',
+  component: 'dds-tag-link',
   decorators: [
-    story => html`
-      <div class="bx--grid">
-        ${story()}
-      </div>
-    `,
+    story =>
+      html`
+        <div class="bx--grid">${story()}</div>
+      `,
   ],
+  argTypes: {
+    href: {
+      control: 'text',
+      defaultValue: 'https://example.com',
+    },
+    copy: {
+      control: 'text',
+      defaultValue: 'Brand: Watson',
+    },
+    hreflang: {
+      table: {
+        disable: true,
+      },
+    },
+    ping: {
+      table: {
+        disable: true,
+      },
+    },
+    rel: {
+      table: {
+        disable: true,
+      },
+    },
+    target: {
+      table: {
+        disable: true,
+      },
+    },
+    linkRole: {
+      table: {
+        disable: true,
+      },
+    },
+    styles: {
+      table: {
+        disable: true,
+      },
+    },
+    'link-role': {
+      table: {
+        disable: true,
+      },
+    },
+  },
   parameters: {
     ...readme.parameters,
     hasStoryPadding: true,
-    knobs: {
-      TagLink: () => ({
-        copy: textNullable('Tag Link (copy)', 'Brand: Watson'),
-        href: textNullable('Tag Link (href)', `https://example.com`),
-      }),
-    },
     propsSet: {
       default: {
         TagLink: {

--- a/packages/web-components/src/components/universal-banner/__stories__/universal-banner.stories.react.tsx
+++ b/packages/web-components/src/components/universal-banner/__stories__/universal-banner.stories.react.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-duplicates */
 /**
  * @license
  *
@@ -7,12 +8,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
-import { select, text } from '@storybook/addon-knobs';
 // Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 /* eslint-disable max-len */
 // @ts-ignore
-import DDSUniversalBanner from '@carbon/ibmdotcom-web-components/es/components-react/universal-banner/universal-banner';
+import DDSUniversalBanner, {
+  PropTypesRef,
+} from '@carbon/ibmdotcom-web-components/es/components-react/universal-banner/universal-banner';
 import DDSUniversalBannerHeading from '@carbon/ibmdotcom-web-components/es/components-react/universal-banner/universal-banner-heading';
 import DDSUniversalBannerCopy from '@carbon/ibmdotcom-web-components/es/components-react/universal-banner/universal-banner-copy';
 import DDSUniversalBannerImage from '@carbon/ibmdotcom-web-components/es/components-react/universal-banner/universal-banner-image';
@@ -28,9 +30,6 @@ import img4ColLg from '../../../../../storybook-images/assets/universal-banner/u
 import img8ColLg from '../../../../../storybook-images/assets/universal-banner/universal-banner-8-col-lg.jpg';
 import img4ColXlg from '../../../../../storybook-images/assets/universal-banner/universal-banner-4-col-xlg.jpg';
 import img8ColXlg from '../../../../../storybook-images/assets/universal-banner/universal-banner-8-col-xlg.jpg';
-
-// import StoryContent from '../../back-to-top/__stories__/data/content';
-import textNullable from '../../../../.storybook/knob-text-nullable';
 
 const imageWidthOptions = {
   [`4 Columns`]: `4-col`,
@@ -49,7 +48,7 @@ const srcsets = {
 };
 
 export const Default = args => {
-  const { heading, copy, ctaCopy, imageWidth } = args?.UniversalBanner ?? {};
+  const { heading, copy, ctaCopy, imageWidth } = args ?? {};
 
   const bannerHeading = document.querySelector('dds-universal-banner-heading');
 
@@ -79,27 +78,53 @@ export const Default = args => {
   );
 };
 
-Default.story = {
-  parameters: {
-    ...readme.parameters,
-    knobs: {
-      UniversalBanner: () => ({
-        heading: textNullable('Heading:', 'Hybrid cloud and AI for smarter business'),
-        copy: text('Copy (optional):', 'Las Vegas, June 15-18, 2025'),
-        ctaCopy: textNullable('CTA copy:', 'Register for Think. Free'),
-        imageWidth: select('Image width:', imageWidthOptions, '4-col'),
-      }),
-    },
-  },
-};
-
 export default {
   title: 'Components/Universal banner',
+  component: PropTypesRef,
   decorators: [
     story => {
       return story();
     },
   ],
+  argTypes: {
+    heading: {
+      control: 'text',
+      defaultValue: 'Hybrid cloud and AI for smarter business',
+    },
+    copy: {
+      control: 'text',
+      defaultValue: 'Las Vegas, June 15-18, 2025',
+    },
+    ctaCopy: {
+      control: 'text',
+      defaultValue: 'Register for Think. Free',
+    },
+    imageWidth: {
+      control: { type: 'select' },
+      options: imageWidthOptions,
+      defaultValue: '4-col',
+    },
+    buttonHref: {
+      table: {
+        disable: true,
+      },
+    },
+    ctaType: {
+      table: {
+        disable: true,
+      },
+    },
+    hasImage: {
+      table: {
+        disable: true,
+      },
+    },
+    _shouldRenderAsLink: {
+      table: {
+        disable: true,
+      },
+    },
+  },
   parameters: {
     ...readme.parameters,
   },

--- a/packages/web-components/src/components/universal-banner/__stories__/universal-banner.stories.react.tsx
+++ b/packages/web-components/src/components/universal-banner/__stories__/universal-banner.stories.react.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-duplicates */
 /**
  * @license
  *
@@ -12,6 +11,7 @@ import React from 'react';
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 /* eslint-disable max-len */
 // @ts-ignore
+// eslint-disable-next-line max-len, prettier/prettier
 import DDSUniversalBanner, {
   PropTypesRef,
 } from '@carbon/ibmdotcom-web-components/es/components-react/universal-banner/universal-banner';

--- a/packages/web-components/src/components/universal-banner/__stories__/universal-banner.stories.ts
+++ b/packages/web-components/src/components/universal-banner/__stories__/universal-banner.stories.ts
@@ -8,7 +8,6 @@
  */
 
 import { html } from 'lit-element';
-import { select, text } from '@storybook/addon-knobs';
 import '../index';
 import readme from './README.stories.mdx';
 
@@ -19,9 +18,6 @@ import img4ColLg from '../../../../../storybook-images/assets/universal-banner/u
 import img8ColLg from '../../../../../storybook-images/assets/universal-banner/universal-banner-8-col-lg.jpg';
 import img4ColXlg from '../../../../../storybook-images/assets/universal-banner/universal-banner-4-col-xlg.jpg';
 import img8ColXlg from '../../../../../storybook-images/assets/universal-banner/universal-banner-8-col-xlg.jpg';
-
-// import StoryContent from '../../back-to-top/__stories__/data/content';
-import textNullable from '../../../../.storybook/knob-text-nullable';
 
 const imageWidthOptions = {
   [`4 Columns`]: `4-col`,
@@ -40,7 +36,7 @@ const srcsets = {
 };
 
 export const Default = args => {
-  const { heading, copy, ctaCopy, imageWidth } = args?.UniversalBanner ?? {};
+  const { heading, copy, ctaCopy } = args ?? {};
 
   const bannerHeading = document.querySelector('dds-universal-banner-heading');
   const bannerCopy = document.querySelector('dds-universal-banner-copy');
@@ -53,13 +49,13 @@ export const Default = args => {
     bannerCopy!.shadowRoot!.textContent = copy;
   }
 
-  const srcset = srcsets[imageWidth];
+  const srcset = srcsets[args['image-width']];
 
   return html`
-    <dds-universal-banner image-width="${imageWidth}">
-      ${imageWidth
+    <dds-universal-banner image-width="${args['image-width']}">
+      ${args['image-width']
         ? html`
-            <dds-universal-banner-image slot="image" default-src="${images[imageWidth]}">
+            <dds-universal-banner-image slot="image" default-src="${images[args['image-width']]}">
               <dds-image-item media="(min-width: 1584px)" srcset="${srcset[2]}"> </dds-image-item>
               <dds-image-item media="(min-width: 1056px)" srcset="${srcset[1]}"> </dds-image-item>
               <dds-image-item media="(min-width: 1312px)" srcset="${srcset[0]}"> </dds-image-item>
@@ -68,29 +64,14 @@ export const Default = args => {
         : ``}
       <dds-universal-banner-heading slot="heading">${heading}</dds-universal-banner-heading>
       <dds-universal-banner-copy slot="copy">${copy}</dds-universal-banner-copy>
-      <dds-button-cta slot="cta" cta-type="local" kind="tertiary" href="https://www.example.com">
-        ${ctaCopy}
-      </dds-button-cta>
+      <dds-button-cta slot="cta" cta-type="local" kind="tertiary" href="https://www.example.com"> ${ctaCopy} </dds-button-cta>
     </dds-universal-banner>
   `;
 };
 
-Default.story = {
-  parameters: {
-    ...readme.parameters,
-    knobs: {
-      UniversalBanner: () => ({
-        heading: textNullable('Heading:', 'Hybrid cloud and AI for smarter business'),
-        copy: text('Copy (optional):', 'Las Vegas, June 15-18, 2025'),
-        ctaCopy: textNullable('CTA copy:', 'Register for Think. Free'),
-        imageWidth: select('Image width:', imageWidthOptions, '4-col'),
-      }),
-    },
-  },
-};
-
 export default {
   title: 'Components/Universal banner',
+  component: 'dds-universal-banner',
   decorators: [
     story => {
       return html`
@@ -98,6 +79,55 @@ export default {
       `;
     },
   ],
+  argTypes: {
+    heading: {
+      control: 'text',
+      defaultValue: 'Hybrid cloud and AI for smarter business',
+    },
+    copy: {
+      control: 'text',
+      defaultValue: 'Las Vegas, June 15-18, 2025',
+    },
+    ctaCopy: {
+      control: 'text',
+      defaultValue: 'Register for Think. Free',
+    },
+    'image-width': {
+      control: { type: 'select' },
+      options: imageWidthOptions,
+      defaultValue: '4-col',
+    },
+    buttonHref: {
+      table: {
+        disable: true,
+      },
+    },
+    ctaType: {
+      table: {
+        disable: true,
+      },
+    },
+    hasImage: {
+      table: {
+        disable: true,
+      },
+    },
+    imageWidth: {
+      table: {
+        disable: true,
+      },
+    },
+    styles: {
+      table: {
+        disable: true,
+      },
+    },
+    'has-image': {
+      table: {
+        disable: true,
+      },
+    },
+  },
   parameters: {
     ...readme.parameters,
   },

--- a/packages/web-components/tools/babel-plugin-create-react-custom-element-type.js
+++ b/packages/web-components/tools/babel-plugin-create-react-custom-element-type.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -411,13 +411,7 @@ module.exports = function generateCreateReactCustomElementType(api, { nonUpgrada
             ]);
 
         const propTypes = t.objectExpression([...buildPropTypes(declaredProps), ...buildEventsPropTypes(customEvents)]);
-        const propTypesWithParent = !context.parentDescriptorSource
-          ? propTypes
-          : t.callExpression(t.memberExpression(t.identifier('Object'), t.identifier('assign')), [
-              t.objectExpression([]),
-              t.identifier('parentPropTypes'),
-              propTypes,
-            ]);
+        const propTypesWithParent = propTypes;
 
         const body = [];
         if (!context.customElementName) {


### PR DESCRIPTION
### Related Ticket(s)

#9524 #9549 #9550 #9551
### Description

Add controls for HR, tag-group, tag-link, universal-banner
### Changelog

**Changed**

- removed props and replaced with controls for web component and react wrappers

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
