### PR TITLE
chore(gh): adds workflow to auto add issues/PRs to project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,22 @@
+name: Add to Project
+on:
+  issues:
+    types: [opened, labeled]
+  workflow_call:
+    secrets:
+      ADD_TO_PROJECT:
+        required: true
+
+# add new project URLs here
+env:
+  DOTCOM_PROJECT_URL: https://github.com/orgs/carbon-design-system/projects/56
+
+jobs:
+  add-to-dotcom-project:
+    name: Add issue to Dotcom project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.1
+      with:
+        project-url: ${{ env.DOTCOM_PROJECT_URL }}
+        github-token: ${{ secrets.ADD_TO_PROJECT }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,7 +2022,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@carbon/eslint-config-ibmdotcom@workspace:packages/eslint-config-ibmdotcom"
   dependencies:
-    "@carbon/eslint-plugin-react-prop-type-comments": 1.35.0-rc.1
+    "@carbon/eslint-plugin-react-prop-type-comments": 1.35.0-rc.2
     "@typescript-eslint/eslint-plugin": ^5.43.0
     "@typescript-eslint/parser": ^5.43.0
     babel-eslint: ^10.1.0
@@ -2054,7 +2054,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/eslint-plugin-react-prop-type-comments@1.35.0-rc.1, @carbon/eslint-plugin-react-prop-type-comments@workspace:packages/eslint-plugin-react-prop-type-comments":
+"@carbon/eslint-plugin-react-prop-type-comments@1.35.0-rc.2, @carbon/eslint-plugin-react-prop-type-comments@workspace:packages/eslint-plugin-react-prop-type-comments":
   version: 0.0.0-use.local
   resolution: "@carbon/eslint-plugin-react-prop-type-comments@workspace:packages/eslint-plugin-react-prop-type-comments"
   peerDependencies:
@@ -2092,12 +2092,12 @@ __metadata:
     "@babel/preset-env": ~7.12.0
     "@babel/preset-react": ~7.12.1
     "@babel/runtime": ^7.5.5
-    "@carbon/ibmdotcom-services": 1.45.0-rc.1
-    "@carbon/ibmdotcom-styles": 1.45.0-rc.1
-    "@carbon/ibmdotcom-utilities": 1.45.0-rc.1
+    "@carbon/ibmdotcom-services": 1.45.0-rc.2
+    "@carbon/ibmdotcom-styles": 1.45.0-rc.2
+    "@carbon/ibmdotcom-utilities": 1.45.0-rc.2
     "@carbon/icons-react": 10.49.0
     "@carbon/pictograms-react": 11.40.0
-    "@carbon/storybook-addon-theme": 1.36.0-rc.1
+    "@carbon/storybook-addon-theme": 1.36.0-rc.2
     "@carbon/telemetry": ^0.1.0
     "@percy-io/in-percy": ^0.1.11
     "@percy/cli": ^1.8.1
@@ -2210,7 +2210,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/ibmdotcom-services-store@1.45.0-rc.1, @carbon/ibmdotcom-services-store@workspace:packages/services-store":
+"@carbon/ibmdotcom-services-store@1.45.0-rc.2, @carbon/ibmdotcom-services-store@workspace:packages/services-store":
   version: 0.0.0-use.local
   resolution: "@carbon/ibmdotcom-services-store@workspace:packages/services-store"
   dependencies:
@@ -2221,8 +2221,8 @@ __metadata:
     "@babel/plugin-transform-modules-commonjs": ^7.10.0
     "@babel/plugin-transform-typescript": ^7.11.0
     "@babel/preset-modules": ^0.1.0
-    "@carbon/ibmdotcom-services": 1.45.0-rc.1
-    "@carbon/ibmdotcom-utilities": 1.45.0-rc.1
+    "@carbon/ibmdotcom-services": 1.45.0-rc.2
+    "@carbon/ibmdotcom-utilities": 1.45.0-rc.2
     async-done: ^1.3.0
     babel-eslint: ^10.0.3
     babel-jest: ^24.0.0
@@ -2247,7 +2247,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/ibmdotcom-services@1.45.0-rc.1, @carbon/ibmdotcom-services@workspace:packages/services":
+"@carbon/ibmdotcom-services@1.45.0-rc.2, @carbon/ibmdotcom-services@workspace:packages/services":
   version: 0.0.0-use.local
   resolution: "@carbon/ibmdotcom-services@workspace:packages/services"
   dependencies:
@@ -2260,7 +2260,7 @@ __metadata:
     "@babel/plugin-transform-runtime": 7.18.5
     "@babel/preset-env": ^7.4.3
     "@babel/runtime": ^7.5.0
-    "@carbon/ibmdotcom-utilities": 1.45.0-rc.1
+    "@carbon/ibmdotcom-utilities": 1.45.0-rc.2
     "@carbon/telemetry": 0.1.0
     "@rollup/plugin-babel": ^5.3.1
     "@rollup/plugin-commonjs": ^21.0.3
@@ -2294,7 +2294,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/ibmdotcom-styles@1.45.0-rc.1, @carbon/ibmdotcom-styles@workspace:packages/styles":
+"@carbon/ibmdotcom-styles@1.45.0-rc.2, @carbon/ibmdotcom-styles@workspace:packages/styles":
   version: 0.0.0-use.local
   resolution: "@carbon/ibmdotcom-styles@workspace:packages/styles"
   dependencies:
@@ -2320,7 +2320,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/ibmdotcom-utilities@1.45.0-rc.1, @carbon/ibmdotcom-utilities@workspace:packages/utilities":
+"@carbon/ibmdotcom-utilities@1.45.0-rc.2, @carbon/ibmdotcom-utilities@workspace:packages/utilities":
   version: 0.0.0-use.local
   resolution: "@carbon/ibmdotcom-utilities@workspace:packages/utilities"
   dependencies:
@@ -2386,10 +2386,10 @@ __metadata:
     "@babel/preset-react": ~7.12.0
     "@babel/template": ~7.12.0
     "@babel/traverse": ~7.12.0
-    "@carbon/ibmdotcom-services": 1.45.0-rc.1
-    "@carbon/ibmdotcom-services-store": 1.45.0-rc.1
-    "@carbon/ibmdotcom-styles": 1.45.0-rc.1
-    "@carbon/ibmdotcom-utilities": 1.45.0-rc.1
+    "@carbon/ibmdotcom-services": 1.45.0-rc.2
+    "@carbon/ibmdotcom-services-store": 1.45.0-rc.2
+    "@carbon/ibmdotcom-styles": 1.45.0-rc.2
+    "@carbon/ibmdotcom-utilities": 1.45.0-rc.2
     "@carbon/icon-helpers": 10.39.0
     "@carbon/icons": 10.48.0
     "@carbon/icons-react": 10.49.0
@@ -2397,7 +2397,7 @@ __metadata:
     "@carbon/motion": ^11.0.0
     "@carbon/telemetry": 0.1.0
     "@carbon/type": 10.45.1
-    "@carbon/web-components": 1.26.0-rc.1
+    "@carbon/web-components": 1.26.0-rc.2
     "@open-wc/semantic-dom-diff": ^0.15.0
     "@percy-io/in-percy": ^0.1.11
     "@percy/cli": ^1.8.1
@@ -2600,7 +2600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/storybook-addon-theme@1.36.0-rc.1, @carbon/storybook-addon-theme@workspace:packages/storybook-addon-theme":
+"@carbon/storybook-addon-theme@1.36.0-rc.2, @carbon/storybook-addon-theme@workspace:packages/storybook-addon-theme":
   version: 0.0.0-use.local
   resolution: "@carbon/storybook-addon-theme@workspace:packages/storybook-addon-theme"
   dependencies:
@@ -2658,7 +2658,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/web-components@1.26.0-rc.1, @carbon/web-components@workspace:packages/carbon-web-components":
+"@carbon/web-components@1.26.0-rc.2, @carbon/web-components@workspace:packages/carbon-web-components":
   version: 0.0.0-use.local
   resolution: "@carbon/web-components@workspace:packages/carbon-web-components"
   dependencies:


### PR DESCRIPTION
### Description

This adds a new GitHub workflow to automatically add new issues and pull requests to the Carbon for IBM.com project. Currently it will add anything newly created labeled. This workflow is just a starting point. In the future, new workflow filters can be created to add to other GitHub projects.

See https://github.com/actions/add-to-project for more use cases.

### Changelog

**New**

- workflow to automatically add new issues to default project

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
