### PR TITLE
chore(cwc): generate cwc internal vendor package

### DIFF
--- a/packages/web-components/.storybook/react/preview.tsx
+++ b/packages/web-components/.storybook/react/preview.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,7 +12,7 @@ import React, { StrictMode } from 'react';
 import coreEvents from '@storybook/core-events';
 import addons from '@storybook/addons';
 import { withKnobs } from '@storybook/addon-knobs';
-import BXSkipToContent from '@carbon/web-components/es/components-react/skip-to-content/skip-to-content';
+import BXSkipToContent from '../../src/internal/vendor/@carbon/web-components/components-react/skip-to-content/skip-to-content';
 import { CURRENT_THEME } from '@carbon/storybook-addon-theme/es/shared';
 import containerStyles from './container.scss'; // eslint-disable-line import/first
 

--- a/packages/web-components/gulp-tasks/config.js
+++ b/packages/web-components/gulp-tasks/config.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -57,6 +57,26 @@ module.exports = {
   sassDestDir: 'scss',
   tasksDir: 'gulp-tasks',
   testsDir: 'tests',
+  carbonWebComponentsCJSSrcDir: path.resolve(
+    __dirname,
+    '../../carbon-web-components/lib'
+  ),
+  carbonWebComponentsESSrcDir: path.resolve(
+    __dirname,
+    '../../carbon-web-components/es'
+  ),
+  carbonWebComponentsVendorSrcDir: path.resolve(
+    __dirname,
+    '../src/internal/vendor/@carbon/web-components'
+  ),
+  carbonWebComponentsVendorESDstDir: path.resolve(
+    __dirname,
+    '../es/internal/vendor/@carbon/web-components'
+  ),
+  carbonWebComponentsVendorCJSDstDir: path.resolve(
+    __dirname,
+    '../lib/internal/vendor/@carbon/web-components'
+  ),
   servicesCJSSrcDir: path.resolve(__dirname, '../../services/lib'),
   servicesESSrcDir: path.resolve(__dirname, '../../services/es'),
   servicesVendorSrcDir: path.resolve(

--- a/packages/web-components/gulp-tasks/vendor.js
+++ b/packages/web-components/gulp-tasks/vendor.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,6 +11,11 @@
 
 const gulp = require('gulp');
 const {
+  carbonWebComponentsCJSSrcDir,
+  carbonWebComponentsESSrcDir,
+  carbonWebComponentsVendorSrcDir,
+  carbonWebComponentsVendorCJSDstDir,
+  carbonWebComponentsVendorESDstDir,
   servicesCJSSrcDir,
   servicesESSrcDir,
   servicesVendorSrcDir,
@@ -27,6 +32,30 @@ const {
   utilitiesVendorCJSDstDir,
   utilitiesVendorESDstDir,
 } = require('./config');
+
+/**
+ * Generates `src/internal/vendor` contents.
+ */
+const carbonWebComponentsVendorSrc = () =>
+  gulp
+    .src([`${carbonWebComponentsESSrcDir}/**/*`, '!**/*-{test,story}.js'])
+    .pipe(gulp.dest(carbonWebComponentsVendorSrcDir));
+
+/**
+ * Generate `es/internal/vendor` contents.
+ */
+const carbonWebComponentsVendorESDst = () =>
+  gulp
+    .src([`${carbonWebComponentsESSrcDir}/**/*`, '!**/*-{test,story}.js'])
+    .pipe(gulp.dest(carbonWebComponentsVendorESDstDir));
+
+/**
+ * Generate `lib/internal/vendor` contents.
+ */
+const carbonWebComponentsVendorCJSDst = () =>
+  gulp
+    .src([`${carbonWebComponentsCJSSrcDir}/**/*`, '!**/*-{test,story}.js'])
+    .pipe(gulp.dest(carbonWebComponentsVendorCJSDstDir));
 
 /**
  * Generates `src/internal/vendor` contents.
@@ -102,6 +131,14 @@ const utilitiesVendorCJSDst = () =>
 
 // Vendor builds
 gulp.task(
+  'vendor:carbon-web-components',
+  gulp.parallel(
+    carbonWebComponentsVendorSrc,
+    carbonWebComponentsVendorCJSDst,
+    carbonWebComponentsVendorESDst
+  )
+);
+gulp.task(
   'vendor:utilities',
   gulp.parallel(utilitiesVendorSrc, utilitiesVendorCJSDst, utilitiesVendorESDst)
 );
@@ -120,6 +157,7 @@ gulp.task(
 gulp.task(
   'vendor',
   gulp.series(
+    gulp.task('vendor:carbon-web-components'),
     gulp.task('vendor:utilities'),
     gulp.task('vendor:services'),
     gulp.task('vendor:services-store')

--- a/packages/web-components/src/component-mixins/cta/cta.ts
+++ b/packages/web-components/src/component-mixins/cta/cta.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,18 +9,18 @@
 
 import { html } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ArrowDown20 from '@carbon/web-components/es/icons/arrow--down/20.js';
-import ArrowRight20 from '@carbon/web-components/es/icons/arrow--right/20.js';
-import Download20 from '@carbon/web-components/es/icons/download/20.js';
-import Launch20 from '@carbon/web-components/es/icons/launch/20.js';
-import PlayOutline20 from '@carbon/web-components/es/icons/play--outline/20.js';
-import Blog20 from '@carbon/web-components/es/icons/blog/20.js';
-import DocumentPDF20 from '@carbon/web-components/es/icons/document--pdf/20.js';
-import NewTab20 from '@carbon/web-components/es/icons/new-tab/20.js';
-import Phone20 from '@carbon/web-components/es/icons/phone/20.js';
-import Calendar20 from '@carbon/web-components/es/icons/calendar/20.js';
-import Email20 from '@carbon/web-components/es/icons/email/20.js';
-import Chat20 from '@carbon/web-components/es/icons/chat/20.js';
+import ArrowDown20 from '../../internal/vendor/@carbon/web-components/icons/arrow--down/20.js';
+import ArrowRight20 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import Download20 from '../../internal/vendor/@carbon/web-components/icons/download/20.js';
+import Launch20 from '../../internal/vendor/@carbon/web-components/icons/launch/20.js';
+import PlayOutline20 from '../../internal/vendor/@carbon/web-components/icons/play--outline/20.js';
+import Blog20 from '../../internal/vendor/@carbon/web-components/icons/blog/20.js';
+import DocumentPDF20 from '../../internal/vendor/@carbon/web-components/icons/document--pdf/20.js';
+import NewTab20 from '../../internal/vendor/@carbon/web-components/icons/new-tab/20.js';
+import Phone20 from '../../internal/vendor/@carbon/web-components/icons/phone/20.js';
+import Calendar20 from '../../internal/vendor/@carbon/web-components/icons/calendar/20.js';
+import Email20 from '../../internal/vendor/@carbon/web-components/icons/email/20.js';
+import Chat20 from '../../internal/vendor/@carbon/web-components/icons/chat/20.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { Constructor } from '../../globals/defs';
 import { CTA_TYPE } from '../../components/cta/defs';

--- a/packages/web-components/src/component-mixins/cta/video.ts
+++ b/packages/web-components/src/component-mixins/cta/video.ts
@@ -1,17 +1,17 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import ArrowDown20 from '@carbon/web-components/es/icons/arrow--down/20.js';
-import ArrowRight20 from '@carbon/web-components/es/icons/arrow--right/20.js';
-import Download20 from '@carbon/web-components/es/icons/download/20.js';
-import Launch20 from '@carbon/web-components/es/icons/launch/20.js';
-import PlayOutline20 from '@carbon/web-components/es/icons/play--outline/20.js';
+import ArrowDown20 from '../../internal/vendor/@carbon/web-components/icons/arrow--down/20.js';
+import ArrowRight20 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import Download20 from '../../internal/vendor/@carbon/web-components/icons/download/20.js';
+import Launch20 from '../../internal/vendor/@carbon/web-components/icons/launch/20.js';
+import PlayOutline20 from '../../internal/vendor/@carbon/web-components/icons/play--outline/20.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { Constructor } from '../../globals/defs';
 import { CTA_TYPE } from '../../components/cta/defs';

--- a/packages/web-components/src/components/back-to-top/__stories__/data/content.ts
+++ b/packages/web-components/src/components/back-to-top/__stories__/data/content.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2022
+ * Copyright IBM Corp. 2016, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,7 +15,7 @@ import '../../../cta-section/index';
 import '../../../link-list/index';
 import '../../../cta/index';
 
-import ArrowRight20 from '@carbon/web-components/es/icons/arrow--right/20';
+import ArrowRight20 from '../../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
 import imgLg1x1 from '../../../../../../storybook-images/assets/960/fpo--1x1--960x960--006.jpg';
 import leadspaceImg from '../../../../../../storybook-images/assets/leadspace/leadspaceMax2.jpg';
 

--- a/packages/web-components/src/components/back-to-top/back-to-top.ts
+++ b/packages/web-components/src/components/back-to-top/back-to-top.ts
@@ -1,18 +1,18 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, property, customElement, LitElement } from 'lit-element';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import throttle from 'lodash-es/throttle.js';
-import UpToTop20 from '@carbon/web-components/es/icons/up-to-top/20.js';
+import UpToTop20 from '../../internal/vendor/@carbon/web-components/icons/up-to-top/20.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './back-to-top.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/background-media/background-media.ts
+++ b/packages/web-components/src/components/background-media/background-media.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,8 +10,8 @@
 import { html, property, customElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import pauseIcon from '@carbon/web-components/es/icons/pause--outline--filled/32.js';
-import playIcon from '@carbon/web-components/es/icons/play--filled/32.js';
+import pauseIcon from '../../internal/vendor/@carbon/web-components/icons/pause--outline--filled/32.js';
+import playIcon from '../../internal/vendor/@carbon/web-components/icons/play--filled/32.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './background-media.scss';
 import { GRADIENT_DIRECTION, MOBILE_POSITION } from './defs';

--- a/packages/web-components/src/components/button-group/button-group.ts
+++ b/packages/web-components/src/components/button-group/button-group.ts
@@ -1,13 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 import { customElement, html, LitElement } from 'lit-element';
-import { BUTTON_KIND } from '@carbon/web-components/es/components/button/defs.js';
+import { BUTTON_KIND } from '../../internal/vendor/@carbon/web-components/components/button/defs.js';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import styles from './button-group.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/button/button.ts
+++ b/packages/web-components/src/components/button/button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,13 +10,13 @@
 import { classMap } from 'lit-html/directives/class-map.js';
 import { html, property, state, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import {
   BUTTON_ICON_LAYOUT,
   BUTTON_KIND,
   BUTTON_SIZE,
-} from '@carbon/web-components/es/components/button/button.js';
+} from '../../internal/vendor/@carbon/web-components/components/button/button.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './button.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/card-in-card/card-in-card.ts
+++ b/packages/web-components/src/components/card-in-card/card-in-card.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import { css, customElement, html } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import PlayVideo from '@carbon/ibmdotcom-styles/icons/svg/play-video.svg';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import DDSCardCTA, { CTA_TYPE } from '../cta/card-cta';

--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,7 +16,7 @@ import {
   query,
 } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import BXLink from '@carbon/web-components/es/components/link/link.js';
+import BXLink from '../../internal/vendor/@carbon/web-components/components/link/link.js';
 import markdownToHtml from '@carbon/ibmdotcom-utilities/es/utilities/markdownToHtml/markdownToHtml.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { BASIC_COLOR_SCHEME } from '../../globals/defs';

--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,12 +18,12 @@ import {
 } from 'lit-element';
 import 'wicg-inert';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import CaretLeft20 from '@carbon/web-components/es/icons/caret--left/20.js';
-import CaretRight20 from '@carbon/web-components/es/icons/caret--right/20.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
-import { selectorTabbable } from '@carbon/web-components/es/globals/settings.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import CaretLeft20 from '../../internal/vendor/@carbon/web-components/icons/caret--left/20.js';
+import CaretRight20 from '../../internal/vendor/@carbon/web-components/icons/caret--right/20.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
+import { selectorTabbable } from '../../internal/vendor/@carbon/web-components/globals/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import sameHeight from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/sameHeight/sameHeight';
 import styles from './carousel.scss';

--- a/packages/web-components/src/components/content-item-horizontal/content-item-horizontal-media.ts
+++ b/packages/web-components/src/components/content-item-horizontal/content-item-horizontal-media.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,8 +16,8 @@ import {
 } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import { baseFontSize, breakpoints } from '@carbon/layout';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import DDSContentItem from '../content-item/content-item';
 import styles from './content-item-horizontal-media.scss';

--- a/packages/web-components/src/components/cta/card-cta.ts
+++ b/packages/web-components/src/components/cta/card-cta.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@
 import { html, property, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import PlayVideo from '@carbon/ibmdotcom-styles/icons/svg/play-video.svg';
 import {
   formatVideoCaption,

--- a/packages/web-components/src/components/cta/cta.ts
+++ b/packages/web-components/src/components/cta/cta.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import { property, customElement, html, LitElement } from 'lit-element';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import styles from './cta.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 

--- a/packages/web-components/src/components/cta/feature-cta.ts
+++ b/packages/web-components/src/components/cta/feature-cta.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@
 import { property, customElement, html } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import PlayVideo from '@carbon/ibmdotcom-styles/icons/svg/play-video.svg';
 import {
   formatVideoCaption,

--- a/packages/web-components/src/components/cta/video-cta-composite.ts
+++ b/packages/web-components/src/components/cta/video-cta-composite.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,9 +9,9 @@
 
 import { html, property, state, customElement, LitElement } from 'lit-element';
 import on from 'carbon-components/es/globals/js/misc/on.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import KalturaPlayerAPI from '../../internal/vendor/@carbon/ibmdotcom-services/services/KalturaPlayer/KalturaPlayer';
 import ModalRenderMixin from '../../globals/mixins/modal-render';

--- a/packages/web-components/src/components/expressive-modal/expressive-modal-body.ts
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal-body.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXModalBody from '@carbon/web-components/es/components/modal/modal-body.js';
+import BXModalBody from '../../internal/vendor/@carbon/web-components/components/modal/modal-body.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './expressive-modal.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/expressive-modal/expressive-modal-close-button.ts
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal-close-button.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { property, customElement } from 'lit-element';
-import BXModalCloseButton from '@carbon/web-components/es/components/modal/modal-close-button.js';
+import BXModalCloseButton from '../../internal/vendor/@carbon/web-components/components/modal/modal-close-button.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { EXPRESSIVE_MODAL_SIZE } from './defs';
 import styles from './expressive-modal.scss';

--- a/packages/web-components/src/components/expressive-modal/expressive-modal-footer.ts
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal-footer.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { property, customElement } from 'lit-element';
-import BXModalFooter from '@carbon/web-components/es/components/modal/modal-footer.js';
+import BXModalFooter from '../../internal/vendor/@carbon/web-components/components/modal/modal-footer.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './expressive-modal.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/expressive-modal/expressive-modal-header.ts
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal-header.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { property, customElement } from 'lit-element';
-import BXModalHeader from '@carbon/web-components/es/components/modal/modal-header.js';
+import BXModalHeader from '../../internal/vendor/@carbon/web-components/components/modal/modal-header.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './expressive-modal.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/expressive-modal/expressive-modal-heading.ts
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal-heading.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXModalHeading from '@carbon/web-components/es/components/modal/modal-heading.js';
+import BXModalHeading from '../../internal/vendor/@carbon/web-components/components/modal/modal-heading.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './expressive-modal.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/expressive-modal/expressive-modal.ts
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,9 +20,9 @@ import {
 } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import on from 'carbon-components/es/globals/js/misc/on.js';
-import { selectorTabbable } from '@carbon/web-components/es/globals/settings.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import { selectorTabbable } from '../../internal/vendor/@carbon/web-components/globals/settings.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import { EXPRESSIVE_MODAL_SIZE, EXPRESSIVE_MODAL_MODE } from './defs';

--- a/packages/web-components/src/components/filter-panel/filter-group-item.ts
+++ b/packages/web-components/src/components/filter-panel/filter-group-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import { customElement, property, query, state } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import BXAccordionItem from '@carbon/web-components/es/components/accordion/accordion-item.js';
+import BXAccordionItem from '../../internal/vendor/@carbon/web-components/components/accordion/accordion-item.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './filter-panel.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/filter-panel/filter-group.ts
+++ b/packages/web-components/src/components/filter-panel/filter-group.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXAccordion from '@carbon/web-components/es/components/accordion/accordion.js';
+import BXAccordion from '../../internal/vendor/@carbon/web-components/components/accordion/accordion.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import './filter-panel-input-select';

--- a/packages/web-components/src/components/filter-panel/filter-modal-button.ts
+++ b/packages/web-components/src/components/filter-panel/filter-modal-button.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXModalFooterButton from '@carbon/web-components/es/components/modal/modal-footer-button.js';
+import BXModalFooterButton from '../../internal/vendor/@carbon/web-components/components/modal/modal-footer-button.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './filter-panel.scss';

--- a/packages/web-components/src/components/filter-panel/filter-modal-footer.ts
+++ b/packages/web-components/src/components/filter-panel/filter-modal-footer.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXModalFooter from '@carbon/web-components/es/components/modal/modal-footer.js';
+import BXModalFooter from '../../internal/vendor/@carbon/web-components/components/modal/modal-footer.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import './filter-panel-input-select';

--- a/packages/web-components/src/components/filter-panel/filter-modal-heading.ts
+++ b/packages/web-components/src/components/filter-panel/filter-modal-heading.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXModalHeading from '@carbon/web-components/es/components/modal/modal-heading.js';
+import BXModalHeading from '../../internal/vendor/@carbon/web-components/components/modal/modal-heading.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './filter-panel.scss';

--- a/packages/web-components/src/components/filter-panel/filter-panel-checkbox.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-checkbox.ts
@@ -1,17 +1,17 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXCheckbox from '@carbon/web-components/es/components/checkbox/checkbox.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import BXCheckbox from '../../internal/vendor/@carbon/web-components/components/checkbox/checkbox';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
-import '@carbon/web-components/es/components/modal/modal.js';
+import '../../internal/vendor/@carbon/web-components/components/modal/modal';
 import styles from './filter-panel.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 

--- a/packages/web-components/src/components/filter-panel/filter-panel-composite.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-composite.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,18 +16,18 @@ import {
   TemplateResult,
 } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import Filter from '@carbon/web-components/es/icons/filter/16.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import Filter from '../../internal/vendor/@carbon/web-components/icons/filter/16.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import { baseFontSize, breakpoints } from '@carbon/layout';
 import './filter-group';
 import './filter-panel';
 import './filter-panel-modal';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './filter-panel.scss';
-import '@carbon/web-components/es/components/checkbox/checkbox.js';
+import '../../internal/vendor/@carbon/web-components/components/checkbox/checkbox.js';
 import DDSFilterGroupItem from './filter-group-item';
 import DDSFilterPanelCheckbox from './filter-panel-checkbox';
 import DDSFilterPanelInputSelect from './filter-panel-input-select';

--- a/packages/web-components/src/components/filter-panel/filter-panel-input-select-item.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-input-select-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import { customElement, html, property, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import Close from '@carbon/web-components/es/icons/close/16.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import Close from '../../internal/vendor/@carbon/web-components/icons/close/16.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './filter-panel.scss';

--- a/packages/web-components/src/components/filter-panel/filter-panel-input-select.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-input-select.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import { customElement, html, property, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import Close from '@carbon/web-components/es/icons/close/16.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import Close from '../../internal/vendor/@carbon/web-components/icons/close/16.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './filter-panel.scss';

--- a/packages/web-components/src/components/filter-panel/filter-panel-modal.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-modal.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,16 +9,16 @@
 
 import { customElement, html, property } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import './filter-group';
 import './filter-modal-button';
 import './filter-modal-heading';
-import BXModal from '@carbon/web-components/es/components/modal/modal.js';
+import BXModal from '../../internal/vendor/@carbon/web-components/components/modal/modal.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import './filter-modal-footer';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './filter-panel.scss';
-import '@carbon/web-components/es/components/checkbox/checkbox.js';
+import '../../internal/vendor/@carbon/web-components/components/checkbox/checkbox.js';
 
 const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;

--- a/packages/web-components/src/components/filter-panel/filter-panel.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import { customElement, html, LitElement, property } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import Reset from '@carbon/web-components/es/icons/reset/16.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import Reset from '../../internal/vendor/@carbon/web-components/icons/reset/16.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './filter-panel.scss';

--- a/packages/web-components/src/components/footer/combo-box.ts
+++ b/packages/web-components/src/components/footer/combo-box.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,8 +10,8 @@
 import settings from 'carbon-components/es/globals/js/settings.js';
 import { TemplateResult } from 'lit-html';
 import { html, property, query, customElement } from 'lit-element';
-import BXComboBoxItem from '@carbon/web-components/es/components/combo-box/combo-box-item.js';
-import Close16 from '@carbon/web-components/es/icons/close/16.js';
+import BXComboBoxItem from '../../internal/vendor/@carbon/web-components/components/combo-box/combo-box-item.js';
+import Close16 from '../../internal/vendor/@carbon/web-components/icons/close/16.js';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import { findIndex, forEach } from '../../globals/internal/collection-helpers';
 import DDSDropdown, { DROPDOWN_KEYBOARD_ACTION } from './dropdown';

--- a/packages/web-components/src/components/footer/defs.ts
+++ b/packages/web-components/src/components/footer/defs.ts
@@ -1,13 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-export { FORM_ELEMENT_COLOR_SCHEME as DROPDOWN_COLOR_SCHEME } from '@carbon/web-components/es/globals/shared-enums.js';
+export { FORM_ELEMENT_COLOR_SCHEME as DROPDOWN_COLOR_SCHEME } from '../../internal/vendor/@carbon/web-components/globals/shared-enums.js';
 
 /**
  * Footer size.

--- a/packages/web-components/src/components/footer/dropdown.ts
+++ b/packages/web-components/src/components/footer/dropdown.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,10 +12,10 @@ import { classMap } from 'lit-html/directives/class-map.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { html, query, customElement, property } from 'lit-element';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import BXDropdown from '@carbon/web-components/es/components/dropdown/dropdown.js';
-import BXDropdownItem from '@carbon/web-components/es/components/dropdown/dropdown-item.js';
-import ChevronDown16 from '@carbon/web-components/es/icons/chevron--down/16.js';
-import WarningFilled16 from '@carbon/web-components/es/icons/warning--filled/16.js';
+import BXDropdown from '../../internal/vendor/@carbon/web-components/components/dropdown/dropdown.js';
+import BXDropdownItem from '../../internal/vendor/@carbon/web-components/components/dropdown/dropdown-item.js';
+import ChevronDown16 from '../../internal/vendor/@carbon/web-components/icons/chevron--down/16.js';
+import WarningFilled16 from '../../internal/vendor/@carbon/web-components/icons/warning--filled/16.js';
 import {
   DROPDOWN_COLOR_SCHEME,
   DROPDOWN_KEYBOARD_ACTION,

--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -1,16 +1,16 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, property, customElement, LitElement } from 'lit-element';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import LocaleAPI from '../../internal/vendor/@carbon/ibmdotcom-services/services/Locale/Locale';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import HybridRenderMixin from '../../globals/mixins/hybrid-render';
@@ -37,8 +37,8 @@ import './legal-nav-item';
 import './legal-nav-cookie-preferences-placeholder';
 import './language-selector-desktop';
 import './language-selector-mobile';
-import '@carbon/web-components/es/components/combo-box/combo-box-item.js';
-import '@carbon/web-components/es/components/select/select-item.js';
+import '../../internal/vendor/@carbon/web-components/components/combo-box/combo-box-item.js';
+import '../../internal/vendor/@carbon/web-components/components/select/select-item.js';
 
 const { stablePrefix: ddsPrefix } = ddsSettings;
 

--- a/packages/web-components/src/components/footer/footer-logo.ts
+++ b/packages/web-components/src/components/footer/footer-logo.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import { html, svg, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import IBM8BarLogoH65White from '@carbon/ibmdotcom-styles/icons/svg/IBM-8bar-logo--h65-white.svg';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/footer/footer-nav-group.ts
+++ b/packages/web-components/src/components/footer/footer-nav-group.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import { html, property, state, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ChevronRight16 from '@carbon/web-components/es/icons/chevron--right/16.js';
+import ChevronRight16 from '../../internal/vendor/@carbon/web-components/icons/chevron--right/16.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import Handle from '../../globals/internal/handle';

--- a/packages/web-components/src/components/footer/footer-nav-item.ts
+++ b/packages/web-components/src/components/footer/footer-nav-item.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, property, customElement } from 'lit-element';
-import BXLink from '@carbon/web-components/es/components/link/link.js';
+import BXLink from '../../internal/vendor/@carbon/web-components/components/link/link.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './footer.scss';

--- a/packages/web-components/src/components/footer/language-selector-desktop.ts
+++ b/packages/web-components/src/components/footer/language-selector-desktop.ts
@@ -1,16 +1,16 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { property, customElement, query, state } from 'lit-element';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
-import BXComboBoxItem from '@carbon/web-components/es/components/combo-box/combo-box-item.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
+import BXComboBoxItem from '../../internal/vendor/@carbon/web-components/components/combo-box/combo-box-item.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { LANGUAGE_SELECTOR_STYLE_SCHEME } from './defs';
 import DDSComboBox, { DROPDOWN_SIZE } from './combo-box';

--- a/packages/web-components/src/components/footer/language-selector-mobile.ts
+++ b/packages/web-components/src/components/footer/language-selector-mobile.ts
@@ -1,15 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { property, customElement } from 'lit-element';
-import BXSelect from '@carbon/web-components/es/components/select/select.js';
-import { INPUT_SIZE } from '@carbon/web-components/es/components/input/input.js';
+import BXSelect from '../../internal/vendor/@carbon/web-components/components/select/select.js';
+import { INPUT_SIZE } from '../../internal/vendor/@carbon/web-components/components/input/input.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './footer.scss';
 

--- a/packages/web-components/src/components/footer/locale-button.ts
+++ b/packages/web-components/src/components/footer/locale-button.ts
@@ -1,16 +1,16 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, property, customElement, LitElement } from 'lit-element';
-import EarthFilled16 from '@carbon/web-components/es/icons/earth--filled/16.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import EarthFilled16 from '../../internal/vendor/@carbon/web-components/icons/earth--filled/16.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { FOOTER_SIZE } from './footer';

--- a/packages/web-components/src/components/image-with-caption/image-with-caption.ts
+++ b/packages/web-components/src/components/image-with-caption/image-with-caption.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,14 +10,14 @@
 import { html, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import on from 'carbon-components/es/globals/js/misc/on.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import '../expressive-modal/expressive-modal';
 import '../expressive-modal/expressive-modal-close-button';
 import '../image/image';
 import '../lightbox-media-viewer/lightbox-image-viewer';
 import '../button/button';
-import ZoomIn20 from '@carbon/web-components/es/icons/zoom--in/20.js';
+import ZoomIn20 from '../../internal/vendor/@carbon/web-components/icons/zoom--in/20.js';
 import deprecate from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/deprecate/deprecate';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './image-with-caption.scss';

--- a/packages/web-components/src/components/image/image.ts
+++ b/packages/web-components/src/components/image/image.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,13 +11,13 @@ import { html, property, customElement, LitElement, state } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import on from 'carbon-components/es/globals/js/misc/on.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import '../expressive-modal/expressive-modal';
 import '../expressive-modal/expressive-modal-close-button';
 import '../lightbox-media-viewer/lightbox-image-viewer';
 import '../button/button';
-import ZoomIn20 from '@carbon/web-components/es/icons/zoom--in/20.js';
+import ZoomIn20 from '../../internal/vendor/@carbon/web-components/icons/zoom--in/20.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './image.scss';
 import ModalRenderMixin from '../../globals/mixins/modal-render';

--- a/packages/web-components/src/components/leadspace/breadcrumb-item.ts
+++ b/packages/web-components/src/components/leadspace/breadcrumb-item.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXBreadcrumbItem from '@carbon/web-components/es/components/breadcrumb/breadcrumb-item.js';
+import BXBreadcrumbItem from '../../internal/vendor/@carbon/web-components/components/breadcrumb/breadcrumb-item.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './leadspace.scss';

--- a/packages/web-components/src/components/leadspace/breadcrumb-link.ts
+++ b/packages/web-components/src/components/leadspace/breadcrumb-link.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXBreadcrumbLink from '@carbon/web-components/es/components/breadcrumb/breadcrumb-link.js';
+import BXBreadcrumbLink from '../../internal/vendor/@carbon/web-components/components/breadcrumb/breadcrumb-link.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './leadspace.scss';

--- a/packages/web-components/src/components/leadspace/breadcrumb.ts
+++ b/packages/web-components/src/components/leadspace/breadcrumb.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXBreadcrumb from '@carbon/web-components/es/components/breadcrumb/breadcrumb.js';
+import BXBreadcrumb from '../../internal/vendor/@carbon/web-components/components/breadcrumb/breadcrumb.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './leadspace.scss';

--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm-composite.ts
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm-composite.ts
@@ -1,16 +1,16 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, property, customElement, LitElement } from 'lit-element';
-import BXModal from '@carbon/web-components/es/components/modal/modal.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
+import BXModal from '../../internal/vendor/@carbon/web-components/components/modal/modal.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import {
   LeavingIBMLabels,
@@ -21,10 +21,10 @@ import './leaving-ibm-modal-body';
 import './leaving-ibm-modal-heading';
 import './leaving-ibm-modal-supplemental';
 import ModalRenderMixin from '../../globals/mixins/modal-render';
-import '@carbon/web-components/es/components/modal/modal-header.js';
-import '@carbon/web-components/es/components/modal/modal-close-button.js';
-import '@carbon/web-components/es/components/modal/modal-footer.js';
-import '@carbon/web-components/es/components/button/button.js';
+import '../../internal/vendor/@carbon/web-components/components/modal/modal-header.js';
+import '../../internal/vendor/@carbon/web-components/components/modal/modal-close-button.js';
+import '../../internal/vendor/@carbon/web-components/components/modal/modal-footer.js';
+import '../../internal/vendor/@carbon/web-components/components/button/button.js';
 import styles from './leaving-ibm.scss';
 
 const { stablePrefix: ddsPrefix } = ddsSettings;

--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm-modal-body.ts
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm-modal-body.ts
@@ -1,17 +1,17 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement, html, property } from 'lit-element';
-import BXModalBody from '@carbon/web-components/es/components/modal/modal-body.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import BXModalBody from '../../internal/vendor/@carbon/web-components/components/modal/modal-body.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
-import '@carbon/web-components/es/components/link/link.js';
+import '../../internal/vendor/@carbon/web-components/components/link/link.js';
 import styles from './leaving-ibm.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 

--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm-modal-heading.ts
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm-modal-heading.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXModalHeading from '@carbon/web-components/es/components/modal/modal-heading.js';
+import BXModalHeading from '../../internal/vendor/@carbon/web-components/components/modal/modal-heading.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './leaving-ibm.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm-modal.ts
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm-modal.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,8 +10,8 @@
 import { property, customElement } from 'lit-element';
 import BXModal, {
   MODAL_SIZE,
-} from '@carbon/web-components/es/components/modal/modal.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
+} from '../../internal/vendor/@carbon/web-components/components/modal/modal.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './leaving-ibm.scss';

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-image-viewer.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-image-viewer.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import { html, property, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import DDSLightboxMediaViewerBody from './lightbox-media-viewer-body';
 import '../expressive-modal/expressive-modal';

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer-body.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer-body.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import { html, LitElement, TemplateResult } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './lightbox-media-viewer.scss';
 

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import { html, property, customElement } from 'lit-element';
 import on from 'carbon-components/es/globals/js/misc/on.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { MediaData } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/kalturaPlayerAPI.d';
 import ModalRenderMixin from '../../globals/mixins/modal-render';

--- a/packages/web-components/src/components/link-with-icon/link-with-icon.ts
+++ b/packages/web-components/src/components/link-with-icon/link-with-icon.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@
 import { html, customElement, TemplateResult, property } from 'lit-element';
 import BXLink, {
   LINK_SIZE,
-} from '@carbon/web-components/es/components/link/link.js';
+} from '../../internal/vendor/@carbon/web-components/components/link/link.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { ICON_PLACEMENT } from '../../globals/defs';

--- a/packages/web-components/src/components/locale-modal/locale-item.ts
+++ b/packages/web-components/src/components/locale-modal/locale-item.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, property, customElement } from 'lit-element';
-import BXLink from '@carbon/web-components/es/components/link/link.js';
+import BXLink from '../../internal/vendor/@carbon/web-components/components/link/link.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './locale-modal.scss';

--- a/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, property, customElement, LitElement } from 'lit-element';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import LocaleAPI from '@carbon/ibmdotcom-services/es/services/Locale/Locale.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import altlangs from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/altlangs/altlangs.js';

--- a/packages/web-components/src/components/locale-modal/locale-modal.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,11 +9,11 @@
 
 import { html, property, state, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ArrowLeft20 from '@carbon/web-components/es/icons/arrow--left/20.js';
-import EarthFilled16 from '@carbon/web-components/es/icons/earth--filled/16.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import { selectorTabbable } from '@carbon/web-components/es/globals/settings.js';
+import ArrowLeft20 from '../../internal/vendor/@carbon/web-components/icons/arrow--left/20.js';
+import EarthFilled16 from '../../internal/vendor/@carbon/web-components/icons/earth--filled/16.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import { selectorTabbable } from '../../internal/vendor/@carbon/web-components/globals/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import DDSExpressiveModal from '../expressive-modal/expressive-modal';
 import '../expressive-modal/expressive-modal-header';

--- a/packages/web-components/src/components/locale-modal/locale-search.ts
+++ b/packages/web-components/src/components/locale-modal/locale-search.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,7 +16,7 @@ import {
   LitElement,
 } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import { INPUT_SIZE } from '@carbon/web-components/es/components/input/input.js';
+import { INPUT_SIZE } from '../../internal/vendor/@carbon/web-components/components/input/input.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import ThrottedInputMixin from '../../globals/mixins/throttled-input';
 import { forEach } from '../../globals/internal/collection-helpers';

--- a/packages/web-components/src/components/locale-modal/region-item.ts
+++ b/packages/web-components/src/components/locale-modal/region-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,9 +9,9 @@
 
 import { html, property, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ArrowRight20 from '@carbon/web-components/es/icons/arrow--right/20.js';
-import BXLink from '@carbon/web-components/es/components/link/link.js';
-import Error20 from '@carbon/web-components/es/icons/error/20.js';
+import ArrowRight20 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import BXLink from '../../internal/vendor/@carbon/web-components/components/link/link.js';
+import Error20 from '../../internal/vendor/@carbon/web-components/icons/error/20.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './locale-modal.scss';
 

--- a/packages/web-components/src/components/locale-modal/regions.ts
+++ b/packages/web-components/src/components/locale-modal/regions.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@
 import { html, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
-import '@carbon/web-components/es/components/search/search.js';
+import '../../internal/vendor/@carbon/web-components/components/search/search.js';
 import styles from './locale-modal.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 

--- a/packages/web-components/src/components/markdown/markdown.ts
+++ b/packages/web-components/src/components/markdown/markdown.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,10 +11,10 @@ import { render } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { html, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import '@carbon/web-components/es/components/link/link.js';
-import '@carbon/web-components/es/components/list/ordered-list.js';
-import '@carbon/web-components/es/components/list/unordered-list.js';
-import '@carbon/web-components/es/components/list/list-item.js';
+import '../../internal/vendor/@carbon/web-components/components/link/link.js';
+import '../../internal/vendor/@carbon/web-components/components/list/ordered-list.js';
+import '../../internal/vendor/@carbon/web-components/components/list/unordered-list.js';
+import '../../internal/vendor/@carbon/web-components/components/list/list-item.js';
 import markdownToHtml from '@carbon/ibmdotcom-utilities/es/utilities/markdownToHtml/markdownToHtml.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './markdown.scss';

--- a/packages/web-components/src/components/masthead/cloud/cloud-left-nav-item.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-left-nav-item.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXSideNavLink from '@carbon/web-components/es/components/ui-shell/side-nav-link.js';
+import BXSideNavLink from '../../../internal/vendor/@carbon/web-components/components/ui-shell/side-nav-link.js';
 import ddsSettings from '../../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './cloud-masthead.scss';
 

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-composite.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement, html, property } from 'lit-element';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import ddsSettings from '../../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { globalInit } from '../../../internal/vendor/@carbon/ibmdotcom-services/services/global/global';
 import './cloud-button-cta';

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead-profile.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead-profile.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { html, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import User20 from '@carbon/web-components/es/icons/user/20.js';
+import User20 from '../../../internal/vendor/@carbon/web-components/icons/user/20.js';
 import ddsSettings from '../../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './cloud-masthead.scss';
 import DDSMastheadProfile from '../masthead-profile';

--- a/packages/web-components/src/components/masthead/cloud/cloud-megamenu-category-heading.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-megamenu-category-heading.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, customElement, LitElement, property } from 'lit-element';
-import ArrowRight32 from '@carbon/web-components/es/icons/arrow--right/32.js';
+import ArrowRight32 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/32.js';
 import ddsSettings from '../../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './cloud-masthead.scss';
 

--- a/packages/web-components/src/components/masthead/cloud/cloud-megamenu-category-link.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-megamenu-category-link.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, property, customElement } from 'lit-element';
-import BXLink from '@carbon/web-components/es/components/link/link.js';
+import BXLink from '../../../internal/vendor/@carbon/web-components/components/link/link.js';
 import ddsSettings from '../../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './cloud-masthead.scss';
 

--- a/packages/web-components/src/components/masthead/cloud/cloud-megamenu-tab.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-megamenu-tab.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import { customElement, html } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import BXTab from '@carbon/web-components/es/components/tabs/tab.js';
+import BXTab from '../../../internal/vendor/@carbon/web-components/components/tabs/tab.js';
 import ddsSettings from '../../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './cloud-masthead.scss';
 

--- a/packages/web-components/src/components/masthead/cloud/cloud-megamenu-tabs.ts
+++ b/packages/web-components/src/components/masthead/cloud/cloud-megamenu-tabs.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXTabs from '@carbon/web-components/es/components/tabs/tabs.js';
+import BXTabs from '../../../internal/vendor/@carbon/web-components/components/tabs/tabs.js';
 import ddsSettings from '../../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './cloud-masthead.scss';
 

--- a/packages/web-components/src/components/masthead/left-nav-item.ts
+++ b/packages/web-components/src/components/masthead/left-nav-item.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXSideNavLink from '@carbon/web-components/es/components/ui-shell/side-nav-link.js';
+import BXSideNavLink from '../../internal/vendor/@carbon/web-components/components/ui-shell/side-nav-link.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 

--- a/packages/web-components/src/components/masthead/left-nav-menu-item.ts
+++ b/packages/web-components/src/components/masthead/left-nav-menu-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@
 import { classMap } from 'lit-html/directives/class-map.js';
 import { html, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import BXSideNavMenuItem from '@carbon/web-components/es/components/ui-shell/side-nav-menu-item.js';
+import BXSideNavMenuItem from '../../internal/vendor/@carbon/web-components/components/ui-shell/side-nav-menu-item.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 

--- a/packages/web-components/src/components/masthead/left-nav-menu-section.ts
+++ b/packages/web-components/src/components/masthead/left-nav-menu-section.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,12 +9,12 @@
 
 import { html, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
-import ChevronLeft20 from '@carbon/web-components/es/icons/chevron--left/20.js';
-import ArrowRight20 from '@carbon/web-components/es/icons/arrow--right/20.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
-import { selectorTabbable } from '@carbon/web-components/es/globals/settings.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
+import ChevronLeft20 from '../../internal/vendor/@carbon/web-components/icons/chevron--left/20.js';
+import ArrowRight20 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
+import { selectorTabbable } from '../../internal/vendor/@carbon/web-components/globals/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { forEach } from '../../globals/internal/collection-helpers';
 import styles from './masthead.scss';

--- a/packages/web-components/src/components/masthead/left-nav-menu.ts
+++ b/packages/web-components/src/components/masthead/left-nav-menu.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,8 +10,8 @@
 import { classMap } from 'lit-html/directives/class-map.js';
 import { html, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ChevronDown20 from '@carbon/web-components/es/icons/chevron--down/20.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import ChevronDown20 from '../../internal/vendor/@carbon/web-components/icons/chevron--down/20.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 

--- a/packages/web-components/src/components/masthead/left-nav-name.ts
+++ b/packages/web-components/src/components/masthead/left-nav-name.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import { html, property, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import BXHeaderName from '@carbon/web-components/es/components/ui-shell/header-name.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import BXHeaderName from '../../internal/vendor/@carbon/web-components/components/ui-shell/header-name.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 import DDSLeftNav from './left-nav';

--- a/packages/web-components/src/components/masthead/left-nav.ts
+++ b/packages/web-components/src/components/masthead/left-nav.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,11 +10,11 @@
 import findLast from 'lodash-es/findLast.js';
 import { html, query, property, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import { selectorTabbable } from '@carbon/web-components/es/globals/settings.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
+import { selectorTabbable } from '../../internal/vendor/@carbon/web-components/globals/settings.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import BXSideNav, {
   SIDE_NAV_USAGE_MODE,
-} from '@carbon/web-components/es/components/ui-shell/side-nav.js';
+} from '../../internal/vendor/@carbon/web-components/components/ui-shell/side-nav.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import focuswrap from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/focuswrap/focuswrap';
 import { find, forEach } from '../../globals/internal/collection-helpers';

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import { html, property, customElement, LitElement } from 'lit-element';
 import { nothing } from 'lit-html';
-import ArrowRight16 from '@carbon/web-components/es/icons/arrow--right/16.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ArrowRight16 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/16.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
 import root from 'window-or-global';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';

--- a/packages/web-components/src/components/masthead/masthead-global-bar.ts
+++ b/packages/web-components/src/components/masthead/masthead-global-bar.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,9 +9,9 @@
 
 import { classMap } from 'lit-html/directives/class-map.js';
 import { html, property, customElement, LitElement } from 'lit-element';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/masthead/masthead-logo.ts
+++ b/packages/web-components/src/components/masthead/masthead-logo.ts
@@ -1,18 +1,18 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, state, property, customElement } from 'lit-element';
-import BXLink from '@carbon/web-components/es/components/link/link.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import BXLink from '../../internal/vendor/@carbon/web-components/components/link/link.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import IBM8BarLogoH23 from '@carbon/ibmdotcom-styles/icons/svg/IBM-8bar-logo--h23.svg';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';

--- a/packages/web-components/src/components/masthead/masthead-menu-button.ts
+++ b/packages/web-components/src/components/masthead/masthead-menu-button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,10 @@
 
 import { classMap } from 'lit-html/directives/class-map.js';
 import { html, state, property, query, customElement } from 'lit-element';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import BXHeaderMenuButton from '@carbon/web-components/es/components/ui-shell/header-menu-button.js';
+import BXHeaderMenuButton from '../../internal/vendor/@carbon/web-components/components/ui-shell/header-menu-button.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import focuswrap from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/focuswrap/focuswrap';
 import Handle from '../../globals/internal/handle';

--- a/packages/web-components/src/components/masthead/masthead-profile-item.ts
+++ b/packages/web-components/src/components/masthead/masthead-profile-item.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXHeaderMenuItem from '@carbon/web-components/es/components/ui-shell/header-menu-item.js';
+import BXHeaderMenuItem from '../../internal/vendor/@carbon/web-components/components/ui-shell/header-menu-item.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 

--- a/packages/web-components/src/components/masthead/masthead-profile.ts
+++ b/packages/web-components/src/components/masthead/masthead-profile.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,11 +10,11 @@
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { html, property, query, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import User20 from '@carbon/web-components/es/icons/user/20.js';
-import UserOnline20 from '@carbon/web-components/es/icons/user--online/20.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
+import User20 from '../../internal/vendor/@carbon/web-components/icons/user/20.js';
+import UserOnline20 from '../../internal/vendor/@carbon/web-components/icons/user--online/20.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/masthead/megamenu-category-group.ts
+++ b/packages/web-components/src/components/masthead/megamenu-category-group.ts
@@ -1,15 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, customElement, LitElement, property } from 'lit-element';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import ArrowRight16 from '@carbon/web-components/es/icons/arrow--right/16.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import ArrowRight16 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/16.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';

--- a/packages/web-components/src/components/masthead/megamenu-category-link.ts
+++ b/packages/web-components/src/components/masthead/megamenu-category-link.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, property, customElement } from 'lit-element';
-import BXLink from '@carbon/web-components/es/components/link/link.js';
+import BXLink from '../../internal/vendor/@carbon/web-components/components/link/link.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 

--- a/packages/web-components/src/components/masthead/megamenu-link-with-icon.ts
+++ b/packages/web-components/src/components/masthead/megamenu-link-with-icon.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { css, customElement, property } from 'lit-element';
-import BXLink from '@carbon/web-components/es/components/link/link.js';
+import BXLink from '../../internal/vendor/@carbon/web-components/components/link/link.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { MEGAMENU_LINK_WITH_ICON_STYLE_SCHEME } from './defs';
 import styles from './masthead.scss';

--- a/packages/web-components/src/components/masthead/megamenu-right-navigation.ts
+++ b/packages/web-components/src/components/masthead/megamenu-right-navigation.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import { html, property, customElement, LitElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
-import ArrowRight16 from '@carbon/web-components/es/icons/arrow--right/16.js';
+import ArrowRight16 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/16.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { MEGAMENU_RIGHT_NAVIGATION_STYLE_SCHEME } from './defs';

--- a/packages/web-components/src/components/masthead/skip-to-content.ts
+++ b/packages/web-components/src/components/masthead/skip-to-content.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement, property } from 'lit-element';
-import BXSkipToContent from '@carbon/web-components/es/components/skip-to-content/skip-to-content.js';
+import BXSkipToContent from '../../internal/vendor/@carbon/web-components/components/skip-to-content/skip-to-content.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 

--- a/packages/web-components/src/components/masthead/top-nav-item.ts
+++ b/packages/web-components/src/components/masthead/top-nav-item.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { property, query, customElement } from 'lit-element';
-import BXHeaderNavItem from '@carbon/web-components/es/components/ui-shell/header-nav-item.js';
+import BXHeaderNavItem from '../../internal/vendor/@carbon/web-components/components/ui-shell/header-nav-item.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 

--- a/packages/web-components/src/components/masthead/top-nav-menu-item.ts
+++ b/packages/web-components/src/components/masthead/top-nav-menu-item.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXHeaderMenuItem from '@carbon/web-components/es/components/ui-shell/header-menu-item.js';
+import BXHeaderMenuItem from '../../internal/vendor/@carbon/web-components/components/ui-shell/header-menu-item.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 

--- a/packages/web-components/src/components/masthead/top-nav-menu.ts
+++ b/packages/web-components/src/components/masthead/top-nav-menu.ts
@@ -1,14 +1,14 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { property, query, customElement } from 'lit-element';
-import BXHeaderMenu from '@carbon/web-components/es/components/ui-shell/header-menu.js';
+import BXHeaderMenu from '../../internal/vendor/@carbon/web-components/components/ui-shell/header-menu.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 

--- a/packages/web-components/src/components/masthead/top-nav-name.ts
+++ b/packages/web-components/src/components/masthead/top-nav-name.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import { html, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import DDSMastheadTopNav from './top-nav';
 import DDSLeftNavName from './left-nav-name';

--- a/packages/web-components/src/components/masthead/top-nav.ts
+++ b/packages/web-components/src/components/masthead/top-nav.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,12 +10,12 @@
 import { classMap } from 'lit-html/directives/class-map.js';
 import { html, property, state, query, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import CaretLeft20 from '@carbon/web-components/es/icons/caret--left/20.js';
-import CaretRight20 from '@carbon/web-components/es/icons/caret--right/20.js';
-import BXHeaderNav from '@carbon/web-components/es/components/ui-shell/header-nav.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import CaretLeft20 from '../../internal/vendor/@carbon/web-components/icons/caret--left/20.js';
+import CaretRight20 from '../../internal/vendor/@carbon/web-components/icons/caret--right/20.js';
+import BXHeaderNav from '../../internal/vendor/@carbon/web-components/components/ui-shell/header-nav.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './masthead.scss';

--- a/packages/web-components/src/components/pricing-table/pricing-table-annotation-toggle.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-annotation-toggle.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import { customElement, html, LitElement, property } from 'lit-element';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import ChevronDown16 from '@carbon/web-components/es/icons/chevron--down/16.js';
-import Close16 from '@carbon/web-components/es/icons/close/16.js';
+import ChevronDown16 from '../../internal/vendor/@carbon/web-components/icons/chevron--down/16.js';
+import Close16 from '../../internal/vendor/@carbon/web-components/icons/close/16.js';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './pricing-table.scss';
 import DDSPricingTableRow from './pricing-table-row';

--- a/packages/web-components/src/components/pricing-table/pricing-table-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-cell.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,8 +10,8 @@
 import { customElement, html } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import DDSStructuredListCell from '../structured-list/structured-list-cell';
 import DDSPricingTableGroup from './pricing-table-group';

--- a/packages/web-components/src/components/pricing-table/pricing-table.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import { customElement, property, query, html } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import { slow01 } from '@carbon/motion/es/index';
 import StickyHeader from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/StickyHeader/StickyHeader';

--- a/packages/web-components/src/components/search-with-typeahead/scoped-search-dropdown-mobile.ts
+++ b/packages/web-components/src/components/search-with-typeahead/scoped-search-dropdown-mobile.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,12 +9,12 @@
 
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import Filter20 from '@carbon/web-components/es/icons/filter/20.js';
+import Filter20 from '../../internal/vendor/@carbon/web-components/icons/filter/20.js';
 import { property, customElement, html } from 'lit-element';
-import BXSelect from '@carbon/web-components/es/components/select/select.js';
-import { INPUT_SIZE } from '@carbon/web-components/es/components/input/input.js';
+import BXSelect from '../../internal/vendor/@carbon/web-components/components/select/select.js';
+import { INPUT_SIZE } from '../../internal/vendor/@carbon/web-components/components/input/input.js';
 import { classMap } from 'lit-html/directives/class-map.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { filter } from '../../globals/internal/collection-helpers';
 import styles from './search-with-typeahead.scss';

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -1,24 +1,24 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { html, property, query, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import Close20 from '@carbon/web-components/es/icons/close/20.js';
-import Search20 from '@carbon/web-components/es/icons/search/20.js';
+import Close20 from '../../internal/vendor/@carbon/web-components/icons/close/20.js';
+import Search20 from '../../internal/vendor/@carbon/web-components/icons/search/20.js';
 import BXDropdown, {
   DROPDOWN_KEYBOARD_ACTION,
-} from '@carbon/web-components/es/components/dropdown/dropdown.js';
-import BXDropdownItem from '@carbon/web-components/es/components/dropdown/dropdown-item.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+} from '../../internal/vendor/@carbon/web-components/components/dropdown/dropdown.js';
+import BXDropdownItem from '../../internal/vendor/@carbon/web-components/components/dropdown/dropdown-item.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import { baseFontSize, breakpoints } from '@carbon/layout';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import SearchTypeaheadAPI from '../../internal/vendor/@carbon/ibmdotcom-services/services/SearchTypeahead/SearchTypeahead';

--- a/packages/web-components/src/components/search/search.ts
+++ b/packages/web-components/src/components/search/search.ts
@@ -1,18 +1,18 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { customElement } from 'lit-element';
-import BXSearch from '@carbon/web-components/es/components/search/search.js';
+import BXSearch from '../../internal/vendor/@carbon/web-components/components/search/search.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './search.scss';
 
-export { SEARCH_COLOR_SCHEME } from '@carbon/web-components/es/components/search/search.js';
+export { SEARCH_COLOR_SCHEME } from '../../internal/vendor/@carbon/web-components/components/search/search.js';
 
 const { stablePrefix: ddsPrefix } = ddsSettings;
 

--- a/packages/web-components/src/components/structured-list/index.ts
+++ b/packages/web-components/src/components/structured-list/index.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,5 +15,5 @@ import './structured-list-body';
 import './structured-list-group';
 import './structured-list-row';
 import './structured-list-cell';
-import '@carbon/web-components/es/components/tooltip/index.js';
-import '@carbon/web-components/es/components/tag/index.js';
+import '../../internal/vendor/@carbon/web-components/components/tooltip/index.js';
+import '../../internal/vendor/@carbon/web-components/components/tag/index.js';

--- a/packages/web-components/src/components/structured-list/structured-list-body.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-body.ts
@@ -1,13 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import BXStructuredListBody from '@carbon/web-components/es/components/structured-list/structured-list-body.js';
+import BXStructuredListBody from '../../internal/vendor/@carbon/web-components/components/structured-list/structured-list-body.js';
 import { customElement } from 'lit-element';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './structured-list.scss';

--- a/packages/web-components/src/components/structured-list/structured-list-cell.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-cell.ts
@@ -1,17 +1,17 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import BXStructuredListCell from '@carbon/web-components/es/components/structured-list/structured-list-cell.js';
+import BXStructuredListCell from '../../internal/vendor/@carbon/web-components/components/structured-list/structured-list-cell.js';
 import { customElement, property, html } from 'lit-element';
-import Info16 from '@carbon/web-components/es/icons/information/16.js';
-import Checkmark20 from '@carbon/web-components/es/icons/checkmark/20.js';
-import Error20 from '@carbon/web-components/es/icons/error/20.js';
+import Info16 from '../../internal/vendor/@carbon/web-components/icons/information/16.js';
+import Checkmark20 from '../../internal/vendor/@carbon/web-components/icons/checkmark/20.js';
+import Error20 from '../../internal/vendor/@carbon/web-components/icons/error/20.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import DDSStructuredListGroup from './structured-list-group';
 import styles from './structured-list.scss';

--- a/packages/web-components/src/components/structured-list/structured-list-head.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-head.ts
@@ -1,13 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import BXStructuredListHead from '@carbon/web-components/es/components/structured-list/structured-list-head.js';
+import BXStructuredListHead from '../../internal/vendor/@carbon/web-components/components/structured-list/structured-list-head.js';
 import { customElement } from 'lit-element';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './structured-list.scss';

--- a/packages/web-components/src/components/structured-list/structured-list-header-cell.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-header-cell.ts
@@ -1,13 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import BXStructuredListHeaderCell from '@carbon/web-components/es/components/structured-list/structured-list-header-cell.js';
+import BXStructuredListHeaderCell from '../../internal/vendor/@carbon/web-components/components/structured-list/structured-list-header-cell.js';
 import { customElement } from 'lit-element';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './structured-list.scss';

--- a/packages/web-components/src/components/structured-list/structured-list-header-row.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-header-row.ts
@@ -1,13 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import BXStructuredListHeaderRow from '@carbon/web-components/es/components/structured-list/structured-list-header-row.js';
+import BXStructuredListHeaderRow from '../../internal/vendor/@carbon/web-components/components/structured-list/structured-list-header-row.js';
 import { customElement } from 'lit-element';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './structured-list.scss';

--- a/packages/web-components/src/components/structured-list/structured-list-row.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-row.ts
@@ -1,13 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import BXStructuredListRow from '@carbon/web-components/es/components/structured-list/structured-list-row.js';
+import BXStructuredListRow from '../../internal/vendor/@carbon/web-components/components/structured-list/structured-list-row.js';
 import { customElement } from 'lit-element';
 import { html } from 'lit-html';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';

--- a/packages/web-components/src/components/table-of-contents/table-of-contents.ts
+++ b/packages/web-components/src/components/table-of-contents/table-of-contents.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,13 +19,13 @@ import {
   customElement,
   LitElement,
 } from 'lit-element';
-import CaretLeft20 from '@carbon/web-components/es/icons/caret--left/20.js';
-import CaretRight20 from '@carbon/web-components/es/icons/caret--right/20.js';
+import CaretLeft20 from '../../internal/vendor/@carbon/web-components/icons/caret--left/20.js';
+import CaretRight20 from '../../internal/vendor/@carbon/web-components/icons/caret--right/20.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import { baseFontSize, breakpoints } from '@carbon/layout';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
-import TableOfContents20 from '@carbon/web-components/es/icons/table-of-contents/20.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
+import TableOfContents20 from '../../internal/vendor/@carbon/web-components/icons/table-of-contents/20.js';
 import throttle from 'lodash-es/throttle.js';
 import StickyHeader from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/StickyHeader/StickyHeader';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,7 +18,7 @@ import {
 } from 'lit-element';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { classMap } from 'lit-html/directives/class-map.js';
-import ChevronRight20 from '@carbon/web-components/es/icons/chevron--right/20.js';
+import ChevronRight20 from '../../internal/vendor/@carbon/web-components/icons/chevron--right/20.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import DDSTab from './tab';

--- a/packages/web-components/src/components/tag-link/tag-link.ts
+++ b/packages/web-components/src/components/tag-link/tag-link.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import { html, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './tag-link.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/video-player/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player/video-player-composite.ts
@@ -1,16 +1,16 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, property, customElement, LitElement } from 'lit-element';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
-import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
+import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import KalturaPlayerAPI from '../../internal/vendor/@carbon/ibmdotcom-services/services/KalturaPlayer/KalturaPlayer';
 import HybridRenderMixin from '../../globals/mixins/hybrid-render';

--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,8 +10,8 @@
 import { html, property, customElement, LitElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
-import ifNonNull from '@carbon/web-components/es/globals/directives/if-non-null.js';
-import FocusMixin from '@carbon/web-components/es/globals/mixins/focus.js';
+import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import PlayVideo from '@carbon/ibmdotcom-styles/icons/svg/play-video.svg';
 import {
   formatVideoCaption,


### PR DESCRIPTION
### Related Ticket(s)

[carbon-web-components]: updating build scripts to use internal vendor packages #9763

### Description

This PR adds the the gulp tasks to build cwc to the internal vendor folder and changes the paths in web-components to reference the internal files instead.

### Changelog

**New**

- add to the gulp tasks in `web-components` to build out the `carbon-web-components` internal vendor package

**Changed**

- change paths to reference the internal `carbon-web-components` vendor files instead

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
