### PR TITLE
chore(tools): add motion package to import sass script

### DIFF
--- a/packages/carbon-web-components/tools/fix-carbon-sass-imports.js
+++ b/packages/carbon-web-components/tools/fix-carbon-sass-imports.js
@@ -15,6 +15,7 @@ const rootCarbonPath = [__dirname, '..', '..', '..', 'node_modules', '@carbon'];
 // map of root Carbon package to local Carbon Sass module index
 const modulesMap = new Map([
   ['colors', 'styles/scss/_colors.scss'],
+  ['feature-flags', 'styles/scss/_feature-flags.scss'],
   ['motion', 'styles/scss/_motion.scss'],
 ]);
 

--- a/packages/carbon-web-components/tools/fix-carbon-sass-imports.js
+++ b/packages/carbon-web-components/tools/fix-carbon-sass-imports.js
@@ -15,7 +15,7 @@ const rootCarbonPath = [__dirname, '..', '..', '..', 'node_modules', '@carbon'];
 // map of root Carbon package to local Carbon Sass module index
 const modulesMap = new Map([
   ['colors', 'styles/scss/_colors.scss'],
-  ['feature-flags', 'styles/scss/_feature-flags.scss'],
+  ['motion', 'styles/scss/_motion.scss'],
 ]);
 
 modulesMap.forEach((localModuleIndex, packageName) => {


### PR DESCRIPTION
### Related Ticket(s)

Closes # {{Provide issue number link(s) to the related ticket(s) that this pull request addresses}}

### Description

The build for CWC now complains about the `@carbon/motion` package path, adding the package to the script so it can pull from the root


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
