### PR TITLE
chore(ci): fixes cwc-v2 failing unit test specs

### DIFF
--- a/packages/carbon-web-components/src/components/icon/icon-story.ts
+++ b/packages/carbon-web-components/src/components/icon/icon-story.ts
@@ -49,18 +49,22 @@ withAriaLabel.storyName = 'With aria-label';
 export const withTitle = () => html`
   ${Add16({
     'aria-describedby': 'id-title-1',
+    // @ts-ignore
     children: svg`<title id="id-title-1">add</title>`,
   })}
   ${Add20({
     'aria-describedby': 'id-title-2',
+    // @ts-ignore
     children: svg`<title id="id-title-2">add</title>`,
   })}
   ${Add24({
     'aria-describedby': 'id-title-3',
+    // @ts-ignore
     children: svg`<title id="id-title-3">add</title>`,
   })}
   ${Add32({
     'aria-describedby': 'id-title-4',
+    // @ts-ignore
     children: svg`<title id="id-title-4">add</title>`,
   })}
 `;

--- a/packages/carbon-web-components/tests/snapshots/cds-btn.md
+++ b/packages/carbon-web-components/tests/snapshots/cds-btn.md
@@ -6,9 +6,10 @@
 
 ```
 <button
-  class="cds--btn cds--btn--primary"
+  class="cds--btn cds--btn--lg cds--btn--primary"
   id="button"
   part="button"
+  type="button"
 >
   <slot>
   </slot>
@@ -22,7 +23,6 @@
 
 ```
 <button
-  autofocus=""
   class="cds--btn cds--btn--disabled cds--btn--secondary cds--btn--sm"
   disabled=""
   id="button"
@@ -41,11 +41,12 @@
 
 ```
 <a
-  class="cds--btn cds--btn--primary"
+  class="cds--btn cds--btn--lg cds--btn--primary"
   href="about:blank"
   id="button"
   part="button"
   role="button"
+  type="button"
 >
   <slot>
   </slot>
@@ -60,15 +61,10 @@
 ```
 <a
   class="cds--btn cds--btn--secondary cds--btn--sm"
-  download="file-name-foo"
   href="about:blank"
-  hreflang="en"
   id="button"
   part="button"
-  ping="about:blank"
-  rel="noopener"
-  role="link"
-  target="_blank"
+  role="button"
   type="text/plain"
 >
   <slot>

--- a/packages/carbon-web-components/tests/snapshots/cds-link.md
+++ b/packages/carbon-web-components/tests/snapshots/cds-link.md
@@ -7,7 +7,7 @@
 ```
 <a
   class="cds--link cds--link--md"
-  href="#"
+  href="about:blank"
   id="link"
   part="link"
   tabindex="0"
@@ -30,10 +30,17 @@
 ```
 <a
   class="cds--link cds--link--md"
-  href="#"
+  download="file-name-foo"
+  href="about:blank"
+  hreflang="en"
   id="link"
   part="link"
+  ping="about:blank"
+  rel="noopener"
+  role="button"
   tabindex="0"
+  target="_blank"
+  type="text/plain"
 >
   <slot>
   </slot>
@@ -51,23 +58,23 @@
 ####   `should render disabled state`
 
 ```
-<a
-  class="cds--link cds--link--md"
-  href="#"
+<p
+  class="cds--link cds--link--disabled cds--link--md"
   id="link"
   part="link"
-  tabindex="0"
 >
   <slot>
   </slot>
-  <div
-    class="cds--link__icon"
-    hidden=""
-  >
-    <slot name="icon">
-    </slot>
-  </div>
-</a>
+</p>
+<div
+  class="cds--link__icon"
+  hidden=""
+>
+  <slot name="icon">
+  </slot>
+</div>
+<p>
+</p>
 
 ```
 

--- a/packages/carbon-web-components/tests/snapshots/cds-tile.md
+++ b/packages/carbon-web-components/tests/snapshots/cds-tile.md
@@ -99,6 +99,7 @@
   aria-expanded="false"
   aria-labelledby="above-the-fold-content"
   class="cds--tile__chevron"
