### PR TITLE
fix(tag): fix the red tag styles

### DIFF
--- a/packages/carbon-web-components/src/components/tag/tag.scss
+++ b/packages/carbon-web-components/src/components/tag/tag.scss
@@ -32,8 +32,7 @@ $css--plex: true !default;
 }
 
 :host(#{$prefix}-tag[type='red']) {
-  // @extend .#{$prefix}--tag--red;
-  background-color: #{$tag-background-red};
+  @extend .#{$prefix}--tag--red;
 }
 
 :host(#{$prefix}-tag[type='magenta']) {


### PR DESCRIPTION
### Description

Fix the red tag styles.

From:
<img width="239" alt="Screenshot 2023-07-28 at 2 28 25 PM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/1007051/d6355e56-46d7-446a-9f35-d767b262f25e">

To:
<img width="221" alt="Screenshot 2023-07-28 at 2 28 16 PM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/1007051/9c713cf9-8882-486f-9740-689989fe58d9">

### Changelog

**Changed**

- fix(tag): fix the red tag styles
