### PR TITLE
feat(masthead-l1): v2.1 layout and styles

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,6 +7,7 @@
 
 @import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/themes';
 @import '../../globals/vars';
+@import '../../globals/imports';
 
 /// @access private
 /// @group dotcom ui-shell Masthead L1
@@ -40,126 +41,311 @@ $search-transition-timing: 95ms;
     }
   }
 
-  .#{$prefix}--masthead__l1-inner-container {
-    width: 100%;
-    display: flex;
-
-    &::before {
-      content: '';
-      position: absolute;
-      background-color: $ui-background;
-      height: 48px;
-      left: calc(-50vw + 50%);
-      right: 100%;
-      z-index: 1;
+  // L1 Mobile Styles
+  @media screen and (max-width: 799px) {
+    .#{$prefix}--masthead__l1-inner-container {
+      width: 100%;
     }
 
-    &::after {
-      content: '';
-      position: absolute;
-      background-color: $ui-background;
-      height: 48px;
-      left: 100%;
-      right: calc(-50vw + 50%);
-    }
-  }
+    .#{$prefix}--masthead__l1-title {
+      @include carbon--type-style(productive-heading-01);
 
-  .#{$prefix}--masthead__l1-name,
-  :host(#{$dds-prefix}-masthead-l1-name) {
-    display: flex;
-    height: 100%;
-    z-index: 1;
-    background-color: $ui-02;
-    color: $text-04;
-    padding: 0 0 0 rem(12px);
-    align-items: stretch;
-    white-space: nowrap;
-
-    @include carbon--breakpoint-down(lg) {
-      padding-left: 0;
-    }
-
-    &[aria-selected='true'] span::after {
-      content: '';
-      display: block;
-      position: absolute;
-      box-sizing: border-box;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      height: rem(3px);
-      background-color: $link-01;
-    }
-  }
-
-  .#{$prefix}--masthead__l1-name-title {
-    display: flex;
-    align-items: stretch;
-    min-width: rem(67px);
-    white-space: nowrap;
-    position: relative;
-
-    a {
-      @include type-style('productive-heading-02');
-
-      display: flex;
-      align-items: center;
+      background-color: transparent;
+      border: none;
+      border-bottom: 1px solid $ui-03;
       color: $text-01;
-      position: relative;
-      text-decoration: none;
-      padding: 0 $carbon--spacing-05;
+      display: flex;
+      justify-content: space-between;
+      padding: $carbon--spacing-05;
+      width: 100%;
+      gap: $carbon--spacing-06;
 
-      &:active,
-      &:focus {
-        outline: 2px solid $interactive-01;
-        outline-offset: -2px;
-      }
-    }
-
-    &:hover {
-      background-color: $hover-ui;
-    }
-  }
-
-  .#{$prefix}--masthead__l1-nav {
-    padding-left: 0;
-
-    li:not([role='none']) {
-      > a {
-        align-items: flex-end;
-      }
-    }
-
-    a.#{$prefix}--header__menu-item {
       &:hover {
         background-color: $hover-ui;
       }
 
+      &:active {
+        background-color: $active-ui;
+      }
+
+      &:active,
       &:focus {
-        border-color: $interactive-01;
+        outline: 2px solid $focus;
+        outline-offset: -2px;
+      }
+
+      &:disabled {
+        color: $disabled-02;
+        border-bottom-color: $disabled-02;
       }
 
       svg {
-        position: relative;
-        top: -2px;
-        fill: $text-01;
+        color: $icon-01;
       }
     }
 
-    a.#{$prefix}--header__menu-title[aria-expanded='true'] {
-      background-color: $ui-03;
-      + .#{$prefix}--header__menu {
-        li {
-          background-color: $ui-background;
+    .#{$prefix}--masthead__l1-dropdown {
+      // Height of viewport minus the L0/L1 combo.
+      max-height: calc(100vh - 98px);
+      overflow-y: scroll;
+    }
 
-          &:hover {
-            background-color: $hover-ui;
-          }
+    .#{$prefix}--masthead__l1-dropdown-item {
+      @include carbon--type-style(body-short-01);
 
