### PR TITLE
chore(mixin): import `carbon-components` mixin

### DIFF
--- a/packages/carbon-web-components/package.json
+++ b/packages/carbon-web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/web-components",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/carbon-web-components/src/components/date-picker/fix-events-plugin.ts
+++ b/packages/carbon-web-components/src/components/date-picker/fix-events-plugin.ts
@@ -9,7 +9,7 @@
 
 import { Instance as FlatpickrInstance } from 'flatpickr/dist/types/instance';
 import { Plugin } from 'flatpickr/dist/types/options';
-import on from 'carbon-components/es/globals/js/misc/on';
+import on from '../../globals/mixins/on';
 import Handle from '../../globals/internal/handle';
 import CDSDatePickerInput from './date-picker-input';
 

--- a/packages/carbon-web-components/src/components/date-picker/focus-plugin.ts
+++ b/packages/carbon-web-components/src/components/date-picker/focus-plugin.ts
@@ -9,7 +9,7 @@
 
 import { Instance as FlatpickrInstance } from 'flatpickr/dist/types/instance';
 import { Plugin } from 'flatpickr/dist/types/options';
-import on from 'carbon-components/es/globals/js/misc/on';
+import on from '../../globals/mixins/on';
 import Handle from '../../globals/internal/handle';
 import CDSDatePickerInput from './date-picker-input';
 

--- a/packages/carbon-web-components/src/components/date-picker/shadow-dom-events-plugin.ts
+++ b/packages/carbon-web-components/src/components/date-picker/shadow-dom-events-plugin.ts
@@ -9,7 +9,7 @@
 
 import { Instance as FlatpickrInstance } from 'flatpickr/dist/types/instance';
 import { Plugin } from 'flatpickr/dist/types/options';
-import on from 'carbon-components/es/globals/js/misc/on';
+import on from '../../globals/mixins/on';
 import Handle from '../../globals/internal/handle';
 import { find } from '../../globals/internal/collection-helpers';
 

--- a/packages/carbon-web-components/src/components/ui-shell/side-nav.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/side-nav.ts
@@ -9,7 +9,7 @@
 
 import { LitElement, html } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
-import on from 'carbon-components/es/globals/js/misc/on';
+import on from '../../globals/mixins/on';
 import { prefix } from '../../globals/settings';
 import HostListenerMixin from '../../globals/mixins/host-listener';
 import HostListener from '../../globals/decorators/host-listener';

--- a/packages/carbon-web-components/src/globals/mixins/form.ts
+++ b/packages/carbon-web-components/src/globals/mixins/form.ts
@@ -1,13 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import on from 'carbon-components/es/globals/js/misc/on';
+import on from './on';
 import Handle from '../internal/handle';
 
 /**

--- a/packages/carbon-web-components/src/globals/mixins/host-listener.ts
+++ b/packages/carbon-web-components/src/globals/mixins/host-listener.ts
@@ -1,13 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import on from 'carbon-components/es/globals/js/misc/on';
+import on from './on';
 import Handle from '../internal/handle';
 
 /**

--- a/packages/carbon-web-components/src/globals/mixins/on.ts
+++ b/packages/carbon-web-components/src/globals/mixins/on.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright IBM Corp. 2016, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default function on(element: any, ...args: any) {
+  element.addEventListener(...args);
+  return {
+    release() {
+      element.removeEventListener(...args);
+      return null;
+    },
+  };
+}

--- a/packages/carbon-web-components/src/globals/wrappers/createReactCustomElementType.ts
+++ b/packages/carbon-web-components/src/globals/wrappers/createReactCustomElementType.ts
@@ -8,7 +8,7 @@
  */
 
 import React, { Component, createElement, forwardRef } from 'react';
-import on from 'carbon-components/es/globals/js/misc/on';
+import on from '../mixins/on';
 import Handle from '../internal/handle';
 
 /**

--- a/packages/carbon-web-components/tests/utils/event-manager.ts
+++ b/packages/carbon-web-components/tests/utils/event-manager.ts
@@ -1,13 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2022
+ * Copyright IBM Corp. 2019, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import on from 'carbon-components/es/globals/js/misc/on';
+import on from '../../src/globals/mixins/on';
 import Handle from '../../src/globals/internal/handle';
 
 interface CustomEventListener {


### PR DESCRIPTION
### Description

This imports the `on` helper function from `carbon-components` into the package, as `carbon-components` is no longer a dependency.

### Changelog

**New**

- `on` mixin added

**Changed**

- change `on` references from `carbon-components` to local

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
