### PR TITLE
fix(modal): small screen view

### DIFF
--- a/packages/carbon-web-components/src/components/modal/modal.scss
+++ b/packages/carbon-web-components/src/components/modal/modal.scss
@@ -87,10 +87,6 @@
   @media screen and (prefers-reduced-motion: reduce) {
     transition: none;
   }
-
-  .#{$prefix}--modal-container {
-    transform: translate3d(0, 0, 0);
-  }
 }
 
 :host(#{$prefix}-modal-header) {

--- a/packages/carbon-web-components/src/components/modal/modal.scss
+++ b/packages/carbon-web-components/src/components/modal/modal.scss
@@ -33,6 +33,10 @@
   }
 
   .#{$prefix}--modal-container {
+    transform: translate3d(0, 0, 0);
+  }
+
+  .#{$prefix}--modal-container {
     @include carbon--breakpoint(md) {
       ::slotted(#{$prefix}-modal-header),
       ::slotted(#{$prefix}-modal-body) {
@@ -82,6 +86,10 @@
 
   @media screen and (prefers-reduced-motion: reduce) {
     transition: none;
+  }
+
+  .#{$prefix}--modal-container {
+    transform: translate3d(0, 0, 0);
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

#10480 
### Description

the modal in small screen for wc was getting slightly bumped up 24px. This fix aligns it properly without changing the desktop view

<img width="1276" alt="Screenshot 2023-05-26 at 7 57 46 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/20210594/29bb0157-166b-429f-b82c-2a31e9a09a68">
<img width="1608" alt="Screenshot 2023-05-26 at 7 58 09 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/20210594/ccf0a2b0-9d5a-4a02-a9f8-9c72f730d787">

### Changelog

**New**

- added translate styles to the modal container

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
