### PR TITLE
chore(gulp): fix gulp watch

### DIFF
--- a/packages/styles/gulp/tasks/watch.js
+++ b/packages/styles/gulp/tasks/watch.js
@@ -15,5 +15,5 @@ const gulp = require('gulp');
  * @module watch
  */
 module.exports = gulp.task('watch', () => {
-  gulp.watch(global.config.scssFiles, gulp.task('sass'));
+  gulp.watch(global.config.scssFiles, gulp.parallel('sass-ltr', 'sass-rtl'));
 });


### PR DESCRIPTION
### Description

Fixes `gulp watch` task. `yarn gulp watch` works now.

### Changelog

**New**

- {{new thing}}

**Changed**

- fix `gulp watch` task for `@carbon/ibmdotcom-styles` package

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