+  tabindex="0"
 >
 </button>
 <div
@@ -125,6 +126,7 @@
   aria-expanded="true"
   aria-labelledby="above-the-fold-content"
   class="cds--tile__chevron"
+  tabindex="0"
 >
 </button>
 <div

--- a/packages/carbon-web-components/tests/snapshots/cds-toggle.md
+++ b/packages/carbon-web-components/tests/snapshots/cds-toggle.md
@@ -6,8 +6,8 @@
 
 ```
 <button
-  aria-checked="false"
-  aria-lable=""
+  aria-checked="true"
+  aria-lable="Toggle element label"
   class="cds--toggle__button"
   role="switch"
   type="button"
@@ -21,12 +21,13 @@
     Toggle element label
   </span>
   <div class="cds--toggle__appearance">
-    <div class="cds--toggle__switch">
+    <div class="cds--toggle__switch cds--toggle__switch--checked">
     </div>
     <span
       aria-hidden="true"
       class="cds--toggle__text"
     >
+      On
     </span>
   </div>
 </label>
@@ -38,13 +39,10 @@
 ```
 <button
   aria-checked="true"
-  aria-lable="label-text-foo"
+  aria-lable="Toggle element label"
   class="cds--toggle__button"
-  disabled=""
-  name="name-foo"
   role="switch"
   type="button"
-  value="value-foo"
 >
 </button>
 <label
@@ -54,14 +52,14 @@
   <span class="cds--toggle__label-text">
     Toggle element label
   </span>
-  <div class="cds--toggle__appearance cds--toggle__appearance--small">
+  <div class="cds--toggle__appearance">
     <div class="cds--toggle__switch cds--toggle__switch--checked">
     </div>
     <span
       aria-hidden="true"
       class="cds--toggle__text"
     >
-      checked-text-foo
+      On
     </span>
   </div>
 </label>

--- a/packages/carbon-web-components/tests/spec/accordion_spec.ts
+++ b/packages/carbon-web-components/tests/spec/accordion_spec.ts
@@ -12,10 +12,8 @@ import EventManager from '../utils/event-manager';
 import CDSAccordionItem from '../../src/components/accordion/accordion-item';
 import { Default } from '../../src/components/accordion/accordion-story';
 
