### PR TITLE
chore(node): update component exports

### DIFF
--- a/packages/carbon-web-components/package.json
+++ b/packages/carbon-web-components/package.json
@@ -15,9 +15,8 @@
       "node": "./lib/components-react-node/",
       "default": "./es/components-react/"
     },
-    "./es/components/": {
-      "node": "./lib/components/",
-      "default": "./es/components/"
+    "./es/components/*": {
+      "default": "./es/components/*"
     },
     "./es/globals/": {
       "node": "./lib/globals/",


### PR DESCRIPTION
### Related Ticket(s)

Fixes #10564 

### Description

This updates the NPM export fields for the `@carbon/web-components` package.

### Changelog

**New**

- {{new thing}}

**Changed**

- update NPM export path for `@carbon/web-components`

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
