### PR TITLE
fix(tabs): basic keyboard navigation

### DIFF
--- a/packages/carbon-web-components/src/components/content-switcher/content-switcher-item.ts
+++ b/packages/carbon-web-components/src/components/content-switcher/content-switcher-item.ts
@@ -94,8 +94,7 @@ class BXContentSwitcherItem extends FocusMixin(LitElement) {
         class="${className}"
         ?disabled="${disabled}"
         aria-controls="${ifNonNull(target)}"
-        aria-selected="${Boolean(selected)}"
-      >
+        aria-selected="${Boolean(selected)}">
         <span class="${prefix}--content-switcher__label"><slot></slot></span>
       </button>
     `;

--- a/packages/carbon-web-components/src/components/content-switcher/content-switcher-item.ts
+++ b/packages/carbon-web-components/src/components/content-switcher/content-switcher-item.ts
@@ -93,9 +93,9 @@ class BXContentSwitcherItem extends FocusMixin(LitElement) {
         role="tab"
         class="${className}"
         ?disabled="${disabled}"
-        tabindex="${selected ? '0' : '-1'}"
         aria-controls="${ifNonNull(target)}"
-        aria-selected="${Boolean(selected)}">
+        aria-selected="${Boolean(selected)}"
+      >
         <span class="${prefix}--content-switcher__label"><slot></slot></span>
       </button>
     `;

--- a/packages/carbon-web-components/src/components/tabs/defs.ts
+++ b/packages/carbon-web-components/src/components/tabs/defs.ts
@@ -47,6 +47,16 @@ export enum TABS_KEYBOARD_ACTION {
    * Keyboard action to trigger tab selection using enter key
    */
   SELECTING = 'selecting',
+
+  /**
+   * Keyboard action to navigate to first tab using home key
+   */
+  HOME = 'home',
+
+  /**
+   * Keyboard action to navigate to last tab using end key
+   */
+  END = 'end',
 }
 
 /**

--- a/packages/carbon-web-components/src/components/tabs/defs.ts
+++ b/packages/carbon-web-components/src/components/tabs/defs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -42,6 +42,11 @@ export enum TABS_KEYBOARD_ACTION {
    * Keyboard action to open/close menu on the trigger button or select/deselect a menu item.
    */
   TRIGGERING = 'triggering',
+
+  /**
+   * Keyboard action to trigger tab selection using enter key
+   */
+  SELECTING = 'selecting',
 }
 
 /**

--- a/packages/carbon-web-components/src/components/tabs/tab.ts
+++ b/packages/carbon-web-components/src/components/tabs/tab.ts
@@ -53,8 +53,7 @@ class BXTab extends BXContentSwitcherItem {
         role="tab"
         tabindex="${disabled ? -1 : 0}"
         ?disabled="${disabled}"
-        aria-selected="${Boolean(selected)}"
-      >
+        aria-selected="${Boolean(selected)}">
         <slot></slot>
       </a>
     `;

--- a/packages/carbon-web-components/src/components/tabs/tab.ts
+++ b/packages/carbon-web-components/src/components/tabs/tab.ts
@@ -32,14 +32,6 @@ class BXTab extends BXContentSwitcherItem {
   highlighted = false;
 
   /**
-   * `true` if this tab is in a focused `<bx-tabs>`.
-   *
-   * @private
-   */
-  @property({ type: Boolean, reflect: true, attribute: 'in-focus' })
-  inFocus = false;
-
-  /**
    * Tab type.
    */
   @property({ reflect: true })
