### PR TITLE
fix(ui-shell): keep side-nav-menu open when on focusout

### DIFF
--- a/packages/carbon-web-components/src/components/ui-shell/side-nav.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/side-nav.ts
@@ -164,7 +164,6 @@ class CDSSideNav extends HostListenerMixin(LitElement) {
       const headerItems = doc.querySelectorAll(
         (this.constructor as typeof CDSSideNav).selectorHeaderItems
       );
-      this._updatedSideNavMenuForceCollapsedState();
       forEach(
         doc.querySelectorAll(
           (this.constructor as typeof CDSSideNav).selectorButtonToggle
@@ -205,7 +204,7 @@ class CDSSideNav extends HostListenerMixin(LitElement) {
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleFocusOut({ relatedTarget }: FocusEvent) {
     const { collapseMode } = this;
-    if (collapseMode === SIDE_NAV_COLLAPSE_MODE.RAIL) {
+    if (collapseMode !== SIDE_NAV_COLLAPSE_MODE.FIXED) {
       if (!this.contains(relatedTarget as Node)) {
         this.expanded = false;
       }

--- a/packages/carbon-web-components/src/components/ui-shell/side-nav.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/side-nav.ts
@@ -204,8 +204,11 @@ class CDSSideNav extends HostListenerMixin(LitElement) {
   @HostListener('focusout')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleFocusOut({ relatedTarget }: FocusEvent) {
-    if (!this.contains(relatedTarget as Node)) {
-      this.expanded = false;
+    const { collapseMode } = this;
+    if (collapseMode === SIDE_NAV_COLLAPSE_MODE.RAIL) {
+      if (!this.contains(relatedTarget as Node)) {
+        this.expanded = false;
+      }
     }
   }
 
@@ -217,7 +220,10 @@ class CDSSideNav extends HostListenerMixin(LitElement) {
   @HostListener('focusin')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleFocusIn() {
-    this.expanded = true;
+    const { collapseMode } = this;
+    if (collapseMode !== SIDE_NAV_COLLAPSE_MODE.FIXED) {
+      this.expanded = true;
+    }
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

[[cwc-v2]: The cds-side-nav-menu collapses when click outside#10612](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/10612)

### Description

Issue: 
- open side-nav-menu
- click outside of the side-nav
- see that the side-nav-menu closes

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/1007051/f096c227-0f15-417a-8c3f-745cd4e7781c

### Changelog

**Changed**

- only toggle the `expanded` for certain collapse modes so that the menu still collapses in mobile view when user focuses out
- remove the `updatedSideNavMenuForceCollapsedState()` from firing whenever the expand toggles - not necessary to fire then

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
