### PR TITLE
chore(notice-choice): remove react wrapper causing build errors

### DIFF
--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -527,5 +527,5 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
     );
   }
 }
-/* @__GENERATE_REACT_CUSTOM_ELEMENT_TYPE__ */
+
 export default NoticeChoice;


### PR DESCRIPTION
### Description

Temporarily remove `notice-choice` React wrapper added in #10421 as it is throwing errors and affecting the CI workflow.

@sanjitbauli Since there is still a current React version this doesn't need to be any sort of blocker. Once it is fixed we can re-enable it.

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- `notice-choice` React wrapper

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
