### PR TITLE
fix(multi-select): move filterable attribute out of scope for styles

### DIFF
--- a/packages/carbon-web-components/src/components/multi-select/multi-select.scss
+++ b/packages/carbon-web-components/src/components/multi-select/multi-select.scss
@@ -37,13 +37,12 @@ $css--plex: true !default;
       outline: none;
     }
   }
+}
 
-  &[filterable] {
-    .#{$prefix}--list-box__field:focus-within {
-      outline: 2px solid $focus;
-      outline-offset: -2px;
-    }
-  }
+:host(#{$prefix}-multi-select[filterable])
+  .#{$prefix}--list-box__field:focus-within {
+  outline: 2px solid $focus;
+  outline-offset: -2px;
 }
 
 :host(#{$prefix}-multi-select[type='inline']) {
@@ -80,10 +79,10 @@ $css--plex: true !default;
       flex-direction: row;
     }
   }
+}
 
-  &[filtered] {
-    display: none;
-  }
+:host(#{$prefix}-multi-select-item[filtered]) {
+  display: none;
 }
 
 :host(#{$prefix}-multi-select-item[size='sm']) {


### PR DESCRIPTION
### Related Ticket(s)

[Filterable doesn't work in multi-select#9729](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9729)

### Description

The filterable option for `multi-select` doesn't appear to work because the styles to hide the options are not coming through when pulling in the package externally outside of storybook.

You can see it currently doesn't appear to filter in this codesandbox: https://codesandbox.io/p/sandbox/dazzling-burnell-4my6t8

 Moving the selector out of the scope should fix this. 

### Changelog

**Changed**

- use separate selector rule when referencing the filterable attribute

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
