### PR TITLE
fix(tabs-extended): apply correct mobile gutters 

### DIFF
--- a/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
+++ b/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
@@ -51,6 +51,10 @@
       }
     }
 
+    .#{$prefix}--tabs-extended {
+      width: inherit;
+    }
+
     .#{$prefix}--accordion__content {
       margin-top: -$carbon--spacing-07;
       margin-bottom: $carbon--spacing-05;

--- a/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
+++ b/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
@@ -54,16 +54,6 @@
     .#{$prefix}--tabs-extended {
       width: inherit;
     }
-
-    .#{$prefix}--accordion__content {
-      margin-top: -$carbon--spacing-07;
-      margin-bottom: $carbon--spacing-05;
-      padding: $carbon--spacing-07 0 0;
-
-      @include carbon--breakpoint(md) {
-        margin-bottom: -$carbon--spacing-05;
-      }
-    }
   }
 }
 

--- a/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
+++ b/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
@@ -180,31 +180,6 @@
         display: none;
       }
     }
-
-    .#{$prefix}--accordion__heading {
-      justify-content: space-between;
-      z-index: 0;
-    }
-
-    .#{$prefix}--accordion__title {
-      max-width: rem(640px);
-      margin-right: $spacing-07;
-    }
-
-    .#{$prefix}--accordion__content {
-      p {
-        @include carbon--type-style('body-long-02', true);
-      }
-    }
-  }
-
-  @media print {
-    :host(#{$dds-prefix}-tabs-extended),
-    :host(#{$dds-prefix}-tabs-extended-media) {
-      .#{$prefix}--accordion__content {
-        display: block;
-      }
-    }
   }
 }
 

