### PR TITLE
feat(masthead-v2): Add selected styles to L1

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -395,6 +395,10 @@ $search-transition-timing: 95ms;
       align-items: flex-end;
       background-color: $ui-background;
 
+      &[active] {
+        border-bottom-color: $focus;
+      }
+
       &:hover {
         background-color: $hover-ui;
       }
@@ -474,6 +478,16 @@ $search-transition-timing: 95ms;
       border: 1px solid transparent;
       border-top: none;
       align-items: flex-end;
+
+      &[active]::after {
+        content: '';
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        height: 3px;
+        background-color: $focus;
+      }
 
       &:hover {
         color: $text-01;

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -202,6 +202,10 @@ $search-transition-timing: 95ms;
     &[with-banner] {
       top: $spacing-13;
     }
+
+    &[has-l1] {
+      --dds-active-l0-border-color: #{$gray-30};
+    }
   }
 
   :host(#{$dds-prefix}-megamenu-overlay),
@@ -381,7 +385,7 @@ $search-transition-timing: 95ms;
       left: 0;
       right: 0;
       height: rem(3px);
-      background-color: $link-01;
+      background-color: var(--dds-active-l0-border-color, $link-01);
     }
   }
 

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -33,14 +33,6 @@ const userStatuses = {
   unauthenticated: UNAUTHENTICATED_STATUS,
 };
 
