### PR TITLE
fix(tabs-extended): ensure accordion doesn't load on desktop, and tabs don't load on mobile

### DIFF
--- a/packages/web-components/src/components/tabs-extended-media/tabs-extended-media.ts
+++ b/packages/web-components/src/components/tabs-extended-media/tabs-extended-media.ts
@@ -31,6 +31,10 @@ class DDSTabsExtendedMedia extends DDSTabsExtended {
   sectionHeading = 'true';
 
   render() {
+    const {
+      _isMobileVersion: isMobileVersion,
+    } = this;
+
     return html`
       <div class="${prefix}--tabs-extended-media">
         ${this.sectionHeading === 'true'
@@ -41,7 +45,7 @@ class DDSTabsExtendedMedia extends DDSTabsExtended {
             `
           : undefined}
         <div class="${prefix}--tabs-extended">
-          ${this._renderAccordion()} ${this._renderTabs()}
+          ${isMobileVersion ? this._renderAccordion() : this._renderTabs()}
           <div class="${prefix}--tab-content">
             <slot @slotchange="${this._handleSlotChange}"></slot>
           </div>


### PR DESCRIPTION
### Related Ticket(s)

Closes #10618 

### Description

The extended tabs component was loading both the tabs component (shown on desktop) and the accordion component (shown on mobile) at the time of page load, despite the window size, and hiding one with CSS. This contributes to an excess of nodes loading in the DOM unnecessarily. 

This PR changes the rendering of the tabs extended and tabs extended with media components to look at the window size and load either the accordion OR the tabs appropriately, thus decreasing nodes. 

### Changelog

**Changed**

- Tabs extended and Tabs Extended with Media now look at window size and load either tabs (desktop) or accordion (mobile), not both.


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
