### PR TITLE
docs(security): add security policy to repo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| 1.x     | :white_check_mark: |
+
+These supported versions include the different discrete version numbers of
+individual packages as listed in the
+[release changelogs](https://github.com/carbon-design-system/carbon/releases).
+
+Please review the
+[release schedule](https://github.com/carbon-design-system/carbon/blob/main/docs/release-schedule.md)
+for full details on what release phase versions are in and the level of support
+provided for each.
+
+## Reporting a Vulnerability
+
+_Please do not report security vulnerabilities through public GitHub issues._
+
+Instead, report a vulnerability through GitHub's security advisory feature at
+https://github.com/carbon-design-system/carbon/security/advisories/new
+
+Please include a description of the issue, the steps you took to create the
+issue, affected versions, and, if known, mitigations for the issue. Our team
+aims to respond to all new vulnerability reports within 7 business days.
+
+Additional information on reporting vulnerabilities to IBM is available at
+https://www.ibm.com/trust/security-psirt
+
+## Preferred languages
+
+We prefer all communications to be in English.
+
+## Comments on this policy
+
+If you have suggestions on how this process could be improved please
+[submit a pull request](https://github.com/carbon-design-system/carbon/compare)
+or [file an issue](https://github.com/carbon-design-system/carbon/issues/new) to
+discuss.


### PR DESCRIPTION
### Description

Add security policy to repository.

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
