### PR TITLE
fix: add carbon sass import updater

### DIFF
--- a/packages/carbon-web-components/package.json
+++ b/packages/carbon-web-components/package.json
@@ -30,6 +30,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "postinstall": "node tools/fix-carbon-sass-imports.js",
+    "prebuild": "node tools/fix-carbon-sass-imports.js",
     "build": "gulp build && yarn wca",
     "build:dist": "gulp build:dist",
     "build:dist:dev": "gulp build:dist:dev",

--- a/packages/carbon-web-components/tools/fix-carbon-sass-imports.js
+++ b/packages/carbon-web-components/tools/fix-carbon-sass-imports.js
@@ -1,0 +1,55 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const path = require('node:path');
+const fs = require('node:fs');
+const localCarbonPath = [__dirname, '..', 'node_modules', '@carbon'];
+const rootCarbonPath = [__dirname, '..', '..', '..', 'node_modules', '@carbon'];
+
+// map of root Carbon package to local Carbon Sass module index
+const modulesMap = new Map([
+  ['colors', 'styles/scss/_colors.scss'],
+  ['feature-flags', 'styles/scss/_feature-flags.scss'],
+]);
+
+modulesMap.forEach((localModuleIndex, packageName) => {
+  const localModuleIndexPath = path.join(...localCarbonPath, localModuleIndex);
+  const localCarbonExists = fs.existsSync(localModuleIndexPath);
+  const projectDependencyPath = path.join(...rootCarbonPath, packageName);
+  const projectCarbonExists = fs.existsSync(projectDependencyPath);
+  if (!localCarbonExists) {
+    throw new Error(
+      `Could not find local Carbon Sass module for ${packageName}`
+    );
+  }
+  if (!projectCarbonExists) {
+    throw new Error(
+      `Could not find Carbon ${packageName} package in project root dependencies`
+    );
+  }
+  const localModuleContents = fs.readFileSync(localModuleIndexPath, 'utf8');
+  const relativePath = path.relative(
+    // go up one directory to offset filename in filepath
+    path.resolve(localModuleIndexPath, '..'),
+    projectDependencyPath
+  );
+  const [fixedPath] = relativePath.split('/@carbon/');
+  if (localModuleContents.includes(fixedPath)) {
+    console.log(
+      `Skipping ${localModuleIndex} as it already has the correct path`
+    );
+    return;
+  }
+  const newContents = localModuleContents.replace(
+    "@forward '@carbon",
+    `@forward '${fixedPath}/@carbon`
+  );
+
+  fs.writeFileSync(localModuleIndexPath, newContents, 'utf8');
+});


### PR DESCRIPTION
### Related Ticket(s)

#10705 

### Description

This PR adds a Node.js script that updates Carbon Sass module import paths based on paths manually specified in a Map. The script currently updates imports for Carbon colors and feature flag modules and runs automatically on after `install` and before `build` scripts. After running the script, the `build` script should no longer emit any errors and build artifacts should reappear in `dist` which will also resolve issues with missing CDN resources

### Changelog

**New**

- Carbon Sass import fixer
- `postinstall` npm script
- `prebuild` npm script

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