-/**
- * platform knob data
- */
-const platformData = {
-  name: 'IBM Cloud',
-  url: 'https://www.ibm.com/cloud',
-};
-
 const urlObject = {
   'en-US': {
     url: 'https://www.example.com/us-en',
@@ -82,6 +74,14 @@ const scopeParameters = [
   },
 ];
 
+const defaultPlatformUrl = 'https://www.example.com';
+
+const dataEndpoints = {
+  cloud: '/common/carbon-for-ibm-dotcom/translations/cloud-masthead',
+  v2: '/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2',
+  'v2.1': '/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1',
+};
+
 async function customTypeaheadApiFunction(searchVal) {
   return fetch(
     `https://ibmdocs-dev.mybluemix.net/docs/api/v1/suggest?query=${searchVal}&lang=undefined&categories=&limit=6`
@@ -118,9 +118,8 @@ export const Default = (args) => {
     ${useMock
       ? html`
           <dds-masthead-composite
-            data-endpoint="/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1"
             platform="${ifNonNull(platform)}"
-            .platformUrl="${ifNonNull(platformData.url)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
@@ -136,14 +135,13 @@ export const Default = (args) => {
         `
       : html`
           <dds-masthead-container
-            data-endpoint="/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1"
+            data-endpoint="${dataEndpoints['v2.1']}"
             platform="${ifNonNull(platform)}"
-            .platformUrl="${ifNonNull(platformData.url)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             has-profile="${hasProfile}"
-            .navLinks="${links}"
             ?has-search="${hasSearch}"
             custom-profile-login="${customProfileLogin}"
             auth-method="${authMethod}"></dds-masthead-container>
@@ -160,6 +158,7 @@ export const withCloudData = ({ parameters }) => {
     platform,
     useMock,
   } = parameters?.props?.MastheadComposite ?? {};
+
   return html`
     <style>
       ${styles}
@@ -167,9 +166,8 @@ export const withCloudData = ({ parameters }) => {
     ${useMock
       ? html`
           <dds-masthead-composite
-            data-endpoint="/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1"
-            platform="Cloud"
-            .platformUrl="${ifNonNull(platformData.url)}"
+            platform="${platform || 'Cloud'}"
+            .platformUrl="https://www.ibm.com/cloud"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
@@ -183,9 +181,9 @@ export const withCloudData = ({ parameters }) => {
         `
       : html`
           <dds-masthead-container
-            data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead"
+            data-endpoint="${dataEndpoints['cloud']}"
             platform="${platform || 'Cloud'}"
-            .platformUrl="${ifNonNull(platformData.url)}"
+            .platformUrl="https://www.ibm.com/cloud"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             ?has-search="${hasSearch}"
@@ -197,7 +195,6 @@ export const withCloudData = ({ parameters }) => {
 
 export const WithCustomTypeahead = (args) => {
   const {
-    endpoint,
     customProfileLogin,
     platform,
     selectedMenuItem,
@@ -220,9 +217,6 @@ export const WithCustomTypeahead = (args) => {
     }
   );
 
-  const defaultEndpoint =
-    '/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1';
-
   return html`
     <style>
       ${styles}
@@ -230,9 +224,8 @@ export const WithCustomTypeahead = (args) => {
     ${useMock
       ? html`
           <dds-masthead-composite
-            data-endpoint="${defaultEndpoint}"
             platform="${ifNonNull(platform)}"
-            .platformUrl="${ifNonNull(platformData.url)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
@@ -248,13 +241,12 @@ export const WithCustomTypeahead = (args) => {
         `
       : html`
           <dds-masthead-container
-            data-endpoint="${ifNonNull(endpoint) ?? defaultEndpoint}"
+            data-endpoint="${dataEndpoints['v2.1']}"
             platform="${ifNonNull(platform)}"
-            .platformUrl="${ifNonNull(platformData.url)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
-            .navLinks="${links}"
             has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             custom-profile-login="${customProfileLogin}"
@@ -269,7 +261,6 @@ WithCustomTypeahead.story = {
 
 export const searchOpenOnload = (args) => {
   const {
-    endpoint,
     customProfileLogin,
     platform,
     selectedMenuItem,
@@ -286,10 +277,9 @@ export const searchOpenOnload = (args) => {
     ${useMock
       ? html`
           <dds-masthead-composite
-            data-endpoint="/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1"
             activate-search
-            platform="${ifNonNull(platformData.name)}"
-            .platformUrl="${ifNonNull(platformData.url)}"
+            platform="${ifNonNull(platform)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
@@ -304,14 +294,13 @@ export const searchOpenOnload = (args) => {
         `
       : html`
           <dds-masthead-container
-            data-endpoint="${ifNonNull(endpoint)}"
+            data-endpoint="${dataEndpoints['v2.1']}"
             activate-search
             platform="${ifNonNull(platform)}"
-            .platformUrl="${ifNonNull(platformData.url)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
-            .navLinks="${links}"
             has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             custom-profile-login="${customProfileLogin}"></dds-masthead-container>
@@ -325,7 +314,6 @@ searchOpenOnload.story = {
 
 export const withPlatform = (args) => {
   const {
-    endpoint,
     selectedMenuItem,
     userStatus,
     hasProfile,
@@ -341,8 +329,7 @@ export const withPlatform = (args) => {
     ${useMock
       ? html`
           <dds-masthead-composite
-            data-endpoint="/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1"
-            platform="${ifNonNull(platformData.name)}"
+            platform="${ifNonNull(platform)}"
             .platformUrl="${ifNonNull(urlObject)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
@@ -357,10 +344,9 @@ export const withPlatform = (args) => {
         `
       : html`
           <dds-masthead-container
-            data-endpoint="${ifNonNull(endpoint)}"
+            data-endpoint="${dataEndpoints['v2.1']}"
             platform="${ifNonNull(platform)}"
-            .platformUrl="${ifNonNull(platformData.url)}"
-            .navLinks="${links}"
+            .platformUrl="${ifNonNull(urlObject)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             has-profile="${hasProfile}"
@@ -387,7 +373,7 @@ withPlatform.story = {
         ),
         selectedMenuItem: textNullable(
           'selected menu item (selected-menu-item)',
-          'Consulting & Services'
+          'Consulting'
         ),
         userStatus: select(
           'The user authenticated status (user-status)',
@@ -414,7 +400,6 @@ withPlatform.story = {
 
 export const withL1 = (args) => {
   const {
-    endpoint,
     selectedMenuItem,
     selectedMenuItemL1,
     userStatus,
@@ -425,8 +410,6 @@ export const withL1 = (args) => {
     useMock,
   } = args?.MastheadComposite ?? {};
 
-  const defaultEndpoint =
-    '/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1';
   return html`
     <style>
       ${styles}
@@ -434,7 +417,8 @@ export const withL1 = (args) => {
     ${useMock
       ? html`
           <dds-masthead-composite
-            data-endpoint="${defaultEndpoint}"
+            platform="${ifNonNull(platform)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             selected-menu-item-l1="${ifNonNull(selectedMenuItemL1)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
@@ -450,16 +434,15 @@ export const withL1 = (args) => {
         `
       : html`
           <dds-masthead-container
-            data-endpoint="${ifNonNull(endpoint) ?? defaultEndpoint}"
+            data-endpoint="${dataEndpoints['v2.1']}"
             platform="${ifNonNull(platform)}"
-            .platformData="${ifNonNull(platformData.url)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             selected-menu-item-l1="${ifNonNull(selectedMenuItemL1)}"
             user-status="${ifNonNull(userStatus)}"
             has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
-            .l1Data="${mastheadL1Data}"
-            .navLinks="${links}"></dds-masthead-container>
+            .l1Data="${mastheadL1Data}"></dds-masthead-container>
         `}
   `;
 };
@@ -513,7 +496,6 @@ withL1.story = {
 
 export const withAlternateLogoAndTooltip = (args) => {
   const {
-    endpoint,
     selectedMenuItem,
     userStatus,
     hasProfile,
@@ -530,7 +512,8 @@ export const withAlternateLogoAndTooltip = (args) => {
     ${useMock
       ? html`
           <dds-masthead-composite
-            data-endpoint="/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1"
+            platform="${ifNonNull(platform)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
@@ -548,12 +531,11 @@ export const withAlternateLogoAndTooltip = (args) => {
       : html`
           <dds-masthead-container
             platform="${ifNonNull(platform)}"
-            .platformData="${ifNonNull(platformData.url)}"
-            data-endpoint="${ifNonNull(endpoint)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
+            data-endpoint="${dataEndpoints['v2.1']}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
-            .navLinks="${links}"
             .logoData="${mastheadLogo === 'alternateWithTooltip'
               ? logoData
               : undefined}"
@@ -581,7 +563,7 @@ withAlternateLogoAndTooltip.story = {
         ),
         selectedMenuItem: textNullable(
           'selected menu item (selected-menu-item)',
-          'Consulting & Services'
+          'Consulting'
         ),
         mastheadLogo: select(
           'masthead logo data (logoData)',
@@ -633,9 +615,8 @@ export const WithScopedSearch = ({ parameters }) => {
     ${useMock
       ? html`
           <dds-masthead-composite
-            data-endpoint="/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1"
             platform="${ifNonNull(platform)}"
-            .platformUrl="${ifNonNull(platformData.url)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
@@ -651,13 +632,12 @@ export const WithScopedSearch = ({ parameters }) => {
         `
       : html`
           <dds-masthead-container
-            data-endpoint="/common/carbon-for-ibm-dotcom/translations/masthead-footer/v2.1"
+            data-endpoint="${dataEndpoints['v2.1']}"
             platform="${ifNonNull(platform)}"
-            .platformUrl="${ifNonNull(platformData.url)}"
+            .platformUrl="${ifNonNull(defaultPlatformUrl)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
             user-status="${ifNonNull(userStatus)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
-            .navLinks="${navLinks}"
             ?has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
             custom-profile-login="${customProfileLogin}"
@@ -726,7 +706,7 @@ export default {
         ),
         selectedMenuItem: textNullable(
           'selected menu item (selected-menu-item)',
-          'Consulting & Services'
+          'Consulting'
         ),
         userStatus: select(
           'The user authenticated status (user-status)',

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -416,6 +416,7 @@ export const withL1 = (args) => {
   const {
     endpoint,
     selectedMenuItem,
+    selectedMenuItemL1,
     userStatus,
     hasProfile,
     hasSearch,
@@ -435,6 +436,7 @@ export const withL1 = (args) => {
           <dds-masthead-composite
             data-endpoint="${defaultEndpoint}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
+            selected-menu-item-l1="${ifNonNull(selectedMenuItemL1)}"
             searchPlaceholder="${ifNonNull(searchPlaceholder)}"
             user-status="${ifNonNull(userStatus)}"
             .authenticatedProfileItems="${ifNonNull(authenticatedProfileItems)}"
@@ -452,6 +454,7 @@ export const withL1 = (args) => {
             platform="${ifNonNull(platform)}"
             .platformData="${ifNonNull(platformData.url)}"
             selected-menu-item="${ifNonNull(selectedMenuItem)}"
+            selected-menu-item-l1="${ifNonNull(selectedMenuItemL1)}"
             user-status="${ifNonNull(userStatus)}"
             has-profile="${hasProfile}"
             ?has-search="${hasSearch}"
@@ -478,8 +481,12 @@ withL1.story = {
           inPercy() ? '' : 'Search all of IBM'
         ),
         selectedMenuItem: textNullable(
-          'selected menu item (selected-menu-item)',
-          'Products'
+          'selected menu item in L0 (selected-menu-item)',
+          ''
+        ),
+        selectedMenuItemL1: textNullable(
+          'selected menu item in L1 (selected-menu-item-l1)',
+          ''
         ),
         userStatus: select(
           'The user authenticated status (user-status)',

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -125,7 +125,10 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
     if (!this.l1Data) return undefined;
 
     return html`
-      <dds-masthead-l1 slot="masthead-l1" .l1Data=${this.l1Data}>
+      <dds-masthead-l1
+        slot="masthead-l1"
+        .l1Data=${this.l1Data}
+        selected-menu-item=${this.selectedMenuItemL1 || ''}>
       </dds-masthead-l1>
     `;
   }
@@ -907,7 +910,9 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
     let selected;
 
     if (selectedMenuItem) {
-      selected = titleEnglish === selectedMenuItem;
+      selected =
+        titleEnglish?.trim()?.toLowerCase() ===
+        selectedMenuItem?.trim()?.toLowerCase();
     } else {
       selected = this._isActiveMenuItem(item);
     }
@@ -1168,6 +1173,12 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
   selectedMenuItem!: string;
 
   /**
+   * The English title of the selected nav item in the L1.
+   */
+  @property({ attribute: 'selected-menu-item-l1' })
+  selectedMenuItemL1!: string;
+
+  /**
    * The profile items for unauthenticated state.
    */
   @property({ attribute: false })
@@ -1385,7 +1396,9 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
             </dds-left-nav>
           `
         : ''}
-      <dds-masthead aria-label="${ifNonNull(mastheadAssistiveText)}">
+      <dds-masthead
+        ?has-l1=${this.l1Data}
+        aria-label="${ifNonNull(mastheadAssistiveText)}">
         <dds-skip-to-content
           href="${skipToContentHref}"
           link-assistive-text="${skipToContentText}"></dds-skip-to-content>


### PR DESCRIPTION
### Related Ticket(s)

Resolves #10500

### Description

Adds "active" menu item styling to L1 menu items.

### Changelog

**New**

- Adds "active" menu item styling to L1 menu items.

**Changed**

- Changes "active" L0 menu item styling if an L1 is present.
- Cleans up `DDSMasthead` Storybook knobs and default data to more accurately represent components.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
