### PR TITLE
fix(popover): style imports

### DIFF
--- a/packages/carbon-web-components/src/components/popover/popover.scss
+++ b/packages/carbon-web-components/src/components/popover/popover.scss
@@ -10,10 +10,26 @@ $css--plex: true !default;
 
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/utilities' as *;
+@use '@carbon/styles/scss/utilities/convert' as *;
 @use '@carbon/styles/scss/utilities/custom-property';
 @use '@carbon/styles/scss/theme';
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/components/popover';
+
+// The distance between the popover container and the triggering element
+// Specify the distance between the popover and the trigger. This value must
+// have a unit otherwise the `calc()` expression will not work
+// stylelint-disable-next-line length-zero-no-unit
+$popover-offset: custom-property.get-var('popover-offset', 0rem);
+
+// Customize the dimensions of the caret by specifying its width or height.
+// These values will be flipped in left or right directions to have the
+// correct dimensions
+$popover-caret-width: custom-property.get-var('popover-caret-width', rem(12px));
+$popover-caret-height: custom-property.get-var(
+  'popover-caret-height',
+  rem(6px)
+);
 
 :host(#{$prefix}-tooltip),
 :host(#{$prefix}-popover) {
@@ -71,62 +87,181 @@ $css--plex: true !default;
   );
 }
 