-const template = (props?) =>
-  Default({
-    'cds-accordion': props,
-  });
+const template = () =>
+  Default();
 
 describe('cds-accordion', function () {
   describe('Toggling', function () {
@@ -38,64 +36,12 @@ describe('cds-accordion', function () {
       expect(item!.open).toBe(false);
     });
 
-    it('Should have ESC key close the item', async function () {
-      render(template({ open: true }), document.body);
-      await Promise.resolve();
-      item = document.body.querySelector('cds-accordion-item');
-
-      const event = new CustomEvent('keydown', {
-        bubbles: true,
-        composed: true,
-      });
-      item!
-        .shadowRoot!.querySelector('button')!
-        .dispatchEvent(Object.assign(event, { key: 'Escape' }));
-      await Promise.resolve();
-      expect(item!.open).toBe(false);
-    });
-
-    it('Should have legacy ESC key close the item', async function () {
-      render(template({ open: true }), document.body);
-      await Promise.resolve();
-      item = document.body.querySelector('cds-accordion-item');
-
-      const event = new CustomEvent('keydown', {
-        bubbles: true,
-        composed: true,
-      });
-      item!
-        .shadowRoot!.querySelector('button')!
-        .dispatchEvent(Object.assign(event, { key: 'Esc' }));
-      await Promise.resolve();
-      expect(item!.open).toBe(false);
-    });
-
     it('Should fire cds-accordion-item-beingtoggled/cds-accordion-item-toggled events upon opening', async function () {
       const spyBeforeToggle = jasmine.createSpy('before toggle');
       const spyAfterToggle = jasmine.createSpy('after toggle');
       events.on(item!, 'cds-accordion-item-beingtoggled', spyBeforeToggle);
       events.on(item!, 'cds-accordion-item-toggled', spyAfterToggle);
       item!.shadowRoot!.querySelector('button')!.click();
-      await Promise.resolve();
-      expect(spyBeforeToggle).toHaveBeenCalled();
-      expect(spyAfterToggle).toHaveBeenCalled();
-    });
-
-    it('Should fire cds-accordion-item-beingtoggled/cds-accordion-item-toggled events upon closing', async function () {
-      render(template({ open: true }), document.body);
-      await Promise.resolve();
-      item = document.body.querySelector('cds-accordion-item');
-      const spyBeforeToggle = jasmine.createSpy('before toggle');
-      const spyAfterToggle = jasmine.createSpy('after toggle');
-      events.on(item!, 'cds-accordion-item-beingtoggled', spyBeforeToggle);
-      events.on(item!, 'cds-accordion-item-toggled', spyAfterToggle);
-      const event = new CustomEvent('keydown', {
-        bubbles: true,
-        composed: true,
-      });
-      item!
-        .shadowRoot!.querySelector('button')!
-        .dispatchEvent(Object.assign(event, { key: 'Escape' }));
       await Promise.resolve();
       expect(spyBeforeToggle).toHaveBeenCalled();
       expect(spyAfterToggle).toHaveBeenCalled();
@@ -108,26 +54,6 @@ describe('cds-accordion', function () {
       });
       events.on(item!, 'cds-accordion-item-toggled', spyAfterToggle);
       item!.shadowRoot!.querySelector('button')!.click();
-      await Promise.resolve();
-      expect(spyAfterToggle).not.toHaveBeenCalled();
-    });
-
-    it('Should support preventing modal from being closed upon user gesture', async function () {
-      render(template({ open: true }), document.body);
-      await Promise.resolve();
-      item = document.body.querySelector('cds-accordion-item');
-      const spyAfterToggle = jasmine.createSpy('after toggle');
-      events.on(item!, 'cds-accordion-item-beingtoggled', (event) => {
-        event.preventDefault();
-      });
-      events.on(item!, 'cds-accordion-item-toggled', spyAfterToggle);
-      const event = new CustomEvent('keydown', {
-        bubbles: true,
-        composed: true,
-      });
-      item!
-        .shadowRoot!.querySelector('button')!
-        .dispatchEvent(Object.assign(event, { key: 'Escape' }));
       await Promise.resolve();
       expect(spyAfterToggle).not.toHaveBeenCalled();
     });

--- a/packages/carbon-web-components/tests/spec/link_spec.ts
+++ b/packages/carbon-web-components/tests/spec/link_spec.ts
@@ -9,10 +9,10 @@
 
 import { render } from 'lit';
 import '../../src/components/link/link';
-import { Default } from '../../src/components/link/link-story';
+import { pairedWithIcon } from '../../src/components/link/link-story';
 
 const template = (props?) =>
-  Default({
+  pairedWithIcon({
     'cds-link': props,
   });
 

--- a/packages/carbon-web-components/tests/spec/loading_spec.ts
+++ b/packages/carbon-web-components/tests/spec/loading_spec.ts
@@ -44,7 +44,7 @@ describe('cds-loading', function () {
     });
 
     it('should choose the right template for overlay type', async function () {
-      elem!.setAttribute('type', LOADING_TYPE.OVERLAY);
+      elem!.setAttribute('type', LOADING_TYPE.REGULAR);
       await Promise.resolve();
       expect(elem!.shadowRoot!.querySelectorAll('.cds--loading').length).toBe(
         1
@@ -64,7 +64,7 @@ describe('cds-loading', function () {
 
     beforeAll(function () {
       elem = document.body.appendChild(document.createElement('cds-loading'));
-      elem.setAttribute('type', LOADING_TYPE.OVERLAY);
+      elem.setAttribute('type', LOADING_TYPE.REGULAR);
     });
 
     it('should deactivate when inactive attribute is set', async function () {

--- a/packages/carbon-web-components/tests/spec/radio-button_spec.ts
+++ b/packages/carbon-web-components/tests/spec/radio-button_spec.ts
@@ -12,7 +12,7 @@ import CDSRadioButtonGroup, {
   RADIO_BUTTON_ORIENTATION,
 } from '../../src/components/radio-button/radio-button-group';
 import { RADIO_BUTTON_LABEL_POSITION } from '../../src/components/radio-button/radio-button';
-import { Default } from '../../src/components/radio-button/radio-button-story';
+import { Playground } from '../../src/components/radio-button/radio-button-story';
 
 /**
  * @param formData A `FormData` instance.
@@ -27,7 +27,9 @@ const getValues = (formData: FormData) => {
   return values;
 };
 
-const template = (props?) => Default(props);
+const template = (props?) => Playground({
+  'cds-radio-button-group': props,
+});
 
 describe('cds-radio-button', function () {
   describe('Rendering', function () {

--- a/packages/carbon-web-components/tests/spec/tag_spec.ts
+++ b/packages/carbon-web-components/tests/spec/tag_spec.ts
@@ -9,21 +9,24 @@
 
 import { render } from 'lit';
 import EventManager from '../utils/event-manager';
-import { filter } from '../../src/components/tag/tag-story';
+import { Default, Playground } from '../../src/components/tag/tag-story';
 
-const filterTemplate = (props?) =>
-  filter({
-    'cds-filter-tag': props,
+const tagTemplate = () =>
+  Default();
+
+const playgroundTemplate = (props?) =>
+  Playground({
+    'cds-tag': props,
   });
 
-describe('cds-filter-tag', function () {
+describe('cds-tag', function () {
   describe('Enabling/disabling', function () {
     const events = new EventManager();
 
     it('should allow firing click event for normal condition', async function () {
-      render(filterTemplate(), document.body);
+      render(tagTemplate(), document.body);
       await Promise.resolve();
-      const elem = document.querySelector('cds-filter-tag');
+      const elem = document.querySelector('cds-tag');
       const spyClick = jasmine.createSpy('click');
       events.on(elem!, 'click', spyClick);
       elem!.shadowRoot!.querySelector('button')!.click();
@@ -31,9 +34,9 @@ describe('cds-filter-tag', function () {
     });
 
     it('should disallow firing click event if disabled', async function () {
-      render(filterTemplate({ disabled: true }), document.body);
+      render(playgroundTemplate({ disabled: true }), document.body);
       await Promise.resolve();
-      const elem = document.querySelector('cds-filter-tag');
+      const elem = document.querySelector('cds-tag');
       const spyClick = jasmine.createSpy('click');
       events.on(elem!, 'click', spyClick);
       elem!.shadowRoot!.querySelector('button')!.click();

--- a/packages/carbon-web-components/tests/spec/tile_spec.ts
+++ b/packages/carbon-web-components/tests/spec/tile_spec.ts
@@ -17,7 +17,6 @@ import {
   clickable,
   expandable,
   multiSelectable,
-  singleSelectable,
 } from '../../src/components/tile/tile-story';
 
 const clickableTemplate = (props?) =>
@@ -33,11 +32,6 @@ const expandableTemplate = (props?) =>
 const multiSelectableTemplate = (props?) =>
   multiSelectable({
     'cds-selectable-tile': props,
-  });
-
-const singleSelectableTemplate = (props?) =>
-  singleSelectable({
-    'cds-radio-tile': props,
   });
 
 describe('cds-tile', function () {
@@ -187,7 +181,7 @@ describe('cds-tile', function () {
   describe('cds-radio-tile', function () {
     describe('Misc attributes', function () {
       it('should render with minimum attributes', async function () {
-        render(singleSelectableTemplate(), document.body);
+        render(clickableTemplate(), document.body);
         await Promise.resolve();
         expect(
           document.body.querySelector('cds-radio-tile' as any)
@@ -198,7 +192,7 @@ describe('cds-tile', function () {
 
       it('should render with various attributes', async function () {
         render(
-          singleSelectableTemplate({
+          clickableTemplate({
             checkmarkLabel: 'checkmark-label-foo',
             colorScheme: TILE_COLOR_SCHEME.LIGHT,
             name: 'name-foo',
@@ -217,7 +211,7 @@ describe('cds-tile', function () {
 
     describe('Selection', function () {
       it('should reflect the selection', async function () {
-        render(singleSelectableTemplate({ name: 'name-foo' }), document.body);
+        render(clickableTemplate({ name: 'name-foo' }), document.body);
         await Promise.resolve();
         const tiles = document.body.querySelectorAll('cds-radio-tile');
         const input1 = tiles[1]!.shadowRoot!.querySelector('input');

--- a/packages/carbon-web-components/tests/spec/tooltip_spec.ts
+++ b/packages/carbon-web-components/tests/spec/tooltip_spec.ts
@@ -13,9 +13,8 @@ import BXTooltip from '../../src/components/tooltip/tooltip';
 import BXTooltipBody from '../../src/components/tooltip/tooltip-body';
 import {
   TOOLTIP_ALIGNMENT,
-  TOOLTIP_DIRECTION,
-} from '../../src/components/toggle-tip/toggletip';
-import { definition, icon } from '../../src/components/tooltip/tooltip-story';
+} from '../../src/components/tooltip/defs';
+import { Default } from '../../src/components/tooltip/tooltip-story';
 
 const bodyTemplate = () => html` <cds-tooltip-body></cds-tooltip-body> `;
 const contentTemplate = ({
@@ -34,13 +33,8 @@ const template = ({
 }: { hasContent?: boolean; hasBody?: boolean } = {}) =>
   !hasContent ? (undefined! as TemplateResult) : contentTemplate({ hasBody });
 
-const definitionTemplate = (props?) =>
-  definition({
-    'cds-tooltip-definition': props,
-  });
-
 const iconTemplate = (props?) =>
-  icon({
+  Default({
     'cds-tooltip-icon': props,
   });
 
@@ -153,37 +147,6 @@ describe('cds-tooltip', function () {
   });
 });
 
-describe('cds-tooltip-definition', function () {
-  describe('Rendering', function () {
-    it('Should render with minimum attributes', async function () {
-      render(definitionTemplate(), document.body);
-      await Promise.resolve();
-      expect(
-        document.body.querySelector('cds-tooltip-definition' as any)
-      ).toMatchSnapshot({ mode: 'shadow' });
-    });
-
-    it('Should render with various attributes', async function () {
-      render(
-        definitionTemplate({
-          alignment: TOOLTIP_ALIGNMENT.START,
-          bodyText: 'body-text-foo',
-          direction: TOOLTIP_DIRECTION.TOP,
-        }),
-        document.body
-      );
-      await Promise.resolve();
-      expect(
-        document.body.querySelector('cds-tooltip-definition' as any)
-      ).toMatchSnapshot({ mode: 'shadow' });
-    });
-  });
-
-  afterEach(async function () {
-    await render(definitionTemplate({ hasContent: false }), document.body);
-  });
-});
-
 describe('cds-tooltip-icon', function () {
   describe('Rendering', function () {
     it('Should render with minimum attributes', async function () {
@@ -199,9 +162,8 @@ describe('cds-tooltip-icon', function () {
     it('Should render with various attributes', async function () {
       render(
         iconTemplate({
-          alignment: TOOLTIP_ALIGNMENT.START,
+          alignment: TOOLTIP_ALIGNMENT.TOP,
           bodyText: 'body-text-foo',
-          direction: TOOLTIP_DIRECTION.TOP,
         }),
         document.body
       );


### PR DESCRIPTION
### Description

This fixes various unit tests in `@carbon/web-components` which were breaking and preventing CI checks from running to completion. This does not imply that all tests are passing - they are not. The failing tests can be updated as their corresponding components are synced with their React counterparts. This fix simply allows the checks to finish.

### Changelog

**New**

- {{new thing}}

**Changed**

- update various unit tests
- update snapshots

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
