### PR TITLE
fix(cwc): storybook link

### DIFF
--- a/packages/carbon-web-components/.storybook/theme.ts
+++ b/packages/carbon-web-components/.storybook/theme.ts
@@ -11,6 +11,6 @@ import { create, ThemeVars } from '@storybook/theming';
 import { version } from '../package.json';
 
 export default create({
-  brandTitle: `carbon-web-components ${version}`,
-  brandUrl: 'https://github.com/carbon-design-system/carbon-web-components',
+  brandTitle: `@carbon/web-components ${version}`,
+  brandUrl: 'https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/carbon-web-components',
 } as ThemeVars);

--- a/packages/carbon-web-components/.storybook/theme.ts
+++ b/packages/carbon-web-components/.storybook/theme.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,5 +12,6 @@ import { version } from '../package.json';
 
 export default create({
   brandTitle: `@carbon/web-components ${version}`,
-  brandUrl: 'https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/carbon-web-components',
+  brandUrl:
+    'https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/carbon-web-components',
 } as ThemeVars);


### PR DESCRIPTION
### Related Ticket(s)

N/A
### Description

Clicking on the storybook title for cwc was linking us back to the old repo

### Changelog


**Changed**

-updated link to the current repo


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
