### PR TITLE
feat(ui-shell): add `target` and `rel` properties to links

### DIFF
--- a/packages/carbon-web-components/src/components/ui-shell/header-nav-item.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/header-nav-item.ts
@@ -32,6 +32,18 @@ class CDSHeaderNavItem extends FocusMixin(LitElement) {
   href!: string;
 
   /**
+   * The link type.
+   */
+  @property({ reflect: true })
+  rel!: string;
+
+  /**
+   * The link target.
+   */
+  @property({ reflect: true })
+  target!: string;
+
+  /**
    * The title.
    */
   @property()
@@ -56,7 +68,7 @@ class CDSHeaderNavItem extends FocusMixin(LitElement) {
   role: string = 'listitem';
 
   render() {
-    const { ariaCurrent, href, isActive, title } = this;
+    const { ariaCurrent, href, isActive, title, rel, target } = this;
     const linkClass = classMap({
       [`${prefix}--header__menu-item`]: true,
       [`${prefix}--header__menu-item--current`]:
@@ -68,7 +80,9 @@ class CDSHeaderNavItem extends FocusMixin(LitElement) {
         part="link"
         class="${linkClass}"
         tabindex="0"
-        href="${ifDefined(href)}">
+        href="${ifDefined(href)}"
+        rel="${ifDefined(rel)}"
+        target="${ifDefined(target)}">
         <span part="title" class="${prefix}--text-truncate--end"
           ><slot>${title}</slot></span
         >

--- a/packages/carbon-web-components/src/components/ui-shell/side-nav-link.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/side-nav-link.ts
@@ -8,6 +8,7 @@
  */
 
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { LitElement, html } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
@@ -54,6 +55,18 @@ class CDSSideNavLink extends FocusMixin(LitElement) {
   href = '';
 
   /**
+   * The link type.
+   */
+  @property({ reflect: true })
+  rel!: string;
+
+  /**
+   * The link target.
+   */
+  @property({ reflect: true })
+  target!: string;
+
+  /**
    * Specify if this is a large variation of the side nav link
    */
   @property({ type: Boolean, reflect: true })
@@ -76,6 +89,8 @@ class CDSSideNavLink extends FocusMixin(LitElement) {
     const {
       active,
       href,
+      rel,
+      target,
       title,
       _handleSlotChangeTitleIcon: handleSlotChangeTitleIcon,
     } = this;
@@ -84,7 +99,12 @@ class CDSSideNavLink extends FocusMixin(LitElement) {
       [`${prefix}--side-nav__link--current`]: active,
     });
     return html`
-      <a part="link" class="${classes}" href="${href}">
+      <a
+        part="link"
+        class="${classes}"
+        href="${href}"
+        rel="${ifDefined(rel)}"
+        target="${ifDefined(target)}">
         <div
           id="title-icon-container"
           part="title-icon-container"


### PR DESCRIPTION
### Related Ticket(s)

None

### Description

Add `target` and `rel` properties to ui-shell links.

### Changelog

**New**

- feat(ui-shell): add `target` and `rel` properties to links