### PR TITLE
feat(stable-selector): dispatch event with shadow DOM

### DIFF
--- a/packages/web-components/src/components/card/__stories__/card.stories.ts
+++ b/packages/web-components/src/components/card/__stories__/card.stories.ts
@@ -41,9 +41,14 @@ export const Default = (args) => {
     footer,
     cardStyles,
   } = args?.Card ?? {};
+
+  window.addEventListener('dds--card', (e) =>
+    console.log((e as CustomEvent).detail.shadowDOM)
+  );
   /* eslint-disable no-nested-ternary */
   return html`
     <dds-card
+      get-shadow-dom
       color-scheme=${cardStyles === 'Inverse card'
         ? 'inverse'
         : cardStyles === 'Outlined card'

--- a/packages/web-components/src/globals/mixins/stable-selector.ts
+++ b/packages/web-components/src/globals/mixins/stable-selector.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -49,6 +49,18 @@ const StableSelectorMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
       this._cleanAndCreateMutationObserver({ create: true });
       window.requestAnimationFrame(() => {
         if (!this.linkNode) this.transposeAttributes();
+        if (this.hasAttribute('get-shadow-dom')) {
+          window.dispatchEvent(
+            new CustomEvent(stableSelector, {
+              bubbles: true,
+              composed: true,
+              detail: {
+                shadowDOM: this.shadowRoot,
+                // maybe some other data can be dispatched through here?
+              },
+            })
+          );
+        }
       });
     }
 


### PR DESCRIPTION
### Related Ticket(s)
None.

### Description
Due to AEM having a hard time accessing the shadow DOM, this PR creates a new event that dispatches on component render if any component has a `get-shadow-dom` attribute, containing the shadowDOM as an event detail. This will make it easier to retriever and modify the shadow DOM through the program by listening to the events on load.

```
<dds-card get-shadow-dom></dds-card>
```

in document:

```
  window.addEventListener('dds--card', (e) =>
    console.log((e as CustomEvent).detail.shadowDOM)
   // do stuff with it
  );
```

As an example, you can open the console in the default Card story to see that the shadow DOM element will be retrieved through listening to the event. We could also add more data to be sent through this event, if needed. Likewise, we could limit the elements retrieved through the event by scoping the query instead of the whole shadow DOM (e.g. only retrieving `.bx--card__wrapper` instead).

Another idea is to add event listeners to certain components that would directly modify certain elements, so when a user dispatches events, the component will modify things directly on the component's side. 

```
          exampleCard.dispatchEvent(
            new CustomEvent('edit-heading', {
              bubbles: true,
              composed: true,
              detail: {
                elementTarget: 'dds-card-heading',
               newText: 'this is a new heading'
              },
            })
          );
```

While this could probably be "easier" on adopters, there might not be a way to generalize this behavior, and worst case scenario we'd have to do this on a case by case basis, which we'd have to take into account if there are ever breaking changes.

The first solution might be a more general one, and provides the shadow DOM to the adopters.


### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
