### PR TITLE
fix(rolloup): point to cwc internal vendor components for custom babel plugin

### DIFF
--- a/packages/web-components/tools/get-rollup-config.js
+++ b/packages/web-components/tools/get-rollup-config.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -104,9 +104,9 @@ function getRollupConfig({
   const inputs = {};
 
   // retaining old dotcom-shell for legacy support
-  inputs[
-    `ibmdotcom-web-components-dotcom-shell${dirSuffixes[dir]}${modeSuffixes[mode]}`
-  ] = 'src/components/dotcom-shell/index.ts';
+  // inputs[
+  //   `ibmdotcom-web-components-dotcom-shell${dirSuffixes[dir]}${modeSuffixes[mode]}`
+  // ] = 'src/components/dotcom-shell/index.ts';
 
   // adding the cloud masthead
   inputs[`cloud-masthead${dirSuffixes[dir]}${modeSuffixes[mode]}`] =
@@ -216,7 +216,14 @@ function getRollupConfig({
       // and we don't want to affect `carbon-web-components`' components application may define elsewhere
       babel.babel({
         babelHelpers: 'inline',
-        include: [/carbon-web-components\/es\/components\//i],
+        include: [/internal\/vendor\/@carbon\/web-components\/components\//i],
+        // include: [/carbon-web-components\/es\/components\//i],
+        // include: [
+        //   path.resolve(
+        //     __dirname,
+        //     '../src/internal/vendor/@carbon/web-components/components'
+        //   ),
+        // ],
         plugins: [
           path.resolve(__dirname, 'babel-plugin-undef-custom-elements'),
         ],

--- a/packages/web-components/tools/get-rollup-config.js
+++ b/packages/web-components/tools/get-rollup-config.js
@@ -104,9 +104,9 @@ function getRollupConfig({
   const inputs = {};
 
   // retaining old dotcom-shell for legacy support
-  // inputs[
-  //   `ibmdotcom-web-components-dotcom-shell${dirSuffixes[dir]}${modeSuffixes[mode]}`
-  // ] = 'src/components/dotcom-shell/index.ts';
+  inputs[
+    `ibmdotcom-web-components-dotcom-shell${dirSuffixes[dir]}${modeSuffixes[mode]}`
+  ] = 'src/components/dotcom-shell/index.ts';
 
   // adding the cloud masthead
   inputs[`cloud-masthead${dirSuffixes[dir]}${modeSuffixes[mode]}`] =
@@ -217,13 +217,6 @@ function getRollupConfig({
       babel.babel({
         babelHelpers: 'inline',
         include: [/internal\/vendor\/@carbon\/web-components\/components\//i],
-        // include: [/carbon-web-components\/es\/components\//i],
-        // include: [
-        //   path.resolve(
-        //     __dirname,
-        //     '../src/internal/vendor/@carbon/web-components/components'
-        //   ),
-        // ],
         plugins: [
           path.resolve(__dirname, 'babel-plugin-undef-custom-elements'),
         ],


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

Edit roll up config for custom babel plugin that prevents the `customElements.define()` from happening for the cwc components - look for the internal vendor carbon web component components instead to prevent the custom registry error 

### Changelog

**Changed**

- point to cwc internal vendor components for custom babel plugin

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
