### PR TITLE
feat(tabs): implement overflow tabs and sync with v11

### DIFF
--- a/packages/carbon-web-components/src/components/tabs/defs.ts
+++ b/packages/carbon-web-components/src/components/tabs/defs.ts
@@ -10,16 +10,6 @@
 export { FORM_ELEMENT_COLOR_SCHEME as TABS_COLOR_SCHEME } from '../../globals/shared-enums';
 
 /**
- * Navigation direction for narrow mode, associated with key symbols.
- */
-export const NAVIGATION_DIRECTION_NARROW = {
-  Up: -1,
-  ArrowUp: -1,
-  Down: 1,
-  ArrowDown: 1,
-};
-
-/**
  * The keyboard action categories for dropdown.
  */
 export enum TABS_KEYBOARD_ACTION {
@@ -29,24 +19,9 @@ export enum TABS_KEYBOARD_ACTION {
   NONE = 'none',
 
   /**
-   * Keyboard action to close menu.
-   */
-  CLOSING = 'closing',
-
-  /**
    * Keyboard action to navigate back/forward.
    */
   NAVIGATING = 'navigating',
-
-  /**
-   * Keyboard action to open/close menu on the trigger button or select/deselect a menu item.
-   */
-  TRIGGERING = 'triggering',
-
-  /**
-   * Keyboard action to trigger tab selection using enter key
-   */
-  SELECTING = 'selecting',
 
   /**
    * Keyboard action to navigate to first tab using home key

--- a/packages/carbon-web-components/src/components/tabs/defs.ts
+++ b/packages/carbon-web-components/src/components/tabs/defs.ts
@@ -7,8 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export { FORM_ELEMENT_COLOR_SCHEME as TABS_COLOR_SCHEME } from '../../globals/shared-enums';
-
 /**
  * The keyboard action categories for dropdown.
  */

--- a/packages/carbon-web-components/src/components/tabs/defs.ts
+++ b/packages/carbon-web-components/src/components/tabs/defs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -72,4 +72,9 @@ export enum TABS_TYPE {
    * Container type.
    */
   CONTAINER = 'container',
+
+  /**
+   * Contained type.
+   */
+  CONTAINED = 'contained',
 }

--- a/packages/carbon-web-components/src/components/tabs/tab-skeleton.ts
+++ b/packages/carbon-web-components/src/components/tabs/tab-skeleton.ts
@@ -16,12 +16,10 @@ import styles from './tabs.scss';
  * Skeleton of tab.
  */
 @customElement(`${prefix}-tab-skeleton`)
-class BXTabSkeleton extends LitElement {
+export default class CDSTabSkeleton extends LitElement {
   render() {
     return html` <div class="${prefix}--tabs__nav-link"></div> `;
   }
 
   static styles = styles;
 }
-
-export default BXTabSkeleton;

--- a/packages/carbon-web-components/src/components/tabs/tab.ts
+++ b/packages/carbon-web-components/src/components/tabs/tab.ts
@@ -20,7 +20,7 @@ import styles from './tabs.scss';
  * @element cds-tab
  */
 @customElement(`${prefix}-tab`)
-class BXTab extends CDSContentSwitcherItem {
+export default class CDSTab extends CDSContentSwitcherItem {
   /**
    * `true` if this tab should be highlighted.
    * If `true`, parent `<cds-tabs>` selects/deselects this tab upon keyboard interaction.
@@ -60,5 +60,3 @@ class BXTab extends CDSContentSwitcherItem {
 
   static styles = styles;
 }
-
-export default BXTab;

--- a/packages/carbon-web-components/src/components/tabs/tab.ts
+++ b/packages/carbon-web-components/src/components/tabs/tab.ts
@@ -50,7 +50,7 @@ export default class CDSTab extends CDSContentSwitcherItem {
       <a
         class="${prefix}--tabs__nav-link"
         role="tab"
-        tabindex="${disabled ? -1 : 0}"
+        tabindex="${selected ? 0 : -1}"
         ?disabled="${disabled}"
         aria-selected="${Boolean(selected)}">
         <slot></slot>

--- a/packages/carbon-web-components/src/components/tabs/tabs-skeleton.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs-skeleton.ts
@@ -16,7 +16,7 @@ import styles from './tabs.scss';
  * Skeleton of tabs.
  */
 @customElement(`${prefix}-tabs-skeleton`)
-class BXTabsSkeleton extends LitElement {
+export default class CDSTabsSkeleton extends LitElement {
   render() {
     return html`
       <div class="${prefix}--tabs-trigger">
@@ -30,5 +30,3 @@ class BXTabsSkeleton extends LitElement {
 
   static styles = styles;
 }
-
-export default BXTabsSkeleton;

--- a/packages/carbon-web-components/src/components/tabs/tabs-story.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs-story.scss
@@ -13,5 +13,4 @@
   flex: 1;
   padding: $spacing-05;
   align-self: stretch;
-  background-color: $layer-01;
 }

--- a/packages/carbon-web-components/src/components/tabs/tabs-story.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs-story.ts
@@ -32,7 +32,75 @@ const types = {
   [`Container type (${TABS_TYPE.CONTAINER})`]: TABS_TYPE.CONTAINER,
 };
 
-export const Default = (args) => {
+export const Default = () => html`
+  <style>
+    ${styles}
+  </style>
+  <cds-tabs value="all">
+    <cds-tab id="tab-all" target="panel-all" value="all">Tab label 1</cds-tab>
+    <cds-tab
+      id="tab-cloudFoundry"
+      target="panel-cloudFoundry"
+      value="cloudFoundry">
+      Tab label 2
+    </cds-tab>
+    <cds-tab id="tab-staging" target="panel-staging" value="staging" disabled>
+      Tab label 3
+    </cds-tab>
+    <cds-tab id="tab-dea" target="panel-dea" value="dea">Tab label 4</cds-tab>
+  </cds-tabs>
+  <div class="${prefix}-ce-demo-devenv--tab-panels">
+    <div id="panel-all" role="tabpanel" aria-labelledby="tab-all" hidden>
+      Tab Panel 1
+    </div>
+    <div
+      id="panel-cloudFoundry"
+      role="tabpanel"
+      aria-labelledby="tab-cloudFoundry"
+      hidden>
+      <form style="margin: 2em">
+        <legend class="${prefix}--label">Validation example</legend>
+        <cds-checkbox id="cb" label-text="Accept privacy policy"></cds-checkbox>
+        <cds-button style="margin-top: 1rem; margin-bottom: 1rem" type="submit">
+          Submit
+        </cds-button>
+        <cds-text-input
+          type="text"
+          label="Text input label"
+          helper-text="Optional help text"
+          id="text-input-1"></cds-text-input>
+      </form>
+    </div>
+    <div
+      id="panel-staging"
+      role="tabpanel"
+      aria-labelledby="tab-staging"
+      hidden>
+      Tab Panel 3
+    </div>
+    <div id="panel-dea" role="tabpanel" aria-labelledby="tab-dea" hidden>
+      Tab Panel 4
+    </div>
+  </div>
+`;
+
+export const skeleton = () => html`
+  <cds-tabs-skeleton>
+    <cds-tab-skeleton></cds-tab-skeleton>
+    <cds-tab-skeleton></cds-tab-skeleton>
+    <cds-tab-skeleton></cds-tab-skeleton>
+    <cds-tab-skeleton></cds-tab-skeleton>
+    <cds-tab-skeleton></cds-tab-skeleton>
+  </cds-tabs-skeleton>
+`;
+
+skeleton.parameters = {
+  percy: {
+    skip: true,
+  },
+};
+
+export const Playground = (args) => {
   const {
     colorScheme,
     triggerContent,
@@ -59,87 +127,60 @@ export const Default = (args) => {
       value="${ifDefined(value)}"
       @cds-tabs-beingselected="${handleBeforeSelected}"
       @cds-tabs-selected="${onSelect}">
-      <cds-tab id="tab-all" target="panel-all" value="all">Option 1</cds-tab>
+      <cds-tab id="tab-all" target="panel-all" value="all">Tab label 1</cds-tab>
       <cds-tab
         id="tab-cloudFoundry"
         target="panel-cloudFoundry"
-        disabled
-        value="cloudFoundry"
-        >Option 2</cds-tab
-      >
-      <cds-tab id="tab-staging" target="panel-staging" value="staging"
-        >Option 3</cds-tab
-      >
-      <cds-tab id="tab-dea" target="panel-dea" value="dea">Option 4</cds-tab>
-      <cds-tab id="tab-router" target="panel-router" value="router"
-        >Option 5</cds-tab
-      >
+        value="cloudFoundry">
+        Tab label 2
+      </cds-tab>
+      <cds-tab id="tab-staging" target="panel-staging" value="staging" disabled>
+        Tab label 3
+      </cds-tab>
+      <cds-tab id="tab-dea" target="panel-dea" value="dea">Tab label 4</cds-tab>
     </cds-tabs>
     <div class="${prefix}-ce-demo-devenv--tab-panels">
       <div id="panel-all" role="tabpanel" aria-labelledby="tab-all" hidden>
-        <h1>Content for option 1</h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </p>
+        Tab Panel 1
       </div>
       <div
         id="panel-cloudFoundry"
         role="tabpanel"
         aria-labelledby="tab-cloudFoundry"
         hidden>
-        <h1>Content for option 2</h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </p>
+        <form style="margin: 2em">
+          <legend class="${prefix}--label">Validation example</legend>
+          <cds-checkbox
+            id="cb"
+            label-text="Accept privacy policy"></cds-checkbox>
+          <cds-button
+            style="margin-top: 1rem; margin-bottom: 1rem"
+            type="submit">
+            Submit
+          </cds-button>
+          <cds-text-input
+            type="text"
+            label="Text input label"
+            helper-text="Optional help text"
+            id="text-input-1"></cds-text-input>
+        </form>
       </div>
       <div
         id="panel-staging"
         role="tabpanel"
         aria-labelledby="tab-staging"
         hidden>
-        <h1>Content for option 3</h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </p>
+        Tab Panel 3
       </div>
       <div id="panel-dea" role="tabpanel" aria-labelledby="tab-dea" hidden>
-        <h1>Content for option 4</h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </p>
-      </div>
-      <div
-        id="panel-router"
-        role="tabpanel"
-        aria-labelledby="tab-router"
-        hidden>
-        <h1>Content for option 5</h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </p>
+        Tab Panel 4
       </div>
     </div>
   `;
 };
 
-Default.storyName = 'Default';
-
-Default.parameters = {
+Playground.parameters = {
+  ...storyDocs.parameters,
   knobs: {
     [`${prefix}-tabs`]: () => ({
       colorScheme: select('Color scheme (color-scheme)', colorSchemes, null),
@@ -148,7 +189,7 @@ Default.parameters = {
         'Select an item'
       ),
       type: select('Tabs type (type)', types, null),
-      value: textNullable('The value of the selected item (value)', 'staging'),
+      value: textNullable('The value of the selected item (value)', 'all'),
       disableSelection: boolean(
         `Disable user-initiated selection change (Call event.preventDefault() in ${prefix}-content-switcher-beingselected event)`,
         false
@@ -159,25 +200,6 @@ Default.parameters = {
   },
 };
 
-export const skeleton = () => html`
-  <cds-tabs-skeleton>
-    <cds-tab-skeleton></cds-tab-skeleton>
-    <cds-tab-skeleton></cds-tab-skeleton>
-    <cds-tab-skeleton></cds-tab-skeleton>
-    <cds-tab-skeleton></cds-tab-skeleton>
-    <cds-tab-skeleton></cds-tab-skeleton>
-  </cds-tabs-skeleton>
-`;
-
-skeleton.parameters = {
-  percy: {
-    skip: true,
-  },
-};
-
 export default {
   title: 'Components/Tabs',
-  parameters: {
-    ...storyDocs.parameters,
-  },
 };

--- a/packages/carbon-web-components/src/components/tabs/tabs-story.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs-story.ts
@@ -30,6 +30,7 @@ const colorSchemes = {
 const types = {
   'Regular type': null,
   [`Container type (${TABS_TYPE.CONTAINER})`]: TABS_TYPE.CONTAINER,
+  [`Container type (${TABS_TYPE.CONTAINED})`]: TABS_TYPE.CONTAINED,
 };
 
 export const Default = () => html`
@@ -79,6 +80,64 @@ export const Default = () => html`
       Tab Panel 3
     </div>
     <div id="panel-dea" role="tabpanel" aria-labelledby="tab-dea" hidden>
+      Tab Panel 4
+    </div>
+  </div>
+`;
+
+export const Contained = () => html`
+  <style>
+    ${styles}
+  </style>
+  <cds-tabs value="all" type="${TABS_TYPE.CONTAINED}">
+    <cds-tab id="tab-all" target="panel-all" value="all">Tab label 1</cds-tab>
+    <cds-tab
+      id="tab-cloudFoundry"
+      target="panel-cloudFoundry"
+      value="cloudFoundry">
+      Tab label 2
+    </cds-tab>
+    <cds-tab id="tab-staging" target="panel-staging" value="staging" disabled>
+      Tab label 3
+    </cds-tab>
+    <cds-tab id="tab-dea" target="panel-dea" value="dea">Tab label 4</cds-tab>
+    <cds-tab id="tab-five" target="panel-five" value="five">
+      Tab label 5
+    </cds-tab>
+  </cds-tabs>
+  <div class="${prefix}-ce-demo-devenv--tab-panels">
+    <div id="panel-all" role="tabpanel" aria-labelledby="tab-all" hidden>
+      Tab Panel 1
+    </div>
+    <div
+      id="panel-cloudFoundry"
+      role="tabpanel"
+      aria-labelledby="tab-cloudFoundry"
+      hidden>
+      <form style="margin: 2em">
+        <legend class="${prefix}--label">Validation example</legend>
+        <cds-checkbox id="cb" label-text="Accept privacy policy"></cds-checkbox>
+        <cds-button style="margin-top: 1rem; margin-bottom: 1rem" type="submit">
+          Submit
+        </cds-button>
+        <cds-text-input
+          type="text"
+          label="Text input label"
+          helper-text="Optional help text"
+          id="text-input-1"></cds-text-input>
+      </form>
+    </div>
+    <div
+      id="panel-staging"
+      role="tabpanel"
+      aria-labelledby="tab-staging"
+      hidden>
+      Tab Panel 3
+    </div>
+    <div id="panel-dea" role="tabpanel" aria-labelledby="tab-dea" hidden>
+      Tab Panel 4
+    </div>
+    <div id="panel-five" role="tabpanel" aria-labelledby="tab-five" hidden>
       Tab Panel 4
     </div>
   </div>

--- a/packages/carbon-web-components/src/components/tabs/tabs-story.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs-story.ts
@@ -12,7 +12,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { TABS_COLOR_SCHEME, TABS_TYPE } from './tabs';
+import { TABS_TYPE } from './tabs';
 import './tab';
 import './tabs-skeleton';
 import './tab-skeleton';
@@ -22,14 +22,8 @@ import { prefix } from '../../globals/settings';
 
 const noop = () => {};
 
-const colorSchemes = {
-  [`Regular`]: null,
-  [`Light (${TABS_COLOR_SCHEME.LIGHT})`]: TABS_COLOR_SCHEME.LIGHT,
-};
-
 const types = {
   'Regular type': null,
-  [`Container type (${TABS_TYPE.CONTAINER})`]: TABS_TYPE.CONTAINER,
   [`Container type (${TABS_TYPE.CONTAINED})`]: TABS_TYPE.CONTAINED,
 };
 
@@ -161,7 +155,6 @@ skeleton.parameters = {
 
 export const Playground = (args) => {
   const {
-    colorScheme,
     triggerContent,
     type,
     value,
@@ -180,7 +173,6 @@ export const Playground = (args) => {
       ${styles}
     </style>
     <cds-tabs
-      color-scheme="${ifDefined(colorScheme)}"
       trigger-content="${ifDefined(triggerContent)}"
       type="${ifDefined(type)}"
       value="${ifDefined(value)}"
@@ -242,7 +234,6 @@ Playground.parameters = {
   ...storyDocs.parameters,
   knobs: {
     [`${prefix}-tabs`]: () => ({
-      colorScheme: select('Color scheme (color-scheme)', colorSchemes, null),
       triggerContent: textNullable(
         'The default content of the trigger button for narrow screen (trigger-content)',
         'Select an item'

--- a/packages/carbon-web-components/src/components/tabs/tabs-story.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs-story.ts
@@ -138,7 +138,7 @@ export const Contained = () => html`
       Tab Panel 4
     </div>
     <div id="panel-five" role="tabpanel" aria-labelledby="tab-five" hidden>
-      Tab Panel 4
+      Tab Panel 5
     </div>
   </div>
 `;

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -118,6 +118,11 @@ $inset-transition: inset 110ms motion(standard, productive);
 :host(#{$prefix}-tab:hover) {
   background-color: transparent;
   box-shadow: 0 -1px 0 $background-hover;
+
+  a.#{$prefix}--tabs__nav-link {
+    border-bottom: $tab-underline-color-hover;
+    color: $text-primary;
+  }
 }
 
 :host(#{$prefix}-tab[type='contained']) {

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/type' as *;
+@use '@carbon/styles/scss/components/button/index' as *;
 @use '@carbon/styles/scss/components/tabs/index';
 @use '@carbon/styles/scss/components/tabs/vars' as *;
 @use '@carbon/styles/scss/utilities/button-reset';
@@ -51,6 +52,8 @@
     @include focus-outline('reset');
     @include type-style('body-compact-01');
 
+    display: flex;
+    align-items: center;
     width: 100%;
     overflow: hidden;
     max-width: 10rem;
@@ -91,7 +94,7 @@
   box-shadow: 0 -1px 0 $background-hover;
 }
 
-:host(#{$prefix}-tab[type='container']) {
+:host(#{$prefix}-tab[type='contained']) {
   @include breakpoint(md) {
     background-color: $layer-accent-01;
 
@@ -110,6 +113,7 @@
   a.#{$prefix}--tabs__nav-link {
     @include breakpoint(md) {
       height: rem(48px);
+      padding: $spacing-03 $spacing-05;
       // height - vertical padding
       /* stylelint-disable declaration-property-unit-whitelist */
       line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
@@ -117,14 +121,12 @@
   }
 }
 
-// `[role]` is only for specificity.
-// We have `:not()` usage in the corresponding Carbon core style
-// which puts specificity of "specific" scenario though the style is for "regular" scenario
-:host(#{$prefix}-tab[type='container'][role]),
-:host(#{$prefix}-tab[type='container'][role]:hover) {
+:host(#{$prefix}-tab[type='contained']),
+:host(#{$prefix}-tab[type='contained']:hover) {
   a.#{$prefix}--tabs__nav-link {
     @include breakpoint(md) {
       border-bottom: none;
+      box-shadow: rem(-1px) 0 0 0 $border-strong;
     }
   }
 }
@@ -154,9 +156,11 @@
   }
 }
 
-:host(#{$prefix}-tab[type='container'][disabled][role])
+:host(#{$prefix}-tab[type='contained'][disabled][role])
   .#{$prefix}--tabs__nav-link {
   @include breakpoint(md) {
+    background-color: $button-disabled;
+    border-bottom: none;
     color: $text-on-color-disabled;
   }
 }
@@ -185,19 +189,12 @@
 
     .#{$prefix}--tabs__nav-link {
       @include type-style('heading-01');
-
-      border-bottom: 3px solid $background-brand;
-
-      &:focus,
-      &:active {
-        border-bottom-width: 2px;
-      }
     }
   }
 }
 
-:host(#{$prefix}-tab[type='container'][selected]),
-:host(#{$prefix}-tab[type='container'][selected]:hover) {
+:host(#{$prefix}-tab[type='contained'][selected]),
+:host(#{$prefix}-tab[type='contained'][selected]:hover) {
   @include breakpoint(md) {
     background-color: $layer-01;
 

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -217,6 +217,10 @@ $inset-transition: inset 110ms motion(standard, productive);
   }
 }
 
+:host(#{$prefix}-tab[type='contained']:hover) {
+  background-color: $layer-accent-hover;
+}
+
 // Disabled tab never gets selected, but we guard for manual addition of `selected` attribute
 :host(#{$prefix}-tab[disabled][selected]),
 :host(#{$prefix}-tab[disabled][selected]:hover),

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -85,49 +85,28 @@
 }
 
 :host(#{$prefix}-tab:hover) {
-  @include breakpoint(md) {
-    background-color: transparent;
-    box-shadow: none;
-  }
-
   background-color: transparent;
   box-shadow: 0 -1px 0 $background-hover;
 }
 
 :host(#{$prefix}-tab[type='contained']) {
-  @include breakpoint(md) {
-    background-color: $layer-accent-01;
-
-    + .#{$prefix}--tabs__nav-item {
-      margin-left: 0;
-      // Draws the border without affecting the inner-content
-      box-shadow: -1px 0 0 0 $border-strong-01;
-    }
-
-    + .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected,
-    &.#{$prefix}--tabs__nav-item--selected + .#{$prefix}--tabs__nav-item {
-      box-shadow: none;
-    }
-  }
+  background-color: $layer-accent-01;
 
   a.#{$prefix}--tabs__nav-link {
-    @include breakpoint(md) {
-      height: rem(48px);
-      padding: $spacing-03 $spacing-05;
-      // height - vertical padding
-      /* stylelint-disable declaration-property-unit-whitelist */
-      line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
-    }
+    height: rem(48px);
+    padding: $spacing-03 $spacing-05;
+    // height - vertical padding
+    /* stylelint-disable declaration-property-unit-whitelist */
+    line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
   }
 }
 
 :host(#{$prefix}-tab[type='contained']),
 :host(#{$prefix}-tab[type='contained']:hover) {
   a.#{$prefix}--tabs__nav-link {
-    @include breakpoint(md) {
-      border-bottom: none;
-      box-shadow: rem(-1px) 0 0 0 $border-strong;
-    }
+    border-bottom: none;
+    // Draws the border without affecting the inner-content
+    box-shadow: rem(-1px) 0 0 0 $border-strong;
   }
 }
 
@@ -141,37 +120,32 @@
   cursor: not-allowed;
   outline: none;
 
-  @include breakpoint(md) {
-    background-color: transparent;
-  }
-
   .#{$prefix}--tabs__nav-link {
     color: $tab-text-disabled;
     pointer-events: none;
     outline: none;
-
-    @include breakpoint(md) {
-      border-bottom: $tab-underline-disabled;
-    }
+    border-bottom: $tab-underline-disabled;
   }
 }
 
 :host(#{$prefix}-tab[type='contained'][disabled][role])
   .#{$prefix}--tabs__nav-link {
-  @include breakpoint(md) {
-    background-color: $button-disabled;
-    border-bottom: none;
-    color: $text-on-color-disabled;
-  }
+  background-color: $button-disabled;
+  border-bottom: none;
+  color: $text-on-color-disabled;
 }
 
 :host(#{$prefix}-tab[selected]) {
+  display: flex;
+  background-color: transparent;
+
+  .#{$prefix}--tabs__nav-link {
+    @include type-style('heading-01');
+  }
   transition: color $duration-fast-01 motion(standard, productive);
 
   &:hover {
-    @include breakpoint(md) {
-      background-color: transparent;
-    }
+    background-color: transparent;
   }
 
   .#{$prefix}--tabs__nav-link {
@@ -182,57 +156,23 @@
       color: $text-primary;
     }
   }
-
-  @include breakpoint(md) {
-    display: flex;
-    background-color: transparent;
-
-    .#{$prefix}--tabs__nav-link {
-      @include type-style('heading-01');
-    }
-  }
 }
 
 :host(#{$prefix}-tab[type='contained'][selected]),
 :host(#{$prefix}-tab[type='contained'][selected]:hover) {
-  @include breakpoint(md) {
-    background-color: $layer-01;
+  background-color: $layer-01;
 
-    .#{$prefix}--tabs__nav-link {
-      // height - vertical padding
-      line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
-      // Draws the border without affecting the inner-content
-      box-shadow: inset 0 2px 0 0 $interactive;
-      border-bottom: none;
-    }
-
-    .#{$prefix}--tabs__nav-link:focus,
-    .#{$prefix}--tabs__nav-link:active {
-      box-shadow: none;
-    }
+  .#{$prefix}--tabs__nav-link {
+    // height - vertical padding
+    line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
+    // Draws the border without affecting the inner-content
+    box-shadow: inset 0 2px 0 0 $interactive;
+    border-bottom: none;
   }
-}
 
-:host(#{$prefix}-tab[highlighted]),
-:host(#{$prefix}-tab[highlighted]:hover) {
-  box-shadow: 0 -1px 0 $background-hover;
-
-  // `highlighted` is not used in wide mode,
-  // but we need guard for a scenario where a tab is highlighted and then the UI turned to wide mode
-  @include breakpoint(md) {
-    background-color: transparent;
+  .#{$prefix}--tabs__nav-link:focus,
+  .#{$prefix}--tabs__nav-link:active {
     box-shadow: none;
-  }
-}
-
-:host(#{$prefix}-tab[highlighted][selected]),
-:host(#{$prefix}-tab[highlighted][selected]:hover) {
-  background-color: $background-selected;
-
-  // `highlighted` is not used in wide mode,
-  // but we need guard for a scenario where a tab is highlighted and then the UI turned to wide mode
-  @include breakpoint(md) {
-    background-color: transparent;
   }
 }
 
@@ -245,23 +185,17 @@
   background-color: transparent;
   box-shadow: none;
 
-  @include breakpoint(md) {
-    @include focus-outline('reset');
-
-    background-color: transparent;
-  }
+  @include focus-outline('reset');
 
   .#{$prefix}--tabs__nav-link {
-    @include breakpoint(md) {
-      @include type-style('body-short-01');
+    @include type-style('body-short-01');
 
-      color: $tab-text-disabled;
-      border-bottom: $tab-underline-disabled;
+    color: $tab-text-disabled;
+    border-bottom: $tab-underline-disabled;
 
-      &:focus,
-      &:active {
-        border-bottom-width: 3px;
-      }
+    &:focus,
+    &:active {
+      border-bottom-width: 3px;
     }
   }
 }
@@ -273,9 +207,7 @@
 }
 
 :host(#{$prefix}-tab-skeleton) {
-  @include breakpoint(md) {
-    margin-left: rem(2px);
-  }
+  margin-left: rem(2px);
 
   .#{$prefix}--tabs__nav-link {
     @include skeleton;
@@ -286,7 +218,5 @@
 }
 
 :host(#{$prefix}-tab-skeleton:first-of-type) {
-  @include breakpoint(md) {
-    margin-left: 0;
-  }
+  margin-left: 0;
 }

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -28,6 +28,7 @@ $inset-transition: inset 110ms motion(standard, productive);
     position: relative;
     overflow: scroll;
     height: 42px; // for some reason, overflow: hidden shrinks the content
+    scrollbar-width: none;
 
     &::-webkit-scrollbar {
       display: none;
@@ -123,18 +124,18 @@ $inset-transition: inset 110ms motion(standard, productive);
 
 :host(#{$prefix}-tabs[type='contained'])
   .#{$prefix}--tabs-nav-content-container {
-  height: rem(48px);
+  height: $spacing-09;
 }
 
 :host(#{$prefix}-tab[type='contained']) {
   background-color: $layer-accent-01;
 
   a.#{$prefix}--tabs__nav-link {
-    height: rem(48px);
+    height: $spacing-09;
     padding: $spacing-03 $spacing-05;
     // height - vertical padding
     /* stylelint-disable declaration-property-unit-whitelist */
-    line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
+    line-height: calc(#{$spacing-09} - (#{$spacing-03} * 2));
   }
 }
 
@@ -206,7 +207,7 @@ $inset-transition: inset 110ms motion(standard, productive);
 
   .#{$prefix}--tabs__nav-link {
     // height - vertical padding
-    line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
+    line-height: calc(#{$spacing-09} - (#{$spacing-03} * 2));
     // Draws the border without affecting the inner-content
     box-shadow: inset 0 2px 0 0 $interactive;
     border-bottom: none;

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -24,8 +24,6 @@
 :host(#{$prefix}-tabs) {
   @include focus-outline('reset');
 
-  display: block;
-
   &[color-scheme='light'] {
     background-color: $layer-01;
   }

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -102,7 +102,7 @@ $inset-transition: inset 110ms motion(standard, productive);
 
   &[selected] {
     .#{$prefix}--tabs__nav-link {
-      @include type-style('heading-01');
+      @include type-style('heading-compact-01');
 
       border-bottom: 2px solid $border-interactive;
     }

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -17,9 +17,40 @@
 @use '@carbon/styles/scss/components/tabs/vars' as *;
 @use '@carbon/styles/scss/utilities/button-reset';
 
+$inset-transition: inset 110ms motion(standard, productive);
+
 :host(#{$prefix}-tabs),
 :host(#{$prefix}-tabs-skeleton) {
   @extend .#{$prefix}--tabs;
+
+  .#{$prefix}--tabs-nav-content-container {
+    flex: 1 1 0%;
+    position: relative;
+    overflow: scroll;
+    height: 42px; // for some reason, overflow: hidden shrinks the content
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  /* Set to zero-slecificity so it can be overridden by dynamic stylesheet */
+  /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
+  :where(.#{$prefix}--tabs-nav-content) {
+    position: absolute;
+    height: 100%;
+    inset-inline-start: 0;
+    transition: $inset-transition;
+  }
+
+  .#{$prefix}--tabs-nav {
+    display: block;
+    position: absolute;
+  }
+
+  .#{$prefix}--tab--overflow-nav-button {
+    z-index: 1;
+  }
 }
 
 :host(#{$prefix}-tabs) {

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -147,6 +147,11 @@ $inset-transition: inset 110ms motion(standard, productive);
   }
 }
 
+:host(#{$prefix}-tab[type='contained'][hide-divider])
+  a.#{$prefix}--tabs__nav-link {
+  box-shadow: rem(-1px) 0 0 0 transparent;
+}
+
 // `[role]` is only for specificity.
 // We have `:not()` usage in the corresponding Carbon core style
 // which puts specificity of "specific" scenario though the style is for "regular" scenario

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -56,10 +56,6 @@ $inset-transition: inset 110ms motion(standard, productive);
 :host(#{$prefix}-tabs) {
   @include focus-outline('reset');
 
-  &[color-scheme='light'] {
-    background-color: $layer-01;
-  }
-
   .#{$prefix}--tabs-trigger svg {
     width: auto;
     height: auto;

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -125,6 +125,11 @@ $inset-transition: inset 110ms motion(standard, productive);
   }
 }
 
+:host(#{$prefix}-tabs[type='contained'])
+  .#{$prefix}--tabs-nav-content-container {
+  height: rem(48px);
+}
+
 :host(#{$prefix}-tab[type='contained']) {
   background-color: $layer-accent-01;
 

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -67,6 +67,11 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
   private tablist: Element | null = null;
 
   /**
+   * The width of the overflow scroll buttons.
+   */
+  private BUTTON_WIDTH = 44;
+
+  /**
    * Navigates through tabs.
    *
    * @param direction `-1` to navigate backward, `1` to navigate forward.
@@ -248,7 +253,6 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
   render() {
     const { _assistiveStatusText: assistiveStatusText } = this;
     const { scrollLeft, clientWidth, scrollWidth } = this.tablist ?? {};
-    const buttonWidth = 44;
     /**
      * Previous Button
      * VISIBLE IF:
@@ -265,7 +269,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
      *   - AND SCROLL_LEFT + CLIENT_WIDTH < SCROLL_WIDTH
      */
     const isNextButtonVisible = this.tablist
-      ? scrollLeft! + buttonWidth + clientWidth! < scrollWidth!
+      ? scrollLeft! + this.BUTTON_WIDTH + clientWidth! < scrollWidth!
       : false;
     const previousButtonClasses = classMap({
       [`${prefix}--tab--overflow-nav-button`]: true,

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -202,6 +202,17 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
     this.requestUpdate();
   };
 
+  _handleSlotchange() {
+    console.log('asdf');
+    const { selectorItemSelected } = this.constructor as typeof CDSTabs;
+    const selectedItem = this.querySelector(selectorItemSelected);
+    const nextItem = this._getNextItem(selectedItem as CDSTab, 1);
+
+    // Specifies child `<cds-tab>` to hide its divider instead of using CSS,
+    // until `:host-context()` gets supported in all major browsers
+    (nextItem as CDSTab).hideDivider = true;
+  }
+
   protected _selectionDidChange(itemToSelect: CDSTab) {
     super._selectionDidChange(itemToSelect);
     this._assistiveStatusText = this.selectedItemAssistiveText;
@@ -427,6 +438,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
       _isIntersectionLeftTrackerInContent: isIntersectionLeftTrackerInContent,
       _isIntersectionRightTrackerInContent: isIntersectionRightTrackerInContent,
       _assistiveStatusText: assistiveStatusText,
+      _handleSlotchange: handleSlotchange,
     } = this;
 
     const previousButtonClasses = classMap({
@@ -462,7 +474,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
           <div class="${prefix}--tabs-nav">
             <div id="tablist" role="tablist" class="${prefix}--tab--list">
               <div class="${prefix}--sub-content-left"></div>
-              <slot></slot>
+              <slot @slotchange=${handleSlotchange}></slot>
               <div class="${prefix}--sub-content-right"></div>
             </div>
           </div>

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -287,6 +287,12 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
     this.requestUpdate();
   };
 
+  @HostListener('scroll')
+  protected _handleScroll = () => {
+    // TODO: debounce
+    this.requestUpdate();
+  };
+
   protected _selectionDidChange(itemToSelect: CDSTab) {
     super._selectionDidChange(itemToSelect);
     this._assistiveStatusText = this.selectedItemAssistiveText;
@@ -331,6 +337,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
 
   disconnectedCallback = () => {
     window.removeEventListener('resize', this._handleResize);
+    this.tablist?.removeEventListener('scroll', this._handleScroll);
     super.disconnectedCallback();
   };
 
@@ -367,6 +374,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
     const { selectorTablist } = this.constructor as typeof CDSTabs;
     const tablist = this.shadowRoot!.querySelector(selectorTablist)!;
     this.tablist = tablist;
+    this.tablist.addEventListener('scroll', this._handleScroll);
     this.requestUpdate();
   }
 

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -10,7 +10,6 @@
 import { html } from 'lit';
 import { property, customElement, state, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import debounce from 'lodash/debounce';
 import { prefix } from '../../globals/settings';
 import HostListenerMixin from '../../globals/mixins/host-listener';
 import HostListener from '../../globals/decorators/host-listener';
@@ -197,14 +196,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
     }
   }
 
-  @HostListener('scroll')
-  protected _handleScroll = () => {
-    debounce(this.requestUpdate as () => void, 500);
-    this.requestUpdate();
-  };
-
   _handleSlotchange() {
-    console.log('asdf');
     const { selectorItemSelected } = this.constructor as typeof CDSTabs;
     const selectedItem = this.querySelector(selectorItemSelected);
     const nextItem = this._getNextItem(selectedItem as CDSTab, 1);
@@ -307,18 +299,6 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
     } = this;
 
     records.forEach(({ isIntersecting, target }) => {
-      if (isIntersecting) {
-        this._contentContainerNode?.addEventListener(
-          'scroll',
-          this._handleScroll
-        );
-      } else {
-        this._contentContainerNode?.removeEventListener(
-          'scroll',
-          this._handleScroll
-        );
-      }
-
       if (target === intersectionLeftSentinelNode) {
         this._isIntersectionLeftTrackerInContent = isIntersecting;
       }
@@ -367,10 +347,6 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
 
   disconnectedCallback() {
     this._cleanAndCreateIntersectionObserverContainer();
-    this._contentContainerNode?.removeEventListener(
-      'scroll',
-      this._handleScroll
-    );
     super.disconnectedCallback();
   }
 

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -167,6 +167,36 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
     }
   }
 
+  /**
+   * Handles click on overflow scroll buttons.
+   *
+   * @param _ Event object
+   * @param [options] The options.
+   * @param [options.direction] `-1` to scroll forward, `1` to scroll backward.
+   */
+  protected _handleScrollButtonClick(_, { direction }) {
+    if (!this.tablist) {
+      return;
+    }
+    const { scrollLeft, clientWidth, scrollWidth } = this.tablist;
+    switch (direction) {
+      case -1:
+        this.tablist.scrollLeft = Math.max(
+          scrollLeft - (scrollWidth / this._totalTabs) * 1.5,
+          0
+        );
+        break;
+      case 1:
+        this.tablist.scrollLeft = Math.min(
+          scrollLeft + (scrollWidth / this._totalTabs) * 1.5,
+          scrollWidth - clientWidth
+        );
+        break;
+      default:
+        break;
+    }
+  }
+
   @HostListener('resize')
   protected _handleResize = () => {
     // TODO: debounce
@@ -286,7 +316,9 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
         aria-hidden="true"
         aria-label="Scroll left"
         type="button"
-        class="${previousButtonClasses}">
+        class="${previousButtonClasses}"
+        @click=${(_) =>
+          this._scroll(_, { direction: NAVIGATION_DIRECTION.Left })}>
         ${ChevronLeft16()}
       </button>
       <div id="tablist" role="tablist" class="${prefix}--tab--list">
@@ -296,7 +328,9 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
         aria-hidden="true"
         aria-label="Scroll right"
         type="button"
-        class="${nextButtonClasses}">
+        class="${nextButtonClasses}"
+        @click=${(_) =>
+          this._scroll(_, { direction: NAVIGATION_DIRECTION.Right })}>
         ${ChevronRight16()}
       </button>
       <div

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -9,10 +9,13 @@
 
 import { html } from 'lit';
 import { property, customElement, query } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { prefix } from '../../globals/settings';
 import HostListenerMixin from '../../globals/mixins/host-listener';
 import HostListener from '../../globals/decorators/host-listener';
 import { find, forEach } from '../../globals/internal/collection-helpers';
+import ChevronRight16 from '@carbon/icons/lib/chevron--right/16';
+import ChevronLeft16 from '@carbon/icons/lib/chevron--left/16';
 import CDSContentSwitcher, {
   NAVIGATION_DIRECTION,
 } from '../content-switcher/content-switcher';
@@ -332,10 +335,36 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
 
   render() {
     const { _assistiveStatusText: assistiveStatusText } = this;
+    const isPreviousButtonVisible = false;
+    const isNextButtonVisible = true;
+    const previousButtonClasses = classMap({
+      [`${prefix}--tab--overflow-nav-button`]: true,
+      [`${prefix}--tab--overflow-nav-button--previous`]: true,
+      [`${prefix}--tab--overflow-nav-button--hidden`]: !isPreviousButtonVisible,
+    });
+    const nextButtonClasses = classMap({
+      [`${prefix}--tab--overflow-nav-button`]: true,
+      [`${prefix}--tab--overflow-nav-button--next`]: true,
+      [`${prefix}--tab--overflow-nav-button--hidden`]: !isNextButtonVisible,
+    });
     return html`
+      <button
+        aria-hidden="true"
+        aria-label="Scroll left"
+        type="button"
+        class="${previousButtonClasses}">
+        ${ChevronLeft16()}
+      </button>
       <div id="tablist" role="tablist" class="${prefix}--tab--list">
         <slot></slot>
       </div>
+      <button
+        aria-hidden="true"
+        aria-label="Scroll right"
+        type="button"
+        class="${nextButtonClasses}">
+        ${ChevronRight16()}
+      </button>
       <div
         class="${prefix}--assistive-text"
         role="status"

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -22,7 +22,7 @@ import {
   TABS_KEYBOARD_ACTION,
   TABS_TYPE,
 } from './defs';
-import BXTab from './tab';
+import CDSTab from './tab';
 import styles from './tabs.scss';
 
 export {
@@ -43,7 +43,7 @@ export {
  * @fires cds-tabs-selected - The custom event fired after a a tab is selected upon a user gesture.
  */
 @customElement(`${prefix}-tabs`)
-class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
+export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
   /**
    * The latest status of this dropdown, for screen reader to accounce.
    */
@@ -122,9 +122,9 @@ class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
    */
   private _clearHighlight() {
     forEach(
-      this.querySelectorAll((this.constructor as typeof BXTabs).selectorItem),
+      this.querySelectorAll((this.constructor as typeof CDSTabs).selectorItem),
       (item) => {
-        (item as BXTab).highlighted = false;
+        (item as CDSTab).highlighted = false;
       }
     );
   }
@@ -145,11 +145,11 @@ class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
     { immediate }: { immediate?: boolean } = {}
   ) {
     const { selectorItem, selectorItemHighlighted, selectorItemSelected } = this
-      .constructor as typeof BXTabs;
+      .constructor as typeof CDSTabs;
     const nextItem = this._getNextItem(
       this.querySelector(
         immediate ? selectorItemSelected : selectorItemHighlighted
-      ) as BXTab,
+      ) as CDSTab,
       direction
     );
     if (!nextItem) {
@@ -157,10 +157,10 @@ class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
     }
 
     if (immediate) {
-      this._handleUserInitiatedSelectItem(nextItem as BXTab);
+      this._handleUserInitiatedSelectItem(nextItem as CDSTab);
     } else {
       forEach(this.querySelectorAll(selectorItem), (item) => {
-        (item as BXTab)[immediate ? 'selected' : 'highlighted'] =
+        (item as CDSTab)[immediate ? 'selected' : 'highlighted'] =
           nextItem === item;
       });
     }
@@ -183,7 +183,7 @@ class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
     const { target } = event;
     if (this === target) {
       this._handleUserInitiatedToggle();
-    } else if ((target as BXTab).value === this.value) {
+    } else if ((target as CDSTab).value === this.value) {
       // Clicking on selected item, simply closes the narrow mode dropdown
       this._handleUserInitiatedToggle(false);
     } else {
@@ -198,7 +198,7 @@ class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
     const { _open: open, _triggerNode: triggerNode } = this;
     const { key, target } = event;
     const narrowMode = Boolean(triggerNode.offsetParent);
-    const action = (this.constructor as typeof BXTabs).getAction(key, {
+    const action = (this.constructor as typeof CDSTabs).getAction(key, {
       narrowMode,
     });
     if (!open && narrowMode) {
@@ -221,7 +221,7 @@ class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
           this._handleUserInitiatedToggle(false);
           break;
         case TABS_KEYBOARD_ACTION.SELECTING:
-          this._handleUserInitiatedSelectItem(target as BXTab);
+          this._handleUserInitiatedSelectItem(target as CDSTab);
           break;
         case TABS_KEYBOARD_ACTION.HOME:
           this._navigate(this._currentIndex + this._totalTabs, {
@@ -244,10 +244,10 @@ class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
         case TABS_KEYBOARD_ACTION.TRIGGERING:
           {
             const { selectorItemHighlighted } = this
-              .constructor as typeof BXTabs;
+              .constructor as typeof CDSTabs;
             const highlightedItem = this.querySelector(
               selectorItemHighlighted
-            ) as BXTab;
+            ) as CDSTab;
             if (highlightedItem) {
               if (highlightedItem.value === this.value) {
                 // Selecting an already-selected item, simply closes the narrow mode dropdown
@@ -268,7 +268,7 @@ class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
     }
   }
 
-  protected _selectionDidChange(itemToSelect: BXTab) {
+  protected _selectionDidChange(itemToSelect: CDSTab) {
     super._selectionDidChange(itemToSelect);
     this._assistiveStatusText = this.selectedItemAssistiveText;
     this._handleUserInitiatedToggle(false);
@@ -307,17 +307,17 @@ class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
 
   shouldUpdate(changedProperties) {
     super.shouldUpdate(changedProperties);
-    const { selectorItem } = this.constructor as typeof BXTabs;
+    const { selectorItem } = this.constructor as typeof CDSTabs;
     if (changedProperties.has('type')) {
       forEach(this.querySelectorAll(selectorItem), (elem) => {
         this._totalTabs++;
-        (elem as BXTab).type = this.type;
+        (elem as CDSTab).type = this.type;
       });
     }
     if (changedProperties.has('value')) {
       const item = find(
         this.querySelectorAll(selectorItem),
-        (elem) => (elem as BXTab).value === this.value
+        (elem) => (elem as CDSTab).value === this.value
       );
       if (item) {
         const range = this.ownerDocument!.createRange();
@@ -426,5 +426,3 @@ class BXTabs extends HostListenerMixin(CDSContentSwitcher) {
     return TABS_KEYBOARD_ACTION.NONE;
   }
 }
-
-export default BXTabs;

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -45,6 +45,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
   /**
    * The currently selected index
    */
+  // @ts-ignore: TS thinks this method is not referred to
   private _currentIndex: number = 0;
 
   /**

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -281,6 +281,12 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
     }
   }
 
+  @HostListener('resize')
+  protected _handleResize = () => {
+    // TODO: debounce
+    this.requestUpdate();
+  };
+
   protected _selectionDidChange(itemToSelect: CDSTab) {
     super._selectionDidChange(itemToSelect);
     this._assistiveStatusText = this.selectedItemAssistiveText;
@@ -317,6 +323,16 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
    */
   @property({ reflect: true })
   type = TABS_TYPE.REGULAR;
+
+  connectedCallback = () => {
+    super.connectedCallback();
+    window.addEventListener('resize', this._handleResize);
+  };
+
+  disconnectedCallback = () => {
+    window.removeEventListener('resize', this._handleResize);
+    super.disconnectedCallback();
+  };
 
   shouldUpdate(changedProperties) {
     super.shouldUpdate(changedProperties);

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -26,28 +26,6 @@ import styles from './tabs.scss';
 
 export { NAVIGATION_DIRECTION, TABS_KEYBOARD_ACTION, TABS_TYPE };
 
-// button gradient width size
-const buttonGradientWidth = 8;
-
-/**
- * @param a An array.
- * @param predicate The callback function.
- * @param [thisObject] The context object for the given callback function.
- * @returns The index of the last item in the given array where `predicate` returns `true`. `-1` if no such item is found.
- */
-function findLastIndex<T>(
-  a: T[],
-  predicate: (search: T, index?: number, thisObject?: any) => boolean,
-  thisObject?: any
-): number {
-  for (let i = a.length - 1; i >= 0; --i) {
-    if (predicate(a[i], i, thisObject)) {
-      return i;
-    }
-  }
-  return -1;
-}
-
 /**
  * Tabs.
  *
@@ -77,6 +55,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
   /**
    * `true` if the tablist is scrollable
    */
+  // @ts-ignore: TS thinks this method is not referred to
   private _isScrollable: boolean = false;
 
   /**

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -20,16 +20,11 @@ import ChevronLeft16 from '@carbon/icons/lib/chevron--left/16';
 import CDSContentSwitcher, {
   NAVIGATION_DIRECTION,
 } from '../content-switcher/content-switcher';
-import { TABS_COLOR_SCHEME, TABS_KEYBOARD_ACTION, TABS_TYPE } from './defs';
+import { TABS_KEYBOARD_ACTION, TABS_TYPE } from './defs';
 import CDSTab from './tab';
 import styles from './tabs.scss';
 
-export {
-  NAVIGATION_DIRECTION,
-  TABS_COLOR_SCHEME,
-  TABS_KEYBOARD_ACTION,
-  TABS_TYPE,
-};
+export { NAVIGATION_DIRECTION, TABS_KEYBOARD_ACTION, TABS_TYPE };
 
 // button gradient width size
 const buttonGradientWidth = 8;
@@ -264,12 +259,6 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
    */
   @query(`.${prefix}--sub-content-right`)
   private _intersectionRightSentinelNode?: HTMLElement;
-
-  /**
-   * The color scheme.
-   */
-  @property({ attribute: 'color-scheme', reflect: true })
-  colorScheme = TABS_COLOR_SCHEME.REGULAR;
 
   /**
    * An assistive text for screen reader to announce, telling the open state.

--- a/packages/carbon-web-components/tests/spec/content-switcher_spec.ts
+++ b/packages/carbon-web-components/tests/spec/content-switcher_spec.ts
@@ -9,7 +9,7 @@
 
 import { render } from 'lit';
 import EventManager from '../utils/event-manager';
-import BXTabs from '../../src/components/tabs/tabs';
+import CDSTabs from '../../src/components/tabs/tabs';
 import { Playground } from '../../src/components/content-switcher/content-switcher-story';
 
 const template = (props?) =>
@@ -45,14 +45,14 @@ describe('cds-content-switcher', function () {
       (itemNodes[2] as HTMLElement).click();
       await Promise.resolve();
       expect(
-        (document.body.querySelector('cds-content-switcher') as BXTabs).value
+        (document.body.querySelector('cds-content-switcher') as CDSTabs).value
       ).toBe('staging');
     });
 
     it('should provide a way to switch item with a value', async function () {
       render(template(), document.body);
       await Promise.resolve();
-      (document.body.querySelector('cds-content-switcher') as BXTabs).value =
+      (document.body.querySelector('cds-content-switcher') as CDSTabs).value =
         'staging';
       await Promise.resolve(); // Update cycle for `<cds-content-switcher>`
       await Promise.resolve(); // Update cycle for `<cds-content-switcher-item>`
@@ -73,7 +73,7 @@ describe('cds-content-switcher', function () {
       const itemNodes = document.body.querySelectorAll(
         'cds-content-switcher-item'
       );
-      (document.body.querySelector('cds-content-switcher') as BXTabs).value =
+      (document.body.querySelector('cds-content-switcher') as CDSTabs).value =
         'all';
       await Promise.resolve();
       events.on(

--- a/packages/carbon-web-components/tests/spec/tabs_spec.ts
+++ b/packages/carbon-web-components/tests/spec/tabs_spec.ts
@@ -9,8 +9,8 @@
 
 import { render } from 'lit';
 import EventManager from '../utils/event-manager';
-import BXTabs from '../../src/components/tabs/tabs';
-import BXTab from '../../src/components/tabs/tab';
+import CDSTabs from '../../src/components/tabs/tabs';
+import CDSTab from '../../src/components/tabs/tab';
 import { Default } from '../../src/components/tabs/tabs-story';
 
 const template = (props?) =>
@@ -90,7 +90,7 @@ describe('cds-tabs', function () {
       const itemNodes = document.body.querySelectorAll('cds-tab');
       (itemNodes[2] as HTMLElement).click();
       await Promise.resolve();
-      expect((document.body.querySelector('cds-tabs') as BXTabs).value).toBe(
+      expect((document.body.querySelector('cds-tabs') as CDSTabs).value).toBe(
         'staging'
       );
     });
@@ -98,7 +98,7 @@ describe('cds-tabs', function () {
     it('should provide a way to switch item with a value', async function () {
       render(template(), document.body);
       await Promise.resolve();
-      (document.body.querySelector('cds-tabs') as BXTabs).value = 'staging';
+      (document.body.querySelector('cds-tabs') as CDSTabs).value = 'staging';
       await Promise.resolve(); // Update cycle for `<cds-tabs>`
       await Promise.resolve(); // Update cycle for `<cds-tab>`
       const itemNodes = document.body.querySelectorAll('cds-tab');
@@ -114,7 +114,7 @@ describe('cds-tabs', function () {
       await Promise.resolve();
       const elem = document.body.querySelector('cds-tabs');
       const itemNodes = document.body.querySelectorAll('cds-tab');
-      (document.body.querySelector('cds-tabs') as BXTabs).value = 'all';
+      (document.body.querySelector('cds-tabs') as CDSTabs).value = 'all';
       await Promise.resolve();
       events.on(elem!, 'cds-tabs-beingselected', (event: CustomEvent) => {
         expect(event.detail.item).toBe(itemNodes[2]);
@@ -155,7 +155,7 @@ describe('cds-tabs', function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('cds-tabs');
-      (elem as BXTabs).value = 'all';
+      (elem as CDSTabs).value = 'all';
       await Promise.resolve(); // Update cycle for `<cds-tabs>`
       await Promise.resolve(); // Update cycle for `<cds-tab>`
       const triggerNode = elem!.shadowRoot!.getElementById('trigger');
@@ -178,7 +178,7 @@ describe('cds-tabs', function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('cds-tabs');
-      (elem as BXTabs).value = 'router';
+      (elem as CDSTabs).value = 'router';
       await Promise.resolve(); // Update cycle for `<cds-tabs>`
       await Promise.resolve(); // Update cycle for `<cds-tab>`
       const triggerNode = elem!.shadowRoot!.getElementById('trigger');
@@ -201,7 +201,7 @@ describe('cds-tabs', function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('cds-tabs');
-      (elem as BXTabs).value = 'all';
+      (elem as CDSTabs).value = 'all';
       (elem as any)._open = true;
       await Promise.resolve(); // Update cycle for `<cds-tabs>`
       await Promise.resolve(); // Update cycle for `<cds-tab>`
@@ -225,7 +225,7 @@ describe('cds-tabs', function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('cds-tabs');
-      (elem as BXTabs).value = 'router';
+      (elem as CDSTabs).value = 'router';
       (elem as any)._open = true;
       await Promise.resolve(); // Update cycle for `<cds-tabs>`
       await Promise.resolve(); // Update cycle for `<cds-tab>`
@@ -249,7 +249,7 @@ describe('cds-tabs', function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('cds-tabs');
-      (elem as BXTabs).value = 'all';
+      (elem as CDSTabs).value = 'all';
       await Promise.resolve(); // Update cycle for `<cds-tabs>`
       await Promise.resolve(); // Update cycle for `<cds-tab>`
       const triggerNode = elem!.shadowRoot!.getElementById('trigger');
@@ -273,7 +273,7 @@ describe('cds-tabs', function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('cds-tabs');
-      (elem as BXTabs).value = 'all';
+      (elem as CDSTabs).value = 'all';
       await Promise.resolve(); // Update cycle for `<cds-tabs>`
       await Promise.resolve(); // Update cycle for `<cds-tab>`
       const triggerNode = elem!.shadowRoot!.getElementById('trigger');
@@ -313,7 +313,7 @@ describe('cds-tabs', function () {
       const elem = document.body.querySelector('cds-tabs');
       (elem as any)._open = true;
       const itemNodes = document.body.querySelectorAll('cds-tab');
-      (itemNodes[2] as BXTab).highlighted = true;
+      (itemNodes[2] as CDSTab).highlighted = true;
       await Promise.resolve();
       const triggerNode = elem!.shadowRoot!.getElementById('trigger');
       spyOnProperty(triggerNode!, 'offsetParent').and.returnValue({});
@@ -324,17 +324,17 @@ describe('cds-tabs', function () {
       );
       await Promise.resolve();
       expect((elem as any)._open).toBe(false);
-      expect((elem as BXTabs).value).toBe('staging');
+      expect((elem as CDSTabs).value).toBe('staging');
     });
 
     it('should simply close the dropdown if user tries to choose the same selection in narrow mode', async function () {
       render(template(), document.body);
       await Promise.resolve();
       const elem = document.body.querySelector('cds-tabs');
-      (elem as BXTabs).value = 'staging';
+      (elem as CDSTabs).value = 'staging';
       (elem as any)._open = true;
       const itemNodes = document.body.querySelectorAll('cds-tab');
-      (itemNodes[2] as BXTab).highlighted = true;
+      (itemNodes[2] as CDSTab).highlighted = true;
       await Promise.resolve(); // Update cycle for `<cds-tabs>`
       await Promise.resolve(); // Update cycle for `<cds-tab>`
       const triggerNode = elem!.shadowRoot!.getElementById('trigger');

--- a/packages/carbon-web-components/tests/spec/tabs_spec.ts
+++ b/packages/carbon-web-components/tests/spec/tabs_spec.ts
@@ -11,10 +11,10 @@ import { render } from 'lit';
 import EventManager from '../utils/event-manager';
 import CDSTabs from '../../src/components/tabs/tabs';
 import CDSTab from '../../src/components/tabs/tab';
-import { Default } from '../../src/components/tabs/tabs-story';
+import { Playground } from '../../src/components/tabs/tabs-story';
 
 const template = (props?) =>
-  Default({
+  Playground({
     'cds-tabs': props,
   });
 


### PR DESCRIPTION
### Related Ticket(s)

#10086

### Description

This PR updates the tabs to match the upstream React version

Note: still missing icon-only variants

### Changelog

**New**

- implement overflow tabs

**Changed**

- update stories

**Removed**

- remove unused styles and breakpoints
- remove dropdown mobile tabs logic

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
