### PR TITLE
feat(progress-indicator): sync with v11

### DIFF
--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-skeleton.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-skeleton.ts
@@ -40,7 +40,7 @@ export default class CDSProgressIndicatorSkeleton extends LitElement {
   }
 
   render() {
-    return html` <slot></slot> `;
+    return html`<slot></slot>`;
   }
 
   /**

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-skeleton.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-skeleton.ts
@@ -11,14 +11,14 @@ import { LitElement, html } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import { forEach } from '../../globals/internal/collection-helpers';
-import BXProgressStepSkeleton from './progress-step-skeleton';
+import CDSProgressStepSkeleton from './progress-step-skeleton';
 import styles from './progress-indicator.scss';
 
 /**
  * Skeleton of progress indicator.
  */
 @customElement(`${prefix}-progress-indicator-skeleton`)
-class BXProgressIndicatorSkeleton extends LitElement {
+export default class CDSProgressIndicatorSkeleton extends LitElement {
   /**
    * `true` if the progress indicator should be vertical. Corresponds to the attribute with the same name.
    */
@@ -30,10 +30,10 @@ class BXProgressIndicatorSkeleton extends LitElement {
       // Propagate `vertical` attribute to descendants until `:host-context()` gets supported in all major browsers
       forEach(
         this.querySelectorAll(
-          (this.constructor as typeof BXProgressIndicatorSkeleton).selectorStep
+          (this.constructor as typeof CDSProgressIndicatorSkeleton).selectorStep
         ),
         (item) => {
-          (item as BXProgressStepSkeleton).vertical = this.vertical;
+          (item as CDSProgressStepSkeleton).vertical = this.vertical;
         }
       );
     }
@@ -52,5 +52,3 @@ class BXProgressIndicatorSkeleton extends LitElement {
 
   static styles = styles;
 }
-
-export default BXProgressIndicatorSkeleton;

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-story.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-story.ts
@@ -75,6 +75,7 @@ export const skeleton = (args) => {
       <cds-progress-step-skeleton></cds-progress-step-skeleton>
       <cds-progress-step-skeleton></cds-progress-step-skeleton>
       <cds-progress-step-skeleton></cds-progress-step-skeleton>
+      <cds-progress-step-skeleton></cds-progress-step-skeleton>
     </cds-progress-indicator-skeleton>
   `;
 };

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-story.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-story.ts
@@ -18,51 +18,91 @@ import './progress-step-skeleton';
 import storyDocs from './progress-indicator-story.mdx';
 import { prefix } from '../../globals/settings';
 
-export const Default = (args) => {
+export const Default = () => html`
+  <cds-progress-indicator>
+    <cds-progress-step
+      state="complete"
+      label="First step"
+      secondary-label="Optional label"
+      description="Step 1: Getting started with Carbon Design System"></cds-progress-step>
+    <cds-progress-step
+      label="Second step with tooltip"
+      state="current"></cds-progress-step>
+    <cds-progress-step
+      label="Third step with tooltip"
+      state="incomplete"></cds-progress-step>
+    <cds-progress-step
+      label="Fourth step"
+      secondary-label="Example invalid step"
+      state="invalid"></cds-progress-step>
+    <cds-progress-step
+      disabled
+      label="Fifth step"
+      state="incomplete"></cds-progress-step>
+  </cds-progress-indicator>
+`;
+
+export const Interactive = () => html`
+  <cds-progress-indicator>
+    <cds-progress-step
+      label="Click me"
+      description="Step 1: Register a onChange event"
+      state="complete"></cds-progress-step>
+    <cds-progress-step
+      label="Really long label"
+      description="The progress indicator will listen for clicks on the steps"
+      state="current"></cds-progress-step>
+    <cds-progress-step
+      label="Third step with tooltip"
+      description="The progress indicator will listen for clicks on the steps"
+      state="incomplete"></cds-progress-step>
+  </cds-progress-indicator>
+`;
+
+export const Playground = (args) => {
   const { vertical } = args?.[`${prefix}-progress-indicator`] ?? {};
   const { iconLabel, secondaryLabelText } =
     args?.[`${prefix}-progress-step`] ?? {};
   return html`
     <cds-progress-indicator ?vertical="${vertical}">
       <cds-progress-step
-        icon-label="${ifDefined(iconLabel)}"
-        label-text="First step"
-        secondary-label-text="${ifDefined(secondaryLabelText)}"
+        description="${ifDefined(iconLabel)}"
+        label="First step"
+        secondary-label="${ifDefined(secondaryLabelText)}"
         state="complete"></cds-progress-step>
       <cds-progress-step
-        icon-label="${ifDefined(iconLabel)}"
-        label-text="Second step with tooltip"
+        description="${ifDefined(iconLabel)}"
+        label="Second step with tooltip"
         state="current"></cds-progress-step>
       <cds-progress-step
-        icon-label="${ifDefined(iconLabel)}"
-        label-text="Third step with tooltip"
+        description="${ifDefined(iconLabel)}"
+        label="Third step with tooltip"
         state="incomplete"></cds-progress-step>
       <cds-progress-step
-        icon-label="${ifDefined(iconLabel)}"
-        label-text="Fourth step"
-        secondary-label-text="Example invalid step"
+        description="${ifDefined(iconLabel)}"
+        label="Fourth step"
+        secondary-label="Example invalid step"
         state="invalid"></cds-progress-step>
       <cds-progress-step
         disabled
-        icon-label="${ifDefined(iconLabel)}"
-        label-text="Fifth step"
+        description="${ifDefined(iconLabel)}"
+        label="Fifth step"
         state="incomplete"></cds-progress-step>
     </cds-progress-indicator>
   `;
 };
 
-Default.storyName = 'Default';
-
-Default.parameters = {
+Playground.parameters = {
+  ...storyDocs.parameters,
   knobs: {
     [`${prefix}-progress-indicator`]: () => ({
       vertical: boolean('Vertical (vertical)', false),
     }),
     [`${prefix}-progress-step`]: () => ({
-      iconLabel: textNullable('Icon label (icon-label)', ''),
+      description: textNullable('Icon label (description)', ''),
       secondaryLabelText: textNullable(
-        'Secondary label text (secondary-label-text)',
-        'Secondary label'
+        'Secondary label text (secondary-label)',
+        'Optional label'
       ),
     }),
   },
@@ -93,7 +133,4 @@ skeleton.parameters = {
 
 export default {
   title: 'Components/Progress indicator',
-  parameters: {
-    ...storyDocs.parameters,
-  },
 };

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-story.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-story.ts
@@ -60,11 +60,14 @@ export const Interactive = () => html`
 `;
 
 export const Playground = (args) => {
-  const { vertical } = args?.[`${prefix}-progress-indicator`] ?? {};
+  const { vertical, spaceEqually } =
+    args?.[`${prefix}-progress-indicator`] ?? {};
   const { iconLabel, secondaryLabelText } =
     args?.[`${prefix}-progress-step`] ?? {};
   return html`
-    <cds-progress-indicator ?vertical="${vertical}">
+    <cds-progress-indicator
+      ?vertical="${vertical}"
+      ?space-equally="${spaceEqually}">
       <cds-progress-step
         description="${ifDefined(iconLabel)}"
         label="First step"
@@ -97,6 +100,7 @@ Playground.parameters = {
   knobs: {
     [`${prefix}-progress-indicator`]: () => ({
       vertical: boolean('Vertical (vertical)', false),
+      spaceEqually: boolean('Space equally (space-equally)', false),
     }),
     [`${prefix}-progress-step`]: () => ({
       description: textNullable('Icon label (description)', ''),

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
@@ -80,7 +80,7 @@ $css--plex: true !default;
   .#{$prefix}--progress-optional {
     margin-top: auto;
     position: initial;
-    margin-left: 2rem;
+    margin-left: $spacing-07;
   }
 
   .#{$prefix}--progress-step-button {

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
@@ -48,13 +48,13 @@ $css--plex: true !default;
 :host(#{$prefix}-progress-step[vertical]),
 :host(#{$prefix}-progress-step-skeleton[vertical]) {
   display: list-item;
-  min-height: $spacing-12;
+  min-height: 3.625rem;
   width: initial;
   min-width: initial;
 
   svg {
     display: inline-block;
-    margin: 0.1rem 0.5rem;
+    margin: 0.1rem 0.25rem 0.1rem 0.5rem;
   }
 
   .#{$prefix}--progress-label {
@@ -80,7 +80,7 @@ $css--plex: true !default;
   .#{$prefix}--progress-optional {
     margin-top: auto;
     position: initial;
-    margin-left: 2.25rem;
+    margin-left: 2rem;
   }
 
   .#{$prefix}--progress-step-button {

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
@@ -117,3 +117,7 @@ $css--plex: true !default;
     background-color: $layer-accent-01;
   }
 }
+
+:host(#{$prefix}-progress-step[spaceEqually]) {
+  flex-grow: 1;
+}

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
@@ -54,7 +54,7 @@ $css--plex: true !default;
 
   svg {
     display: inline-block;
-    margin: 0.1rem 0.25rem 0.1rem 0.5rem;
+    margin: 0.1rem $spacing-02 0.1rem $spacing-03;
   }
 
   .#{$prefix}--progress-label {

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
@@ -108,13 +108,6 @@ $css--plex: true !default;
   @extend .#{$prefix}--progress-step--incomplete;
 }
 
-:host(#{$prefix}-progress-step-skeleton) .#{$prefix}--progress-label {
-  @include skeleton;
-
-  height: rem(12px);
-  width: rem(40px);
-}
-
 :host(#{$prefix}-progress-step-skeleton) {
   svg {
     fill: $layer-selected-inverse;

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
@@ -82,6 +82,10 @@ $css--plex: true !default;
     position: initial;
     margin-left: 2.25rem;
   }
+
+  .#{$prefix}--progress-step-button {
+    display: block;
+  }
 }
 
 :host(#{$prefix}-progress-step[vertical][state='current']) svg {

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.ts
@@ -11,7 +11,7 @@ import { LitElement, html } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import { forEach } from '../../globals/internal/collection-helpers';
-import BXProgressStep from './progress-step';
+import CDSProgressStep from './progress-step';
 import styles from './progress-indicator.scss';
 
 /**
@@ -20,7 +20,7 @@ import styles from './progress-indicator.scss';
  * @element cds-progress-indicator
  */
 @customElement(`${prefix}-progress-indicator`)
-class BXProgressIndicator extends LitElement {
+export default class CDSProgressIndicator extends LitElement {
   /**
    * `true` if the progress indicator should be vertical.
    */
@@ -39,10 +39,10 @@ class BXProgressIndicator extends LitElement {
       // Propagate `vertical` attribute to descendants until `:host-context()` gets supported in all major browsers
       forEach(
         this.querySelectorAll(
-          (this.constructor as typeof BXProgressIndicator).selectorStep
+          (this.constructor as typeof CDSProgressIndicator).selectorStep
         ),
         (item) => {
-          (item as BXProgressStep).vertical = this.vertical;
+          (item as CDSProgressStep).vertical = this.vertical;
         }
       );
     }
@@ -61,5 +61,3 @@ class BXProgressIndicator extends LitElement {
 
   static styles = styles;
 }
-
-export default BXProgressIndicator;

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.ts
@@ -22,10 +22,18 @@ import styles from './progress-indicator.scss';
 @customElement(`${prefix}-progress-indicator`)
 export default class CDSProgressIndicator extends LitElement {
   /**
-   * `true` if the progress indicator should be vertical.
+   * Determines whether or not the progress indicator should be rendered
+   * vertically.
    */
   @property({ type: Boolean, reflect: true })
   vertical = false;
+
+  /**
+   * Specify whether the progress steps should be split equally in size in the
+   * div
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'space-equally' })
+  spaceEqually = false;
 
   connectedCallback() {
     if (!this.hasAttribute('role')) {
@@ -35,14 +43,29 @@ export default class CDSProgressIndicator extends LitElement {
   }
 
   updated(changedProperties) {
+    const spacingValue = this.vertical ? false : this.spaceEqually;
     if (changedProperties.has('vertical')) {
-      // Propagate `vertical` attribute to descendants until `:host-context()` gets supported in all major browsers
+      // Propagate `vertical` attribute to descendants until
+      // `:host-context()` gets supported in all major browsers
       forEach(
         this.querySelectorAll(
           (this.constructor as typeof CDSProgressIndicator).selectorStep
         ),
         (item) => {
           (item as CDSProgressStep).vertical = this.vertical;
+          (item as CDSProgressStep).spaceEqually = spacingValue;
+        }
+      );
+    }
+    if (changedProperties.has('spaceEqually')) {
+      // Propagate `spaceEqually` attribute to descendants until
+      // `:host-context()` gets supported in all major browsers
+      forEach(
+        this.querySelectorAll(
+          (this.constructor as typeof CDSProgressIndicator).selectorStep
+        ),
+        (item) => {
+          (item as CDSProgressStep).spaceEqually = spacingValue;
         }
       );
     }

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.ts
@@ -49,7 +49,7 @@ export default class CDSProgressIndicator extends LitElement {
   }
 
   render() {
-    return html` <slot></slot> `;
+    return html`<slot></slot>`;
   }
 
   /**

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-step-skeleton.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-step-skeleton.ts
@@ -16,7 +16,7 @@ import styles from './progress-indicator.scss';
  * Skeleton of progress step.
  */
 @customElement(`${prefix}-progress-step-skeleton`)
-class BXProgressStepSkeleton extends LitElement {
+export default class CDSProgressStepSkeleton extends LitElement {
   /**
    * `true` if the progress indicator should be vertical. Corresponds to the attribute with the same name.
    */
@@ -38,5 +38,3 @@ class BXProgressStepSkeleton extends LitElement {
 
   static styles = styles;
 }
-
-export default BXProgressStepSkeleton;

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-step-skeleton.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-step-skeleton.ts
@@ -11,6 +11,8 @@ import { LitElement, html } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import styles from './progress-indicator.scss';
+import CircleDash from '@carbon/web-components/es/icons/circle-dash/16';
+import '../skeleton-text';
 
 /**
  * Skeleton of progress step.
@@ -27,10 +29,10 @@ export default class CDSProgressStepSkeleton extends LitElement {
     return html`
       <div
         class="${prefix}--progress-step-button ${prefix}--progress-step-button--unclickable">
-        <svg>
-          <path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" />
-        </svg>
-        <p class="${prefix}--progress-label"></p>
+        ${CircleDash()}
+        <p class="${prefix}--progress-label">
+          <cds-skeleton-text width="40px" linecount="1"></cds-skeleton-text>
+        </p>
         <span class="${prefix}--progress-line"></span>
       </div>
     `;

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-step.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-step.ts
@@ -37,7 +37,7 @@ const icons = {
  * @slot secondary-label-text - The secondary progress label.
  */
 @customElement(`${prefix}-progress-step`)
-class BXProgressStep extends FocusMixin(LitElement) {
+export default class CDSProgressStep extends FocusMixin(LitElement) {
   /**
    * `true` if the progress step should be disabled.
    */
@@ -124,5 +124,3 @@ class BXProgressStep extends FocusMixin(LitElement) {
   };
   static styles = styles;
 }
-
-export default BXProgressStep;

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-step.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-step.ts
@@ -85,6 +85,14 @@ export default class CDSProgressStep extends FocusMixin(LitElement) {
   @property({ type: Boolean, reflect: true })
   vertical = false;
 
+  /**
+   * `true` if the progress step should be spaced equally.
+   *
+   * @private
+   */
+  @property({ type: Boolean, reflect: true })
+  spaceEqually = false;
+
   connectedCallback() {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'listitem');

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-step.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-step.ts
@@ -50,17 +50,26 @@ export default class CDSProgressStep extends FocusMixin(LitElement) {
   @property({ attribute: 'icon-label' })
   iconLabel!: string;
 
+  @property({ reflect: true })
+  description!: string;
+
   /**
    * The primary progress label.
    */
   @property({ attribute: 'label-text' })
   labelText!: string;
 
+  @property()
+  label!: string;
+
   /**
    * The secondary progress label.
    */
   @property({ attribute: 'secondary-label-text' })
   secondaryLabelText!: string;
+
+  @property({ attribute: 'secondary-label' })
+  secondaryLabel!: string;
 
   /**
    * The progress state.
@@ -90,31 +99,43 @@ export default class CDSProgressStep extends FocusMixin(LitElement) {
   }
 
   render() {
-    const { iconLabel, labelText, secondaryLabelText, state } = this;
+    const {
+      description,
+      iconLabel,
+      label,
+      secondaryLabelText,
+      secondaryLabel,
+      state,
+    } = this;
+    const svgLabel = iconLabel || description;
+    const optionalLabel = secondaryLabelText || secondaryLabel;
     return html`
-      ${icons[state]({
-        class: {
-          [PROGRESS_STEP_STAT.INVALID]: `${prefix}--progress__warning`,
-        }[state],
-        children: !iconLabel ? undefined : svg`<title>${iconLabel}</title>`,
-      })}
-      <slot>
-        <p
-          role="button"
-          class="${prefix}--progress-label"
-          tabindex="0"
-          aria-describedby="label-tooltip">
-          ${labelText}
-        </p>
-      </slot>
-      <slot name="secondary-label-text">
-        ${!secondaryLabelText
-          ? undefined
-          : html`
-              <p class="${prefix}--progress-optional">${secondaryLabelText}</p>
-            `}
-      </slot>
-      <span class="${prefix}--progress-line"></span>
+      <div class="${prefix}--progress-step-button">
+        ${icons[state]({
+          class: {
+            [PROGRESS_STEP_STAT.INVALID]: `${prefix}--progress__warning`,
+          }[state],
+          children: svgLabel ? svg`<title>${svgLabel}</title>` : undefined,
+        })}
+        <slot>
+          <p
+            role="button"
+            class="${prefix}--progress-label"
+            tabindex="0"
+            aria-describedby="label-tooltip"
+            title="${label}">
+            ${label}
+          </p>
+        </slot>
+        <slot name="secondary-label-text">
+          ${!optionalLabel
+            ? undefined
+            : html`<p class="${prefix}--progress-optional">
+                ${optionalLabel}
+              </p>`}
+        </slot>
+        <span class="${prefix}--progress-line"></span>
+      </div>
     `;
   }
 

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-step.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-step.ts
@@ -118,7 +118,7 @@ export default class CDSProgressStep extends FocusMixin(LitElement) {
     const svgLabel = iconLabel || description;
     const optionalLabel = secondaryLabelText || secondaryLabel;
     return html`
-      <div class="${prefix}--progress-step-button">
+      <div class="${prefix}--progress-step-button" tabindex="0">
         ${icons[state]({
           class: {
             [PROGRESS_STEP_STAT.INVALID]: `${prefix}--progress__warning`,
@@ -129,7 +129,6 @@ export default class CDSProgressStep extends FocusMixin(LitElement) {
           <p
             role="button"
             class="${prefix}--progress-label"
-            tabindex="0"
             aria-describedby="label-tooltip"
             title="${label}">
             ${label}

--- a/packages/carbon-web-components/tests/spec/progress-indicator_spec.ts
+++ b/packages/carbon-web-components/tests/spec/progress-indicator_spec.ts
@@ -9,10 +9,10 @@
 
 import { render } from 'lit';
 import { PROGRESS_STEP_STAT } from '../../src/components/progress-indicator/progress-step';
-import { Default } from '../../src/components/progress-indicator/progress-indicator-story';
+import { Playground } from '../../src/components/progress-indicator/progress-indicator-story';
 
 const template = (props?) =>
-  Default({
+  Playground({
     'cds-progress-step': props,
   });
 


### PR DESCRIPTION
### Related Ticket(s)

#10092

### Description

This PR updates the progress switcher to match the v11 React component

### Changelog

**New**

- `space-equally` property for nonvertical progress indicator

**Changed**

- update and fix skeleton state
- sync attributes to match React props

**Removed**
- extraneous styles

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