@@ -59,8 +51,10 @@ class BXTab extends BXContentSwitcherItem {
       <a
         class="${prefix}--tabs__nav-link"
         role="tab"
+        tabindex="${disabled ? -1 : 0}"
         ?disabled="${disabled}"
-        aria-selected="${Boolean(selected)}">
+        aria-selected="${Boolean(selected)}"
+      >
         <slot></slot>
       </a>
     `;

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -211,20 +211,6 @@
   }
 }
 
-:host(#{$prefix}-tab[in-focus][selected]),
-:host(#{$prefix}-tab[in-focus][selected]:hover) {
-  @include carbon--breakpoint(md) {
-    @include focus-outline('outline');
-
-    // `[role]` is only for specificity.
-    // We have `:not()` usage in the corresponding Carbon core style
-    // which puts specificity of "specific" scenario though the style is for "regular" scenario
-    a.#{$prefix}--tabs__nav-link[role] {
-      border-bottom-width: 2px;
-    }
-  }
-}
-
 :host(#{$prefix}-tab[highlighted][selected]),
 :host(#{$prefix}-tab[highlighted][selected]:hover) {
   background-color: $selected-ui;

--- a/packages/carbon-web-components/tests/spec/tabs_spec.ts
+++ b/packages/carbon-web-components/tests/spec/tabs_spec.ts
@@ -9,7 +9,6 @@
 
 import { render } from 'lit-html';
 import EventManager from '../utils/event-manager';
-import { forEach } from '../../src/globals/internal/collection-helpers';
 import BXTabs from '../../src/components/tabs/tabs';
 import BXTab from '../../src/components/tabs/tab';
 import { Default } from '../../src/components/tabs/tabs-story';
@@ -19,9 +18,9 @@ const template = (props?) =>
     'bx-tabs': props,
   });
 
-describe('bx-tabs', function () {
-  describe('Toggling', function () {
-    it('should toggle "open" attribute', async function () {
+describe('bx-tabs', function() {
+  describe('Toggling', function() {
+    it('should toggle "open" attribute', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -34,7 +33,7 @@ describe('bx-tabs', function () {
       expect(inner!.classList.contains('bx--tabs-trigger--open')).toBe(false);
     });
 
-    it('should always close dropdown when clicking document', async function () {
+    it('should always close dropdown when clicking document', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -45,7 +44,7 @@ describe('bx-tabs', function () {
       expect(elem!.classList.contains('bx--tabs-trigger--open')).toBe(false);
     });
 
-    it('should close dropdown when clicking on an item', async function () {
+    it('should close dropdown when clicking on an item', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -57,10 +56,10 @@ describe('bx-tabs', function () {
     });
   });
 
-  describe('Selecting an item', function () {
+  describe('Selecting an item', function() {
     const events = new EventManager();
 
-    it('should add/remove "selected" attribute', async function () {
+    it('should add/remove "selected" attribute', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const itemNodes = document.body.querySelectorAll('bx-tab');
@@ -73,7 +72,7 @@ describe('bx-tabs', function () {
       expect(itemNodes[4].hasAttribute('selected')).toBe(false);
     });
 
-    it('should update text', async function () {
+    it('should update text', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -85,7 +84,7 @@ describe('bx-tabs', function () {
       ).toBe('Option 3');
     });
 
-    it('should update value', async function () {
+    it('should update value', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const itemNodes = document.body.querySelectorAll('bx-tab');
@@ -96,7 +95,7 @@ describe('bx-tabs', function () {
       );
     });
 
-    it('should provide a way to switch item with a value', async function () {
+    it('should provide a way to switch item with a value', async function() {
       render(template(), document.body);
       await Promise.resolve();
       (document.body.querySelector('bx-tabs') as BXTabs).value = 'staging';
@@ -110,7 +109,7 @@ describe('bx-tabs', function () {
       expect(itemNodes[4].hasAttribute('selected')).toBe(false);
     });
 
-    it('should provide a way to cancel switching item', async function () {
+    it('should provide a way to cancel switching item', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -133,42 +132,13 @@ describe('bx-tabs', function () {
       ).toBe('Option 1');
     });
 
-    afterEach(async function () {
+    afterEach(async function() {
       events.reset();
     });
   });
 
-  describe('Focus style', function () {
-    it('should support setting focus style to child tabs', async function () {
-      render(template(), document.body);
-      await Promise.resolve();
-      const elem = document.body.querySelector('bx-tabs');
-      const itemNodes = document.body.querySelectorAll('bx-tab');
-      const event = new CustomEvent('focusin', { bubbles: true });
-      (elem as HTMLElement).dispatchEvent(event);
-      expect(
-        Array.prototype.every.call(itemNodes, (item) => (item as BXTab).inFocus)
-      ).toBe(true);
-    });
-
-    it('should support unsetting focus style to child tabs', async function () {
-      render(template(), document.body);
-      await Promise.resolve();
-      const elem = document.body.querySelector('bx-tabs');
-      const itemNodes = document.body.querySelectorAll('bx-tab');
-      forEach(itemNodes, (item) => {
-        (item as BXTab).inFocus = true;
-      });
-      const event = new CustomEvent('focusout', { bubbles: true });
-      (elem as HTMLElement).dispatchEvent(event);
-      expect(
-        Array.prototype.every.call(itemNodes, (item) => (item as BXTab).inFocus)
-      ).toBe(false);
-    });
-  });
-
-  describe('Keyboard navigation', function () {
-    it('should support closing narrow mode dropdown by ESC key', async function () {
+  describe('Keyboard navigation', function() {
+    it('should support closing narrow mode dropdown by ESC key', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -181,7 +151,7 @@ describe('bx-tabs', function () {
       expect((elem as any)._open).toBe(false);
     });
 
-    it('should support left key in non-narrow mode', async function () {
+    it('should support left key in non-narrow mode', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -204,7 +174,7 @@ describe('bx-tabs', function () {
       expect(itemNodes[4].hasAttribute('selected')).toBe(true);
     });
 
-    it('should support right key in non-narrow mode', async function () {
+    it('should support right key in non-narrow mode', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -227,7 +197,7 @@ describe('bx-tabs', function () {
       expect(itemNodes[4].hasAttribute('selected')).toBe(false);
     });
 
-    it('should support up key in narrow mode', async function () {
+    it('should support up key in narrow mode', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -251,7 +221,7 @@ describe('bx-tabs', function () {
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(true);
     });
 
-    it('should support down key in narrow mode', async function () {
+    it('should support down key in narrow mode', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -275,7 +245,7 @@ describe('bx-tabs', function () {
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(false);
     });
 
-    it('should open the dropdown with down key in narrow mode', async function () {
+    it('should open the dropdown with down key in narrow mode', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -299,7 +269,7 @@ describe('bx-tabs', function () {
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(false);
     });
 
-    it('should open the dropdown with up key in narrow mode', async function () {
+    it('should open the dropdown with up key in narrow mode', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -323,7 +293,7 @@ describe('bx-tabs', function () {
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(false);
     });
 
-    it('should open the dropdown with space key in narrow mode', async function () {
+    it('should open the dropdown with space key in narrow mode', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -337,7 +307,7 @@ describe('bx-tabs', function () {
       expect((elem as any)._open).toBe(true);
     });
 
-    it('should select the highlighted item with space key in narrow mode', async function () {
+    it('should select the highlighted item with space key in narrow mode', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -357,7 +327,7 @@ describe('bx-tabs', function () {
       expect((elem as BXTabs).value).toBe('staging');
     });
 
-    it('should simply close the dropdown if user tries to choose the same selection in narrow mode', async function () {
+    it('should simply close the dropdown if user tries to choose the same selection in narrow mode', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -377,7 +347,7 @@ describe('bx-tabs', function () {
       expect((elem as any)._open).toBe(false);
     });
 
-    it('should support closing the dropdown without an highlighted item in narrow mode', async function () {
+    it('should support closing the dropdown without an highlighted item in narrow mode', async function() {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -393,7 +363,7 @@ describe('bx-tabs', function () {
     });
   });
 
-  afterEach(async function () {
+  afterEach(async function() {
     await render(undefined!, document.body);
   });
 });

--- a/packages/carbon-web-components/tests/spec/tabs_spec.ts
+++ b/packages/carbon-web-components/tests/spec/tabs_spec.ts
@@ -18,9 +18,9 @@ const template = (props?) =>
     'bx-tabs': props,
   });
 
-describe('bx-tabs', function() {
-  describe('Toggling', function() {
-    it('should toggle "open" attribute', async function() {
+describe('bx-tabs', function () {
+  describe('Toggling', function () {
+    it('should toggle "open" attribute', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -33,7 +33,7 @@ describe('bx-tabs', function() {
       expect(inner!.classList.contains('bx--tabs-trigger--open')).toBe(false);
     });
 
-    it('should always close dropdown when clicking document', async function() {
+    it('should always close dropdown when clicking document', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -44,7 +44,7 @@ describe('bx-tabs', function() {
       expect(elem!.classList.contains('bx--tabs-trigger--open')).toBe(false);
     });
 
-    it('should close dropdown when clicking on an item', async function() {
+    it('should close dropdown when clicking on an item', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -56,10 +56,10 @@ describe('bx-tabs', function() {
     });
   });
 
-  describe('Selecting an item', function() {
+  describe('Selecting an item', function () {
     const events = new EventManager();
 
-    it('should add/remove "selected" attribute', async function() {
+    it('should add/remove "selected" attribute', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const itemNodes = document.body.querySelectorAll('bx-tab');
@@ -72,7 +72,7 @@ describe('bx-tabs', function() {
       expect(itemNodes[4].hasAttribute('selected')).toBe(false);
     });
 
-    it('should update text', async function() {
+    it('should update text', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -84,7 +84,7 @@ describe('bx-tabs', function() {
       ).toBe('Option 3');
     });
 
-    it('should update value', async function() {
+    it('should update value', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const itemNodes = document.body.querySelectorAll('bx-tab');
@@ -95,7 +95,7 @@ describe('bx-tabs', function() {
       );
     });
 
-    it('should provide a way to switch item with a value', async function() {
+    it('should provide a way to switch item with a value', async function () {
       render(template(), document.body);
       await Promise.resolve();
       (document.body.querySelector('bx-tabs') as BXTabs).value = 'staging';
@@ -109,7 +109,7 @@ describe('bx-tabs', function() {
       expect(itemNodes[4].hasAttribute('selected')).toBe(false);
     });
 
-    it('should provide a way to cancel switching item', async function() {
+    it('should provide a way to cancel switching item', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -132,13 +132,13 @@ describe('bx-tabs', function() {
       ).toBe('Option 1');
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
       events.reset();
     });
   });
 
-  describe('Keyboard navigation', function() {
-    it('should support closing narrow mode dropdown by ESC key', async function() {
+  describe('Keyboard navigation', function () {
+    it('should support closing narrow mode dropdown by ESC key', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -151,7 +151,7 @@ describe('bx-tabs', function() {
       expect((elem as any)._open).toBe(false);
     });
 
-    it('should support left key in non-narrow mode', async function() {
+    it('should support left key in non-narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -174,7 +174,7 @@ describe('bx-tabs', function() {
       expect(itemNodes[4].hasAttribute('selected')).toBe(true);
     });
 
-    it('should support right key in non-narrow mode', async function() {
+    it('should support right key in non-narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -197,7 +197,7 @@ describe('bx-tabs', function() {
       expect(itemNodes[4].hasAttribute('selected')).toBe(false);
     });
 
-    it('should support up key in narrow mode', async function() {
+    it('should support up key in narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -221,7 +221,7 @@ describe('bx-tabs', function() {
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(true);
     });
 
-    it('should support down key in narrow mode', async function() {
+    it('should support down key in narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -245,7 +245,7 @@ describe('bx-tabs', function() {
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(false);
     });
 
-    it('should open the dropdown with down key in narrow mode', async function() {
+    it('should open the dropdown with down key in narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -269,7 +269,7 @@ describe('bx-tabs', function() {
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(false);
     });
 
-    it('should open the dropdown with up key in narrow mode', async function() {
+    it('should open the dropdown with up key in narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -293,7 +293,7 @@ describe('bx-tabs', function() {
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(false);
     });
 
-    it('should open the dropdown with space key in narrow mode', async function() {
+    it('should open the dropdown with space key in narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -307,7 +307,7 @@ describe('bx-tabs', function() {
       expect((elem as any)._open).toBe(true);
     });
 
-    it('should select the highlighted item with space key in narrow mode', async function() {
+    it('should select the highlighted item with space key in narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -327,7 +327,7 @@ describe('bx-tabs', function() {
       expect((elem as BXTabs).value).toBe('staging');
     });
 
-    it('should simply close the dropdown if user tries to choose the same selection in narrow mode', async function() {
+    it('should simply close the dropdown if user tries to choose the same selection in narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -347,7 +347,7 @@ describe('bx-tabs', function() {
       expect((elem as any)._open).toBe(false);
     });
 
-    it('should support closing the dropdown without an highlighted item in narrow mode', async function() {
+    it('should support closing the dropdown without an highlighted item in narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('bx-tabs');
@@ -363,7 +363,7 @@ describe('bx-tabs', function() {
     });
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await render(undefined!, document.body);
   });
 });


### PR DESCRIPTION
### Related Ticket(s)
https://github.com/carbon-design-system/carbon-web-components/issues/970
https://github.com/carbon-design-system/carbon-web-components/issues/707

### Description
This PR ensures that the Tabs and Content Switcher components are able to be work with tab navigation.

### Changelog

**New**

- added tab-index in the tab shadow dom
- added home/end key functionality

**Changed**

- triggering the content switching upon pressing the enter key

**Removed**

- remove unneeded inFocus property in the tab item component

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
