### PR TITLE
fix(leaving-ibm): update body content padding

### DIFF
--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm.scss
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm.scss
@@ -39,4 +39,8 @@
     color: $text-02;
     @include carbon--type-style('label-02');
   }
+
+  > p {
+    padding-right: 0;
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

Fixes #7416 

### Description

Update body content padding in `leaving-ibm` component.

### Changelog

**New**

- {{new thing}}

**Changed**

- update body content padding

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
