### PR TITLE
Additional Masthead tests including coverage for DOM pruning and lazy loading

### DIFF
--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-authenticated.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-authenticated.e2e.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright IBM Corp. 2021, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Sets the correct path (default Masthead)
+ *
+ * @type {string}
+ * @private
+ */
+const _pathDefault =
+  '/iframe.html?id=components-masthead--with-v-2-data&knob-use%20mock%20nav%20data%20(use-mock)=true&knob-The%20user%20authenticated%20status%20(user-status)=test.user@ibm.com';
+
+describe('dds-masthead | authenticated (desktop)', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 780).visit(`/${_pathDefault}`);
+  });
+
+  it('should open the login menu with 4 items', () => {
+    cy.get('dds-masthead-profile')
+      .shadow()
+      .find('a')
+      .click();
+    cy.get('dds-masthead-profile-item').should('have.length', 4);
+    cy.takeSnapshots();
+  });
+
+  it('should not render profile menu when disabled', () => {
+    cy.get('dds-masthead-composite').invoke('attr', 'has-profile', 'false');
+    cy.get('dds-masthead-profile').should('not.exist');
+    cy.takeSnapshots();
+  });
+});
+
+describe('dds-masthead | default (mobile)', () => {
+  beforeEach(() => {
+    cy.viewport(320, 780).visit(`/${_pathDefault}`);
+  });
+
+  it('should open the login menu with 4 items', () => {
+    cy.get('dds-masthead-profile')
+      .shadow()
+      .find('a')
+      .click();
+    cy.get('dds-masthead-profile-item').should('have.length', 4);
+    cy.takeSnapshots();
+  });
+});

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-authenticated.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-authenticated.e2e.js
@@ -46,6 +46,6 @@ describe('dds-masthead | default (mobile)', () => {
       .find('a')
       .click();
     cy.get('dds-masthead-profile-item').should('have.length', 4);
-    cy.takeSnapshots();
+    cy.takeSnapshots('mobile');
   });
 });

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-v2.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-v2.e2e.js
@@ -231,6 +231,29 @@ describe('dds-masthead | default (mobile)', () => {
     cy.takeSnapshots('mobile');
   });
 
+  it('should load the mobile menu | level 3', () => {
+    cy.get('dds-masthead-menu-button')
+      .shadow()
+      .find('button')
+      .click();
+
+    cy.get('dds-left-nav-menu')
+      .filter(':visible')
+      .first()
+      .shadow()
+      .find('button')
+      .click();
+
+    cy.get('dds-left-nav-menu')
+      .filter(':visible')
+      .first()
+      .shadow()
+      .find('button')
+      .click();
+
+    cy.takeSnapshots('mobile');
+  });
+
   it('should load analytics attributes throughout menu', () => {
     cy.get('dds-masthead-menu-button')
       .shadow()

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-v2.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-v2.e2e.js
@@ -33,15 +33,9 @@ function checkAnalyticsAttributes(element, attributes) {
  *   The name of the custom element to check the registry for.
  */
 function customElementIsRegistered(customElementName) {
-  cy.waitUntil(
-    () =>
-      cy.window().then(window => {
-        return window.customElements.get(customElementName) !== undefined;
-      }),
-    {
-      errorMsg: `${customElementName} is not registered`,
-    }
-  );
+  cy.waitUntil(() => cy.window().then(window => window.customElements.get(customElementName) !== undefined), {
+    errorMsg: `${customElementName} is not registered`,
+  });
 }
 
 describe('dds-masthead | default (desktop)', () => {


### PR DESCRIPTION
### Related Ticket(s)

Resolves #9607 

### Description

This adds e2e Cypress tests for the [DOM pruning](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/9595) and [lazy loading](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/9602) [performance optimizations](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9582) that were previously made.

Together with #10053, this resolves #9607.

### Changelog

**New**

- Tests for the masthead around DOM pruning and lazy loading performance optimizations
- Bonus new tests for authenticated state
- Bonus new test for mobile menu level 3 navigation
