### PR TITLE
chore: enable lit/no-native-attributes rule

### DIFF
--- a/packages/eslint-config-ibmdotcom/index.js
+++ b/packages/eslint-config-ibmdotcom/index.js
@@ -13,6 +13,7 @@ module.exports = {
     'eslint:recommended',
     'plugin:jsx-a11y/recommended',
     'plugin:jsdoc/recommended',
+    'plugin:lit/recommended',
   ],
   plugins: ['react', 'jsdoc', 'jsx-a11y', 'react-hooks', 'tree-shaking'],
   rules: {
@@ -33,6 +34,9 @@ module.exports = {
         ignoreMemberSort: true,
       },
     ],
+
+    'lit/no-native-attributes': 'error',
+
     'react/jsx-uses-vars': 1,
     'react/jsx-uses-react': 1,
 


### PR DESCRIPTION
### Related Ticket(s)

#10602

~Depends on #10623~

### Description

Enable the rule from [`eslint-plugin-lit`](https://github.com/43081j/eslint-plugin-lit/tree/master):

- [Disallows use of native attributes as properties (no-native-attributes)](https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-native-attributes.md)

Looks like we have 85 problems with:

- `title` - 20
- `autofocus` - 4
- `slot` - 55
- `role` - 3
- `id` - 2
- `hidden` - 1

### Changelog

**New**

- chore: enable lit/no-native-attributes rule