### PR TITLE
docs(readme): add discord link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" />
   </a>
   <a href="https://percy.io/538fc19a/Carbon-for-IBM.com-Web-Components">
-  <img src="https://percy.io/static/images/percy-badge.svg" alt="This project is using Percy.io for visual regression testing." />
-</a>
+    <img src="https://percy.io/static/images/percy-badge.svg" alt="This project is using Percy.io for visual regression testing." />
+  </a>
+  <a href="https://discord.gg/J7JEUEkTRX">
+    <img src="https://img.shields.io/discord/689212587170201628?color=5865F2" alt="Chat with us on Discord">
+  </a>
 </p>
 
 ## Getting started


### PR DESCRIPTION
Hey there! Just a small PR to add a link to discord in the readme. I'm opening PRs suggesting we do this for all the top repos in the carbon-design-system org.