### PR TITLE
chore(changelog): incorporate carbon web components to change log generation task

### DIFF
--- a/tasks/get-changelog.js
+++ b/tasks/get-changelog.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,6 +18,10 @@ program
   .option(
     '-v, --wcVersion <web components release version>',
     'Web Components release version'
+  )
+  .option(
+    '-c, --cwcVersion <carbon web components release version>',
+    'Carbon Web Components release version'
   );
 
 /**
@@ -47,6 +51,13 @@ const { tagTo } = args;
  * @type {string}
  */
 const { wcVersion } = args;
+
+/**
+ * Web Components release version (-v)
+ *
+ * @type {string}
+ */
+const { cwcVersion } = args;
 
 /**
  * Uses a delimiter for splitting the comments into an array
@@ -117,6 +128,10 @@ function getChangelog(pkgName, folder) {
   // Set Web Components version next to package name
   if (pkgName === 'Web Components') {
     changelog = `## ${pkgName} (${wcVersion})\n`;
+  }
+
+  if (pkgName === 'Carbon Web Components') {
+    changelog = `## ${pkgName} (${cwcVersion})\n`;
   }
 
   // Stores the list of features
@@ -215,6 +230,10 @@ function getChangelog(pkgName, folder) {
 function generateLog() {
   let log = '';
 
+  log += getChangelog(
+    'Carbon Web Components',
+    './packages/carbon-web-components'
+  );
   log += getChangelog('Web Components', './packages/web-components');
   log += getChangelog('React', './packages/react');
   log += getChangelog('Styles', './packages/styles');


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Housekeeping: incorporate Carbon Web Components into the change log generation task

### Changelog

**New**

- add parameter for carbon web components version and generate changelog for cwc

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
