### PR TITLE
chore(checks): pin node version to 18.15

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -13,15 +13,12 @@ concurrency:
 jobs:
   check-packages:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: ['18.x']
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.15
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
@@ -33,15 +30,12 @@ jobs:
           yarn lerna run --stream --ignore=@carbon/ibmdotcom-web-components ci-check
   web-components:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: ['18.x']
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.15
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
@@ -53,15 +47,12 @@ jobs:
         run: xvfb-run --auto-servernum yarn lerna run --stream --prefix --scope=@carbon/ibmdotcom-web-components ci-check
   a11y:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: ['18.x']
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.15
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache


### PR DESCRIPTION
### Description

A current [bug](https://github.com/nodejs/node/issues/47563) in the latest version of Node is causing CI checks to fail. The bug has been fixed but not yet back-ported, so in the meantime will test pinning the version to `18.15`.

### Changelog

**New**

- {{new thing}}

**Changed**

- pin `ci-check` workflow Node version to `18.15`

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
