### PR TITLE
fix: replace `className` property to avoid override native property

### DIFF
--- a/packages/carbon-web-components/src/components/button/button.ts
+++ b/packages/carbon-web-components/src/components/button/button.ts
@@ -118,8 +118,8 @@ class CDSButton extends HostListenerMixin(FocusMixin(LitElement)) {
   /**
    * Specify an optional className to be added to your Button
    */
-  @property({ reflect: true, attribute: 'class-name' })
-  className;
+  @property({ reflect: true, attribute: 'button-class-name' })
+  buttonClassName;
 
   /**
    * Specify the message read by screen readers for the danger button variant
@@ -242,7 +242,7 @@ class CDSButton extends HostListenerMixin(FocusMixin(LitElement)) {
   render() {
     const {
       autofocus,
-      className,
+      buttonClassName,
       dangerDescriptor,
       disabled,
       download,
@@ -277,9 +277,9 @@ class CDSButton extends HostListenerMixin(FocusMixin(LitElement)) {
       [`${prefix}--btn--selected`]: isSelected && kind === 'ghost',
     };
 
-    if (className) {
+    if (buttonClassName) {
       const outputObject = {};
-      className?.split(' ').forEach((element) => {
+      buttonClassName?.split(' ').forEach((element) => {
         outputObject[element] = true;
       });
       defaultClasses = outputObject;

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -360,7 +360,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
       // Ensures no extra whitespace text node
       // prettier-ignore
       return html`
-        <cds-copy class-name="${classes}" @click="${handleCopyClick}">
+        <cds-copy button-class-name="${classes}" @click="${handleCopyClick}">
           <code slot="icon"><slot></slot></code>
           <span slot="tooltip-content"><slot name="button-description"></slot> </span>
         </cds-copy>
@@ -430,7 +430,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
         : html`
             <cds-copy-button
               ?disabled=${disabled}
-              class-name=${disabledCopyButtonClasses}
+              button-class-name=${disabledCopyButtonClasses}
               feedback=${feedback}
               feedback-timeout=${feedbackTimeout}
               @click="${handleCopyClick}">
@@ -442,7 +442,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
             <cds-button
               kind="ghost"
               size="sm"
-              class-name=${expandButtonClass}
+              button-class-name=${expandButtonClass}
               ?disabled=${disabled}
               @click=${() => this._handleClickExpanded()}>
               <span class="${prefix}--snippet-btn--text">

--- a/packages/carbon-web-components/src/components/copy-button/copy-button.ts
+++ b/packages/carbon-web-components/src/components/copy-button/copy-button.ts
@@ -25,8 +25,8 @@ class CDSCopyButton extends FocusMixin(LitElement) {
   /**
    * Specify an optional className to be added to your Button
    */
-  @property({ reflect: true, attribute: 'class-name' })
-  className;
+  @property({ reflect: true, attribute: 'button-class-name' })
+  buttonClassName;
 
   /**
    * `true` if the button should be disabled.
@@ -47,12 +47,12 @@ class CDSCopyButton extends FocusMixin(LitElement) {
   feedbackTimeout = 2000;
 
   render() {
-    const { className, disabled, feedback, feedbackTimeout } = this;
+    const { buttonClassName, disabled, feedback, feedbackTimeout } = this;
 
     let classes = `${prefix}--copy-btn`;
 
-    if (className) {
-      classes += ` ${className}`;
+    if (buttonClassName) {
+      classes += ` ${buttonClassName}`;
     }
 
     return html`
@@ -60,7 +60,7 @@ class CDSCopyButton extends FocusMixin(LitElement) {
         ?disabled=${disabled}
         feedback=${feedback}
         feedback-timeout=${feedbackTimeout}
-        class-name=${classes}>
+        button-class-name=${classes}>
         ${Copy16({ slot: 'icon', class: `${prefix}--snippet__icon` })}
         <span slot="tooltip-content"><slot></slot></span>
       </cds-copy>

--- a/packages/carbon-web-components/src/components/pagination/pagination.ts
+++ b/packages/carbon-web-components/src/components/pagination/pagination.ts
@@ -408,7 +408,7 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
           <cds-button
             pagination
             ?disabled="${prevButtonDisabled}"
-            class-name="${prevButtonClasses}"
+            button-class-name="${prevButtonClasses}"
             tooltip-text="${backwardText}"
             @click="${handleClickPrevButton}">
             ${CaretLeft16({ slot: 'icon' })}
@@ -417,7 +417,7 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
             tooltip-position="top-right"
             pagination
             ?disabled="${nextButtonDisabled}"
-            class-name="${nextButtonClasses}"
+            button-class-name="${nextButtonClasses}"
             tooltip-text="${forwardText}"
             @click="${handleClickNextButton}">
             ${CaretRight16({ slot: 'icon' })}

--- a/packages/carbon-web-components/src/components/tile/tile-group.ts
+++ b/packages/carbon-web-components/src/components/tile/tile-group.ts
@@ -220,8 +220,8 @@ class CDSTileGroup extends HostListenerMixin(LitElement) {
   /**
    * Provide an optional className to be applied to the component
    */
-  @property({ reflect: true, attribute: 'class-name' })
-  className;
+  @property({ reflect: true, attribute: 'fieldset-class-name' })
+  fieldsetClassName;
 
   /**
    * Specify whether the group is disabled
@@ -265,9 +265,9 @@ class CDSTileGroup extends HostListenerMixin(LitElement) {
   }
 
   render() {
-    const { className, disabled } = this;
+    const { fieldsetClassName, disabled } = this;
     return html`
-      <fieldset class="${className}" ?disabled=${disabled}>
+      <fieldset class="${fieldsetClassName}" ?disabled=${disabled}>
         <slot name="legend" class="${prefix}--label"></slot>
         <slot></slot>
       </fieldset>


### PR DESCRIPTION
### Related Ticket(s)

Proposal to fix #10602

### Description

Replace `className` property to avoid override native property:

https://developer.mozilla.org/en-US/docs/Web/API/Element/className

### Changelog

**Changed**

- fix: replace `className` property to avoid override native property
