### PR TITLE
chore(skeleton-text): sync with v11

### DIFF
--- a/packages/carbon-web-components/src/components/skeleton-text/defs.ts
+++ b/packages/carbon-web-components/src/components/skeleton-text/defs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,9 +20,4 @@ export enum SKELETON_TEXT_TYPE {
    * Heading variant.
    */
   HEADING = 'heading',
-
-  /**
-   * Line variant.
-   */
-  LINE = 'line',
 }

--- a/packages/carbon-web-components/src/components/skeleton-text/skeleton-text-story.ts
+++ b/packages/carbon-web-components/src/components/skeleton-text/skeleton-text-story.ts
@@ -19,36 +19,33 @@ const types = {
   [`Heading (${SKELETON_TEXT_TYPE.HEADING})`]: SKELETON_TEXT_TYPE.HEADING,
 };
 
-export const Default = (args) => {
-  const { type } = args?.[`${prefix}-skeleton-text`] ?? {};
-  return html`
-    <cds-skeleton-text type="${ifDefined(type)}"></cds-skeleton-text>
-  `;
-};
+export const Default = () => html` <cds-skeleton-text></cds-skeleton-text>`;
+
+Default.storyName = 'Default';
 
 Default.parameters = {
-  knobs: {
-    [`${prefix}-skeleton-text`]: () => ({
-      type: select('Skeleton text type (type)', types, null),
-    }),
+  percy: {
+    skip: true,
   },
 };
 
-export const Lines = (args) => {
-  const { paragraph, lineCount, width } =
+export const Playground = (args) => {
+  const { type, paragraph, lineCount, width } =
     args?.[`${prefix}-skeleton-text`] ?? {};
   return html`
     <cds-skeleton-text
-      type="line"
+      type="${ifDefined(type)}"
       ?paragraph="${paragraph}"
       lineCount="${lineCount}"
-      width="${width}"></cds-skeleton-text>
+      width="${width}">
+    </cds-skeleton-text>
   `;
 };
 
-Lines.parameters = {
+Playground.parameters = {
   knobs: {
     [`${prefix}-skeleton-text`]: () => ({
+      type: select('Skeleton text type (type)', types, null),
       paragraph: boolean('Use multiple lines of text (paragraph)', true),
       lineCount: number('The number of lines in a paragraph (lineCount)', 3),
       width: text(
@@ -60,7 +57,7 @@ Lines.parameters = {
 };
 
 export default {
-  title: 'Components/Skeleton text',
+  title: 'Components/Skeleton/Skeleton text',
   parameters: {
     ...storyDocs.parameters,
     percy: {

--- a/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.scss
+++ b/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.scss
@@ -11,4 +11,8 @@
 :host(#{$prefix}-skeleton-text) {
   display: block;
   width: 100%;
+
+  .#{$prefix}--skeleton__text {
+    margin-top: 0;
+  }
 }

--- a/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.ts
+++ b/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.ts
@@ -27,7 +27,7 @@ function getRandomInt(min: number, max: number, n: number) {
  * @element cds-skeleton-text
  */
 @customElement(`${prefix}-skeleton-text`)
-class BXSkeletonText extends LitElement {
+class CDSSkeletonText extends LitElement {
   /**
    * The type of skeleton text.
    */
@@ -43,7 +43,6 @@ class BXSkeletonText extends LitElement {
   /**
    * will generate multiple lines of text
    */
-
   @property({ type: Boolean, reflect: true })
   paragraph = false;
 
@@ -82,4 +81,4 @@ class BXSkeletonText extends LitElement {
   static styles = styles;
 }
 
-export default BXSkeletonText;
+export default CDSSkeletonText;


### PR DESCRIPTION
### Related Ticket(s)

#10090

### Description

This PR updates the skeleton text export name and story to match the core v11 component

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
