### PR TITLE
fix(script): remove postinstall script and add import script to package.json files

### DIFF
--- a/packages/carbon-web-components/package.json
+++ b/packages/carbon-web-components/package.json
@@ -30,7 +30,6 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "postinstall": "node tools/fix-carbon-sass-imports.js",
     "prebuild": "node tools/fix-carbon-sass-imports.js",
     "build": "gulp build && yarn wca",
     "build:dist": "gulp build:dist",
@@ -53,6 +52,7 @@
   },
   "files": [
     "custom-elements.json",
+    "tools/fix-carbon-sass-imports.js",
     "dist/**/*",
     "es/**/*",
     "lib/**/*",

--- a/packages/carbon-web-components/package.json
+++ b/packages/carbon-web-components/package.json
@@ -52,7 +52,6 @@
   },
   "files": [
     "custom-elements.json",
-    "tools/fix-carbon-sass-imports.js",
     "dist/**/*",
     "es/**/*",
     "lib/**/*",


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

The imports script was causing errors when the package is pull into an external app - remove the script from `postinstall`

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