+:host(#{$prefix}-tooltip-content[align^='bottom']),
+:host(#{$prefix}-popover-content[align^='bottom']) {
+  .#{$prefix}--popover-caret {
+    bottom: 0;
+    left: 50%;
+    width: $popover-caret-width;
+    height: $popover-caret-height;
+    clip-path: polygon(0% 100%, 50% 0%, 100% 100%);
+    transform: translate(-50%, $popover-offset);
+  }
+}
+
 :host(#{$prefix}-tooltip-content[align='bottom']),
 :host(#{$prefix}-popover-content[align='bottom']) {
-  @extend .#{$prefix}--popover--bottom;
+  .#{$prefix}--popover-content {
+    bottom: 0;
+    left: 50%;
+    transform: translate(-50%, calc(100% + $popover-offset));
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='bottom-left']),
 :host(#{$prefix}-popover-content[align='bottom-left']) {
-  @extend .#{$prefix}--popover--bottom-left;
+  .#{$prefix}--popover-content {
+    bottom: 0;
+    left: 0;
+    transform: translate(
+      calc(-1 * $popover-offset),
+      calc(100% + $popover-offset)
+    );
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='bottom-right']),
 :host(#{$prefix}-popover-content[align='bottom-right']) {
-  @extend .#{$prefix}--popover--bottom-right;
+  .#{$prefix}--popover-content {
+    right: 0;
+    bottom: 0;
+    transform: translate($popover-offset, calc(100% + $popover-offset));
+  }
+}
+
+:host(#{$prefix}-tooltip-content[align^='left']),
+:host(#{$prefix}-popover-content[align^='left']) {
+  .#{$prefix}--popover-caret {
+    top: 50%;
+    right: 100%;
+    width: $popover-caret-height;
+    height: $popover-caret-width;
+    clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+    transform: translate(calc(-1 * $popover-offset + 100%), -50%);
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='left']),
 :host(#{$prefix}-popover-content[align='left']) {
-  @extend .#{$prefix}--popover--left;
+  .#{$prefix}--popover-content {
+    top: 50%;
+    right: 100%;
+    // Add in 0.1px to prevent rounding errors where the content is
+    // moved farther than the caret
+    transform: translate(calc(-1 * $popover-offset + 0.1px), -50%);
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='left-bottom']),
 :host(#{$prefix}-popover-content[align='left-bottom']) {
-  @extend .#{$prefix}--popover--left-bottom;
+  .#{$prefix}--popover-content {
+    right: 100%;
+    bottom: -50%;
+    // Add in 0.1px to prevent rounding errors where the content is
+    // moved farther than the caret
+    transform: translate(
+      calc(-1 * $popover-offset),
+      calc(0.5 * $popover-offset - 16px)
+    );
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='left-top']),
 :host(#{$prefix}-popover-content[align='left-top']) {
-  @extend .#{$prefix}--popover--left-top;
+  .#{$prefix}--popover-content {
+    top: -50%;
+    right: 100%;
+    // Add in 0.1px to prevent rounding errors where the content is
+    // moved farther than the caret
+    transform: translate(
+      calc(-1 * $popover-offset),
+      calc(-1 * 0.5 * $popover-offset + 16px)
+    );
+  }
+}
+
+:host(#{$prefix}-tooltip-content[align^='right']),
+:host(#{$prefix}-popover-content[align^='right']) {
+  .#{$prefix}--popover-caret {
+    top: 50%;
+    left: 100%;
+    width: $popover-caret-height;
+    height: $popover-caret-width;
+    clip-path: polygon(0% 50%, 100% 0%, 100% 100%);
+    transform: translate(calc($popover-offset - 100%), -50%);
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='right']),
 :host(#{$prefix}-popover-content[align='right']) {
-  @extend .#{$prefix}--popover--right;
+  .#{$prefix}--popover-content {
+    top: 50%;
+    left: 100%;
+    // Add in 0.1px to prevent rounding errors where the content is
+    // moved farther than the caret
+    transform: translate($popover-offset, -50%);
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='right-bottom']),
 :host(#{$prefix}-popover-content[align='right-bottom']) {
-  @extend .#{$prefix}--popover--right-bottom;
+  .#{$prefix}--popover-content {
+    bottom: 50%;
+    left: 100%;
+    transform: translate($popover-offset, calc(0.5 * $popover-offset + 16px));
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='right-top']),
 :host(#{$prefix}-popover-content[align='right-top']) {
-  @extend .#{$prefix}--popover--right-top;
+  .#{$prefix}--popover-content {
+    top: 50%;
+    left: 100%;
+    transform: translate(
+      $popover-offset,
+      calc(0.5 * $popover-offset * -1 - 16px)
+    );
+  }
+}
+
+:host(#{$prefix}-tooltip-content[align^='top']),
+:host(#{$prefix}-popover-content[align^='top']) {
+  .#{$prefix}--popover-caret {
+    top: 0;
+    left: 50%;
+    width: $popover-caret-width;
+    height: $popover-caret-height;
+    clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+    transform: translate(-50%, calc(-1 * $popover-offset));
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='top']),
 :host(#{$prefix}-popover-content[align='top']) {
-  @extend .#{$prefix}--popover--top;
+  .#{$prefix}--popover-content {
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, calc(-100% - $popover-offset));
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='top-left']),
 :host(#{$prefix}-popover-content[align='top-left']) {
-  @extend .#{$prefix}--popover--top-left;
+  .#{$prefix}--popover-content {
+    top: 0;
+    left: 0;
+    transform: translate(
+      calc(-1 * $popover-offset),
+      calc(-100% - $popover-offset)
+    );
+  }
 }
 
 :host(#{$prefix}-tooltip-content[align='top-right']),
 :host(#{$prefix}-popover-content[align='top-right']) {
-  @extend .#{$prefix}--popover--top-right;
+  .#{$prefix}--popover-content {
+    top: 0;
+    right: 0;
+    transform: translate($popover-offset, calc(-100% - $popover-offset));
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

Closes #10827 

### Description

Since styles were updated in @carbon/styles in popover: https://github.com/carbon-design-system/carbon/commit/734a3bea26e5b74a520312b7683ecb2a852ac741. We can no longer extend how we were doing it before

fixes all components with popover (copy-button, code-snippet, etc)

### Changelog

**New**

- {{new thing}}

**Changed**

- instead of extending i manually copy and pasted the styles over

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
