### PR TITLE
fix(ui-shell): global action button popover visibility

### DIFF
--- a/packages/carbon-web-components/src/components/ui-shell/header.scss
+++ b/packages/carbon-web-components/src/components/ui-shell/header.scss
@@ -93,6 +93,10 @@ $css--plex: true !default;
   &:hover ::slotted(svg) {
     fill: $icon-primary;
   }
+
+  .#{$prefix}--popover {
+    z-index: 8001;
+  }
 }
 
 :host(#{$prefix}-header-nav-item),

--- a/packages/carbon-web-components/src/components/ui-shell/ui-shell-story.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/ui-shell-story.ts
@@ -372,14 +372,18 @@ export const HeaderBaseWActionsRightPanel = () => {
         >[Platform]</cds-header-name
       >
       <div class="${prefix}--header__global">
-        <cds-header-global-action aria-label="Search">
+        <cds-header-global-action aria-label="Search" tooltip-text="Search">
           ${Search20({ slot: 'icon' })}
         </cds-header-global-action>
-        <cds-header-global-action active aria-label="Notification">
+        <cds-header-global-action
+          active
+          aria-label="Notification"
+          tooltip-text="Notification">
           ${Notification20({ slot: 'icon' })}
         </cds-header-global-action>
         <cds-header-global-action
           aria-label="App Switcher"
+          tooltip-text="App Switcher"
           tooltip-alignment="right">
           ${SwitcherIcon20({ slot: 'icon' })}
         </cds-header-global-action>
@@ -400,15 +404,18 @@ export const HeaderBaseWActionsSwitcher = () => {
         >[Platform]</cds-header-name
       >
       <div class="${prefix}--header__global">
-        <cds-header-global-action aria-label="Search">
+        <cds-header-global-action aria-label="Search" tooltip-text="Search">
           ${Search20({ slot: 'icon' })}
         </cds-header-global-action>
-        <cds-header-global-action aria-label="Notification">
+        <cds-header-global-action
+          aria-label="Notification"
+          tooltip-text="Notification">
           ${Notification20({ slot: 'icon' })}
         </cds-header-global-action>
         <cds-header-global-action
           active
           aria-label="App Switcher"
+          tooltip-text="App Switcher"
           tooltip-alignment="right">
           ${SwitcherIcon20({ slot: 'icon' })}
         </cds-header-global-action>


### PR DESCRIPTION
### Related Ticket(s)

#10711

### Description

updates so the popover for the header-global-action buttons are visible when right panel is visible 
<img width="1119" alt="Screenshot 2023-07-19 at 11 46 35 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/20210594/313427c5-64de-4dfd-b70c-f7eee8ab64f5">


### Changelog

**Changed**

- added z-index increase

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
