### PR TITLE
fix(skip-to-content): v2 storybook

### DIFF
--- a/packages/web-components/.storybook/preview.ts
+++ b/packages/web-components/.storybook/preview.ts
@@ -61,8 +61,8 @@ export const decorators = [
       <style>
         ${containerStyles}
       </style>
-      <bx-skip-to-content href="#main-content"
-        >Skip to main content</bx-skip-to-content
+      <cds-skip-to-content href="#main-content"
+        >Skip to main content</cds-skip-to-content
       >
       <div
         id="main-content"


### PR DESCRIPTION
### Related Ticket(s)

none
### Description

fixes skip to content in storybook uses `cds` prefix
### Changelog


**Changed**

- bx to cds

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
