### PR TITLE
feat(masthead-l1): Removing the has pseudo-class

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -221,7 +221,7 @@ $search-transition-timing: 95ms;
 
       color: $text-01;
 
-      // Headings that are not links. 
+      // Headings that are not links.
       &.no-link {
         padding-block: $carbon--spacing-04;
         padding-inline-start: $carbon--spacing-05;
@@ -585,10 +585,8 @@ $search-transition-timing: 95ms;
       > * {
         break-inside: avoid;
       }
-    }
 
-    // Contains a wide col child. 
-    .#{$prefix}--masthead__l1-dropdown-links {
+      // Contains a wide col child.
       &.has-wide {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
@@ -644,7 +642,7 @@ $search-transition-timing: 95ms;
         margin-bottom: $spacing-03;
       }
 
-      // Headings that do not contain links. 
+      // Headings that do not contain links.
       &.no-link {
         padding: $spacing-03 $spacing-05;
         margin-bottom: $spacing-03;

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -222,7 +222,7 @@ $search-transition-timing: 95ms;
       color: $text-01;
 
       // Headings that are not links.
-      &.no-link {
+      &.#{$prefix}--masthead__l1-dropdown-heading--no-link {
         padding-block: $carbon--spacing-04;
         padding-inline-start: $carbon--spacing-05;
         padding-inline-end: $carbon--spacing-08;
@@ -587,7 +587,7 @@ $search-transition-timing: 95ms;
       }
 
       // Contains a wide col child.
-      &.has-wide {
+      &.#{$prefix}--masthead__l1-dropdown--has-column-wide {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
 
@@ -643,7 +643,7 @@ $search-transition-timing: 95ms;
       }
 
       // Headings that do not contain links.
-      &.no-link {
+      &.#{$prefix}--masthead__l1-dropdown-heading--no-link {
         padding: $spacing-03 $spacing-05;
         margin-bottom: $spacing-03;
       }

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -221,7 +221,8 @@ $search-transition-timing: 95ms;
 
       color: $text-01;
 
-      &:not(:has(> .#{$prefix}--masthead__l1-dropdown-item)) {
+      // Headings that are not links. 
+      &.no-link {
         padding-block: $carbon--spacing-04;
         padding-inline-start: $carbon--spacing-05;
         padding-inline-end: $carbon--spacing-08;
@@ -576,8 +577,7 @@ $search-transition-timing: 95ms;
         column-gap: 0;
       }
 
-      .#{$prefix}--masthead__l1-dropdown__3-col
-        &:not(:has(.#{$prefix}--masthead__l1-dropdown-column-wide)) {
+      .#{$prefix}--masthead__l1-dropdown__3-col & {
         column-count: 3;
         column-gap: 0;
       }
@@ -585,9 +585,11 @@ $search-transition-timing: 95ms;
       > * {
         break-inside: avoid;
       }
+    }
 
-      .#{$prefix}--masthead__l1-dropdown__3-col
-        &:has(.#{$prefix}--masthead__l1-dropdown-column-wide) {
+    // Contains a wide col child. 
+    .#{$prefix}--masthead__l1-dropdown-links {
+      &.has-wide {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
 
@@ -642,7 +644,8 @@ $search-transition-timing: 95ms;
         margin-bottom: $spacing-03;
       }
 
-      &:not(:has(.#{$prefix}--masthead__l1-dropdown-item)) {
+      // Headings that do not contain links. 
+      &.no-link {
         padding: $spacing-03 $spacing-05;
         margin-bottom: $spacing-03;
       }

--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -402,7 +402,7 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
     const normalColumns = menuSections.filter((section) => !(section.span > 1));
     const dropdownClasses = classMap({
       [`${prefix}--masthead__l1-dropdown-links`]: true,
-      [`has-wide`]: hasWideColumn,
+      [`${prefix}--masthead__l1-dropdown--has-column-wide`]: hasWideColumn,
     });
 
     return html`
@@ -759,16 +759,10 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
         `
       : html` ${heading.title} `;
 
-    let noLink: boolean = false;
-
-    if (!heading.url) {
-      noLink = true;
-    }
-
-    const headingClasses = classMap({
-      [`${prefix}--masthead__l1-dropdown-heading`]: true,
-      [`no-link`]: noLink,
-    });
+      const headingClasses = classMap({ 
+        [`${prefix}--masthead__l1-dropdown-heading`]: true, 
+        [`${prefix}--masthead__l1-dropdown-heading--no-link`]: Boolean(heading.url) === false, 
+      });
 
     let renderedHeading = headingContent;
     switch (heading.headingLevel) {

--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -400,6 +400,10 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
 
     const wideColumns = menuSections.filter((section) => section.span > 1);
     const normalColumns = menuSections.filter((section) => !(section.span > 1));
+    const dropdownClasses = classMap({
+      [`${prefix}--masthead__l1-dropdown-links`]: true,
+      [`has-wide`]: hasWideColumn
+    });
 
     return html`
       <li @focusout=${handleDropdownClose} @keydown=${handleDropdownClose}>
@@ -416,7 +420,7 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
                 ${unsafeHTML(announcement)}
               </div>`
             : ''}
-          <div class="${prefix}--masthead__l1-dropdown-links">
+          <div class="${dropdownClasses}">
             ${hasWideColumn && wideColumnFirst
               ? this._renderL1DropdownSections(wideColumns, hasWideColumn, true)
               : ''}
@@ -751,9 +755,16 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
           </a>
         `
       : html` ${heading.title} `;
+     
+    let noLink: boolean = false;
+
+    if (!heading.url) {
+      noLink = true;
+    }
 
     const headingClasses = classMap({
       [`${prefix}--masthead__l1-dropdown-heading`]: true,
+      [`no-link`]: noLink
     });
 
     let renderedHeading = headingContent;

--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -402,7 +402,7 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
     const normalColumns = menuSections.filter((section) => !(section.span > 1));
     const dropdownClasses = classMap({
       [`${prefix}--masthead__l1-dropdown-links`]: true,
-      [`has-wide`]: hasWideColumn
+      [`has-wide`]: hasWideColumn,
     });
 
     return html`
@@ -755,7 +755,7 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
           </a>
         `
       : html` ${heading.title} `;
-     
+
     let noLink: boolean = false;
 
     if (!heading.url) {
@@ -764,7 +764,7 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
 
     const headingClasses = classMap({
       [`${prefix}--masthead__l1-dropdown-heading`]: true,
-      [`no-link`]: noLink
+      [`no-link`]: noLink,
     });
 
     let renderedHeading = headingContent;

--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -759,10 +759,11 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
         `
       : html` ${heading.title} `;
 
-      const headingClasses = classMap({ 
-        [`${prefix}--masthead__l1-dropdown-heading`]: true, 
-        [`${prefix}--masthead__l1-dropdown-heading--no-link`]: Boolean(heading.url) === false, 
-      });
+    const headingClasses = classMap({
+      [`${prefix}--masthead__l1-dropdown-heading`]: true,
+      [`${prefix}--masthead__l1-dropdown-heading--no-link`]:
+        Boolean(heading.url) === false,
+    });
 
     let renderedHeading = headingContent;
     switch (heading.headingLevel) {


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

The `:has` pseudo-class is not supported across all browsers yet (lookin' at you Firefox). This PR removes the usage of `:has` inside the masthead L1 styles, without changing the look on the front end. 

### Changelog

**Changed**

- Added a `classMap` to the L1 dropdown links element to dynamically add a class if the dropdown contains a wide column. 
- Added a similar functionality to the pre-existing headingClasses `classMap` to account for when headings inside dropdowns are not links. 
- Updated the corresponding styles to use the new classes instead of `:has`.