-          a.#{$prefix}--header__menu-item {
+      background-color: transparent;
+      border: none;
+      border-bottom: 1px solid $ui-03;
+      text-decoration: none;
+      color: $text-01;
+      display: flex;
+      justify-content: space-between;
+      padding: $carbon--spacing-05;
+      width: 100%;
+      min-height: $spacing-07;
+      gap: $carbon--spacing-06;
+
+      &:hover {
+        background-color: $hover-ui;
+      }
+
+      &:active {
+        background-color: $active-ui;
+      }
+
+      &:active,
+      &:focus {
+        outline: 2px solid $focus;
+        outline-offset: -2px;
+      }
+
+      &:disabled {
+        color: $disabled-02;
+        border-bottom-color: $disabled-02;
+      }
+
+      &.is-open {
+        background-color: $selected-ui;
+      }
+
+      svg {
+        color: $icon-01;
+      }
+    }
+
+    .#{$prefix}--masthead__l1-dropdown-announcement {
+      @include carbon--type-style(body-short-01);
+
+      margin: 0 $carbon--spacing-05 $carbon--spacing-05;
+      padding: $carbon--spacing-05 0;
+      border-bottom: 1px solid $ui-03;
+    }
+
+    .#{$prefix}--masthead__l1-dropdown-heading {
+      @include carbon--type-style(productive-heading-01);
+
+      color: $text-01;
+
+      &:not(:has(> .#{$prefix}--masthead__l1-dropdown-item)) {
+        padding: $carbon--spacing-05;
+        padding-inline-end: $carbon--spacing-08;
+        width: 100%;
+        min-height: $spacing-07;
+      }
+
+      .#{$prefix}--masthead__l1-dropdown-item {
+        @include carbon--type-style(productive-heading-01);
+
+        color: $text-01;
+        justify-content: flex-start;
+        padding: $carbon--spacing-05;
+        width: 100%;
+        min-height: $spacing-07;
+        gap: $carbon--spacing-03;
+      }
+
+      &:not(:nth-of-type(1)) {
+        margin-top: $carbon--spacing-07;
+      }
+    }
+
+    .#{$prefix}--masthead__l1-dropdown-viewall {
+      @include carbon--type-style(body-short-01);
+
+      background-color: transparent;
+      text-decoration: none;
+      display: flex;
+      justify-content: flex-start;
+      padding: $carbon--spacing-05;
+      width: 100%;
+      min-height: $spacing-07;
+      gap: $carbon--spacing-03;
+
+      &:hover {
+        background-color: $hover-ui;
+      }
+
+      &:active {
+        background-color: $active-ui;
+      }
+
+      &:active,
+      &:focus {
+        outline: 2px solid $focus;
+        outline-offset: -2px;
+      }
+    }
+
+    .#{$prefix}--masthead__l1-dropdown-subsection {
+      padding-bottom: $carbon--spacing-07;
+
+      .#{$prefix}--masthead__l1-dropdown-item {
+        padding-inline-end: $carbon--spacing-08;
+        border-bottom: none;
+      }
+    }
+
+    .#{$prefix}--masthead__l1-dropdown-login {
+      color: $interactive-01;
+
+      svg {
+        color: inherit;
+      }
+    }
+
+    .#{$prefix}--masthead__l1-dropdown-cta {
+      background-color: $interactive-01;
+      color: $ui-02;
+
+      svg {
+        color: inherit;
+      }
+    }
+  }
+
+  // L1 Desktop Styles
+  @media screen and (min-width: 800px) {
+    .#{$prefix}--masthead__l1-inner-container {
+      width: 100%;
+      display: flex;
+
+      &::before {
+        content: '';
+        position: absolute;
+        background-color: $ui-background;
+        height: 48px;
+        left: calc(-50vw + 50%);
+        right: 100%;
+        z-index: 1;
+      }
+
+      &::after {
+        content: '';
+        position: absolute;
+        background-color: $ui-background;
+        height: 48px;
+        left: 100%;
+        right: calc(-50vw + 50%);
+      }
+    }
+
+    .#{$prefix}--masthead__l1-name,
+    :host(#{$dds-prefix}-masthead-l1-name) {
+      display: flex;
+      height: 100%;
+      z-index: 1;
+      background-color: $ui-02;
+      color: $text-04;
+      padding: 0 0 0 rem(12px);
+      align-items: stretch;
+      white-space: nowrap;
+
+      @include carbon--breakpoint-down(lg) {
+        padding-left: 0;
+      }
+
+      &[aria-selected='true'] span::after {
+        content: '';
+        display: block;
+        position: absolute;
+        box-sizing: border-box;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: rem(3px);
+        background-color: $link-01;
+      }
+    }
+
+    .#{$prefix}--masthead__l1-name-title {
+      display: flex;
+      align-items: stretch;
+      min-width: rem(67px);
+      white-space: nowrap;
+      position: relative;
+
+      a {
+        @include type-style('productive-heading-02');
+
+        display: flex;
+        align-items: center;
+        color: $text-01;
+        position: relative;
+        text-decoration: none;
+        padding: 0 $carbon--spacing-05;
+
+        &:active,
+        &:focus {
+          outline: 2px solid $interactive-01;
+          outline-offset: -2px;
+        }
+      }
+
+      &:hover {
+        background-color: $hover-ui;
+      }
+    }
+
+    .#{$prefix}--masthead__l1-nav {
+      padding-left: 0;
+
+      li:not([role='none']) {
+        > a {
+          align-items: flex-end;
+        }
+      }
+
+      a.#{$prefix}--header__menu-item {
+        &:hover {
+          background-color: $hover-ui;
+        }
+
+        &:focus {
+          border-color: $interactive-01;
+        }
+
+        svg {
+          position: relative;
+          top: -2px;
+          fill: $text-01;
+        }
+      }
+
+      a.#{$prefix}--header__menu-title[aria-expanded='true'] {
+        background-color: $ui-03;
+        + .#{$prefix}--header__menu {
+          li {
+            background-color: $ui-background;
+
             &:hover {
-              color: $text-01;
               background-color: $hover-ui;
+            }
+
+            a.#{$prefix}--header__menu-item {
+              &:hover {
+                color: $text-01;
+                background-color: $hover-ui;
+              }
             }
           }
         }

