### PR TITLE
fix(button): match the `part="button"` size with the host

### DIFF
--- a/packages/carbon-web-components/src/components/button/button.scss
+++ b/packages/carbon-web-components/src/components/button/button.scss
@@ -23,6 +23,11 @@ $css--plex: true !default;
 :host(#{$prefix}-modal-footer-button) {
   @include layer-tokens.emit-layer-tokens(1);
   display: inline-flex;
+
+  .#{$prefix}--btn {
+    flex-grow: 1;
+    max-width: 100%;
+  }
 }
 
 :host(#{$prefix}-button[isExpressive]) ::slotted([slot='icon']),


### PR DESCRIPTION
### Related Ticket(s)

Fix #10428

### Description

Match the `part="button"` size with the host.

### Changelog

**Changed**

- fix(button): match the `part="button"` size with the host
