### PR TITLE
fix(masthead): left nav focuswrap

### DIFF
--- a/packages/web-components/src/components/masthead/left-nav-menu-section.ts
+++ b/packages/web-components/src/components/masthead/left-nav-menu-section.ts
@@ -198,7 +198,7 @@ class DDSLeftNavMenuSection extends HostListenerMixin(FocusMixin(LitElement)) {
         }
 
         if (tabbable) {
-          document.addEventListener(
+          this.addEventListener(
             'transitionend',
             () => {
               (tabbable as HTMLElement).focus();

--- a/packages/web-components/src/components/masthead/left-nav.ts
+++ b/packages/web-components/src/components/masthead/left-nav.ts
@@ -84,7 +84,6 @@ class DDSLeftNav extends StableSelectorMixin(BXSideNav) {
       (event.composedPath()[1] as HTMLElement).tagName ===
       selectorButtonToggle.toUpperCase()
     ) {
-      console.log('ELSE IF');
       const { comparisonResult } = event.detail;
       const {
         selectorExpandedMenuSection,

--- a/packages/web-components/src/components/masthead/left-nav.ts
+++ b/packages/web-components/src/components/masthead/left-nav.ts
@@ -25,6 +25,7 @@ import DDSLeftNavOverlay from './left-nav-overlay';
 import styles from './masthead.scss';
 import DDSLeftNavMenuSection from './left-nav-menu-section';
 import DDSMasthead from './masthead';
+import { lowerCase, upperCase } from 'lodash-es';
 
 const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;
@@ -80,7 +81,11 @@ class DDSLeftNav extends StableSelectorMixin(BXSideNav) {
       if (toggle) {
         (toggle as HTMLElement).focus();
       }
-    } else if ((event.target as HTMLElement).matches?.(selectorButtonToggle)) {
+    } else if (
+      (event.composedPath()[1] as HTMLElement).tagName ===
+      selectorButtonToggle.toUpperCase()
+    ) {
+      console.log('ELSE IF');
       const { comparisonResult } = event.detail;
       const {
         selectorExpandedMenuSection,

--- a/packages/web-components/src/components/masthead/left-nav.ts
+++ b/packages/web-components/src/components/masthead/left-nav.ts
@@ -25,7 +25,6 @@ import DDSLeftNavOverlay from './left-nav-overlay';
 import styles from './masthead.scss';
 import DDSLeftNavMenuSection from './left-nav-menu-section';
 import DDSMasthead from './masthead';
-import { lowerCase, upperCase } from 'lodash-es';
 
 const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;


### PR DESCRIPTION
### Related Ticket(s)

#10026 
### Description

Similar to the updates made here: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/10019

because of the updates to v11 we have to target the event.target differently to get the appropriate value
![Feb-27-2023 13-16-57](https://user-images.githubusercontent.com/20210594/221674405-0a315d88-f632-4c01-a158-40d54a320cc8.gif)


### Changelog

**Changed**

- updated the else if statement to make sure the right values are getting passed


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
