### PR TITLE
chore(icons): update icon imports

### DIFF
--- a/packages/carbon-web-components/src/components/data-table/table-row.ts
+++ b/packages/carbon-web-components/src/components/data-table/table-row.ts
@@ -10,7 +10,7 @@
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
-import ChevronRight16 from '@carbon/web-components/es/icons/chevron--right/16';
+import ChevronRight16 from '@carbon/icons/lib/chevron--right/16';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import FocusMixin from '../../globals/mixins/focus';
 import styles from './data-table.scss';

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-step-skeleton.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-step-skeleton.ts
@@ -11,7 +11,7 @@ import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import styles from './progress-indicator.scss';
-import CircleDash from '@carbon/web-components/es/icons/circle-dash/16';
+import CircleDash from '@carbon/icons/lib/circle-dash/16';
 import '../skeleton-text';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 


### PR DESCRIPTION
### Description

Update import paths for Carbon icons

### Changelog

**New**

- {{new thing}}

**Changed**

- Carbon icon paths updated for `progress-step-skeleton` and `table-row`

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
