### PR TITLE
fix(button): add the missed `slot="icon"` styles

### DIFF
--- a/packages/carbon-web-components/src/components/button/button.scss
+++ b/packages/carbon-web-components/src/components/button/button.scss
@@ -23,6 +23,10 @@ $css--plex: true !default;
 :host(#{$prefix}-modal-footer-button) {
   @include layer-tokens.emit-layer-tokens(1);
   display: inline-flex;
+
+  ::slotted([slot='icon']) {
+    @extend .#{$prefix}--btn__icon;
+  }
 }
 
 :host(#{$prefix}-button[isExpressive]) ::slotted([slot='icon']),


### PR DESCRIPTION
### Related Ticket(s)

Fix #10600

### Description

Add the missed `slot="icon"` styles

### Changelog

**Changed**

- fix(button): add the missed `slot="icon"` styles
