### PR TITLE
feat(masthead-l1): implement v2.1 layout & styles for desktop

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -146,19 +146,6 @@ $search-transition-timing: 95ms;
       }
     }
 
-    .#{$prefix}--masthead__l1-dropdown-subsection {
-      padding-bottom: $carbon--spacing-07;
-      border-bottom: 1px solid $ui-03;
-
-      .#{$prefix}--masthead__l1-dropdown-item {
-        padding-block: $carbon--spacing-04;
-        padding-inline-start: $carbon--spacing-05;
-        padding-inline-end: $carbon--spacing-08;
-        border-bottom: none;
-        color: $text-02;
-      }
-    }
-
     .#{$prefix}--masthead__l1-dropdown-announcement {
       @include carbon--type-style(body-short-01);
 
@@ -222,6 +209,18 @@ $search-transition-timing: 95ms;
       &:focus {
         outline: 2px solid $focus;
         outline-offset: -2px;
+      }
+    }
+
+    .#{$prefix}--masthead__l1-dropdown-subsection {
+      padding-bottom: $carbon--spacing-07;
+
+      .#{$prefix}--masthead__l1-dropdown-item {
+        padding-block: $carbon--spacing-04;
+        padding-inline-start: $carbon--spacing-05;
+        padding-inline-end: $carbon--spacing-08;
+        border-bottom: none;
+        color: $text-01;
       }
     }
 

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -17,7 +17,6 @@ import root from 'window-or-global';
 import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
-import settings from 'carbon-components/es/globals/js/settings.js';
 import { globalInit } from '../../internal/vendor/@carbon/ibmdotcom-services/services/global/global';
 import MastheadLogoAPI from '../../internal/vendor/@carbon/ibmdotcom-services/services/MastheadLogo/MastheadLogo';
 import {
@@ -71,7 +70,6 @@ import {
   LEGACY_MEGAMENU_RIGHT_NAVIGATION_STYLE_SCHEME,
 } from './defs';
 
-const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;
 
 // Magic Number: 799px matches masthead.scss's `$breakpoint--desktop-nav`.

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -17,6 +17,7 @@ import root from 'window-or-global';
 import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
+import settings from 'carbon-components/es/globals/js/settings.js';
 import { globalInit } from '../../internal/vendor/@carbon/ibmdotcom-services/services/global/global';
 import MastheadLogoAPI from '../../internal/vendor/@carbon/ibmdotcom-services/services/MastheadLogo/MastheadLogo';
 import {
@@ -70,6 +71,7 @@ import {
   LEGACY_MEGAMENU_RIGHT_NAVIGATION_STYLE_SCHEME,
 } from './defs';
 
+const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;
 
 // Magic Number: 799px matches masthead.scss's `$breakpoint--desktop-nav`.


### PR DESCRIPTION
### Related Ticket(s)
- #9954
- [ADCMS-2911](https://jsw.ibm.com/browse/ADCMS-2911): [L1 Nav]: Implement design updates (Desktop/Tablet)

### Description

Updates the L1 nav for desktop sizes

### Changelog

**Changed**

- updates masthead-l1 to v2.1 layout & styles