### PR TITLE
feat(storybook): switch to storybook controls for video-player and content-block-mixed

### DIFF
--- a/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.react.tsx
+++ b/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.react.tsx
@@ -13,6 +13,8 @@ import React from 'react';
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
 import DDSContentBlockMixed from '@carbon/ibmdotcom-web-components/es/components-react/content-block-mixed/content-block-mixed';
+// @ts-ignore
+import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-react/content-block-mixed/content-block-mixed';
 import DDSContentBlockHeading from '@carbon/ibmdotcom-web-components/es/components-react/content-block/content-block-heading';
 import DDSContentBlockCopy from '@carbon/ibmdotcom-web-components/es/components-react/content-block/content-block-copy';
 import DDSContentGroupCards from '@carbon/ibmdotcom-web-components/es/components-react/content-group-cards/content-group-cards';
@@ -84,19 +86,28 @@ const ctaTypes = {
 const complementaryStyleSchemes = {
   'Regular style scheme': null,
   // eslint-disable-next-line max-len
-  [`With border (${CONTENT_BLOCK_COMPLEMENTARY_STYLE_SCHEME.WITH_BORDER})`]: CONTENT_BLOCK_COMPLEMENTARY_STYLE_SCHEME.WITH_BORDER,
+  [`With border (${CONTENT_BLOCK_COMPLEMENTARY_STYLE_SCHEME.WITH_BORDER})`]:
+    CONTENT_BLOCK_COMPLEMENTARY_STYLE_SCHEME.WITH_BORDER,
 };
 
 const image = ({ heading: imageHeading } = { heading: undefined }) => (
-  <DDSImage slot="media" alt="Image alt text" defaultSrc={imgLg16x9} heading={imageHeading}>
+  <DDSImage
+    slot="media"
+    alt="Image alt text"
+    defaultSrc={imgLg16x9}
+    heading={imageHeading}>
     <DDSImageItem media="(min-width: 672px)" srcset={imgLg16x9} />
     <DDSImageItem media="(min-width: 400px)" srcset={imgMd16x9} />
     <DDSImageItem media="(min-width: 320px)" srcset={imgSm16x9} />
   </DDSImage>
 );
 
-export const Default = args => {
-  const { heading, copy: groupCopy, cardsGroupHeading, ctaType } = args?.ContentBlockMixed ?? {};
+export const Default = ({
+  heading,
+  copy: groupCopy,
+  cardsGroupHeading,
+  ctaType,
+}) => {
   const headingComponent = document.querySelector('dds-content-block-heading');
 
   if (headingComponent) {
@@ -111,11 +122,12 @@ export const Default = args => {
         <DDSContentGroupHeading>{cardsGroupHeading}</DDSContentGroupHeading>
         <DDSContentGroupCardsItem href="www.ibm.com">
           <DDSCardHeading>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt
           </DDSCardHeading>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-            aliqua.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </p>
           <DDSCardFooter>
             <ArrowRight20 slot="icon" />
@@ -123,11 +135,12 @@ export const Default = args => {
         </DDSContentGroupCardsItem>
         <DDSContentGroupCardsItem href="www.ibm.com">
           <DDSCardHeading>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt
           </DDSCardHeading>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-            aliqua.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </p>
           <DDSCardFooter>
             <ArrowRight20 slot="icon" />
@@ -137,22 +150,27 @@ export const Default = args => {
       <DDSContentGroupPictograms>
         <DDSContentGroupHeading>{heading}</DDSContentGroupHeading>
         <DDSContentGroupCopy>{groupCopy}</DDSContentGroupCopy>
-        {pictogramsItems.map(({ heading: itemHeading, copy: itemCopy, linkWithIcon }) => (
-          <DDSPictogramItem>
-            <TouchScreen slot="pictogram" />
-            <DDSContentItemHeading>{itemHeading}</DDSContentItemHeading>
-            <DDSContentItemCopy>{itemCopy}</DDSContentItemCopy>
-            <DDSLinkWithIcon href={linkWithIcon.href} slot="footer">
-              {linkWithIcon.copy} <ArrowRight20 slot="icon" />
-            </DDSLinkWithIcon>
-          </DDSPictogramItem>
-        ))}
+        {pictogramsItems.map(
+          ({ heading: itemHeading, copy: itemCopy, linkWithIcon }) => (
+            <DDSPictogramItem>
+              <TouchScreen slot="pictogram" />
+              <DDSContentItemHeading>{itemHeading}</DDSContentItemHeading>
+              <DDSContentItemCopy>{itemCopy}</DDSContentItemCopy>
+              <DDSLinkWithIcon href={linkWithIcon.href} slot="footer">
+                {linkWithIcon.copy} <ArrowRight20 slot="icon" />
+              </DDSLinkWithIcon>
+            </DDSPictogramItem>
+          )
+        )}
       </DDSContentGroupPictograms>
       <DDSContentGroupSimple>
         <DDSContentGroupHeading>{heading}</DDSContentGroupHeading>
         <DDSContentGroupCopy>{groupCopy}</DDSContentGroupCopy>
         {image({ heading })}
-        <DDSCardLinkCTA slot="footer" ctaType={ctaType} href="https://example.com">
+        <DDSCardLinkCTA
+          slot="footer"
+          ctaType={ctaType}
+          href="https://example.com">
           <DDSCardLinkHeading>Lorem ipsum dolor sit amet</DDSCardLinkHeading>
           <DDSCardCTAFooter></DDSCardCTAFooter>
         </DDSCardLinkCTA>
@@ -161,9 +179,14 @@ export const Default = args => {
   );
 };
 
-export const withLinkList = args => {
-  const { heading, copy: groupCopy, cardsGroupHeading, complementaryStyleScheme, ctaType, linkListHeading } =
-    args?.ContentBlockMixed ?? {};
+export const withLinkList = ({
+  heading,
+  copy: groupCopy,
+  cardsGroupHeading,
+  complementaryStyleScheme,
+  ctaType,
+  linkListHeading,
+}) => {
   const headingComponent = document.querySelector('dds-content-block-heading');
 
   if (headingComponent) {
@@ -171,18 +194,20 @@ export const withLinkList = args => {
   }
 
   return (
-    <DDSContentBlockMixed complementary-style-scheme={complementaryStyleScheme || undefined}>
+    <DDSContentBlockMixed
+      complementary-style-scheme={complementaryStyleScheme || undefined}>
       <DDSContentBlockHeading>{heading}</DDSContentBlockHeading>
       <DDSContentBlockCopy>{groupCopy}</DDSContentBlockCopy>
       <DDSContentGroupCards>
         <DDSContentGroupHeading>{cardsGroupHeading}</DDSContentGroupHeading>
         <DDSContentGroupCardsItem href="www.ibm.com">
           <DDSCardHeading>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt
           </DDSCardHeading>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-            aliqua.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </p>
           <DDSCardFooter>
             <ArrowRight20 slot="icon" />
@@ -190,11 +215,12 @@ export const withLinkList = args => {
         </DDSContentGroupCardsItem>
         <DDSContentGroupCardsItem href="www.ibm.com">
           <DDSCardHeading>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt
           </DDSCardHeading>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-            aliqua.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </p>
           <DDSCardFooter>
             <ArrowRight20 slot="icon" />
@@ -204,22 +230,27 @@ export const withLinkList = args => {
       <DDSContentGroupPictograms>
         <DDSContentGroupHeading>{heading}</DDSContentGroupHeading>
         <DDSContentGroupCopy>{groupCopy}</DDSContentGroupCopy>
-        {pictogramsItems.map(({ heading: itemHeading, copy: itemCopy, linkWithIcon }) => (
-          <DDSPictogramItem>
-            <TouchScreen slot="pictogram" />
-            <DDSContentItemHeading>{itemHeading}</DDSContentItemHeading>
-            <DDSContentItemCopy>{itemCopy}</DDSContentItemCopy>
-            <DDSLinkWithIcon href={linkWithIcon.href} slot="footer">
-              {linkWithIcon.copy} <ArrowRight20 slot="icon" />
-            </DDSLinkWithIcon>
-          </DDSPictogramItem>
-        ))}
+        {pictogramsItems.map(
+          ({ heading: itemHeading, copy: itemCopy, linkWithIcon }) => (
+            <DDSPictogramItem>
+              <TouchScreen slot="pictogram" />
+              <DDSContentItemHeading>{itemHeading}</DDSContentItemHeading>
+              <DDSContentItemCopy>{itemCopy}</DDSContentItemCopy>
+              <DDSLinkWithIcon href={linkWithIcon.href} slot="footer">
+                {linkWithIcon.copy} <ArrowRight20 slot="icon" />
+              </DDSLinkWithIcon>
+            </DDSPictogramItem>
+          )
+        )}
       </DDSContentGroupPictograms>
       <DDSContentGroupSimple>
         <DDSContentGroupHeading>{heading}</DDSContentGroupHeading>
         <DDSContentGroupCopy>{groupCopy}</DDSContentGroupCopy>
         {image({ heading })}
-        <DDSCardLinkCTA slot="footer" ctaType={ctaType} href="https://example.com">
+        <DDSCardLinkCTA
+          slot="footer"
+          ctaType={ctaType}
+          href="https://example.com">
           <DDSCardLinkHeading>Lorem ipsum dolor sit amet</DDSCardLinkHeading>
           <DDSCardCTAFooter></DDSCardCTAFooter>
         </DDSCardLinkCTA>
@@ -241,61 +272,65 @@ export const withLinkList = args => {
 
 withLinkList.story = {
   name: 'With link list',
+  argTypes: {
+    linkListHeading: {
+      control: { type: 'text' },
+      name: 'Link list heading (heading)',
+      description: 'The link list heading content',
+      defaultValue: 'Tutorials',
+    },
+    complementaryStyleScheme: {
+      control: { type: 'select' },
+      name: 'Complementary style scheme (complementary-style-scheme)',
+      description: 'Option to include border below Content Block Mixed',
+      options: complementaryStyleSchemes,
+      defaultValue: null,
+    },
+  },
   parameters: {
     gridContentClasses: 'bx--col-lg-12',
-    knobs: {
-      ContentBlockMixed: () => ({
-        heading: text('Heading (heading)', 'Lorem ipsum dolor sit amet'),
-        copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat
-          libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
-          `,
-        cardsGroupHeading: text('Cards group heading (heading)', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'),
-        ctaType: select('CTA type (cta-type)', ctaTypes, CTA_TYPE.LOCAL),
-        linkListHeading: text('Link list heading (heading)', 'Tutorials'),
-        complementaryStyleScheme: select(
-          'Complementary style scheme (complementary-style-scheme)',
-          complementaryStyleSchemes,
-          null
-        ),
-      }),
-    },
   },
 };
 
 export default {
   title: 'Components/Content block mixed',
+  component: PropTypesRef,
   decorators: [
     (story, { parameters }) => {
       return (
         <div className="bx--grid">
           <div className="bx--row">
-            <div className={`${parameters.gridContentClasses} bx--no-gutter`}>{story()}</div>
+            <div className={`${parameters.gridContentClasses} bx--no-gutter`}>
+              {story()}
+            </div>
           </div>
         </div>
       );
     },
   ],
+  argTypes: {
+    heading: {
+      control: { type: 'text' },
+      name: 'Heading (heading)',
+      defaultValue: 'Lorem ipsum dolor sit amet',
+    },
+    cardsGroupHeading: {
+      control: { type: 'text' },
+      name: 'Card group heading (heading)',
+      description: 'The card group heading content',
+      defaultValue: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    },
+    ctaType: {
+      control: { type: 'select' },
+      name: 'CTA type (cta-type)',
+      description: 'The CTA type (local, jump, or external)',
+      options: ctaTypes,
+      defaultValue: CTA_TYPE.LOCAL,
+    },
+  },
   parameters: {
     ...readme.parameters,
     gridContentClasses: 'bx--col-lg-8',
     hasStoryPadding: true,
-    knobs: {
-      ContentBlockMixed: () => ({
-        heading: text('Heading (heading)', 'Lorem ipsum dolor sit amet'),
-        copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat
-          libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
-          `,
-        cardsGroupHeading: text('Cards group heading (heading)', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'),
-        ctaType: select('CTA type (cta-type)', ctaTypes, CTA_TYPE.LOCAL),
-      }),
-    },
   },
 };

--- a/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.react.tsx
+++ b/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.react.tsx
@@ -7,7 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { select, text } from '@storybook/addon-knobs';
 import React from 'react';
 // Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.

--- a/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.ts
+++ b/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.ts
@@ -16,12 +16,10 @@ import '../../content-group-simple/index';
 import ArrowRight20 from '@carbon/web-components/es/icons/arrow--right/20';
 import { html } from 'lit-element';
 import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import { select } from '@storybook/addon-knobs';
 import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--001.jpg';
 import imgMd16x9 from '../../../../../storybook-images/assets/480/fpo--16x9--480x270--001.jpg';
 import imgSm16x9 from '../../../../../storybook-images/assets/320/fpo--16x9--320x180--001.jpg';
 import readme from './README.stories.mdx';
-import textNullable from '../../../../.storybook/knob-text-nullable';
 import styles from './content-block-mixed.stories.scss';
 import { CTA_TYPE } from '../../cta/defs';
 import { CONTENT_BLOCK_COMPLEMENTARY_STYLE_SCHEME } from '../../content-block/defs';
@@ -81,177 +79,122 @@ const image = ({ heading: imageHeading } = { heading: undefined }) => html`
   </dds-image>
 `;
 
-export default {
-  title: 'Components/Content block mixed',
-  decorators: [
-    (story, { parameters }) => html`
-      <style>
-        ${styles}
-      </style>
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="${parameters.gridContentClasses} bx--no-gutter">
-            ${story()}
-          </div>
-        </div>
-      </div>
-    `,
-  ],
-  parameters: {
-    ...readme.parameters,
-    gridContentClasses: 'bx--col-lg-8',
-    hasStoryPadding: true,
-    knobs: {
-      ContentBlockMixed: () => ({
-        heading: textNullable(
-          'Heading (heading)',
-          'Lorem ipsum dolor sit amet'
-        ),
-        copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat
-          libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
-          `,
-        cardsGroupHeading: textNullable(
-          'Cards group heading (heading)',
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
-        ),
-        ctaType: select('CTA type (cta-type)', ctaTypes, CTA_TYPE.LOCAL),
-      }),
-    },
-    propsSet: {
-      default: {
-        ContentBlockMixed: {
-          heading: 'Lorem ipsum dolor sit amet',
-          copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat
-          libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
-          `,
-          cardsGroupHeading:
-            'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-          ctaType: 'local',
-        },
+export const Default = ({
+  heading,
+  cardsGroupHeading,
+  ctaType,
+  groupCopy,
+}) => html`
+  <dds-content-block-mixed>
+    <dds-content-block-heading>${heading}</dds-content-block-heading>
+    <dds-content-block-copy>${groupCopy}</dds-content-block-copy>
+    <dds-content-group-cards>
+      <dds-content-group-heading
+        >${cardsGroupHeading}</dds-content-group-heading
+      >
+      <dds-content-group-cards-item href="www.ibm.com">
+        <dds-card-heading>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+          eiusmod tempor incididunt
+        </dds-card-heading>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+        <dds-card-footer icon-placement="left">
+          ${ArrowRight20({ slot: 'icon' })}
+        </dds-card-footer>
+      </dds-content-group-cards-item>
+      <dds-content-group-cards-item href="www.ibm.com">
+        <dds-card-heading>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+          eiusmod tempor incididunt
+        </dds-card-heading>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+        <dds-card-footer icon-placement="left">
+          ${ArrowRight20({ slot: 'icon' })}
+        </dds-card-footer>
+      </dds-content-group-cards-item>
+    </dds-content-group-cards>
+    <dds-content-group-pictograms>
+      <dds-content-group-heading>${heading}</dds-content-group-heading>
+      <dds-content-group-copy>${groupCopy}</dds-content-group-copy>
+      ${pictogramsItems.map(
+        ({ heading: itemHeading, copy: itemCopy, linkWithIcon }) => html`
+          <dds-pictogram-item>
+            <svg
+              version="1.1"
+              slot="pictogram"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              x="0px"
+              y="0px"
+              width="64"
+              height="64"
+              viewBox="8 8 32 32"
+              xml:space="preserve">
+              <g>
+                <g>
+                  <path
+                    style="fill:none;stroke-width:0.72;stroke-linejoin:round;stroke-miterlimit:10;"
+                    d="M15,29H9V10h25v19h-7
+                       M34,26h-7 M15,26H9 M30,29v8h9V21h-5 M30,34h9 M20.998,27.621c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v2.378
+                       l-0.005-6.962c0-0.573-0.447-1.037-0.998-1.037S17,22.464,17,23.037v5.882v4.924C17,36.139,18.792,38,21.002,38
+                       S25,36.121,25,33.842v-5.04c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v1.196l-0.005-1.935
+                       c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z" />
+                </g>
+              </g>
+              <g></g>
+            </svg>
+            <dds-content-item-heading>${itemHeading}</dds-content-item-heading>
+            <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
+            <dds-link-with-icon href="${linkWithIcon.href}" slot="footer">
+              ${linkWithIcon.copy} ${ArrowRight20({ slot: 'icon' })}
+            </dds-link-with-icon>
+          </dds-pictogram-item>
+        `
+      )}
+    </dds-content-group-pictograms>
+    <dds-content-group-simple>
+      <dds-content-group-heading>${heading}</dds-content-group-heading>
+      <dds-content-group-copy>${groupCopy}</dds-content-group-copy>
+      ${image({ heading })}
+      <dds-card-link-cta
+        slot="footer"
+        cta-type=${ctaType}
+        href="https://example.com">
+        <dds-card-link-heading
+          >Lorem ipsum dolor sit amet</dds-card-link-heading
+        >
+        <dds-card-cta-footer></dds-card-cta-footer>
+      </dds-card-link-cta>
+    </dds-content-group-simple>
+  </dds-content-block-mixed>
+`;
+
+Default.story = {
+  name: 'Default',
+  argTypes: {
+    complementaryStyleScheme: {
+      table: {
+        disable: true,
       },
     },
   },
 };
 
-export const Default = (args) => {
-  const {
-    heading,
-    copy: groupCopy,
-    cardsGroupHeading,
-    ctaType,
-  } = args?.ContentBlockMixed ?? {};
-  return html`
-    <dds-content-block-mixed>
-      <dds-content-block-heading>${heading}</dds-content-block-heading>
-      <dds-content-block-copy>${groupCopy}</dds-content-block-copy>
-      <dds-content-group-cards>
-        <dds-content-group-heading
-          >${cardsGroupHeading}</dds-content-group-heading
-        >
-        <dds-content-group-cards-item href="www.ibm.com">
-          <dds-card-heading>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-            eiusmod tempor incididunt
-          </dds-card-heading>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          </p>
-          <dds-card-footer icon-placement="left">
-            ${ArrowRight20({ slot: 'icon' })}
-          </dds-card-footer>
-        </dds-content-group-cards-item>
-        <dds-content-group-cards-item href="www.ibm.com">
-          <dds-card-heading>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-            eiusmod tempor incididunt
-          </dds-card-heading>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          </p>
-          <dds-card-footer icon-placement="left">
-            ${ArrowRight20({ slot: 'icon' })}
-          </dds-card-footer>
-        </dds-content-group-cards-item>
-      </dds-content-group-cards>
-      <dds-content-group-pictograms>
-        <dds-content-group-heading>${heading}</dds-content-group-heading>
-        <dds-content-group-copy>${groupCopy}</dds-content-group-copy>
-        ${pictogramsItems.map(
-          ({ heading: itemHeading, copy: itemCopy, linkWithIcon }) => html`
-            <dds-pictogram-item>
-              <svg
-                version="1.1"
-                slot="pictogram"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-                x="0px"
-                y="0px"
-                width="64"
-                height="64"
-                viewBox="8 8 32 32"
-                xml:space="preserve">
-                <g>
-                  <g>
-                    <path
-                      style="fill:none;stroke-width:0.72;stroke-linejoin:round;stroke-miterlimit:10;"
-                      d="M15,29H9V10h25v19h-7
-                      M34,26h-7 M15,26H9 M30,29v8h9V21h-5 M30,34h9 M20.998,27.621c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v2.378
-                      l-0.005-6.962c0-0.573-0.447-1.037-0.998-1.037S17,22.464,17,23.037v5.882v4.924C17,36.139,18.792,38,21.002,38
-                      S25,36.121,25,33.842v-5.04c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v1.196l-0.005-1.935
-                      c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z" />
-                  </g>
-                </g>
-                <g></g>
-              </svg>
-              <dds-content-item-heading
-                >${itemHeading}</dds-content-item-heading
-              >
-              <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
-              <dds-link-with-icon href="${linkWithIcon.href}" slot="footer">
-                ${linkWithIcon.copy} ${ArrowRight20({ slot: 'icon' })}
-              </dds-link-with-icon>
-            </dds-pictogram-item>
-          `
-        )}
-      </dds-content-group-pictograms>
-      <dds-content-group-simple>
-        <dds-content-group-heading>${heading}</dds-content-group-heading>
-        <dds-content-group-copy>${groupCopy}</dds-content-group-copy>
-        ${image({ heading })}
-        <dds-card-link-cta
-          slot="footer"
-          cta-type=${ctaType}
-          href="https://example.com">
-          <dds-card-link-heading
-            >Lorem ipsum dolor sit amet</dds-card-link-heading
-          >
-          <dds-card-cta-footer></dds-card-cta-footer>
-        </dds-card-link-cta>
-      </dds-content-group-simple>
-    </dds-content-block-mixed>
-  `;
-};
-
-export const WithLinkList = (args) => {
-  const {
-    heading,
-    copy: groupCopy,
-    cardsGroupHeading,
-    complementaryStyleScheme,
-    ctaType,
-    linkListHeading,
-  } = args?.ContentBlockMixed ?? {};
-  return html`
+export const WithLinkList = ({
+  heading,
+  groupCopy,
+  cardsGroupHeading,
+  complementaryStyleScheme,
+  ctaType,
+  linkListHeading,
+}) =>
+  html`
     <dds-content-block-mixed
       complementary-style-scheme="${ifNonNull(complementaryStyleScheme)}">
       <dds-content-block-heading>${heading}</dds-content-block-heading>
@@ -292,40 +235,40 @@ export const WithLinkList = (args) => {
         <dds-content-group-copy>${groupCopy}</dds-content-group-copy>
         ${pictogramsItems.map(
           ({ heading: itemHeading, copy: itemCopy, linkWithIcon }) => html`
-            <dds-pictogram-item>
-              <svg
-                version="1.1"
-                slot="pictogram"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-                x="0px"
-                y="0px"
-                width="64"
-                height="64"
-                viewBox="8 8 32 32"
-                xml:space="preserve"
-              >
-                <g>
-                  <g>
-                    <path
-                      style="fill:none;stroke-width:0.72;stroke-linejoin:round;stroke-miterlimit:10;"
-                      d="M15,29H9V10h25v19h-7
-                      M34,26h-7 M15,26H9 M30,29v8h9V21h-5 M30,34h9 M20.998,27.621c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v2.378
-                      l-0.005-6.962c0-0.573-0.447-1.037-0.998-1.037S17,22.464,17,23.037v5.882v4.924C17,36.139,18.792,38,21.002,38
-                      S25,36.121,25,33.842v-5.04c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v1.196l-0.005-1.935
-                      c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z"
-                    />
-                  </g>
-                </g>
-                <g"></g>
-              </svg>
-              <dds-content-item-heading>${itemHeading}</dds-content-item-heading>
-              <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
-              <dds-link-with-icon href="${linkWithIcon.href}" slot="footer">
-                ${linkWithIcon.copy} ${ArrowRight20({ slot: 'icon' })}
-              </dds-link-with-icon>
-            </dds-pictogram-item>
-          `
+             <dds-pictogram-item>
+               <svg
+                 version="1.1"
+                 slot="pictogram"
+                 xmlns="http://www.w3.org/2000/svg"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 x="0px"
+                 y="0px"
+                 width="64"
+                 height="64"
+                 viewBox="8 8 32 32"
+                 xml:space="preserve"
+               >
+                 <g>
+                   <g>
+                     <path
+                       style="fill:none;stroke-width:0.72;stroke-linejoin:round;stroke-miterlimit:10;"
+                       d="M15,29H9V10h25v19h-7
+                       M34,26h-7 M15,26H9 M30,29v8h9V21h-5 M30,34h9 M20.998,27.621c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v2.378
+                       l-0.005-6.962c0-0.573-0.447-1.037-0.998-1.037S17,22.464,17,23.037v5.882v4.924C17,36.139,18.792,38,21.002,38
+                       S25,36.121,25,33.842v-5.04c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v1.196l-0.005-1.935
+                       c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z"
+                     />
+                   </g>
+                 </g>
+                 <g"></g>
+               </svg>
+               <dds-content-item-heading>${itemHeading}</dds-content-item-heading>
+               <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
+               <dds-link-with-icon href="${linkWithIcon.href}" slot="footer">
+                 ${linkWithIcon.copy} ${ArrowRight20({ slot: 'icon' })}
+               </dds-link-with-icon>
+             </dds-pictogram-item>
+           `
         )}
       </dds-content-group-pictograms>
       <dds-content-group-simple>
@@ -359,59 +302,110 @@ export const WithLinkList = (args) => {
       </dds-link-list>
     </dds-content-block-mixed>
   `;
-};
 
 WithLinkList.story = {
   name: 'With link list',
+  argTypes: {
+    linkListHeading: {
+      control: { type: 'text' },
+      name: 'Link list heading (heading)',
+      description: 'The link list heading content',
+      defaultValue: 'Tutorials',
+    },
+    complementaryStyleScheme: {
+      control: { type: 'select' },
+      name: 'Complementary style scheme (complementary-style-scheme)',
+      description: 'Option to include border below Content Block Mixed',
+      options: complementaryStyleSchemes,
+      defaultValue: null,
+    },
+  },
   parameters: {
     gridContentClasses: 'bx--col-lg-12',
-    knobs: {
-      ContentBlockMixed: () => ({
-        heading: textNullable(
-          'Heading (heading)',
-          'Lorem ipsum dolor sit amet'
-        ),
-        copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat
-          libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
-          `,
-        cardsGroupHeading: textNullable(
-          'Cards group heading (heading)',
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
-        ),
-        ctaType: select('CTA type (cta-type)', ctaTypes, CTA_TYPE.LOCAL),
-        linkListHeading: textNullable(
-          'Link list heading (heading)',
-          'Tutorials'
-        ),
-        complementaryStyleScheme: select(
-          'Complementary style scheme (complementary-style-scheme)',
-          complementaryStyleSchemes,
-          null
-        ),
-      }),
+  },
+};
+
+export default {
+  title: 'Components/Content block mixed',
+  component: 'dds-content-block-mixed',
+  decorators: [
+    (story, { parameters }) => html`
+      <style>
+        ${styles}
+      </style>
+      <div class="bx--grid">
+        <div class="bx--row">
+          <div class="${parameters.gridContentClasses} bx--no-gutter">
+            ${story()}
+          </div>
+        </div>
+      </div>
+    `,
+  ],
+  argTypes: {
+    heading: {
+      control: { type: 'text' },
+      name: 'Heading (heading)',
+      defaultValue: 'Lorem ipsum dolor sit amet',
     },
-    propsSet: {
-      default: {
-        ContentBlockMixed: {
-          heading: 'Lorem ipsum dolor sit amet',
-          copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat
-          libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-          Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
-          `,
-          cardsGroupHeading:
-            'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-          ctaType: 'local',
-          linkListHeading: 'Tutorials',
-          complementaryStyleScheme: null,
-        },
+    cardsGroupHeading: {
+      control: { type: 'text' },
+      name: 'Card group heading (heading)',
+      description: 'The card group heading content',
+      defaultValue: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    },
+    ctaType: {
+      control: { type: 'select' },
+      name: 'CTA type (cta-type)',
+      description: 'The CTA type (local, jump, or external)',
+      options: ctaTypes,
+      defaultValue: CTA_TYPE.LOCAL,
+    },
+    groupCopy: {
+      defaultValue: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+       Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
+       Phasellus at elit sollicitudin, sodales nulla quis, consequat
+       libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+       Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
+       Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.`,
+      table: {
+        disable: true,
       },
     },
+    'complementary-style-scheme': {
+      table: {
+        disable: true,
+      },
+    },
+    copy: {
+      table: {
+        disable: true,
+      },
+    },
+    media: {
+      table: {
+        disable: true,
+      },
+    },
+    footer: {
+      table: {
+        disable: true,
+      },
+    },
+    complementary: {
+      table: {
+        disable: true,
+      },
+    },
+    styles: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  parameters: {
+    ...readme.parameters,
+    gridContentClasses: 'bx--col-lg-8',
+    hasStoryPadding: true,
   },
 };

--- a/packages/web-components/src/components/video-player/__stories__/video-player.stories.react.tsx
+++ b/packages/web-components/src/components/video-player/__stories__/video-player.stories.react.tsx
@@ -7,56 +7,115 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { boolean, text } from '@storybook/addon-knobs';
 import React from 'react';
 import DDSVideoPlayerContainer from '@carbon/ibmdotcom-web-components/es/components-react/video-player/video-player-container';
+// eslint-disable-next-line max-len
+import DDSLightboxVideoPlayerContainer from '@carbon/ibmdotcom-web-components/es/components-react/lightbox-media-viewer/lightbox-video-player-container';
 import readme from './README.stories.react.mdx';
 
-export const Default = args => {
-  const { aspectRatio, caption, hideCaption, videoId } = args?.VideoPlayerContainer ?? {};
-  return <DDSVideoPlayerContainer aspectRatio={aspectRatio} caption={caption} hideCaption={hideCaption} videoId={videoId} />;
+export const Default = ({ caption, hideCaption, thumbnail, videoId }) => {
+  return (
+    <DDSVideoPlayerContainer
+      playing-mode="inline"
+      caption={caption}
+      hideCaption={hideCaption}
+      thumbnail={thumbnail}
+      videoId={videoId}
+    />
+  );
 };
 
-export const aspectRatio1x1 = args => {
-  const { aspectRatio, caption, hideCaption, videoId } = args?.VideoPlayerContainer ?? {};
-  return <DDSVideoPlayerContainer aspectRatio={aspectRatio} caption={caption} hideCaption={hideCaption} videoId={videoId} />;
+export const aspectRatio1x1 = ({
+  aspectRatio,
+  caption,
+  hideCaption,
+  thumbnail,
+  videoId,
+}) => {
+  return (
+    <DDSVideoPlayerContainer
+      aspectRatio={aspectRatio}
+      caption={caption}
+      hideCaption={hideCaption}
+      thumbnail={thumbnail}
+      videoId={videoId}
+    />
+  );
 };
 
 aspectRatio1x1.story = {
   name: 'Aspect ratio 1:1',
-  parameters: {
-    knobs: {
-      VideoPlayerContainer: () => {
-        return {
-          aspectRatio: '1x1',
-          caption: text('Custom caption (caption):', ''),
-          hideCaption: boolean('Hide caption (hideCaption):', false),
-          thumbnail: text('Custom thumbnail (thumbnail):', ''),
-          videoId: '1_9h94wo6b',
-        };
+  argTypes: {
+    aspectRatio: {
+      defaultValue: '1x1',
+      table: {
+        disable: true,
       },
     },
   },
 };
 
-export const aspectRatio4x3 = args => {
-  const { aspectRatio, caption, hideCaption, videoId } = args?.VideoPlayerContainer ?? {};
-  return <DDSVideoPlayerContainer aspectRatio={aspectRatio} caption={caption} hideCaption={hideCaption} videoId={videoId} />;
+export const aspectRatio4x3 = ({
+  aspectRatio,
+  caption,
+  hideCaption,
+  thumbnail,
+  videoId,
+}) => {
+  return (
+    <DDSVideoPlayerContainer
+      aspectRatio={aspectRatio}
+      caption={caption}
+      hideCaption={hideCaption}
+      thumbnail={thumbnail}
+      videoId={videoId}
+    />
+  );
 };
 
 aspectRatio4x3.story = {
   name: 'Aspect ratio 4:3',
-  parameters: {
-    knobs: {
-      VideoPlayerContainer: () => {
-        return {
-          aspectRatio: '4x3',
-          caption: text('Custom caption (caption):', ''),
-          hideCaption: boolean('Hide caption (hideCaption):', false),
-          thumbnail: text('Custom thumbnail (thumbnail):', ''),
-          videoId: '1_9h94wo6b',
-        };
+  argTypes: {
+    aspectRatio: {
+      defaultValue: '4x3',
+      table: {
+        disable: true,
       },
+    },
+  },
+};
+
+export const withLightboxMediaViewer = ({
+  aspectRatio,
+  caption,
+  hideCaption,
+  thumbnail,
+  videoId,
+  customVideoDescription,
+}) => {
+  return (
+    <>
+      <DDSVideoPlayerContainer
+        aspectRatio={aspectRatio}
+        caption={caption}
+        hideCaption={hideCaption}
+        thumbnail={thumbnail}
+        videoId={videoId}
+        videoDescription={customVideoDescription}
+        playingMode="lightbox"
+      />
+      <DDSLightboxVideoPlayerContainer></DDSLightboxVideoPlayerContainer>
+    </>
+  );
+};
+
+withLightboxMediaViewer.story = {
+  name: 'With lightbox media viewer',
+  argTypes: {
+    customVideoDescription: {
+      control: { type: 'text' },
+      name: 'Custom video description',
+      defaultValue: 'This is a custom video description.',
     },
   },
 };
@@ -64,7 +123,7 @@ aspectRatio4x3.story = {
 export default {
   title: 'Components/Video Player',
   decorators: [
-    story => (
+    (story) => (
       <div className="bx--grid">
         <div className="bx--row">
           <div className="bx--col-sm-4 bx--col-lg-8">{story()}</div>
@@ -72,15 +131,31 @@ export default {
       </div>
     ),
   ],
+  argTypes: {
+    caption: {
+      control: { type: 'text' },
+      name: 'Custom caption (caption):',
+      defaultValue: '',
+      description: '',
+    },
+    hideCaption: {
+      control: { type: 'boolean' },
+      name: 'Hide caption (hideCaption):',
+      defaultValue: false,
+    },
+    thumbnail: {
+      control: { type: 'text' },
+      name: 'Custom thumbnail (thumbnail):',
+      defaultValue: '',
+    },
+    videoId: {
+      defaultValue: '1_9h94wo6b',
+      table: {
+        disable: true,
+      },
+    },
+  },
   parameters: {
     ...readme.parameters,
-    knobs: {
-      VideoPlayerContainer: () => ({
-        caption: text('Custom caption (caption):', ''),
-        hideCaption: boolean('Hide caption (hideCaption):', false),
-        thumbnailUrl: text('Custom thumbnail (thumbnail):', ''),
-        videoId: '1_9h94wo6b',
-      }),
-    },
   },
 };

--- a/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
@@ -8,166 +8,132 @@
  */
 
 import { html } from 'lit-element';
-import { boolean, text } from '@storybook/addon-knobs';
 import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
 import readme from './README.stories.mdx';
 import '../video-player-container';
 import '../../lightbox-media-viewer/lightbox-video-player-container';
 
-export const Default = (args) => {
-  const { caption, hideCaption, thumbnail, videoId } = args?.VideoPlayer ?? {};
-  return html`
-    <dds-video-player-container
-      playing-mode="inline"
-      video-id=${videoId}
-      caption=${caption}
-      ?hide-caption=${hideCaption}
-      thumbnail=${thumbnail}></dds-video-player-container>
-  `;
-};
+export const Default = ({ caption, hideCaption, thumbnail, videoId }) => html`
+  <dds-video-player-container
+    playing-mode="inline"
+    video-id=${videoId}
+    caption=${caption}
+    ?hide-caption=${hideCaption}
+    thumbnail=${thumbnail}></dds-video-player-container>
+`;
 
-export const aspectRatio1x1 = (args) => {
-  const { aspectRatio, caption, hideCaption, thumbnail, videoId } =
-    args?.VideoPlayer ?? {};
-  return html`
-    <dds-video-player-container
-      playing-mode="inline"
-      video-id=${videoId}
-      aspect-ratio=${aspectRatio}
-      caption=${caption}
-      ?hide-caption=${hideCaption}
-      thumbnail=${thumbnail}></dds-video-player-container>
-  `;
-};
-
-export const aspectRatio4x3 = (args) => {
-  const { aspectRatio, caption, hideCaption, thumbnail, videoId } =
-    args?.VideoPlayer ?? {};
-  return html`
-    <dds-video-player-container
-      playing-mode="inline"
-      video-id=${videoId}
-      aspect-ratio=${aspectRatio}
-      caption=${caption}
-      ?hide-caption=${hideCaption}
-      thumbnail=${thumbnail}></dds-video-player-container>
-  `;
-};
-
-export const withLightboxMediaViewer = (args) => {
-  const {
-    aspectRatio,
-    caption,
-    hideCaption,
-    thumbnail,
-    videoId,
-    customVideoDescription,
-  } = args?.VideoPlayer ?? {};
-  return html`
-    <dds-video-player-container
-      video-id=${videoId}
-      aspect-ratio=${aspectRatio}
-      caption=${caption}
-      video-description="${ifNonNull(customVideoDescription)}"
-      ?hide-caption=${hideCaption}
-      thumbnail=${thumbnail}
-      playing-mode="lightbox">
-    </dds-video-player-container>
-    <dds-lightbox-video-player-container></dds-lightbox-video-player-container>
-  `;
-};
-
-aspectRatio4x3.story = {
-  name: 'Aspect ratio 4:3',
-  parameters: {
-    knobs: {
-      VideoPlayer: () => {
-        return {
-          aspectRatio: '4x3',
-          caption: text('Custom caption (caption):', ''),
-          hideCaption: boolean('Hide caption (hideCaption):', false),
-          thumbnail: text('Custom thumbnail (thumbnail):', ''),
-          videoId: '1_9h94wo6b',
-        };
-      },
-    },
-    propsSet: {
-      default: {
-        VideoPlayer: {
-          aspectRatio: '4x3',
-          caption: '',
-          hideCaption: false,
-          thumbnail: '',
-          videoId: '1_9h94wo6b',
-        },
+Default.story = {
+  name: 'Default',
+  argTypes: {
+    customVideoDescription: {
+      table: {
+        disable: true,
       },
     },
   },
 };
+
+export const aspectRatio1x1 = ({
+  aspectRatio,
+  caption,
+  hideCaption,
+  thumbnail,
+  videoId,
+}) => html`
+  <dds-video-player-container
+    playing-mode="inline"
+    video-id=${videoId}
+    aspect-ratio=${aspectRatio}
+    caption=${caption}
+    ?hide-caption=${hideCaption}
+    thumbnail=${thumbnail}></dds-video-player-container>
+`;
 
 aspectRatio1x1.story = {
   name: 'Aspect ratio 1:1',
-  parameters: {
-    knobs: {
-      VideoPlayer: () => {
-        return {
-          aspectRatio: '1x1',
-          caption: text('Custom caption (caption):', ''),
-          hideCaption: boolean('Hide caption (hideCaption):', false),
-          thumbnail: text('Custom thumbnail (thumbnail):', ''),
-          videoId: '1_9h94wo6b',
-        };
+  argTypes: {
+    aspectRatio: {
+      defaultValue: '1x1',
+      table: {
+        disable: true,
       },
     },
-    propsSet: {
-      default: {
-        VideoPlayer: {
-          aspectRatio: '1x1',
-          caption: '',
-          hideCaption: false,
-          thumbnail: '',
-          videoId: '1_9h94wo6b',
-        },
+    customVideoDescription: {
+      table: {
+        disable: true,
       },
     },
   },
 };
 
-withLightboxMediaViewer.story = {
-  name: 'With lightbox media viewer',
-  parameters: {
-    knobs: {
-      VideoPlayer: () => {
-        return {
-          aspectRatio: '16x9',
-          customVideoDescription: text(
-            'Custom video description',
-            'This is a custom video description.'
-          ),
-          caption: text('Custom caption (caption):', ''),
-          hideCaption: boolean('Hide caption (hideCaption):', false),
-          thumbnail: text('Custom thumbnail (thumbnail):', ''),
-          videoId: '1_9h94wo6b',
-        };
+export const aspectRatio4x3 = ({
+  aspectRatio,
+  caption,
+  hideCaption,
+  thumbnail,
+  videoId,
+}) =>
+  html`
+    <dds-video-player-container
+      playing-mode="inline"
+      video-id=${videoId}
+      aspect-ratio=${aspectRatio}
+      caption=${caption}
+      ?hide-caption=${hideCaption}
+      thumbnail=${thumbnail}></dds-video-player-container>
+  `;
+
+aspectRatio4x3.story = {
+  name: 'Aspect ratio 4:3',
+  argTypes: {
+    aspectRatio: {
+      defaultValue: '4x3',
+      table: {
+        disable: true,
       },
     },
-    propsSet: {
-      default: {
-        VideoPlayer: {
-          aspectRatio: '16x9',
-          customVideoDescription: 'This is a custom video description',
-          caption: '',
-          hideCaption: false,
-          thumbnail: '',
-          videoId: '1_9h94wo6b',
-        },
+    customVideoDescription: {
+      table: {
+        disable: true,
       },
+    },
+  },
+};
+
+export const withLightboxMediaViewer = ({
+  aspectRatio,
+  caption,
+  hideCaption,
+  thumbnail,
+  videoId,
+  customVideoDescription,
+}) => html`
+  <dds-video-player-container
+    video-id=${videoId}
+    aspect-ratio=${aspectRatio}
+    caption=${caption}
+    video-description="${ifNonNull(customVideoDescription)}"
+    ?hide-caption=${hideCaption}
+    thumbnail=${thumbnail}
+    playing-mode="lightbox">
+  </dds-video-player-container>
+  <dds-lightbox-video-player-container></dds-lightbox-video-player-container>
+`;
+
+withLightboxMediaViewer.story = {
+  name: 'With lightbox media viewer',
+  argTypes: {
+    customVideoDescription: {
+      control: { type: 'text' },
+      name: 'Custom video description',
+      defaultValue: 'This is a custom video description.',
     },
   },
 };
 
 export default {
   title: 'Components/Video player',
+  component: 'dds-video-player-composite',
   decorators: [
     (story) => html`
       <div class="bx--grid">
@@ -177,27 +143,122 @@ export default {
       </div>
     `,
   ],
+  argTypes: {
+    caption: {
+      control: { type: 'text' },
+      name: 'Custom caption (caption):',
+      defaultValue: '',
+    },
+    hideCaption: {
+      control: { type: 'boolean' },
+      name: 'Hide caption (hide-caption):',
+      defaultValue: false,
+    },
+    thumbnail: {
+      control: { type: 'text' },
+      name: 'Custom thumbnail (thumbnail):',
+      defaultValue: '',
+    },
+    videoId: {
+      defaultValue: '1_9h94wo6b',
+      table: {
+        disable: true,
+      },
+    },
+    'auto-play': {
+      table: {
+        disable: true,
+      },
+    },
+    'video-description': {
+      table: {
+        disable: true,
+      },
+    },
+    isPlaying: {
+      table: {
+        disable: true,
+      },
+    },
+    autoPlay: {
+      table: {
+        disable: true,
+      },
+    },
+    embeddedVideos: {
+      table: {
+        disable: true,
+      },
+    },
+    formatCaption: {
+      table: {
+        disable: true,
+      },
+    },
+    formatDuration: {
+      table: {
+        disable: true,
+      },
+    },
+    backgroundMode: {
+      table: {
+        disable: true,
+      },
+    },
+    mediaData: {
+      table: {
+        disable: true,
+      },
+    },
+    aspectRatio: {
+      table: {
+        disable: true,
+      },
+    },
+    playingMode: {
+      table: {
+        disable: true,
+      },
+    },
+    videoThumbnailWidth: {
+      table: {
+        disable: true,
+      },
+    },
+    'hide-caption': {
+      table: {
+        disable: true,
+      },
+    },
+    'background-mode': {
+      table: {
+        disable: true,
+      },
+    },
+    'video-thumbnail-width': {
+      table: {
+        disable: true,
+      },
+    },
+    'playing-mode': {
+      table: {
+        disable: true,
+      },
+    },
+    'video-id': {
+      table: {
+        disable: true,
+      },
+    },
+    'aspect-ratio': {
+      table: {
+        disable: true,
+      },
+    },
+  },
   parameters: {
     ...readme.parameters,
     hasStoryPadding: true,
-    knobs: {
-      VideoPlayer: () => ({
-        caption: text('Custom caption (caption):', ''),
-        hideCaption: boolean('Hide caption (hideCaption):', false),
-        thumbnail: text('Custom thumbnail (thumbnail):', ''),
-        videoId: '1_9h94wo6b',
-      }),
-    },
-    propsSet: {
-      default: {
-        VideoPlayer: {
-          caption: '',
-          hideCaption: false,
-          thumbnail: '',
-          videoId: '1_9h94wo6b',
-        },
-      },
-    },
     percy: {
       skip: true,
     },


### PR DESCRIPTION
### Related Ticket(s)

[video-player]: use controls #9552
[Content-block-mixed]: use controls #9503

### Description

Switch to storybook controls for `video-player` and `content-block-mixed` and its React Wrappers

### Changelog

**Changed**

- change video-player storybook to use controls
- change content-block-mixed storybook to use controls

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