--- a/packages/web-components/src/components/masthead/__stories__/links.ts
+++ b/packages/web-components/src/components/masthead/__stories__/links.ts
@@ -446,6 +446,7 @@ const mastheadL1Data: MastheadL1 = {
             heading: {
               headingLevel: 2,
               title: 'Heading level 2',
+              url: 'https://example.com',
             },
             items: [
               {

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -16,12 +16,14 @@ import {
 } from 'lit-element';
 import { nothing, render } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
 import root from 'window-or-global';
 import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
+import settings from 'carbon-components/es/globals/js/settings.js';
 import { globalInit } from '../../internal/vendor/@carbon/ibmdotcom-services/services/global/global';
 import MastheadLogoAPI from '../../internal/vendor/@carbon/ibmdotcom-services/services/MastheadLogo/MastheadLogo';
 import {
@@ -69,6 +71,7 @@ import '../search-with-typeahead/search-with-typeahead-item';
 import styles from './masthead.scss';
 import { MEGAMENU_LAYOUT_SCHEME, MEGAPANEL_VIEW_ALL_POSITION } from './defs';
 
+const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;
 
 // Magic Number: 799px matches masthead.scss's `$breakpoint--desktop-nav`.
@@ -127,52 +130,11 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
 
     const { _isMobileVersion: isMobileVersion } = this;
     return html`
-      <dds-masthead-l1 slot="masthead-l1">
-        ${isMobileVersion
-          ? html` ${this._renderL1MobileNav()} `
-          : html` ${this._renderL1TopNav()} `}
-      </dds-masthead-l1>
+      <dds-masthead-l1
+        slot="masthead-l1"
+        .l1Data=${this.l1Data}
+        .isMobileVersion=${isMobileVersion}></dds-masthead-l1>
     `;
-  }
-
-  /**
-   * Renders L1 for desktop screensizes
-   *
-   * @returns {TemplateResult} L1 for desktop screensizes
-   */
-  protected _renderL1TopNav() {
-    const { selectedMenuItem, l1Data } = this;
-    const { url, title } = l1Data!;
-    const isSelected = !this._hasAutoSelectedItems && !selectedMenuItem;
-
-    return html`
-      ${!title
-        ? undefined
-        : html`
-            <dds-masthead-l1-name
-              title="${title}"
-              aria-selected="${isSelected}"
-              url="${ifDefined(url)}"></dds-masthead-l1-name>
-          `}
-      <dds-top-nav-l1 selected-menu-item=${selectedMenuItem}>
-        ${this._renderNavItems({
-          target: NAV_ITEMS_RENDER_TARGET.TOP_NAV,
-          hasL1: true,
-        })}
-      </dds-top-nav-l1>
-    `;
-  }
-
-  /**
-   * Renders L1 for mobile screensizes.
-   *
-   * @returns {TemplateResult} L1 for mobile screensizes.
-   */
-  protected _renderL1MobileNav() {
-    const { l1Data } = this;
-    const { url, title } = l1Data!;
-
-    return html` <a href="${ifDefined(url)}">${title}</a> `;
   }
 
   /**

--- a/packages/web-components/src/components/masthead/masthead-l1.scss
+++ b/packages/web-components/src/components/masthead/masthead-l1.scss
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2020, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '@carbon/ibmdotcom-styles/scss/globals/vars';
+@import '@carbon/ibmdotcom-styles/scss/components/masthead/masthead-l1';

--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -1,17 +1,33 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, customElement, LitElement } from 'lit-element';
+import {
+  html,
+  customElement,
+  LitElement,
+  property,
+  TemplateResult as _TemplateResult,
+} from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
-import styles from './masthead.scss';
+import styles from './masthead-l1.scss';
+import {
+  L1MenuItem as _L1MenuItem,
+  L1SubmenuSectionHeading,
+  MastheadL1,
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
+import { ifDefined } from 'lit-html/directives/if-defined';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+import ChevronDown16 from '../../internal/vendor/@carbon/web-components/icons/chevron--down/16.js';
+import ArrowRight16 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/16';
+import { classMap } from 'lit-html/directives/class-map';
 
 const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;
@@ -26,11 +42,228 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  */
 @customElement(`${ddsPrefix}-masthead-l1`)
 class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
+  @property()
+  l1Data?: MastheadL1;
+
+  @property()
+  isMobileVersion?: boolean;
+
+  /**
+   * Renders L1 for desktop screensizes
+   *
+   * @returns {_TemplateResult} L1 for desktop screensizes
+   */
+  protected _renderL1TopNav() {
+    const { l1Data } = this;
+    const { url, title } = l1Data!;
+
+    return html`
+      ${!title
+        ? undefined
+        : html`
+            <dds-masthead-l1-name title="${title}" url="${ifDefined(url)}">
+            </dds-masthead-l1-name>
+          `}
+      <dds-top-nav-l1> L1 TOP NAV. </dds-top-nav-l1>
+    `;
+  }
+
+  /**
+   * Renders L1 for mobile screensizes.
+   *
+   * @returns {_TemplateResult} L1 for mobile screensizes.
+   */
+  protected _renderL1MobileNav() {
+    const { l1Data } = this;
+    const { url, title, actions, menuItems } = l1Data ?? {};
+    const { cta, login } = actions ?? {};
+
+    setTimeout(() => {
+      console.clear();
+      console.log(l1Data);
+    }, 250);
+
+    return html`
+      <button class="${prefix}--masthead__l1-title">
+        ${title}${ChevronDown16()}
+      </button>
+      <ul class="${prefix}--masthead__l1-dropdown">
+        ${url
+          ? html`<li>
+              <a class="bx--masthead__l1-dropdown-item" href="${url}"
+                >Overview</a
+              >
+            </li>`
+          : ''}
+        ${menuItems?.map((menuItem) => this._renderL1MobileSubnav(menuItem))}
+        ${login
+          ? html`<li>
+              <a
+                class="bx--masthead__l1-dropdown-item bx--masthead__l1-dropdown-login"
+                href="${ifDefined(login.url)}"
+                >${login.title}${ArrowRight16()}</a
+              >
+            </li>`
+          : ''}
+        ${cta
+          ? html`<li>
+              <a
+                class="bx--masthead__l1-dropdown-item bx--masthead__l1-dropdown-cta"
+                href="${ifDefined(cta.url)}"
+                >${cta.title}${ArrowRight16()}</a
+              >
+            </li>`
+          : ''}
+      </ul>
+    `;
+  }
+
+  /**
+   * Renders L1MenuItems with subsections containing announcements, headings, links, and footers.
+   *
+   * @param {_L1MenuItem[]} menuItem Array of menu items containing subnavs
+   * @returns {_TemplateResult} rendered output
+   */
+  protected _renderL1MobileSubnav(menuItem) {
+    const { _toggleMobileSubsection: toggleMobileSubsection } = this
+      .constructor as typeof DDSMastheadL1;
+    const { title, url, submenu } = menuItem;
+
+    if (!submenu && url) {
+      return html`
+        <li>
+          <a class="bx--masthead__l1-dropdown-item" href="${url}">${title}</a>
+        </li>
+      `;
+    } else if (!submenu) {
+      return html`
+        <li><span class="bx--masthead__l1-dropdown-item">${title}</span></li>
+      `;
+    }
+
+    const { announcement, menuSections, footer } = submenu ?? {};
+
+    return html`
+      <li>
+        <button
+          class="bx--masthead__l1-dropdown-item"
+          @click=${toggleMobileSubsection}>
+          ${title}${ChevronDown16()}
+        </button>
+        <div class="bx--masthead__l1-dropdown-subsection" hidden>
+          ${announcement
+            ? html`<div class="bx--masthead__l1-dropdown-announcement">
+                ${unsafeHTML(announcement)}
+              </div>`
+            : ''}
+          ${menuSections
+            ? menuSections.map((section) => {
+                const { heading, items } = section;
+
+                return html`
+                  ${heading
+                    ? html`${this._renderL1SubSectionHeading(heading)}`
+                    : ''}
+                  ${items
+                    ? html` <ul>
+                        ${items.map((item) => {
+                          const { title, url } = item;
+
+                          return html`<a
+                            class="bx--masthead__l1-dropdown-item"
+                            href="${url}"
+                            >${title}</a
+                          >`;
+                        })}
+                      </ul>`
+                    : ''}
+                `;
+              })
+            : ''}
+          ${footer
+            ? html`<a
+                class="bx--masthead__l1-dropdown-viewall"
+                href="${footer.url}"
+                >${footer.title}${ArrowRight16()}</a
+              >`
+            : ''}
+        </div>
+      </li>
+    `;
+  }
+
+  /**
+   * Toggles the mobile navigation subsection.
+   *
+   * @param {PointerEvent} event The click event from the user
+   */
+  protected static _toggleMobileSubsection(event: PointerEvent) {
+    const { currentTarget } = event;
+    const button = currentTarget as HTMLElement;
+    button.classList.toggle('is-open');
+    button.nextElementSibling?.toggleAttribute('hidden');
+  }
+
+  /**
+   * Renders a heading object in the proper <H#> element.
+   *
+   * @param heading The heading object to be rendered.
+   * @returns {_TemplateResult} Rendered heading.
+   */
+  protected _renderL1SubSectionHeading(heading: L1SubmenuSectionHeading) {
+    const { isMobileVersion } = this;
+
+    const headingContent = heading.url
+      ? html`<a class="bx--masthead__l1-dropdown-item" href="${heading.url}"
+          >${heading.title}${ArrowRight16()}</a
+        >`
+      : html`${heading.title}`;
+
+    const headingClasses = {
+      [`${prefix}--masthead__l1-dropdown-heading`]: !!isMobileVersion,
+    };
+
+    let renderedHeading = headingContent;
+    switch (heading.headingLevel) {
+      case 2:
+        renderedHeading = html`<h2 class=${classMap(headingClasses)}>
+          ${headingContent}
+        </h2>`;
+        break;
+      case 3:
+        renderedHeading = html`<h3 class=${classMap(headingClasses)}>
+          ${headingContent}
+        </h3>`;
+        break;
+      case 4:
+        renderedHeading = html`<h4 class=${classMap(headingClasses)}>
+          ${headingContent}
+        </h4>`;
+        break;
+      case 5:
+        renderedHeading = html`<h5 class=${classMap(headingClasses)}>
+          ${headingContent}
+        </h5>`;
+        break;
+      case 6:
+        renderedHeading = html`<h6 class=${classMap(headingClasses)}>
+          ${headingContent}
+        </h6>`;
+        break;
+      default:
+        renderedHeading = headingContent;
+    }
+
+    return renderedHeading;
+  }
+
   render() {
+    const { isMobileVersion } = this;
     return html`
       <div class="${prefix}--masthead__l1-inner-container">
-        <slot name="name"></slot>
-        <slot></slot>
+        ${isMobileVersion
+          ? html` ${this._renderL1MobileNav()} `
+          : html` ${this._renderL1TopNav()} `}
       </div>
     `;
   }


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-2739](https://jsw.ibm.com/browse/ADCMS-2739)

### Description

Implements design updates Mobile accordion navigation.

<img width="516" alt="Screenshot 2023-03-08 at 12 18 45 PM" src="https://user-images.githubusercontent.com/25532785/223784117-fecc48b4-12d8-476a-be25-52919fce19ef.png">
<img width="620" alt="Screenshot 2023-03-08 at 12 18 52 PM" src="https://user-images.githubusercontent.com/25532785/223784122-8d488b4e-2720-492c-af76-1c6187ade0ff.png">
<img width="660" alt="Screenshot 2023-03-08 at 12 19 04 PM" src="https://user-images.githubusercontent.com/25532785/223784125-88f0ab09-c0eb-47ee-8718-04e7d0f7e7e1.png">


### Changelog

**Changed**

- Updates layout & styles of L1 nav per Masthead 2.1 design specs
