### PR TITLE
fix(buttons): added missing aria-labels for tooltip-buttons

### DIFF
--- a/packages/carbon-web-components/src/components/button/button.ts
+++ b/packages/carbon-web-components/src/components/button/button.ts
@@ -341,7 +341,8 @@ class CDSButton extends HostListenerMixin(FocusMixin(LitElement)) {
               class="${classes}"
               ?autofocus="${autofocus}"
               ?disabled="${disabled}"
-              type="${ifDefined(type)}">
+              type="${ifDefined(type)}"
+              aria-label="${ifDefined(tooltipText)}">
               <slot @slotchange="${handleSlotChange}"></slot>
               <slot name="icon" @slotchange="${handleSlotChange}"></slot>
             </button>

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet-story.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet-story.ts
@@ -66,7 +66,7 @@ export const multiline = () => {
   // prettier-ignore
   return html`
     <cds-code-snippet
-      type="multi">${children}<span slot="button-description">Copy to clipboard</span>
+      type="multi" tooltip-content="Copy to Clipboard">${children}
     </cds-code-snippet>
 `;
 };
@@ -106,7 +106,7 @@ export const multilineWithLayer = () => {
   return html`
   <sb-template-layers>
   <cds-code-snippet
-      type="multi">${children}<span slot="button-description">Copy to clipboard</span>
+      type="multi" tooltip-content="Copy to Clipboard">${children}
     </cds-code-snippet>
   </sb-template-layers>
 `;
@@ -114,10 +114,9 @@ export const multilineWithLayer = () => {
 
 export const singleline = () => {
   return html`
-    <cds-code-snippet type="single">
+    <cds-code-snippet type="single" tooltip-content="Copy to Clipboard">
       yarn add carbon-components@latest carbon-components-react@latest
       @carbon/icons-react@latest carbon-icons@latest
-      <span slot="button-description">Copy to clipboard</span>
     </cds-code-snippet>
   `;
 };
@@ -125,12 +124,9 @@ export const singleline = () => {
 export const singlelineWithLayer = () => {
   return html`
     <sb-template-layers>
-      <cds-code-snippet type="single"
+      <cds-code-snippet type="single" tooltip-content="Copy to Clipboard"
         >yarn add carbon-components@latest carbon-components-react@latest
-        @carbon/icons-react@latest carbon-icons@latest<span
-          slot="button-description"
-          >Copy to clipboard</span
-        ></cds-code-snippet
+        @carbon/icons-react@latest carbon-icons@latest ></cds-code-snippet
       >
     </sb-template-layers>
   `;
@@ -181,9 +177,8 @@ export const Playground = (args) => {
       ?wrap-text="${wrapText}"
       feedback=${feedback}
       feedback-timeout=${feedbackTimeout}
-      >yarn add @carbon/react<span slot="button-description"
-        >${copyButtonDescription}</span
-      >
+      tooltip-content="${copyButtonDescription}"
+      >yarn add @carbon/reacttooltip-content="Copy to Clipboard"
     </cds-code-snippet>
   `;
 };

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -278,6 +278,12 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
   showMoreText = 'Show more';
 
   /**
+   * Tooltip content for the copy button.
+   */
+  @property({ attribute: 'tooltip-content' })
+  tooltipContent = 'Copy to clipboard';
+
+  /**
    * `true` if the button should be disabled.
    */
   @property({ type: Boolean, reflect: true, attribute: 'wrap-text' })
@@ -290,9 +296,6 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
   type = CODE_SNIPPET_TYPE.SINGLE;
 
   connectedCallback() {
-    if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'listitem');
-    }
     super.connectedCallback();
     if (this._hObserveResize) {
       this._hObserveResize = this._hObserveResize.release();
@@ -326,6 +329,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
       minCollapsedNumberOfRows,
       type,
       wrapText,
+      tooltipContent,
       showMoreText,
       showLessText,
       _expandedCode: expandedCode,
@@ -434,7 +438,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
               feedback=${feedback}
               feedback-timeout=${feedbackTimeout}
               @click="${handleCopyClick}">
-              <slot name="button-description"></slot>
+              ${tooltipContent}
             </cds-copy-button>
           `}
       ${shouldShowMoreLessBtn

--- a/packages/carbon-web-components/src/components/copy-button/copy-button.ts
+++ b/packages/carbon-web-components/src/components/copy-button/copy-button.ts
@@ -62,7 +62,7 @@ class CDSCopyButton extends FocusMixin(LitElement) {
         feedback-timeout=${feedbackTimeout}
         button-class-name=${classes}>
         ${Copy16({ slot: 'icon', class: `${prefix}--snippet__icon` })}
-        <span slot="tooltip-content"><slot></slot></span>
+        <slot slot="tooltip-content"></slot>
       </cds-copy>
     `;
   }

--- a/packages/carbon-web-components/src/components/copy/copy.ts
+++ b/packages/carbon-web-components/src/components/copy/copy.ts
@@ -112,8 +112,10 @@ class CDSCopy extends CDSIconButton {
       });
 
     super.updated(changedProperties);
-    // @ts-ignore: TS thinks `host` doesn't exist on `parentNode` 
-    this.shadowRoot?.querySelector('button')?.setAttribute('aria-label', this.parentNode?.host.textContent); 
+
+    this.shadowRoot
+      ?.querySelector('button') // @ts-ignore: TS thinks `host` doesn't exist on `parentNode`
+      ?.setAttribute('aria-label', this.parentNode?.host.textContent);
   }
 
   static styles = styles;

--- a/packages/carbon-web-components/src/components/copy/copy.ts
+++ b/packages/carbon-web-components/src/components/copy/copy.ts
@@ -112,6 +112,10 @@ class CDSCopy extends CDSIconButton {
       });
 
     super.updated(changedProperties);
+
+    this.shadowRoot
+      ?.querySelector('button')
+      ?.setAttribute('aria-label', this.parentNode?.host.textContent); // eslint-disable-line
   }
 
   static styles = styles;

--- a/packages/carbon-web-components/src/components/copy/copy.ts
+++ b/packages/carbon-web-components/src/components/copy/copy.ts
@@ -112,10 +112,8 @@ class CDSCopy extends CDSIconButton {
       });
 
     super.updated(changedProperties);
-
-    this.shadowRoot
-      ?.querySelector('button')
-      ?.setAttribute('aria-label', this.parentNode?.host.textContent); // eslint-disable-line
+    // @ts-ignore: TS thinks `host` doesn't exist on `parentNode` 
+    this.shadowRoot?.querySelector('button')?.setAttribute('aria-label', this.parentNode?.host.textContent); 
   }
 
   static styles = styles;

--- a/packages/carbon-web-components/src/components/icon-button/icon-button.ts
+++ b/packages/carbon-web-components/src/components/icon-button/icon-button.ts
@@ -66,6 +66,9 @@ class CDSIconButton extends CDSButton {
         ?.querySelector(`${prefix}-tooltip`)
         ?.shadowRoot?.querySelector(`.${prefix}--tooltip`)
         ?.classList.add(`${prefix}--icon-tooltip`);
+
+      const tooltipContent = this.querySelector('[slot=tooltip-content]')?.textContent;
+      this.shadowRoot?.querySelector(`${prefix}-tooltip`)?.querySelector(`button`)?.setAttribute('aria-label', String(tooltipContent));
     }
   }
 

--- a/packages/carbon-web-components/src/components/icon-button/icon-button.ts
+++ b/packages/carbon-web-components/src/components/icon-button/icon-button.ts
@@ -67,8 +67,13 @@ class CDSIconButton extends CDSButton {
         ?.shadowRoot?.querySelector(`.${prefix}--tooltip`)
         ?.classList.add(`${prefix}--icon-tooltip`);
 
-      const tooltipContent = this.querySelector('[slot=tooltip-content]')?.textContent;
-      this.shadowRoot?.querySelector(`${prefix}-tooltip`)?.querySelector(`button`)?.setAttribute('aria-label', String(tooltipContent));
+      const tooltipContent = this.querySelector(
+        '[slot=tooltip-content]'
+      )?.textContent;
+      this.shadowRoot
+        ?.querySelector(`${prefix}-tooltip`)
+        ?.querySelector(`button`)
+        ?.setAttribute('aria-label', String(tooltipContent));
     }
   }
 

--- a/packages/carbon-web-components/src/components/overflow-menu/overflow-menu.ts
+++ b/packages/carbon-web-components/src/components/overflow-menu/overflow-menu.ts
@@ -128,9 +128,6 @@ class CDSOverflowMenu
     if (!this.hasAttribute('aria-haspopup')) {
       this.setAttribute('aria-haspopup', 'true');
     }
-    if (!this.hasAttribute('aria-expanded')) {
-      this.setAttribute('aria-expanded', 'false');
-    }
     if (!this.shadowRoot) {
       this.attachShadow({ mode: 'open' });
     }
@@ -158,7 +155,10 @@ class CDSOverflowMenu
       const { _menuBody: menuBody } = this;
       if (menuBody) {
         menuBody.open = open;
-        this.setAttribute('aria-expanded', String(Boolean(open)));
+        
+        const tooltipContent = this.querySelector('[slot=tooltip-content]')?.textContent;
+        button?.setAttribute('aria-expanded', String(Boolean(open)));
+        button?.setAttribute('aria-label', String(tooltipContent));
       }
     }
 

--- a/packages/carbon-web-components/src/components/overflow-menu/overflow-menu.ts
+++ b/packages/carbon-web-components/src/components/overflow-menu/overflow-menu.ts
@@ -155,8 +155,10 @@ class CDSOverflowMenu
       const { _menuBody: menuBody } = this;
       if (menuBody) {
         menuBody.open = open;
-        
-        const tooltipContent = this.querySelector('[slot=tooltip-content]')?.textContent;
+
+        const tooltipContent = this.querySelector(
+          '[slot=tooltip-content]'
+        )?.textContent;
         button?.setAttribute('aria-expanded', String(Boolean(open)));
         button?.setAttribute('aria-label', String(tooltipContent));
       }

--- a/packages/carbon-web-components/src/components/tooltip/tooltip-story.mdx
+++ b/packages/carbon-web-components/src/components/tooltip/tooltip-story.mdx
@@ -31,10 +31,10 @@ import Information16 from '@carbon/icons/lib/information/16';
 ```html
 <cds-tooltip
   align="bottom">
-   <div class="sb-tooltip-trigger">
+   <div class="sb-tooltip-trigger" aria-labelledby="content">
   ${Information16()}
   </div>
-  <cds-tooltip-content>
+  <cds-tooltip-content id="content">
     Occassionally, services are updated in a specified time window to ensure no down time for customers.
   </cds-tooltip-content>
 </cds-tooltip>

--- a/packages/carbon-web-components/src/components/tooltip/tooltip-story.ts
+++ b/packages/carbon-web-components/src/components/tooltip/tooltip-story.ts
@@ -41,10 +41,10 @@ export const Default = () => {
       ${styles}
     </style>
     <cds-tooltip align="bottom">
-      <button class="sb-tooltip-trigger" role="button">
+      <button class="sb-tooltip-trigger" role="button" aria-labelledby="content">
         ${Information16()}
       </button>
-      <cds-tooltip-content>
+      <cds-tooltip-content id="content">
         Occassionally, services are updated in a specified time window to ensure
         no down time for customers.
       </cds-tooltip-content>
@@ -58,10 +58,10 @@ export const Alignment = () => {
       ${styles}
     </style>
     <cds-tooltip align="bottom-left">
-      <button class="sb-tooltip-trigger" role="button">
+      <button class="sb-tooltip-trigger" role="button" aria-labelledby="content">
         ${Information16()}
       </button>
-      <cds-tooltip-content> Tooltip alignment </cds-tooltip-content>
+      <cds-tooltip-content id="content"> Tooltip alignment </cds-tooltip-content>
     </cds-tooltip>
   `;
 };
@@ -72,10 +72,10 @@ export const Duration = () => {
       ${styles}
     </style>
     <cds-tooltip enter-delay-ms=${0} leave-delay-ms=${300}>
-      <button class="sb-tooltip-trigger" role="button">
+      <button class="sb-tooltip-trigger" role="button" aria-labelledby="content">
         ${Information16()}
       </button>
-      <cds-tooltip-content> Label one </cds-tooltip-content>
+      <cds-tooltip-content id="content"> Label one </cds-tooltip-content>
     </cds-tooltip>
   `;
 };
@@ -99,10 +99,10 @@ export const Playground = (args) => {
       enter-delay-ms=${enterDelay}
       leave-delay-ms=${leaveDelay}
       ?closeOnActivation=${closeOnActivation}>
-      <button class="sb-tooltip-trigger" role="button">
+      <button class="sb-tooltip-trigger" role="button" aria-labelledby="content">
         ${Information16()}
       </button>
-      <cds-tooltip-content> ${label} </cds-tooltip-content>
+      <cds-tooltip-content id="content"> ${label} </cds-tooltip-content>
     </cds-tooltip>
   `;
 };

--- a/packages/carbon-web-components/src/components/tooltip/tooltip-story.ts
+++ b/packages/carbon-web-components/src/components/tooltip/tooltip-story.ts
@@ -41,7 +41,10 @@ export const Default = () => {
       ${styles}
     </style>
     <cds-tooltip align="bottom">
-      <button class="sb-tooltip-trigger" role="button" aria-labelledby="content">
+      <button
+        class="sb-tooltip-trigger"
+        role="button"
+        aria-labelledby="content">
         ${Information16()}
       </button>
       <cds-tooltip-content id="content">
@@ -58,10 +61,15 @@ export const Alignment = () => {
       ${styles}
     </style>
     <cds-tooltip align="bottom-left">
-      <button class="sb-tooltip-trigger" role="button" aria-labelledby="content">
+      <button
+        class="sb-tooltip-trigger"
+        role="button"
+        aria-labelledby="content">
         ${Information16()}
       </button>
-      <cds-tooltip-content id="content"> Tooltip alignment </cds-tooltip-content>
+      <cds-tooltip-content id="content">
+        Tooltip alignment
+      </cds-tooltip-content>
     </cds-tooltip>
   `;
 };
@@ -72,7 +80,10 @@ export const Duration = () => {
       ${styles}
     </style>
     <cds-tooltip enter-delay-ms=${0} leave-delay-ms=${300}>
-      <button class="sb-tooltip-trigger" role="button" aria-labelledby="content">
+      <button
+        class="sb-tooltip-trigger"
+        role="button"
+        aria-labelledby="content">
         ${Information16()}
       </button>
       <cds-tooltip-content id="content"> Label one </cds-tooltip-content>
@@ -99,7 +110,10 @@ export const Playground = (args) => {
       enter-delay-ms=${enterDelay}
       leave-delay-ms=${leaveDelay}
       ?closeOnActivation=${closeOnActivation}>
-      <button class="sb-tooltip-trigger" role="button" aria-labelledby="content">
+      <button
+        class="sb-tooltip-trigger"
+        role="button"
+        aria-labelledby="content">
         ${Information16()}
       </button>
       <cds-tooltip-content id="content"> ${label} </cds-tooltip-content>

--- a/packages/carbon-web-components/src/components/tooltip/tooltip.ts
+++ b/packages/carbon-web-components/src/components/tooltip/tooltip.ts
@@ -173,7 +173,6 @@ class CDSTooltip extends HostListenerMixin(CDSPopover) {
       this.open
         ? toolTipContent?.setAttribute('open', '')
         : toolTipContent?.removeAttribute('open');
-      this.setAttribute('aria-expanded', String(Boolean(this.open)));
     }
 
     ['align', 'caret'].forEach((name) => {


### PR DESCRIPTION
### Related Ticket(s)

#10599 
### Description

The overflow-menu wasn't passing the accessibility checker because of a missing label. Digging deeper most buttons with tooltips were not passing the accessibility checker for the same reason

Updated the following components:
- overflow-menu
- button (icon variation)
- icon-button
- code-snippet
- copy
- copy-button
- tooltip
### Changelog

**New**

- added an aria-label where needed to support the accessibility checker


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
