### PR TITLE
fix(masthead-l1): fix focusout logic

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -60,19 +60,25 @@ function handleDropdownClose(event: FocusEvent | KeyboardEvent) {
       }
       case 'focusout': {
         const { relatedTarget } = event as FocusEvent;
-        if (
-          !relatedTarget ||
-          !currentTarget ||
-          !(
-            (relatedTarget as Node).compareDocumentPosition(
-              currentTarget as Node
-            ) & 8
-          )
-        ) {
+        const hasUnknownTargets = !relatedTarget || !currentTarget;
+        let focusHasEscaped = false;
+
+        if (!hasUnknownTargets) {
+          const comparison = (relatedTarget as Node).compareDocumentPosition(
+            currentTarget as Node
+          );
+
+          focusHasEscaped =
+            !(comparison & 8) && // relatedTarget is not ancestor of currentTarget
+            relatedTarget !== currentTarget;
+        }
+
+        if (hasUnknownTargets || focusHasEscaped) {
           openDropdowns.forEach((el) => {
             el.classList.remove('is-open');
           });
         }
+
         break;
       }
       default:


### PR DESCRIPTION
### Related Ticket(s)

Closes #10521

### Description

Previous logic used only `Node.compareDocumentPosition()` and closed if the `currentTarget` did not contain `relatedTarget`. This forgot to account for `currentTarget === relatedTarget`.

### Changelog

**Changed**

- fixed focusout handler bug in masthead L1
