### PR TITLE
fix(accordion): misisng animation styles

### DIFF
--- a/packages/carbon-web-components/.storybook/_container.scss
+++ b/packages/carbon-web-components/.storybook/_container.scss
@@ -13,16 +13,9 @@
 @use '@carbon/styles/scss/fonts';
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/themes' as *;
+@use '@carbon/styles/scss/type' as *;
 
-@import '@carbon/type/scss/type';
-@import '@carbon/type/scss/font-face/mono';
-@import '@carbon/type/scss/font-face/sans';
-@import '@carbon/type/scss/font-face/serif';
-
-@include carbon--type-reset();
-@include carbon--font-face-mono();
-@include carbon--font-face-sans();
-@include carbon--font-face-serif();
+@include reset();
 
 // The default theme is "white" (White)
 :root {

--- a/packages/carbon-web-components/.storybook/_container.scss
+++ b/packages/carbon-web-components/.storybook/_container.scss
@@ -7,7 +7,22 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/styles' as *;
+@use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/utilities/convert' as *;
+@use '@carbon/styles/scss/utilities';
+@use '@carbon/styles/scss/fonts';
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/themes' as *;
+
+@import '@carbon/type/scss/type';
+@import '@carbon/type/scss/font-face/mono';
+@import '@carbon/type/scss/font-face/sans';
+@import '@carbon/type/scss/font-face/serif';
+
+@include carbon--type-reset();
+@include carbon--font-face-mono();
+@include carbon--font-face-sans();
+@include carbon--font-face-serif();
 
 // The default theme is "white" (White)
 :root {

--- a/packages/carbon-web-components/src/components/accordion/accordion-item.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion-item.ts
@@ -85,6 +85,19 @@ class BXAccordionItem extends FocusMixin(LitElement) {
         )
       )
     ) {
+      const { selectorAccordionContent } = this
+        .constructor as typeof BXAccordionItem;
+
+      !this.open
+        ? this.setAttribute('expanding', '')
+        : this.setAttribute('collapsing', '');
+      this.shadowRoot!.querySelector(
+        selectorAccordionContent
+      )!.addEventListener('animationend', () => {
+        this.removeAttribute('expanding');
+        this.removeAttribute('collapsing');
+      });
+
       this.open = open;
       this.dispatchEvent(
         new CustomEvent(
@@ -242,6 +255,10 @@ class BXAccordionItem extends FocusMixin(LitElement) {
    */
   static get eventToggle() {
     return `${prefix}-accordion-item-toggled`;
+  }
+
+  static get selectorAccordionContent() {
+    return `.${prefix}--accordion__content`;
   }
 
   static styles = styles;

--- a/packages/carbon-web-components/src/components/accordion/accordion.scss
+++ b/packages/carbon-web-components/src/components/accordion/accordion.scss
@@ -24,14 +24,6 @@ $css--plex: true !default;
 
   display: block;
   outline: none;
-
-  .#{$prefix}--accordion__heading {
-    padding-top: calc(
-      (#{$spacing-08} - #{map-get($body-long-01, 'line-height')}rem) / 2
-    );
-    min-height: $spacing-08;
-  }
-
   .#{$prefix}--accordion__content {
     @extend .#{$prefix}--accordion__content;
 
@@ -57,6 +49,14 @@ $css--plex: true !default;
   &[isFlush] {
     @extend .#{$prefix}--accordion--flush;
   }
+}
+
+:host(#{$prefix}-accordion-item[expanding]) {
+  @extend .#{$prefix}--accordion__item--expanding;
+}
+
+:host(#{$prefix}-accordion-item[collapsing]) {
+  @extend .#{$prefix}--accordion__item--collapsing;
 }
 
 :host(#{$prefix}-accordion-item[open]:not([disabled])) {


### PR DESCRIPTION
### Related Ticket(s)

N/A
### Description

added missing animation styles on open and close

added back the styles in storybook... otherwise they overwrite all slotted `p` styles, but wasn't exactly sure what was broken before? 

- what this pr shows
<img width="597" alt="Screen Shot 2023-03-09 at 7 24 59 PM" src="https://user-images.githubusercontent.com/20210594/224207526-57e2a9b5-e35d-4fff-8453-ecdd06b582e7.png">

- how it shows with previous container styles
<img width="587" alt="Screen Shot 2023-03-09 at 7 26 08 PM" src="https://user-images.githubusercontent.com/20210594/224207532-25d3a0ab-6697-404c-8570-2b815d1e744b.png">

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
