### PR TITLE
fix(masthead-v2): remove breaking redundancy in masthead mobile test

### DIFF
--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-v2.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-v2.e2e.js
@@ -257,12 +257,6 @@ describe('dds-masthead | default (mobile)', () => {
       .find('button')
       .click();
 
-    cy.get('dds-left-nav-menu')
-      .filter(':visible')
-      .first()
-      .shadow()
-      .find('button')
-      .click();
 
     cy.get('dds-left-nav-menu')
       .filter(':visible')


### PR DESCRIPTION
### Related Ticket(s)

none

### Description

There's some duplicated steps in one of the new tests we merged in this morning. I don't know why it passed earlier, but now it's causing timeouts (see https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/10066).

### Changelog

**Removed**

- Removes duplicate test steps to fix test runs.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
