### PR TITLE
fix(styles): remove FOUC

### DIFF
--- a/packages/styles/scss/components/back-to-top/_back-to-top.scss
+++ b/packages/styles/scss/components/back-to-top/_back-to-top.scss
@@ -10,6 +10,10 @@
 @import 'carbon-components/scss/components/button/button';
 
 @mixin back-to-top {
+  :host(#{$dds-prefix}-back-to-top:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-back-to-top) {
     position: sticky;
     bottom: 0;

--- a/packages/styles/scss/components/background-media/_background-media.scss
+++ b/packages/styles/scss/components/background-media/_background-media.scss
@@ -11,6 +11,10 @@
 @import '../image/image';
 
 @mixin background-media {
+  :host(#{$dds-prefix}-background-media:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-background-media) {
     position: relative;
     height: 100%;

--- a/packages/styles/scss/components/buttongroup/_buttongroup.scss
+++ b/packages/styles/scss/components/buttongroup/_buttongroup.scss
@@ -13,6 +13,10 @@
 @mixin buttongroup {
   @include button;
 
+  :host(#{$dds-prefix}-button-group:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--buttongroup,
   :host(#{$dds-prefix}-button-group),
   :host(#{$dds-prefix}-leadspace-block-cta) {

--- a/packages/styles/scss/components/callout-quote/index.scss
+++ b/packages/styles/scss/components/callout-quote/index.scss
@@ -12,6 +12,10 @@
 @import '../../globals/utils/hang';
 
 @mixin callout-quote {
+  :host(#{$dds-prefix}-callout-quote:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--callout-quote,
   :host(#{$dds-prefix}-callout-quote) {
     .#{$prefix}--quote {

--- a/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
+++ b/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
@@ -11,6 +11,10 @@
 @import '../../internal/callout/callout';
 
 @mixin callout-with-media {
+  :host(#{$dds-prefix}-callout-with-media:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-callout-with-media),
   .#{$prefix}--callout-with-media {
     display: block;

--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -43,6 +43,10 @@
 }
 
 @mixin card-group {
+  :host(#{$dds-prefix}-card-group:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-card-group),
   .#{$prefix}--card-group {
     @include themed-items;

--- a/packages/styles/scss/components/card-in-card/_card-in-card.scss
+++ b/packages/styles/scss/components/card-in-card/_card-in-card.scss
@@ -14,6 +14,10 @@
 @import '../card/index';
 
 @mixin card-in-card {
+  :host(#{$dds-prefix}-card-in-card:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-card-in-card),
   .#{$prefix}--card-in-card {
     height: auto;

--- a/packages/styles/scss/components/card-link/_card-link.scss
+++ b/packages/styles/scss/components/card-link/_card-link.scss
@@ -9,6 +9,10 @@
 @import '../card/index';
 
 @mixin card-link {
+  :host(#{$dds-prefix}-card-link:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--card__CTA--disabled {
     cursor: not-allowed;
   }

--- a/packages/styles/scss/components/card-section-images/_card-section-images.scss
+++ b/packages/styles/scss/components/card-section-images/_card-section-images.scss
@@ -8,3 +8,13 @@
 @import '../../globals/imports';
 @import '../../internal/content-section/content-section';
 @import '../card-group/card-group';
+
+@mixin card-section-images {
+  :host(#{$dds-prefix}-card-section-images:not(:defined)) {
+    display: none;
+  }
+}
+
+@include exports('card-section-images') {
+  @include card-section-images;
+}

--- a/packages/styles/scss/components/card-section-offset/_card-section-offset.scss
+++ b/packages/styles/scss/components/card-section-offset/_card-section-offset.scss
@@ -12,6 +12,10 @@
 @import '../card-group/card-group';
 
 @mixin card-section-offset {
+  :host(#{$dds-prefix}-card-section-offset:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-card-section-offset) {
     display: block;
     position: relative;

--- a/packages/styles/scss/components/card-section-simple/_card-section-simple.scss
+++ b/packages/styles/scss/components/card-section-simple/_card-section-simple.scss
@@ -8,3 +8,13 @@
 @import '../../globals/imports';
 @import '../../internal/content-section/content-section';
 @import '../card-group/card-group';
+
+@mixin card-section-simple {
+  :host(#{$dds-prefix}-card-section-simple:not(:defined)) {
+    display: none;
+  }
+}
+
+@include exports('card-section-simple') {
+  @include card-section-simple;
+}

--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -14,6 +14,10 @@
 @import 'carbon-components/scss/components/tag/tag';
 
 @mixin card {
+  :host(#{$dds-prefix}-card:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--card,
   :host(#{$dds-prefix}-card),
   :host(#{$dds-prefix}-link-list-item-card),

--- a/packages/styles/scss/components/carousel/_carousel.scss
+++ b/packages/styles/scss/components/carousel/_carousel.scss
@@ -12,148 +12,158 @@
 @import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/grid/vendor/@carbon/layout/breakpoint';
 @import '../../globals/vars';
 
-:host(#{$dds-prefix}-carousel),
-.#{$prefix}--carousel {
-  --#{$dds-prefix}--carousel--page-size: 1;
-
-  @include carbon--breakpoint(md) {
-    --#{$dds-prefix}--carousel--page-size: 2;
+@mixin carousel {
+  :host(#{$dds-prefix}-carousel:not(:defined)) {
+    display: none;
   }
 
-  @include carbon--breakpoint(lg) {
-    --#{$dds-prefix}--carousel--page-size: 3;
-  }
-
-  [role='region'] {
-    display: contents;
-  }
-
-  display: flex;
-  flex-direction: column;
-
-  overflow: hidden;
-  width: calc(
-    100% + var(--#{$dds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
-  );
-  margin-right: calc(
-    -1 * var(--#{$dds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
-  );
-  padding-left: $spacing-05;
-  padding-right: calc(
-    #{$spacing-05} + var(--#{$dds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
-  );
-
-  @include carbon--breakpoint(md) {
-    padding-left: 0;
-  }
-
-  ::slotted(:not([name])) {
-    flex: 0 0
-      calc(
-        (
-            100% - (var(--#{$dds-prefix}--carousel--page-size, 1) - 1) * #{$spacing-05}
-          ) / var(--#{$dds-prefix}--carousel--page-size, 1)
-      );
-    height: auto;
-    margin-right: $spacing-05;
-    vertical-align: middle;
-  }
-
-  .#{$prefix}--carousel__scroll-container {
-    grid-area: body;
-    position: relative;
-    overflow: hidden;
-    margin-right: calc(
-      -1 * (#{$spacing-05} + var(--#{$dds-prefix}--carousel--overflow-hint-size, #{$spacing-05}))
-    );
-  }
-
-  .#{$prefix}--carousel__scroll-contents {
-    position: relative;
-    margin-right: calc(
-      #{$spacing-05} + var(--#{$dds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
-    );
-    display: flex;
-    // Achieves `sameHeight` effect for card group.
-    // The cards must have `height:auto`.
-    align-items: stretch;
-  }
-
-  .#{$prefix}--carousel__scroll-contents--scrolling {
-    transition: left $duration--slow-01 motion(standard, productive);
-  }
-
-  .#{$prefix}--carousel__navigation {
-    @include carbon--type-style('body-long-02', true);
-
-    grid-area: navigation;
-    display: grid;
-    grid-template-columns: auto auto auto;
-    justify-content: flex-end;
-    align-items: center;
-    gap: $spacing-05;
-    margin-top: $spacing-05;
-  }
-
-  .#{$prefix}--btn.#{$prefix}--carousel__navigation__btn {
-    padding: 0;
-    min-height: $container-03;
-    width: $container-03;
-    height: $container-03;
-
-    svg {
-      margin: auto;
-    }
-  }
-}
-
-:host(#{$dds-prefix}-carousel[in-modal]) {
-  padding: 0 0 $spacing-05;
-  width: 100%;
-  height: 100%;
-
-  @include carbon--breakpoint(md) {
-    padding-bottom: 0;
-  }
-
-  .#{$prefix}--carousel__scroll-container {
-    flex-grow: 1;
-  }
-
-  .#{$prefix}--carousel__scroll-contents {
-    height: 100%;
-  }
-}
-
-@media print {
   :host(#{$dds-prefix}-carousel),
   .#{$prefix}--carousel {
-    --#{$dds-prefix}--carousel--page-size: 4;
+    --#{$dds-prefix}--carousel--page-size: 1;
 
-    flex-flow: row wrap;
-    margin: 0;
-    padding: 0;
-    max-width: 100%;
-    width: 100%;
-
-    .#{$prefix}--carousel__scroll-container {
-      margin: 0;
-      overflow: visible;
+    @include carbon--breakpoint(md) {
+      --#{$dds-prefix}--carousel--page-size: 2;
     }
 
-    .#{$prefix}--carousel__scroll-contents {
-      flex-wrap: wrap;
-      gap: $spacing-05;
-      margin: 0;
-      position: initial;
+    @include carbon--breakpoint(lg) {
+      --#{$dds-prefix}--carousel--page-size: 3;
     }
 
-    .#{$prefix}--carousel__navigation {
-      display: none;
+    [role='region'] {
+      display: contents;
+    }
+
+    display: flex;
+    flex-direction: column;
+
+    overflow: hidden;
+    width: calc(
+      100% + var(--#{$dds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+    );
+    margin-right: calc(
+      -1 * var(--#{$dds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+    );
+    padding-left: $spacing-05;
+    padding-right: calc(
+      #{$spacing-05} + var(--#{$dds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+    );
+
+    @include carbon--breakpoint(md) {
+      padding-left: 0;
     }
 
     ::slotted(:not([name])) {
-      margin: 0;
+      flex: 0 0
+        calc(
+          (
+              100% - (var(--#{$dds-prefix}--carousel--page-size, 1) - 1) * #{$spacing-05}
+            ) / var(--#{$dds-prefix}--carousel--page-size, 1)
+        );
+      height: auto;
+      margin-right: $spacing-05;
+      vertical-align: middle;
+    }
+
+    .#{$prefix}--carousel__scroll-container {
+      grid-area: body;
+      position: relative;
+      overflow: hidden;
+      margin-right: calc(
+        -1 * (#{$spacing-05} + var(--#{$dds-prefix}--carousel--overflow-hint-size, #{$spacing-05}))
+      );
+    }
+
+    .#{$prefix}--carousel__scroll-contents {
+      position: relative;
+      margin-right: calc(
+        #{$spacing-05} + var(--#{$dds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+      );
+      display: flex;
+      // Achieves `sameHeight` effect for card group.
+      // The cards must have `height:auto`.
+      align-items: stretch;
+    }
+
+    .#{$prefix}--carousel__scroll-contents--scrolling {
+      transition: left $duration--slow-01 motion(standard, productive);
+    }
+
+    .#{$prefix}--carousel__navigation {
+      @include carbon--type-style('body-long-02', true);
+
+      grid-area: navigation;
+      display: grid;
+      grid-template-columns: auto auto auto;
+      justify-content: flex-end;
+      align-items: center;
+      gap: $spacing-05;
+      margin-top: $spacing-05;
+    }
+
+    .#{$prefix}--btn.#{$prefix}--carousel__navigation__btn {
+      padding: 0;
+      min-height: $container-03;
+      width: $container-03;
+      height: $container-03;
+
+      svg {
+        margin: auto;
+      }
     }
   }
+
+  :host(#{$dds-prefix}-carousel[in-modal]) {
+    padding: 0 0 $spacing-05;
+    width: 100%;
+    height: 100%;
+
+    @include carbon--breakpoint(md) {
+      padding-bottom: 0;
+    }
+
+    .#{$prefix}--carousel__scroll-container {
+      flex-grow: 1;
+    }
+
+    .#{$prefix}--carousel__scroll-contents {
+      height: 100%;
+    }
+  }
+
+  @media print {
+    :host(#{$dds-prefix}-carousel),
+    .#{$prefix}--carousel {
+      --#{$dds-prefix}--carousel--page-size: 4;
+
+      flex-flow: row wrap;
+      margin: 0;
+      padding: 0;
+      max-width: 100%;
+      width: 100%;
+
+      .#{$prefix}--carousel__scroll-container {
+        margin: 0;
+        overflow: visible;
+      }
+
+      .#{$prefix}--carousel__scroll-contents {
+        flex-wrap: wrap;
+        gap: $spacing-05;
+        margin: 0;
+        position: initial;
+      }
+
+      .#{$prefix}--carousel__navigation {
+        display: none;
+      }
+
+      ::slotted(:not([name])) {
+        margin: 0;
+      }
+    }
+  }
+}
+
+@include exports('carousel') {
+  @include carousel;
 }

--- a/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
+++ b/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
@@ -10,6 +10,9 @@
 @import '../card-group/card-group';
 
 @mixin content-block-cards {
+  :host(#{$dds-prefix}-content-block-cards:not(:defined)) {
+    display: none;
+  }
   :host(#{$dds-prefix}-content-block-cards),
   .#{$prefix}--content-block-cards .#{$prefix}--content-block {
     display: block;

--- a/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
+++ b/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
@@ -9,6 +9,10 @@
 @import '../../globals/utils/hang';
 
 @mixin content-block-headlines {
+  :host(#{$dds-prefix}-content-block-headlines:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-content-block-headlines),
   .#{$prefix}--content-block-headlines {
     .#{$prefix}--content-block {

--- a/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
+++ b/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
@@ -9,6 +9,10 @@
 @import '../content-item-horizontal/content-item-horizontal';
 
 @mixin content-block-horizontal {
+  :host(#{$dds-prefix}-content-block-horizontal:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-content-block-horizontal),
   :host(#{$dds-prefix}-content-group-horizontal) {
     padding-top: $layout-03;

--- a/packages/styles/scss/components/content-block-media/_content-block-media.scss
+++ b/packages/styles/scss/components/content-block-media/_content-block-media.scss
@@ -17,6 +17,10 @@
 }
 
 @mixin content-block-media {
+  :host(#{$dds-prefix}-content-block-media:not(:defined)) {
+    display: none;
+  }
+  
   .#{$prefix}--content-block-media,
   :host(#{$dds-prefix}-content-block-media) {
     @include themed-items;

--- a/packages/styles/scss/components/content-block-mixed/_content-block-mixed.scss
+++ b/packages/styles/scss/components/content-block-mixed/_content-block-mixed.scss
@@ -6,6 +6,10 @@
  */
 
 @mixin content-block-mixed {
+  :host(#{$dds-prefix}-content-block-mixed:not(:defined)) {
+    display: none;
+  }
+  
   :host(dds-content-block-mixed),
   .#{$prefix}--content-block-mixed {
     .#{$prefix}--content-group-pictograms {

--- a/packages/styles/scss/components/content-block-segmented/_content-block-segmented.scss
+++ b/packages/styles/scss/components/content-block-segmented/_content-block-segmented.scss
@@ -8,6 +8,10 @@
 @import '../../globals/imports';
 
 @mixin content-block-segmented {
+  :host(#{$dds-prefix}-content-block-segmented:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-content-block-segmented),
   .#{$prefix}--content-block-segmented {
     .#{$prefix}--row {

--- a/packages/styles/scss/components/content-block-simple/_content-block-simple.scss
+++ b/packages/styles/scss/components/content-block-simple/_content-block-simple.scss
@@ -6,6 +6,10 @@
  */
 
 @mixin content-block-simple {
+  :host(#{$dds-prefix}-content-block-simple:not(:defined)) {
+    display: none;
+  }
+  
   .#{$prefix}--content-block {
     // empty for now
   }

--- a/packages/styles/scss/components/content-group-banner/_content-group-banner.scss
+++ b/packages/styles/scss/components/content-group-banner/_content-group-banner.scss
@@ -9,6 +9,10 @@
 @import '../../globals/imports';
 
 @mixin content-group-banner {
+  :host(#{$dds-prefix}-content-group-banner:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-content-group-banner),
   .#{$prefix}--content-group-banner {
     background: $ui-background;

--- a/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
+++ b/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
@@ -14,6 +14,10 @@
 }
 
 @mixin content-group-cards {
+  :host(#{$dds-prefix}-content-group-cards:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-content-group-cards),
   .#{$prefix}--content-group-cards {
     ::slotted([slot='copy']),

--- a/packages/styles/scss/components/content-group-horizontal/_content-group-horizontal.scss
+++ b/packages/styles/scss/components/content-group-horizontal/_content-group-horizontal.scss
@@ -10,6 +10,10 @@
 @import '../content-block-horizontal/content-block-horizontal';
 
 @mixin content-group-horizontal {
+  :host(#{$dds-prefix}-content-group-horizontal:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-content-group-horizontal) ::slotted([slot='heading']),
   .#{$prefix}--content-group-horizontal .#{$prefix}--content-block__heading {
     margin-bottom: $layout-05;

--- a/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
+++ b/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
@@ -6,6 +6,10 @@
  */
 
 @mixin content-group-pictograms {
+  :host(#{$dds-prefix}-content-group-pictograms:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-content-group-pictograms)
     ::slotted(#{$dds-prefix}-content-group-copy),
   .#{$prefix}--content-group-pictograms .#{$prefix}--content-group__copy {

--- a/packages/styles/scss/components/content-group-simple/_content-group-simple.scss
+++ b/packages/styles/scss/components/content-group-simple/_content-group-simple.scss
@@ -6,6 +6,10 @@
  */
 
 @mixin content-group-simple {
+  :host(#{$dds-prefix}-content-group-simple:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-content-group-simple)
     ::slotted(#{$dds-prefix}-content-group-copy),
   .#{$prefix}--content-group-simple .#{$prefix}--content-group__copy {

--- a/packages/styles/scss/components/content-item-horizontal-media/_content-item-horizontal-media.scss
+++ b/packages/styles/scss/components/content-item-horizontal-media/_content-item-horizontal-media.scss
@@ -10,6 +10,10 @@
 @import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/breakpoint';
 
 @mixin content-item-horizontal-media {
+  :host(#{$dds-prefix}-content-item-horizontal-media:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-content-item-horizontal-media) {
     padding: $carbon--spacing-07 $carbon--spacing-05 $carbon--spacing-10;
     display: block;

--- a/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
@@ -9,6 +9,10 @@
 @import '../link-list/index';
 
 @mixin content-item-horizontal {
+  :host(#{$dds-prefix}-content-item-horizontal:not(:defined)) {
+    display: none;
+  }
+  
   // Web component
   :host(#{$dds-prefix}-content-item-horizontal),
   // React

--- a/packages/styles/scss/components/cta-block/_cta-block.scss
+++ b/packages/styles/scss/components/cta-block/_cta-block.scss
@@ -26,6 +26,10 @@
 }
 
 @mixin cta-block--pattern {
+  :host(#{$dds-prefix}-cta-block:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-cta-block),
   .#{$prefix}--cta-block {
     padding-top: $carbon--layout-03;

--- a/packages/styles/scss/components/ctasection/_ctasection.scss
+++ b/packages/styles/scss/components/ctasection/_ctasection.scss
@@ -26,6 +26,10 @@
 }
 
 @mixin cta-section--pattern {
+  :host(#{$dds-prefix}-cta-section:not(:defined)) {
+    display: none;
+  }
+  
   :host(#{$dds-prefix}-cta-section),
   .#{$prefix}--cta-section {
     .#{$prefix}--cta-section__cta {

--- a/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
+++ b/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
@@ -11,6 +11,10 @@
 @import '../masthead/index';
 
 @mixin dotcom-shell {
+  :host(#{$dds-prefix}-dotcom-shell-container:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-dotcom-shell),
   .#{$prefix}--dotcom-shell {
     display: flex;

--- a/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
+++ b/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
@@ -20,6 +20,10 @@
   $icon-size: carbon--rem(20px);
   $offset-close-icon: $carbon--spacing-07 - (($button-size - $icon-size) / 2);
 
+  :host(#{$dds-prefix}-expressive-modal:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-expressive-modal),
   #{$modal}--expressive {
     color: $text-01;

--- a/packages/styles/scss/components/feature-card-block-large/_feature-card-block-large.scss
+++ b/packages/styles/scss/components/feature-card-block-large/_feature-card-block-large.scss
@@ -21,6 +21,10 @@ $fcb-breakpoint-up--lg: map-get(
   ) - carbon--rem(1px);
 
 @mixin feature-card-block-large {
+  :host(#{$dds-prefix}-feature-card-block-large:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-feature-card-block-large),
   .#{$prefix}--feature-card-block-large {
     margin-bottom: $carbon--layout-03;

--- a/packages/styles/scss/components/feature-card-block-medium/_feature-card-block-medium.scss
+++ b/packages/styles/scss/components/feature-card-block-medium/_feature-card-block-medium.scss
@@ -11,6 +11,10 @@
 @import '../feature-card/feature-card';
 
 @mixin feature-card-block-medium {
+  :host(#{$dds-prefix}-feature-card-block-medium:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--feature-card-block-medium,
   :host(#{$dds-prefix}-feature-card-block-medium) {
     color: $text-01;

--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -65,6 +65,10 @@ $fcb-breakpoint-up--lg: map-get(
 }
 
 @mixin feature-card {
+  :host(#{$dds-prefix}-feature-card:not(:defined)),
+  :host(#{$dds-prefix}-feature-cta:not(:defined)) {
+    display: none;
+  }
   // all feature cards
   :host(#{$dds-prefix}-feature-card),
   :host(#{$dds-prefix}-feature-cta),

--- a/packages/styles/scss/components/feature-section/_feature-section.scss
+++ b/packages/styles/scss/components/feature-section/_feature-section.scss
@@ -12,6 +12,10 @@
 @import '../../globals/utils/ratio-base';
 
 @mixin feature-section {
+  :host(#{$dds-prefix}-feature-section:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--feature-section {
     position: relative;
     padding-left: $carbon--spacing-05;

--- a/packages/styles/scss/components/filter-panel/_filter-panel.scss
+++ b/packages/styles/scss/components/filter-panel/_filter-panel.scss
@@ -12,6 +12,10 @@
 @import '@carbon/web-components/scss/components/checkbox/checkbox';
 
 @mixin filter-panel {
+  :host(#{$dds-prefix}-filter-panel:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--filter__heading {
     @include carbon--type-style('heading-01');
 

--- a/packages/styles/scss/components/footer/_footer.scss
+++ b/packages/styles/scss/components/footer/_footer.scss
@@ -10,6 +10,10 @@
 /// @group footer
 
 @mixin footer {
+  :host(#{$dds-prefix}-footer-container:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-footer),
   .#{$prefix}--footer {
     width: 100%;

--- a/packages/styles/scss/components/horizontalrule/_horizontalrule.scss
+++ b/packages/styles/scss/components/horizontalrule/_horizontalrule.scss
@@ -14,6 +14,10 @@
   $high-contrast: $ui-05;
   $thin-weight: carbon--rem(1px);
 
+  :host(#{$dds-prefix}-hr:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-hr)[size='small'] {
     @extend .#{$prefix}--hr--small;
   }

--- a/packages/styles/scss/components/image-with-caption/image-with-caption.scss
+++ b/packages/styles/scss/components/image-with-caption/image-with-caption.scss
@@ -12,6 +12,10 @@
 @import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/motion/motion.scss';
 
 @mixin image-with-caption {
+  :host(#{$dds-prefix}-image-with-caption:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--image-with-caption,
   :host(#{$dds-prefix}-image)[heading] {
     display: block;

--- a/packages/styles/scss/components/image/_image.scss
+++ b/packages/styles/scss/components/image/_image.scss
@@ -10,6 +10,10 @@
 @import '../../globals/utils/ratio-base';
 
 @mixin image {
+  :host(#{$dds-prefix}-image:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--image {
     position: relative;
   }

--- a/packages/styles/scss/components/leadspace-block/_leadspace-block.scss
+++ b/packages/styles/scss/components/leadspace-block/_leadspace-block.scss
@@ -26,6 +26,10 @@
 }
 
 @mixin leadspace-block {
+  :host(#{$dds-prefix}-leadspace-block:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-leadspace-block)
     ::slotted(#{$dds-prefix}-leadspace-block-content) {
     @extend %leadspace-block-padding;

--- a/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
+++ b/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
@@ -6,6 +6,10 @@
  */
 
 @mixin leadspace-with-search {
+  :host(#{$dds-prefix}-leadspace-with-search:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--leadspace-with-search {
     padding-top: $layout-04;
     padding-bottom: $layout-04;

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -68,6 +68,10 @@ $btn-min-width: 26;
 }
 
 @mixin leadspace {
+  :host(#{$dds-prefix}-leadspace:not(:defined)) {
+    display: none;
+  }
+
   ::slotted([slot='action']),
   .#{$prefix}--buttongroup {
     padding-top: $carbon--layout-03;

--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -11,6 +11,10 @@
 @import '../video-player/video-player';
 
 @mixin lightbox-media-viewer {
+  :host(#{$dds-prefix}-lightbox-media-viewer:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--modal--expressive--fullwidth
     .#{$prefix}--modal-container
     .#{$prefix}--modal-content {

--- a/packages/styles/scss/components/link-list/_link-list.scss
+++ b/packages/styles/scss/components/link-list/_link-list.scss
@@ -6,6 +6,10 @@
  */
 
 @mixin link-list {
+  :host(#{$dds-prefix}-link-list:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--link-list {
     padding-bottom: $carbon--layout-05;
 

--- a/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
+++ b/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
@@ -11,6 +11,10 @@
 @import '../lightbox-media-viewer/lightbox-media-viewer';
 
 @mixin link-with-icon {
+  :host(#{$dds-prefix}-link-with-icon:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--link-with-icon,
   :host(#{$dds-prefix}-link-with-icon),
   :host(#{$dds-prefix}-link-list-item),

--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -16,6 +16,10 @@
 /// @group locale-modal
 
 @mixin locale-modal {
+  :host(#{$dds-prefix}-locale-modal:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-locale-modal),
   .#{$prefix}--locale-modal-container {
     @include carbon--theme(

--- a/packages/styles/scss/components/logo-grid/_logo-grid.scss
+++ b/packages/styles/scss/components/logo-grid/_logo-grid.scss
@@ -13,6 +13,10 @@
 @import '../../internal/content-block/content-block';
 
 @mixin logo-grid {
+  :host(#{$dds-prefix}-logo-grid:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--logo-grid,
   :host(#{$dds-prefix}-logo-grid) {
     .#{$prefix}--content-block {

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -167,6 +167,11 @@ $search-transition-timing: 95ms;
 
 /// @access private
 @mixin masthead {
+  :host(#{$dds-prefix}-masthead-container:not(:defined)),
+  :host(#{$dds-prefix}-cloud-masthead-container:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-masthead-composite),
   :host(#{$dds-prefix}-cloud-masthead-container) {
     z-index: 900;

--- a/packages/styles/scss/components/notice-choice/_notice-choice.scss
+++ b/packages/styles/scss/components/notice-choice/_notice-choice.scss
@@ -7,6 +7,10 @@
 @import '../../globals/vars';
 @import '../../globals/imports';
 @mixin notice-choice {
+  :host(#{$dds-prefix}-notice-choice:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--nc {
     max-width: 640px;
     p,

--- a/packages/styles/scss/components/pictogram-item/_pictogram-item.scss
+++ b/packages/styles/scss/components/pictogram-item/_pictogram-item.scss
@@ -11,6 +11,10 @@
 @import '../link-with-icon/link-with-icon';
 
 @mixin pictogram-item {
+  :host(#{$dds-prefix}-pictogram-item:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--pictogram-item,
   :host(#{$dds-prefix}-pictogram-item) {
     .#{$prefix}--pictogram-item__row {

--- a/packages/styles/scss/components/pricing-table/_pricing-table.scss
+++ b/packages/styles/scss/components/pricing-table/_pricing-table.scss
@@ -24,6 +24,10 @@
 }
 
 @mixin pricing-table {
+  :host(#{$dds-prefix}-pricing-table:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--pricing-table,
   :host(#{$dds-prefix}-pricing-table) {
     @extend .#{$dds-prefix}--structured-list;

--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -12,6 +12,10 @@
 @import '../../components/link-with-icon/link-with-icon';
 
 @mixin quote {
+  :host(#{$dds-prefix}-quote:not(:defined)) {
+    display: none;
+  }
+
   .#{$prefix}--quote,
   :host(#{$dds-prefix}-quote) {
     background: $ui-background;

--- a/packages/styles/scss/components/search-with-typeahead/_search-with-typeahead.scss
+++ b/packages/styles/scss/components/search-with-typeahead/_search-with-typeahead.scss
@@ -18,6 +18,10 @@ $search-transition-timing: 95ms;
 $button-transition: background-color 110ms, border-color 110ms, color 110ms;
 
 @mixin search-with-typeahead {
+  :host(#{$dds-prefix}-search-with-typeahead:not(:defined)) {
+    display: none;
+  }
+
   // main nav/search container excluding
   // profile and logo icons for masthead use
   :host(#{$dds-prefix}-top-nav),

--- a/packages/styles/scss/components/structured-list/_structured-list.scss
+++ b/packages/styles/scss/components/structured-list/_structured-list.scss
@@ -65,6 +65,10 @@
 }
 
 @mixin structured-list {
+  :host(#{$dds-prefix}-structured-list:not(:defined)) {
+    display: none;
+  }
+
   // Inherited Table Styles
   .#{$prefix}--structured-list-header-row,
   :host(#{$dds-prefix}-structured-list-header-row) {

--- a/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
@@ -75,6 +75,10 @@ $hover-transition-timing: 95ms;
 }
 
 @mixin tableofcontents {
+  :host(#{$dds-prefix}-table-of-contents:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-table-of-contents),
   .#{$prefix}--tableofcontents {
     text-size-adjust: 100%;

--- a/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
+++ b/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
@@ -13,6 +13,10 @@
 @import 'carbon-components/scss/components/accordion/keyframes';
 
 @mixin tabs-extended-media {
+  :host(#{$dds-prefix}-tabs-extended-media:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-tabs-extended-media) {
     margin: 0;
     display: flex;

--- a/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
+++ b/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
@@ -14,6 +14,10 @@
 @import 'carbon-components/scss/components/accordion/keyframes';
 
 @mixin tabs-extended {
+  :host(#{$dds-prefix}-tabs-extended:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-tabs-extended),
   :host(#{$dds-prefix}-tabs-extended-media) {
     .#{$prefix}--tabs {

--- a/packages/styles/scss/components/tag-group/_tag-group.scss
+++ b/packages/styles/scss/components/tag-group/_tag-group.scss
@@ -8,20 +8,30 @@
 @import '../../globals/imports';
 @import '../../globals/vars';
 
-:host(#{$dds-prefix}-tag-group) {
-  display: flex;
-  flex-flow: row wrap;
-  gap: $spacing-03;
+@mixin tag-group {
+  :host(#{$dds-prefix}-tag-group:not(:defined)) {
+    display: none;
+  }
 
-  ::slotted(#{$dds-prefix}-tag-link) {
+  :host(#{$dds-prefix}-tag-group) {
     display: flex;
-  }
+    flex-flow: row wrap;
+    gap: $spacing-03;
 
-  // !important necessary for React wrappers since Carbon React styles override margin without this
-  ::slotted(.#{$prefix}--tag),
-  ::slotted(#{$prefix}-filter-tag),
-  ::slotted(#{$prefix}-tag) {
-    // stylelint-disable-next-line declaration-no-important
-    margin: 0 !important;
+    ::slotted(#{$dds-prefix}-tag-link) {
+      display: flex;
+    }
+
+    // !important necessary for React wrappers since Carbon React styles override margin without this
+    ::slotted(.#{$prefix}--tag),
+    ::slotted(#{$prefix}-filter-tag),
+    ::slotted(#{$prefix}-tag) {
+      // stylelint-disable-next-line declaration-no-important
+      margin: 0 !important;
+    }
   }
+}
+
+@include exports('tag-group') {
+  @include tag-group;
 }

--- a/packages/styles/scss/components/tag-link/_tag-link.scss
+++ b/packages/styles/scss/components/tag-link/_tag-link.scss
@@ -8,26 +8,36 @@
 @import '../../globals/imports';
 @import '../../globals/vars';
 
-:host(#{$dds-prefix}-tag-link) a {
-  @include carbon--type-style(body-long-01, true);
-
-  padding: carbon--rem(6px) $carbon--spacing-05;
-  border-radius: carbon--rem(15px);
-  background-color: $ui-01;
-  color: $text-02;
-  text-decoration: none;
-
-  &:hover {
-    background-color: $hover-ui;
-    color: $text-01;
+@mixin tag-link {
+  :host(#{$dds-prefix}-tag-link:not(:defined)) {
+    display: none;
   }
 
-  &:active {
-    background-color: $active-ui;
-  }
+  :host(#{$dds-prefix}-tag-link) a {
+    @include carbon--type-style(body-long-01, true);
 
-  &:focus {
-    outline: none;
-    box-shadow: inset 0 0 0 2px $focus;
+    padding: carbon--rem(6px) $carbon--spacing-05;
+    border-radius: carbon--rem(15px);
+    background-color: $ui-01;
+    color: $text-02;
+    text-decoration: none;
+
+    &:hover {
+      background-color: $hover-ui;
+      color: $text-01;
+    }
+
+    &:active {
+      background-color: $active-ui;
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: inset 0 0 0 2px $focus;
+    }
   }
+}
+
+@include exports('tag-link') {
+  @include tag-link;
 }

--- a/packages/styles/scss/components/universal-banner/_universal-banner.scss
+++ b/packages/styles/scss/components/universal-banner/_universal-banner.scss
@@ -8,222 +8,232 @@
 @import '../../globals/imports';
 @import '../../globals/vars';
 
-:host(#{$dds-prefix}-universal-banner) {
-  @include carbon--theme($carbon--theme--g100, true);
-
-  display: block;
-  background-color: $ui-background;
-
-  .#{$prefix}--universal-banner-content-wrapper {
-    @include carbon--make-row;
-  }
-
-  .#{$prefix}--universal-banner-layout-container {
-    @include carbon--make-container;
-
-    max-height: $spacing-13;
-
-    /* stylelint-disable selector-pseudo-class-no-unknown */
-    &:where(a) {
-      /* stylelint-enable selector-pseudo-class-no-unknown */
-      display: block;
-      text-decoration: none;
-      border: $spacing-01 solid transparent;
-
-      &:hover,
-      &:active {
-        background: $hover-ui;
-      }
-
-      &:focus,
-      &:active {
-        outline: carbon--rem(1px) solid $ui-background;
-        outline-offset: carbon--rem(-1px);
-        border-color: $focus;
-      }
-    }
-  }
-
-  .#{$prefix}--universal-banner-text-container,
-  .#{$prefix}--universal-banner-cta-container,
-  .#{$prefix}--universal-banner-icon {
-    padding-block: $spacing-05;
-
-    @include carbon--breakpoint('lg') {
-      padding-block: $spacing-07;
-    }
-  }
-
-  .#{$prefix}--universal-banner-image-container {
-    max-height: $spacing-13;
-    padding-inline-end: $spacing-05;
-    position: relative;
-
-    ::slotted(#{$dds-prefix}-universal-banner-image) {
-      position: absolute;
-      width: calc(100% + #{$spacing-05});
-      height: 100%;
-      inset-inline-end: 0;
-      inset-block-start: 0;
-
-      @include carbon--breakpoint('max') {
-        width: 100%;
-      }
-    }
-  }
-
-  .#{$prefix}--universal-banner-text-container {
-    @include carbon--make-col(4, 4);
-
-    padding-inline: $spacing-05;
-    max-width: calc(100% - (20px + #{$spacing-05}));
-
-    @include carbon--breakpoint('md') {
-      @include carbon--make-col(7, 8);
-    }
-
-    @include carbon--breakpoint('lg') {
-      padding-inline-end: $spacing-09;
-    }
-  }
-
-  .#{$prefix}--universal-banner-cta-container {
+@mixin universal-banner {
+  :host(#{$dds-prefix}-universal-banner:not(:defined)) {
     display: none;
-
-    @include carbon--breakpoint('lg') {
-      @include carbon--make-col(4, 16);
-    }
-
-    @include carbon--breakpoint('xlg') {
-      @include carbon--make-col(3, 16);
-    }
-
-    @include carbon--breakpoint('max') {
-      @include carbon--make-col(4, 16);
-    }
   }
 
-  .#{$prefix}--universal-banner-icon {
-    width: calc(20px + #{$spacing-05});
-    padding-inline-end: $spacing-05;
-    color: $text-01;
-    text-align: right;
-
-    svg {
-      margin-top: $spacing-01;
-    }
-
-    @include carbon--breakpoint('md') {
-      @include carbon--make-col(1, 8);
-
-      padding-inline-end: 0;
-    }
-
-    @include carbon--breakpoint('lg') {
-      display: none;
-    }
-  }
-
-  &[has-image] {
-    .#{$prefix}--universal-banner-image-container {
-      display: none;
-    }
-  }
-
-  &[image-width='4-col'] {
-    .#{$prefix}--universal-banner-image-container {
-      @include carbon--breakpoint('lg') {
-        @include carbon--make-col(4, 16);
-      }
-    }
-
-    .#{$prefix}--universal-banner-text-container {
-      @include carbon--breakpoint('lg') {
-        @include carbon--make-col(7, 16);
-      }
-    }
-
-    .#{$prefix}--universal-banner-cta-container {
-      @include carbon--breakpoint('lg') {
-        @include carbon--make-col-offset(1, 16);
-      }
-    }
-  }
-
-  &[image-width='8-col'] {
-    .#{$prefix}--universal-banner-image-container {
-      @include carbon--make-col(8, 16);
-    }
-
-    .#{$prefix}--universal-banner-text-container {
-      @include carbon--breakpoint('lg') {
-        @include carbon--make-col(4, 16);
-      }
-    }
-  }
-
-  &:not([has-image]) {
-    .#{$prefix}--universal-banner-text-container {
-      @include carbon--breakpoint('lg') {
-        @include carbon--make-col(11, 16);
-      }
-    }
-
-    .#{$prefix}--universal-banner-cta-container {
-      @include carbon--breakpoint('lg') {
-        @include carbon--make-col-offset(1, 16);
-      }
-    }
-  }
-
-  ::slotted(#{$dds-prefix}-button-cta) {
+  :host(#{$dds-prefix}-universal-banner) {
     @include carbon--theme($carbon--theme--g100, true);
 
-    width: 100%;
     display: block;
-    max-width: 320px;
+    background-color: $ui-background;
+
+    .#{$prefix}--universal-banner-content-wrapper {
+      @include carbon--make-row;
+    }
+
+    .#{$prefix}--universal-banner-layout-container {
+      @include carbon--make-container;
+
+      max-height: $spacing-13;
+
+      /* stylelint-disable selector-pseudo-class-no-unknown */
+      &:where(a) {
+        /* stylelint-enable selector-pseudo-class-no-unknown */
+        display: block;
+        text-decoration: none;
+        border: $spacing-01 solid transparent;
+
+        &:hover,
+        &:active {
+          background: $hover-ui;
+        }
+
+        &:focus,
+        &:active {
+          outline: carbon--rem(1px) solid $ui-background;
+          outline-offset: carbon--rem(-1px);
+          border-color: $focus;
+        }
+      }
+    }
+
+    .#{$prefix}--universal-banner-text-container,
+    .#{$prefix}--universal-banner-cta-container,
+    .#{$prefix}--universal-banner-icon {
+      padding-block: $spacing-05;
+
+      @include carbon--breakpoint('lg') {
+        padding-block: $spacing-07;
+      }
+    }
+
+    .#{$prefix}--universal-banner-image-container {
+      max-height: $spacing-13;
+      padding-inline-end: $spacing-05;
+      position: relative;
+
+      ::slotted(#{$dds-prefix}-universal-banner-image) {
+        position: absolute;
+        width: calc(100% + #{$spacing-05});
+        height: 100%;
+        inset-inline-end: 0;
+        inset-block-start: 0;
+
+        @include carbon--breakpoint('max') {
+          width: 100%;
+        }
+      }
+    }
+
+    .#{$prefix}--universal-banner-text-container {
+      @include carbon--make-col(4, 4);
+
+      padding-inline: $spacing-05;
+      max-width: calc(100% - (20px + #{$spacing-05}));
+
+      @include carbon--breakpoint('md') {
+        @include carbon--make-col(7, 8);
+      }
+
+      @include carbon--breakpoint('lg') {
+        padding-inline-end: $spacing-09;
+      }
+    }
+
+    .#{$prefix}--universal-banner-cta-container {
+      display: none;
+
+      @include carbon--breakpoint('lg') {
+        @include carbon--make-col(4, 16);
+      }
+
+      @include carbon--breakpoint('xlg') {
+        @include carbon--make-col(3, 16);
+      }
+
+      @include carbon--breakpoint('max') {
+        @include carbon--make-col(4, 16);
+      }
+    }
+
+    .#{$prefix}--universal-banner-icon {
+      width: calc(20px + #{$spacing-05});
+      padding-inline-end: $spacing-05;
+      color: $text-01;
+      text-align: right;
+
+      svg {
+        margin-top: $spacing-01;
+      }
+
+      @include carbon--breakpoint('md') {
+        @include carbon--make-col(1, 8);
+
+        padding-inline-end: 0;
+      }
+
+      @include carbon--breakpoint('lg') {
+        display: none;
+      }
+    }
+
+    &[has-image] {
+      .#{$prefix}--universal-banner-image-container {
+        display: none;
+      }
+    }
+
+    &[image-width='4-col'] {
+      .#{$prefix}--universal-banner-image-container {
+        @include carbon--breakpoint('lg') {
+          @include carbon--make-col(4, 16);
+        }
+      }
+
+      .#{$prefix}--universal-banner-text-container {
+        @include carbon--breakpoint('lg') {
+          @include carbon--make-col(7, 16);
+        }
+      }
+
+      .#{$prefix}--universal-banner-cta-container {
+        @include carbon--breakpoint('lg') {
+          @include carbon--make-col-offset(1, 16);
+        }
+      }
+    }
+
+    &[image-width='8-col'] {
+      .#{$prefix}--universal-banner-image-container {
+        @include carbon--make-col(8, 16);
+      }
+
+      .#{$prefix}--universal-banner-text-container {
+        @include carbon--breakpoint('lg') {
+          @include carbon--make-col(4, 16);
+        }
+      }
+    }
+
+    &:not([has-image]) {
+      .#{$prefix}--universal-banner-text-container {
+        @include carbon--breakpoint('lg') {
+          @include carbon--make-col(11, 16);
+        }
+      }
+
+      .#{$prefix}--universal-banner-cta-container {
+        @include carbon--breakpoint('lg') {
+          @include carbon--make-col-offset(1, 16);
+        }
+      }
+    }
+
+    ::slotted(#{$dds-prefix}-button-cta) {
+      @include carbon--theme($carbon--theme--g100, true);
+
+      width: 100%;
+      display: block;
+      max-width: 320px;
+
+      @include carbon--breakpoint('xlg') {
+        width: calc(100% + #{$spacing-05});
+      }
+    }
+
+    #{$dds-prefix}-link-with-icon {
+      @include carbon--breakpoint('md') {
+        display: none;
+      }
+    }
+  }
+
+  :host(#{$dds-prefix}-universal-banner-heading) {
+    @include carbon--type-style('expressive-heading-02', true);
+
+    display: block;
+    color: $text-01;
+    max-width: 960px;
+
+    @include carbon--breakpoint('lg') {
+      width: calc(100% - #{$spacing-10});
+    }
+
+    @include carbon--breakpoint('lg') {
+      width: calc(100% - #{$spacing-10});
+    }
 
     @include carbon--breakpoint('xlg') {
-      width: calc(100% + #{$spacing-05});
+      width: calc(100% - #{$spacing-07});
     }
   }
 
-  #{$dds-prefix}-link-with-icon {
-    @include carbon--breakpoint('md') {
-      display: none;
+  :host(#{$dds-prefix}-universal-banner-copy) {
+    @include carbon--type-style('body-short-02', true);
+
+    display: block;
+    color: $text-01;
+  }
+
+  :host(#{$dds-prefix}-universal-banner-image) {
+    .#{$prefix}--image__img {
+      object-fit: cover;
     }
   }
 }
 
-:host(#{$dds-prefix}-universal-banner-heading) {
-  @include carbon--type-style('expressive-heading-02', true);
-
-  display: block;
-  color: $text-01;
-  max-width: 960px;
-
-  @include carbon--breakpoint('lg') {
-    width: calc(100% - #{$spacing-10});
-  }
-
-  @include carbon--breakpoint('lg') {
-    width: calc(100% - #{$spacing-10});
-  }
-
-  @include carbon--breakpoint('xlg') {
-    width: calc(100% - #{$spacing-07});
-  }
-}
-
-:host(#{$dds-prefix}-universal-banner-copy) {
-  @include carbon--type-style('body-short-02', true);
-
-  display: block;
-  color: $text-01;
-}
-
-:host(#{$dds-prefix}-universal-banner-image) {
-  .#{$prefix}--image__img {
-    object-fit: cover;
-  }
+@include exports('universal-banner') {
+  @include universal-banner
 }

--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -12,6 +12,10 @@
 $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
 
 @mixin video-player {
+  :host(#{$dds-prefix}-video-player:not(:defined)) {
+    display: none;
+  }
+
   :host(#{$dds-prefix}-video-player),
   .#{$prefix}--video-player {
     color: var(--#{$dds-prefix}--video-caption--color, $text-02);


### PR DESCRIPTION
### Related Ticket(s)

#10607 
### Description

added styles to remove FOUC from all components


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
