### PR TITLE
fix(inputs): update autocomplete

### DIFF
--- a/packages/carbon-web-components/src/components/number-input/number-input.ts
+++ b/packages/carbon-web-components/src/components/number-input/number-input.ts
@@ -281,7 +281,7 @@ class CDSNumberInput extends CDSTextInput {
 
     const input = html`
       <input
-        ?autocomplete="${this.autocomplete}"
+        autocomplete="${this.autocomplete}"
         ?autofocus="${this.autofocus}"
         ?data-invalid="${normalizedProps.invalid}"
         ?disabled="${normalizedProps.disabled}"

--- a/packages/carbon-web-components/src/components/text-input/text-input.ts
+++ b/packages/carbon-web-components/src/components/text-input/text-input.ts
@@ -439,7 +439,7 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
           <div class="${fieldWrapperClasses}" ?data-invalid="${invalid}">
             ${normalizedProps.icon}
             <input
-              ?autocomplete="${this.autocomplete}"
+              autocomplete="${this.autocomplete}"
               ?autofocus="${this.autofocus}"
               class="${inputClasses}"
               ?data-invalid="${invalid}"

--- a/packages/carbon-web-components/src/components/textarea/textarea.ts
+++ b/packages/carbon-web-components/src/components/textarea/textarea.ts
@@ -135,7 +135,7 @@ class CDSTextarea extends CDSTextInput {
       <div class="${textareaWrapperClasses}" ?data-invalid="${this.invalid}">
         ${icon()}
         <textarea
-          ?autocomplete="${this.autocomplete}"
+          autocomplete="${this.autocomplete}"
           ?autofocus="${this.autofocus}"
           class="${textareaClasses}"
           cols="${ifDefined(this.cols)}"


### PR DESCRIPTION
### Related Ticket(s)

related to pr: https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/10540
### Description

updated v1 to adjust the autocomplete property for input.... adding the same update to cwc-v2


**Removed**

- `autocomplete` should not be a boolean when being used in `input`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
