### PR TITLE
fix(tile): fix expanable content visibility

### DIFF
--- a/packages/carbon-web-components/src/components/tile/tile.scss
+++ b/packages/carbon-web-components/src/components/tile/tile.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2022
+// Copyright IBM Corp. 2019, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -83,6 +83,7 @@ $css--plex: true !default;
   ::slotted(#{$prefix}-tile-below-the-fold-content) {
     opacity: 1;
     transition: $duration--fast-02 motion(standard, productive);
+    visibility: visible;
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

#10202 

### Description

Fixes styles for `tile - expanded` content to be visible when tile is expanded.

### Changelog

**New**

- {{new thing}}

**Changed**

- make expanded content `visible`

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
