### PR TITLE
chore(e2e): fixes `e2e-integration` tests

### DIFF
--- a/.github/workflows/e2e-integration.yml
+++ b/.github/workflows/e2e-integration.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable --immutable-cache
       - name: Build
         run: yarn lerna run --stream --ignore @carbon/ibmdotcom-react build
       - name: Build CDN components
@@ -54,7 +54,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable --immutable-cache
       - name: Build
         run: yarn lerna run --stream --ignore @carbon/ibmdotcom-services-store --ignore @carbon/ibmdotcom-web-components build
       - name: Run e2e codesandbox tests

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable --immutable-cache
       - name: Install xvfb
         run: sudo apt-get install xvfb
       - name: Build
@@ -53,7 +53,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable --immutable-cache
       - name: Install xvfb
         run: sudo apt-get install xvfb
       - name: Build
@@ -81,7 +81,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable --immutable-cache
       - name: Install xvfb
         run: sudo apt-get install xvfb
       - name: Build
@@ -111,7 +111,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable --immutable-cache
       - name: Install xvfb
         run: sudo apt-get install xvfb
       - name: Build

--- a/packages/react/tests/e2e/build/build-examples.js
+++ b/packages/react/tests/e2e/build/build-examples.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -93,6 +93,15 @@ const _packages = {
 };
 
 /**
+ * Use older version of Yarn for example builds.
+ * Later versions would require changes to every example's package.json file.
+ *
+ * @type {string}
+ * @private
+ */
+const _oldYarnVersion = '1.22.19';
+
+/**
  * Stores the list of examples
  *
  * @type {*[]}
@@ -155,14 +164,16 @@ function _setupPackages() {
  * @private
  */
 function _buildExamples() {
+  // Use older Yarn version for example builds.
+  // Setting the version earlier in the build chain will alter the root project.
   log(chalk.yellow('Installing all examples...'));
   // need to install twice for some reason, need to look into this
-  execSync('yarn install --network-timeout 100000', {
+  execSync(`yarn set version ${_oldYarnVersion} && yarn install --network-timeout 100000`, {
     cwd: _exampleBuild,
     stdio: 'inherit',
   });
 
-  execSync('yarn cache clean && yarn install --network-timeout 100000', {
+  execSync(`yarn set version ${_oldYarnVersion} && yarn cache clean && yarn install --network-timeout 100000`, {
     cwd: _exampleBuild,
     stdio: 'inherit',
   });

--- a/packages/web-components/tests/e2e/cypress/integration/dotcom-shell/dotcom-shell.cdn.e2e.js
+++ b/packages/web-components/tests/e2e/cypress/integration/dotcom-shell/dotcom-shell.cdn.e2e.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,7 +11,7 @@ describe('dds-dotcom-shell (cdn)', () => {
   it('should load the default dds-dotcom-shell example', () => {
     cy.visit('/dotcom-shell/cdn.html');
 
-    cy.get('[data-autoid="dds--masthead__megamenu"]');
+    cy.get('[data-autoid="dds--masthead-default__l0-nav0"]').should('not.be.empty');
 
     // Take a snapshot for visual diffing
     cy.percySnapshot('dds-dotcom-shell | cdn | default');

--- a/packages/web-components/tests/e2e/cypress/integration/dotcom-shell/dotcom-shell.e2e.js
+++ b/packages/web-components/tests/e2e/cypress/integration/dotcom-shell/dotcom-shell.e2e.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,7 +11,7 @@ describe('dds-dotcom-shell', () => {
   it('should load the default dds-dotcom-shell example', () => {
     cy.visit('/dotcom-shell');
 
-    cy.get('[data-autoid="dds--masthead__megamenu"]');
+    cy.get('[data-autoid="dds--masthead-default__l0-nav0"]').should('not.be.empty');
 
     // Take a snapshot for visual diffing
     cy.percySnapshot('dds-dotcom-shell | default');

--- a/packages/web-components/tests/e2e/cypress/integration/masthead/masthead.cdn.e2e.js
+++ b/packages/web-components/tests/e2e/cypress/integration/masthead/masthead.cdn.e2e.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,7 +11,7 @@ describe('dds-masthead (cdn)', () => {
   it('should load the default dds-masthead example', () => {
     cy.visit('/masthead/cdn.html');
 
-    cy.get('[data-autoid="dds--masthead__megamenu"]');
+    cy.get('[data-autoid="dds--masthead-default__l0-nav0"]').should('not.be.empty');
 
     // Take a snapshot for visual diffing
     cy.percySnapshot('dds-masthead | cdn | default');

--- a/packages/web-components/tests/e2e/cypress/integration/masthead/masthead.e2e.js
+++ b/packages/web-components/tests/e2e/cypress/integration/masthead/masthead.e2e.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,7 +11,7 @@ describe('dds-masthead', () => {
   it('should load the default dds-masthead example', () => {
     cy.visit('/masthead');
 
-    cy.get('[data-autoid="dds--masthead__megamenu"]');
+    cy.get('[data-autoid="dds--masthead-default__l0-nav0"]').should('not.be.empty');
 
     // Take a snapshot for visual diffing
     cy.percySnapshot('dds-masthead | default');


### PR DESCRIPTION
### Description

This fixes the `e2e-integration` GH actions that are failing for `react` and `web-components`. With the upgrade to Yarn v3, building the Codesandbox examples needed for e2e tests becomes problematic as they have not been upgraded. The simplest solution is to switch back to an older version of Yarn for the test builds only.

### Changelog

**New**

- Use `execa` for `web-components` build process. Now that `vendor/@carbon/web-components` are bundled with `ibmdotcom-web-components`, the packed file is huge. This exceeds the `maxBuffer` limit in `execSync`, while `execa` has no such issue.

**Changed**

- update `dotcom-shell` and `masthead` e2e tests

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
