### PR TITLE
fix(ui-shell): add missed header-side-nav-items import

### DIFF
--- a/packages/carbon-web-components/src/components/ui-shell/index.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/index.ts
@@ -16,6 +16,7 @@ import './header-nav';
 import './side-nav-link';
 import './header-menu';
 import './header-menu-item';
+import './header-side-nav-items';
 import './side-nav-items';
 import './header-menu-button';
 import './header-nav-item';

--- a/packages/carbon-web-components/src/components/ui-shell/index.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/index.ts
@@ -7,22 +7,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import './side-nav-menu-item';
 import './header';
-import './side-nav';
-import './side-nav-divider';
+import './header-global-action';
+import './header-menu';
+import './header-menu-button';
+import './header-menu-item';
 import './header-name';
 import './header-nav';
-import './side-nav-link';
-import './header-menu';
-import './header-menu-item';
-import './header-side-nav-items';
-import './side-nav-items';
-import './header-menu-button';
 import './header-nav-item';
-import './header-global-action';
 import './header-panel';
-import './switcher';
-import './switcher-item';
-import './switcher-divider';
+import './header-side-nav-items';
+import './side-nav';
+import './side-nav-divider';
+import './side-nav-items';
+import './side-nav-link';
 import './side-nav-menu';
+import './side-nav-menu-item';
+import './switcher';
+import './switcher-divider';
+import './switcher-item';


### PR DESCRIPTION
### Related Ticket(s)

None

### Description

Add missed header-side-nav-items import.
Also sort the imports.

### Changelog

**New**

- fix(ui-shell): add missed header-side-nav-items import
