### PR TITLE
fix(progress-indicator): add missing import for progress indicator skeleton

### DIFF
--- a/packages/carbon-web-components/src/components/progress-indicator/index.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/index.ts
@@ -1,12 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021
+ * Copyright IBM Corp. 2021, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import './progress-indicator';
+import './progress-indicator-skeleton';
 import './progress-step';
 import './progress-step-skeleton';


### PR DESCRIPTION
### Related Ticket(s)

[BX Progress Indicator Skeleton]: Vue: Unknown custom element: <bx-progress-indicator-skeleton> #9825

### Description

For adopter using `import "@carbon/web-components/es/components/progress-indicator/index.js"` and `bx-progress-indicator-skeleton` there is an error. Seems adding the missing import to the `index.js` file should resolve the issue.

### Changelog

**New**

- add import for `progress-indicator-skeleton` in the index.js file

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
