### PR TITLE
fix(masthead): update logo url protocol

### DIFF
--- a/packages/carbon-web-components/src/components/dropdown/dropdown.ts
+++ b/packages/carbon-web-components/src/components/dropdown/dropdown.ts
@@ -122,7 +122,7 @@ class BXDropdown extends ValidityMixin(
         this.querySelectorAll(
           (this.constructor as typeof BXDropdown).selectorItemSelected
         ),
-        item => {
+        (item) => {
           (item as BXDropdownItem).selected = false;
         }
       );
@@ -312,7 +312,7 @@ class BXDropdown extends ValidityMixin(
             this.querySelectorAll(
               (this.constructor as typeof BXDropdown).selectorItemHighlighted
             ),
-            item => {
+            (item) => {
               (item as BXDropdownItem).highlighted = false;
             }
           );
@@ -331,7 +331,7 @@ class BXDropdown extends ValidityMixin(
       this.querySelectorAll(
         (this.constructor as typeof BXDropdown).selectorItem
       ),
-      item => {
+      (item) => {
         (item as BXDropdownItem).highlighted = false;
       }
     );
@@ -537,20 +537,20 @@ class BXDropdown extends ValidityMixin(
   shouldUpdate(changedProperties) {
     const { selectorItem } = this.constructor as typeof BXDropdown;
     if (changedProperties.has('size')) {
-      forEach(this.querySelectorAll(selectorItem), elem => {
+      forEach(this.querySelectorAll(selectorItem), (elem) => {
         (elem as BXDropdownItem).size = this.size;
       });
     }
     if (changedProperties.has('value')) {
       // `<bx-multi-select>` updates selection beforehand
       // because our rendering logic for `<bx-multi-select>` looks for selected items via `qSA()`
-      forEach(this.querySelectorAll(selectorItem), elem => {
+      forEach(this.querySelectorAll(selectorItem), (elem) => {
         (elem as BXDropdownItem).selected =
           (elem as BXDropdownItem).value === this.value;
       });
       const item = find(
         this.querySelectorAll(selectorItem),
-        elem => (elem as BXDropdownItem).value === this.value
+        (elem) => (elem as BXDropdownItem).value === this.value
       );
       if (item) {
         const range = this.ownerDocument!.createRange();
@@ -570,7 +570,7 @@ class BXDropdown extends ValidityMixin(
     if (changedProperties.has('disabled')) {
       const { disabled } = this;
       // Propagate `disabled` attribute to descendants until `:host-context()` gets supported in all major browsers
-      forEach(this.querySelectorAll(selectorItem), elem => {
+      forEach(this.querySelectorAll(selectorItem), (elem) => {
         (elem as BXDropdownItem).disabled = disabled;
       });
     }
@@ -651,8 +651,7 @@ class BXDropdown extends ValidityMixin(
           <div
             part="helper-text"
             class="${helperClasses}"
-            ?hidden="${inline || !hasHelperText}"
-          >
+            ?hidden="${inline || !hasHelperText}">
             <slot name="helper-text" @slotchange="${handleSlotchangeHelperText}"
               >${helperText}</slot
             >
@@ -677,8 +676,7 @@ class BXDropdown extends ValidityMixin(
             part="menu-body"
             class="${prefix}--list-box__menu"
             role="listbox"
-            tabindex="-1"
-          >
+            tabindex="-1">
             <slot></slot>
           </div>
         `;
@@ -686,8 +684,7 @@ class BXDropdown extends ValidityMixin(
       <label
         part="label-text"
         class="${labelClasses}"
-        ?hidden="${!hasLabelText}"
-      >
+        ?hidden="${!hasLabelText}">
         <slot name="label-text" @slotchange="${handleSlotchangeLabelText}"
           >${labelText}</slot
         >
@@ -698,8 +695,7 @@ class BXDropdown extends ValidityMixin(
         ?data-invalid=${invalid}
         @click=${handleClickInner}
         @keydown=${handleKeydownInner}
-        @keypress=${handleKeypressInner}
-      >
+        @keypress=${handleKeypressInner}>
         ${validityIcon}
         <div
           part="trigger-button"
@@ -710,8 +706,7 @@ class BXDropdown extends ValidityMixin(
           aria-expanded="${String(open)}"
           aria-haspopup="listbox"
           aria-owns="menu-body"
-          aria-controls="menu-body"
-        >
+          aria-controls="menu-body">
           ${this._renderPrecedingTriggerContent()}${this._renderTriggerContent()}${this._renderFollowingTriggerContent()}
           <div class="${iconContainerClasses}">
             ${ChevronDown16({ 'aria-label': toggleLabel })}
@@ -724,8 +719,7 @@ class BXDropdown extends ValidityMixin(
         class="${prefix}--assistive-text"
         role="status"
         aria-live="assertive"
-        aria-relevant="additions text"
-      >
+        aria-relevant="additions text">
         ${assistiveStatusText}
       </div>
     `;

--- a/packages/carbon-web-components/src/components/tile/selectable-tile.ts
+++ b/packages/carbon-web-components/src/components/tile/selectable-tile.ts
@@ -123,8 +123,7 @@ class BXSelectableTile extends FocusMixin(LitElement) {
         name="${ifNonNull(name)}"
         value="${ifNonNull(value)}"
         .checked=${selected}
-        @change=${handleChange}
-      />
+        @change=${handleChange} />
       <label for="input" class="${classes}" tabindex="0">
         <div class="${prefix}--tile__checkmark">
           ${CheckmarkFilled16({

--- a/packages/carbon-web-components/src/components/tooltip/tooltip.ts
+++ b/packages/carbon-web-components/src/components/tooltip/tooltip.ts
@@ -25,8 +25,10 @@ const { prefix } = settings;
  * @element bx-tooltip
  */
 @customElement(`${prefix}-tooltip`)
-class BXTooltip extends HostListenerMixin(LitElement)
-  implements BXFloatingMenuTrigger {
+class BXTooltip
+  extends HostListenerMixin(LitElement)
+  implements BXFloatingMenuTrigger
+{
   /**
    * The menu body.
    */
@@ -67,7 +69,7 @@ class BXTooltip extends HostListenerMixin(LitElement)
    */
   @HostListener('keydown')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
-  private _handleKeydown = async event => {
+  private _handleKeydown = async (event) => {
     if ([' ', 'Enter'].includes(event.key)) {
       this._handleClick();
     } else if (event.key === 'Escape') {
@@ -126,7 +128,7 @@ class BXTooltip extends HostListenerMixin(LitElement)
       if (!this._menuBody) {
         this._menuBody = find(
           this.childNodes,
-          elem => (elem.constructor as typeof BXFloatingMenu).FLOATING_MENU
+          (elem) => (elem.constructor as typeof BXFloatingMenu).FLOATING_MENU
         );
       }
       if (this._menuBody) {

--- a/packages/react/src/components/ButtonGroup/ButtonGroup.js
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.js
@@ -32,8 +32,7 @@ const ButtonGroup = ({ buttons }) => {
     <ol
       className={`${prefix}--buttongroup`}
       data-autoid={`${stablePrefix}--button-group`}
-      ref={groupRef}
-    >
+      ref={groupRef}>
       {buttons.map((button, key) => {
         return (
           <li key={key} className={`${prefix}--buttongroup-item`}>
@@ -42,8 +41,7 @@ const ButtonGroup = ({ buttons }) => {
               isExpressive
               {...button}
               type="button"
-              kind={key === 0 ? 'primary' : 'tertiary'}
-            >
+              kind={key === 0 ? 'primary' : 'tertiary'}>
               {button.copy}
             </Button>
           </li>

--- a/packages/react/src/components/Icon/IbmLogo.js
+++ b/packages/react/src/components/Icon/IbmLogo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2022
+ * Copyright IBM Corp. 2016, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -43,7 +43,10 @@ const IbmLogo = ({ autoid, logoData, isSearchActive }) => {
             dangerouslySetInnerHTML={{ __html: logoData.svg }}
           />
         ) : (
-          <a aria-label="IBM®" data-autoid={autoid} href={`http://www.ibm.com`}>
+          <a
+            aria-label="IBM®"
+            data-autoid={autoid}
+            href={`https://www.ibm.com`}>
             {!useAlternateLogo && <MastheadLogo />}
           </a>
         )}

--- a/packages/web-components/src/components/button-group/button-group.ts
+++ b/packages/web-components/src/components/button-group/button-group.ts
@@ -29,7 +29,7 @@ class DDSButtonGroup extends StableSelectorMixin(LitElement) {
   private _handleSlotChange(event: Event) {
     const childItems = (event.target as HTMLSlotElement)
       .assignedNodes()
-      .filter(elem =>
+      .filter((elem) =>
         (elem as HTMLElement).matches !== undefined
           ? (elem as HTMLElement).matches(
               (this.constructor as typeof DDSButtonGroup).selectorItem
@@ -64,9 +64,7 @@ class DDSButtonGroup extends StableSelectorMixin(LitElement) {
   }
 
   render() {
-    return html`
-      <slot @slotchange="${this._handleSlotChange}"></slot>
-    `;
+    return html` <slot @slotchange="${this._handleSlotChange}"></slot> `;
   }
 
   connectedCallback() {


### PR DESCRIPTION
### Related Ticket(s)

#9567 

### Description

This updates the React masthead logo URL to use `https`.

### Changelog

**Changed**

- React masthead logo URL changed to use `https`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
