### PR TITLE
fix(styles): update disabled card hover styles

### DIFF
--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2022
+ * Copyright IBM Corp. 2016, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -40,6 +40,14 @@
 
       .#{$prefix}--card__wrapper {
         background-color: $hover-ui;
+      }
+
+      &.#{$prefix}--card__CTA--disabled.#{$prefix}--tile--clickable {
+        background-color: $ui-01;
+
+        > * {
+          background-color: $ui-01;
+        }
       }
 
       ::slotted(#{$dds-prefix}-image),


### PR DESCRIPTION
### Related Ticket(s)

#9815

### Description

Removes hover styles from `disabled` card links.

### Changelog

**New**

- add disabled hover styles to card links

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
