### PR TITLE
fix(styles): add missing styles for breadcrumb and modal

### DIFF
--- a/packages/carbon-web-components/src/components/breadcrumb/breadcrumb.scss
+++ b/packages/carbon-web-components/src/components/breadcrumb/breadcrumb.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2022
+// Copyright IBM Corp. 2019, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -17,6 +17,13 @@ $css--plex: true !default;
 
 :host(#{$prefix}-breadcrumb-item) {
   @extend .#{$prefix}--breadcrumb-item;
+
+  // TODO: see if we can remove this ::after section after v11 upgrade
+  &::after {
+    margin-left: $spacing-03;
+    color: $text-primary;
+    content: '/';
+  }
 }
 
 :host(#{$prefix}-breadcrumb-overflow-menu) {

--- a/packages/carbon-web-components/src/components/modal/modal.scss
+++ b/packages/carbon-web-components/src/components/modal/modal.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2022
+// Copyright IBM Corp. 2019, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -74,6 +74,10 @@
 
 :host(#{$prefix}-modal[open]) {
   @extend .#{$prefix}--modal, .is-visible;
+
+  // TODO: look into if following two lines are necessary after v11 upgrade
+  opacity: 1;
+  visibility: inherit;
 }
 
 :host(#{$prefix}-modal-header) {


### PR DESCRIPTION
### Related Ticket(s)

[breadcrumb]: / separator not showing on v1.27.0 #9936
Modal not displaying with @carbon/web-components 1.23.0 #9923

### Description

Some styles have not been extending from `carbon-components` for `bx-modal` and `bx-breadcrumb` components. Will need to dig further to see why they aren't showing, but in the mean time we can add those styles to ours.

### Changelog

**Changed**

- added styles from `carbon-components` that are not showing for `bx-modal` and `bx-breadcrumb`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