--- a/packages/web-components/src/components/tabs-extended-media/__stories__/tabs-extended-media.stories.ts
+++ b/packages/web-components/src/components/tabs-extended-media/__stories__/tabs-extended-media.stories.ts
@@ -189,6 +189,11 @@ export const WithMixedContent = (args) => {
         </bx-accordion>
       </dds-tab>
     `,
+    html`
+      <dds-tab label="Disabled" disabled>
+        <p>${exampleStrings[0]}</p>
+      </dds-tab>
+    `,
   ];
 
   return html`

--- a/packages/web-components/src/components/tabs-extended-media/__stories__/tabs-extended-media.stories.ts
+++ b/packages/web-components/src/components/tabs-extended-media/__stories__/tabs-extended-media.stories.ts
@@ -9,11 +9,14 @@
 
 import { html } from 'lit-element';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import '../../../internal/vendor/@carbon/web-components/components/accordion/index';
 import { boolean, select } from '@storybook/addon-knobs';
 import readme from './README.stories.mdx';
 import '../index';
+import '../../card-group/index';
 import '../../content-item-horizontal/index';
 import '../../image/index';
+import '../../video-player/video-player-composite';
 import { MEDIA_ALIGN, MEDIA_TYPE } from '../../content-item-horizontal/defs';
 import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--001.jpg';
 import textNullable from '../../../../.storybook/knob-text-nullable';
@@ -29,8 +32,9 @@ const mediaType = {
 };
 
 export const Default = (args) => {
-  const { sectionHeading, sectionHeadingText, align, type } =
+  const { sectionHeading, sectionHeadingText } =
     args?.TabsExtendedWithMedia ?? {};
+  const { align, type } = args?.TabsExtendedWithMediaDefault ?? {};
   const tabs: any[] = [];
 
   for (let i = 1; i < 5; i++) {
@@ -89,13 +93,8 @@ export const Default = (args) => {
 Default.story = {
   parameters: {
     knobs: {
-      TabsExtendedWithMedia: () => {
-        const sectionHeading = boolean('Section heading', true);
-        const sectionHeadingText =
-          sectionHeading && textNullable('Heading', 'Section heading');
+      TabsExtendedWithMediaDefault: () => {
         return {
-          sectionHeading,
-          sectionHeadingText,
           align: select('Alignment (align)', mediaAlign, MEDIA_ALIGN.LEFT),
           type: select('Media type', mediaType, MEDIA_TYPE.IMAGE),
         };
@@ -103,14 +102,103 @@ Default.story = {
     },
     propsSet: {
       default: {
-        TabsExtendedWithMedia: {
-          sectionHeading: 'TitleHeading',
+        TabsExtendedWithMediaDefault: {
           align: 'left',
-          type: 'image',
+          type: MEDIA_TYPE.IMAGE,
         },
       },
     },
   },
+};
+
+export const WithMixedContent = (args) => {
+  const { sectionHeading, sectionHeadingText } =
+    args?.TabsExtendedWithMedia ?? {};
+
+  // Needed to bypass html`` template strings from putting strings with line breaks
+  // (which are forced by prettier formatting) into <pre> tags.
+  const exampleStrings = [
+    `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.`,
+    `Donec tempus, urna eu elementum porta, justo massa porta nulla, et mattis mauris augue sit amet dolor.`,
+  ];
+
+  const cardGroupItems = [
+    html`
+      <dds-card-group-item cta-type="local" href="/">
+        <dds-card-eyebrow>Topic (Local)</dds-card-eyebrow>
+        <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
+        <p>${exampleStrings[0]}</p>
+        <dds-card-cta-footer slot="footer"></dds-card-cta-footer>
+      </dds-card-group-item>
+    `,
+    html`
+      <dds-card-group-item cta-type="external" href="https://example.com">
+        <dds-card-eyebrow>Topic (External)</dds-card-eyebrow>
+        <dds-card-heading>Consectetur adipiscing elit</dds-card-heading>
+        <p>${exampleStrings[1]}</p>
+        <dds-card-cta-footer slot="footer"></dds-card-cta-footer>
+      </dds-card-group-item>
+    `,
+  ];
+
+  const tabs = [
+    html`
+      <dds-tab label="Image">
+        <dds-image alt="Image alt text" default-src="${imgLg16x9}"></dds-image>
+      </dds-tab>
+    `,
+    html`
+      <dds-tab label="Card Group">
+        <dds-card-group cards-per-row="3" grid-mode="narrow">
+          ${[...Array(5).keys()].map((i) => cardGroupItems[i % 2])}
+        </dds-card-group>
+      </dds-tab>
+    `,
+    html`
+      <dds-tab label="Accordion">
+        <bx-accordion>
+          <bx-accordion-item title-text="Image">
+            <dds-image
+              alt="Image alt text"
+              default-src="${imgLg16x9}"></dds-image>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat.
+            </p>
+          </bx-accordion-item>
+          <bx-accordion-item title-text="Video">
+            <dds-video-player-composite
+              video-id="1_9h94wo6b"></dds-video-player-composite>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat.
+            </p>
+          </bx-accordion-item>
+          <bx-accordion-item title-text="Text">
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat.
+            </p>
+          </bx-accordion-item>
+        </bx-accordion>
+      </dds-tab>
+    `,
+  ];
+
+  return html`
+    <dds-tabs-extended-media section-heading=${sectionHeading}>
+      <dds-content-section-heading
+        >${ifNonNull(sectionHeadingText)}</dds-content-section-heading
+      >
+      ${tabs}
+    </dds-tabs-extended-media>
+  `;
 };
 
 export default {
@@ -132,6 +220,24 @@ export default {
   parameters: {
     ...readme.parameters,
     hasStoryPadding: true,
-    knobs: {},
+    knobs: {
+      TabsExtendedWithMedia: () => {
+        const sectionHeading = boolean('Section heading', true);
+        const sectionHeadingText =
+          sectionHeading && textNullable('Heading', 'Section heading');
+
+        return {
+          sectionHeading,
+          sectionHeadingText,
+        };
+      },
+    },
+    propsSet: {
+      default: {
+        TabsExtendedWithMedia: {
+          sectionHeading: 'TitleHeading',
+        },
+      },
+    },
   },
 };

--- a/packages/web-components/src/components/tabs-extended-media/tabs-extended-media.scss
+++ b/packages/web-components/src/components/tabs-extended-media/tabs-extended-media.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -12,7 +12,6 @@ import { html, state, LitElement, TemplateResult, property } from 'lit-element';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import '../../internal/vendor/@carbon/web-components/components/accordion/index';
-import ChevronRight20 from '../../internal/vendor/@carbon/web-components/icons/chevron--right/20.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import DDSTab from './tab';

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -11,6 +11,7 @@ import settings from 'carbon-components/es/globals/js/settings.js';
 import { html, state, LitElement, TemplateResult, property } from 'lit-element';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import '../../internal/vendor/@carbon/web-components/components/accordion/index';
 import ChevronRight20 from '../../internal/vendor/@carbon/web-components/icons/chevron--right/20.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
@@ -184,41 +185,25 @@ class DDSTabsExtended extends StableSelectorMixin(LitElement) {
     });
   }
 
-  protected _renderAccordion(): TemplateResult | string | void {
+  protected _renderAccordion() {
     const { _tabItems: tabs } = this;
     return html`
-      <ul class="${prefix}--accordion">
+      <bx-accordion class="${prefix}--accordion">
         ${tabs.map((tab, index) => {
           const { disabled } = tab as DDSTab;
           const active = index === this._activeTabIndex;
           const label = (tab as DDSTab).getAttribute('label');
-          const classes = classMap({
-            'bx--accordion__item': true,
-            'bx--accordion__item--active': active,
-            'bx--accordion__item--disabled': disabled,
-          });
+
           return html`
-            <li class="${classes}">
-              <button
-                class="${prefix}--accordion__heading"
-                aria-expanded="${active}"
-                aria-controls="pane-${index}"
-                @click="${(e) => this._handleClick(index, e)}"
-                tabindex="${index + 1}"
-                ?disabled="${disabled}">
-                ${ChevronRight20({
-                  part: 'expando-icon',
-                  class: `${prefix}--accordion__arrow`,
-                })}
-                <div class="${prefix}--accordion__title">${label}</div>
-              </button>
-              <div id="pane-${index}" class="${prefix}--accordion__content">
-                ${unsafeHTML((tab as DDSTab).innerHTML)}
-              </div>
-            </li>
+            <bx-accordion-item
+              title-text="${label}"
+              ?open="${active}"
+              ?disabled="${disabled}">
+              ${unsafeHTML((tab as DDSTab).innerHTML)}
+            </bx-accordion-item>
           `;
         })}
-      </ul>
+      </bx-accordion>
     `;
   }
 

--- a/packages/web-components/tests/snapshots/dds-tabs-extended-media.md
+++ b/packages/web-components/tests/snapshots/dds-tabs-extended-media.md
@@ -11,8 +11,11 @@
     </slot>
   </div>
   <div class="bx--tabs-extended">
-    <ul class="bx--accordion">
-    </ul>
+    <bx-accordion
+      class="bx--accordion"
+      role="list"
+    >
+    </bx-accordion>
     <div class="bx--tabs">
       <ul
         class="bx--tabs__nav bx--tabs__nav--hidden"
@@ -38,8 +41,11 @@
     </slot>
   </div>
   <div class="bx--tabs-extended">
-    <ul class="bx--accordion">
-    </ul>
+    <bx-accordion
+      class="bx--accordion"
+      role="list"
+    >
+    </bx-accordion>
     <div class="bx--tabs">
       <ul
         class="bx--tabs__nav bx--tabs__nav--hidden"

--- a/packages/web-components/tests/snapshots/dds-tabs-extended.md
+++ b/packages/web-components/tests/snapshots/dds-tabs-extended.md
@@ -6,8 +6,11 @@
 
 ```
 <div class="bx--tabs-extended bx--tabs-extended--horizontal">
-  <ul class="bx--accordion">
-  </ul>
+  <bx-accordion
+    class="bx--accordion"
+    role="list"
+  >
+  </bx-accordion>
   <div class="bx--tabs">
     <ul
       class="bx--tabs__nav bx--tabs__nav--hidden"
@@ -27,8 +30,11 @@
 
 ```
 <div class="bx--tabs-extended bx--tabs-extended--horizontal">
-  <ul class="bx--accordion">
-  </ul>
+  <bx-accordion
+    class="bx--accordion"
+    role="list"
+  >
+  </bx-accordion>
   <div class="bx--tabs">
     <ul
       class="bx--tabs__nav bx--tabs__nav--hidden"


### PR DESCRIPTION
### Related Ticket(s)

Resolves #10298

### Description

This PR aligns elements in the mobile version of the `<dds-tabs-extended>` component to the Carbon grid. It achieves this by replacing the custom accordion markup with `<bx-accordion>` web components, which has the correct mobile styling.

### Changelog

**Added**
- Adds "With Mixed Content" Story that demonstrates selected web components used within tabs. 

**Changed**
- Replaces custom accordion markup with `@carbon/web-components`' `<bx-accordion>` markup.
- Makes tabs extend the full width available to them.

**Removed**
- Removes styles that were used for custom markup.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
