### PR TITLE
fix(ghost-button): icon alignment for larger sizes

### DIFF
--- a/packages/carbon-web-components/src/components/button/button.scss
+++ b/packages/carbon-web-components/src/components/button/button.scss
@@ -110,3 +110,10 @@ $css--plex: true !default;
 :host(#{$prefix}-button-set[stacked]) {
   @extend .#{$prefix}--btn-set--stacked;
 }
+
+//TODO: remove once we are able to upgrade @carbon/styles to include https://github.com/carbon-design-system/carbon/pull/13287
+.#{$prefix}--btn--xl:not(.#{$prefix}--btn--icon-only),
+.#{$prefix}--btn--2xl:not(.#{$prefix}--btn--icon-only) {
+  align-items: start;
+  padding: $button-padding-ghost;  
+}

--- a/packages/carbon-web-components/src/components/button/button.scss
+++ b/packages/carbon-web-components/src/components/button/button.scss
@@ -115,5 +115,5 @@ $css--plex: true !default;
 .#{$prefix}--btn--xl:not(.#{$prefix}--btn--icon-only),
 .#{$prefix}--btn--2xl:not(.#{$prefix}--btn--icon-only) {
   align-items: start;
-  padding: $button-padding-ghost;  
+  padding: $button-padding-ghost;
 }


### PR DESCRIPTION
### Related Ticket(s)

#10691 
### Description

ghost button with icon wasn't aligning correctly 

Showing fixed button with hover state in 2xl size
![Screenshot 2023-07-18 at 1 15 25 PM](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/20210594/228c8015-710c-494d-b881-169f885e95e7)

### Changelog

**New**

- {{new thing}}

**Changed**

- added styles to temporarly resolve this, but eventually should be able to remove once we can upgrade `@carbon/styles`

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
