### PR TITLE
fix(locale-modal): set ipcinfo cookie with selected locale

### DIFF
--- a/packages/web-components/src/components/locale-modal/locale-item.ts
+++ b/packages/web-components/src/components/locale-modal/locale-item.ts
@@ -11,6 +11,7 @@ import { html, property } from 'lit-element';
 import BXLink from '../../internal/vendor/@carbon/web-components/components/link/link.js';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
+import ipcinfoCookie from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/ipcinfoCookie/ipcinfoCookie';
 import styles from './locale-modal.scss';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
@@ -53,6 +54,21 @@ class DDSLocaleItem extends BXLink {
    */
   @property({ reflect: true })
   role = 'listitem';
+
+  /**
+   * method to handle when country/region has been selected
+   * sets the ipcInfo cookie with selected locale
+   */
+  _handleClick() {
+    const { locale } = this;
+
+    const localeSplit = locale.split('-');
+    const localeObj = {
+      cc: localeSplit[1],
+      lc: localeSplit[0],
+    };
+    ipcinfoCookie.set(localeObj);
+  }
 
   /**
    * @returns The inner content.


### PR DESCRIPTION
### Related Ticket(s)

[[Locale Cookie Not Being Set In Web Component Locale Selector]: Locales cannont be properly set when using the webcomponents version of the footer/locale selector#10581](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/10581)

### Description

The web components version of the locale modal doesn't set the locale in the `ipcInfo` cookie when user selects a locale from the modal. This cookie ensures that the user's locale preference/selection persists throughout IBM.com.

### Changelog

**Changed**

- set `ipcInfo` cookie on `dds-locale-item` click

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
