### PR TITLE
chore(gh): revert to node 14 for react workflow

### DIFF
--- a/.github/workflows/snapshot-update.yml
+++ b/.github/workflows/snapshot-update.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: ['18.x']
+        node-version: ['14.x']
     steps:
       - uses: actions/checkout@v3
         with:
           token: ${{secrets.MERGE_ACTION}}
-      - name: Use Node.js 18.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
### Description

Revert to Node 14 for this workflow.

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
