### PR TITLE
docs(migation): update migration docs

### DIFF
--- a/docs/cwc-v2-migration.md
+++ b/docs/cwc-v2-migration.md
@@ -18,25 +18,35 @@ For Carbon v11 migration guidance, see their
 | button                    | View changes [here](#button)           |
 | checkbox                  | View changes [here](#checkbox)         |
 | code-snippet              | View changes [here](#code-snippet)     |
+| combo-box                 | View changes [here](#combo-box)        |
 | copy-button               | View changes [here](#copy-button)      |
+| data-table                | View changes [here](#data-table)       |
 | date-picker               | View changes [here](#date-picker)      |
 | dropdown                  | View changes [here](#dropdown)         |
 | file-uploader             | View changes [here](#file-uploader)    |
 | form-group                | New component in v2.                   |
 | icon-button               | New component in v2.                   |
 | input                     | Replaced by `text-input`               |
+| layer                     | New component in v2.                   |
 | link                      | View changes [here](#link)             |
+| modal                     | View changes [here](#modal)            |
 | multi-select              | View changes [here](#multi-select)     |
 | notification              | View changes [here](#notification)     |
 | number-input              | View changes [here](#number-input)     |
 | overflow-menu             | View changes [here](#overflow-menu)    |
+| pagination                | View changes [here](#pagination)       |
 | progress-bar              | New component in v2.                   |
 | radio-button              | View changes [here](#radio-button)     |
+| search                    | View changes [here](#search)           |
 | select                    | View changes [here](#select)           |
 | slider                    | View changes [here](#slider)           |
 | stack                     | New component in v2.                   |
+| tag                       | View changes [here](#tag)              |
 | textarea                  | View changes [here](#textarea)         |
 | text-input                | New component in v2. Replaces `input`. |
+| tile                      | View changes [here](#tile)             |
+| toggle                    | View changes [here](#toggle)           |
+| toggletip                 | New component in v2.                   |
 | tooltip                   | View changes [here](#tooltip)          |
 | ui-shell                  | View changes [here](#ui-shell)         |
 
@@ -47,7 +57,11 @@ For Carbon v11 migration guidance, see their
 
 ### button
 
+- New `cds-button-set` component
 - `danger-primary` new option for `kind` property
+- `size` now accepts `xs`, `sm`, `md`, `lg`, and `xl`, instead of `''`, `sm`, `lg`, `field`
+- `tooltip-text` can add a tooltip component that appears on hover
+- `tooltip-alignment` and `tooltip-position` can be used to modify the tooltip
 
 ### breadcrumb
 
@@ -63,11 +77,33 @@ For Carbon v11 migration guidance, see their
 
 - New properties: `copy-text`, `disabled`, `feedback`, `feedback-timeout`, `hide-copy-button`, `maxCollapsedNumberOfRows`, `maxExpandedNumberOfRows`, `minCollapsedNumberOfRows`, `minExpandedNumberOfRows`, `show-less-text`, `show-more-text`, `wrap-text`, `tooltip-content`
 - Removed properties: `code-assistive-text`, `collapse-button-text`, `color-scheme`, `copy-button-assistive-text`, `copy-button-feedback-text`, `copy-button-feedback-timeout`, `expand-button-text`
+
+### combo-box
+
+- `direction` property expects 'top' or 'bottom' value
+- `size="md"` is now used instead of `size=""`
+- `label-text` is now `title-text`
+- `trigger-content` is now `label` 
+- New attributes: `hide-label`, `invalid`, `invalid-text`, `read-only`, `warn`, `warn-text`
+- Removed `color-scheme` property
+
 ### copy-button
 
 - `feedback-text` property replaced with `feedback`
 - Removed `button-assistive-text` property
 - New `class-name` & `disabled` properties
+
+### data-table
+
+- New optional `table-head` component
+- New and old interactive features/logic are now built-in to the component -- can still be customizable
+- New properties: `batch-expansion`, `collator`, `expandable`, `filterRows`, `is-selectable`, `is-sortable`, `locale`, 
+`overflow-menu-on-hover`, `radio`, `use-static-width`, `use-zebra-styles`
+- `size` now accepts `xs`, `sm`, `md`, `lg`, and `xl`, instead of `compact`, `short`, `''`, and `tall`
+- `table-toolbar` can now be further customized with extra features
+- Removed `color-scheme` in favor of `use-zebra-styles`
+- Removed `table-expand-row` in favor of `table-row` with `expandable` attribute
+- Removed smaller `skeleton` table components in favor of `cds-table-skeleton` with `row-count` and `column-count` attributes
 
 ### date-picker
 
@@ -78,6 +114,11 @@ For Carbon v11 migration guidance, see their
 ### dropdown
 
 - `direction` property expects 'top' or 'bottom' value
+- `size="md"` is now used instead of `size=""`
+- `label-text` is now `title-text`
+- `trigger-content` is now `label`
+- New attributes: `hide-label`, `invalid`, `invalid-text`, `read-only`, `warn`, `warn-text`
+- Removed `color-scheme` property
 
 ### file-uploader
 
@@ -94,6 +135,10 @@ For Carbon v11 migration guidance, see their
 
 - `size` property replaced `REGULAR = ''` with `MEDIUM = 'md'`
 - New `inline` & `visited` properties
+
+### modal
+- `<p>` inside the `modal-body` is replaced with `cds-modal-body-content`
+- New attributes: `alert`, `full-width`, `has-scrolling-content`, `prevent-close`, `prevent-close-on-click-outside`
 
 ### multi-select
 
@@ -132,6 +177,16 @@ For Carbon v11 migration guidance, see their
 - New `overlfow-menu` properties: `index`
 - Removed `overlfow-menu` properties: `color-scheme`
 
+### pagination
+
+- Removed `page-sizes-select` in favor of a `cds-select` component
+- Removed `pages-select` component in favor of built-in logic
+- `prev-button-text` is now `backward-text`
+- `next-button-text` is now `forward-text`
+- `at-last-page` is now `is-last-page`
+- New properties: `items-per-page-text`, `page-input-disabled`, `page-size-input-disabled`, `page-size-label-text`, `pages-unkown`,
+ `size`, `total-items`, `total-pages`
+
 ### radio-button
 
 - New `radio-button-group` properties: `defaultSelected`, `legend-text`, `readOnly`
@@ -153,6 +208,14 @@ For Carbon v11 migration guidance, see their
 - New `warn` and `warn-text` properties for warn state
 - New `hide-text-input` property for option to hide text input on side of slider
 
+### search
+
+- Removed `color-scheme` property
+- `size` property expected values have been changed from '' (default), 'sm', and 'xl' --> 'sm', 'md' (default), and 'lg'
+- Can use custom icon over magnifying glass
+- `closeButtonAssistiveText` is now `closeButtonLabelText`
+- New properties: `autocomplete`, `expandable`, 
+
 ### select
 
 - Removed `color-scheme` property
@@ -162,12 +225,38 @@ For Carbon v11 migration guidance, see their
 - New `warn` and `warn-text` properties for warn state
 - New `hide-label` property for option to hide label
 
+### tag
+- Removed `filter-tag` in favor of `filter` attribute
+
 ### textarea
 
 - Removed `color-scheme` property
 - New `max-count` property that limits character count in component
 - New `enable-counter` property for option to display character counter
 - New `warn` and `warn-text` properties for warn state
+
+### tile
+
+- `fieldset` has been replaced with `tile-group` that handles selection logic
+- "Single selectable" tiles are now `radio-tile`s
+- `expandable-tile` can now include interactable components within
+
+### toggle
+
+- `checked-text` is now `label-a`
+- `unchecked-text` is now `label-b`
+- `size="small"` is now `size="sm"`
+- New properties: `hide-checkbox`, `read-only`
+
+### tooltip
+
+- tooltip now displays on hover instead of click
+- Removed `direction` property
+- `alignment` property now has 12 directions to choose from
+- `start` alignment is now `bottom-left`
+- `center` alignment is now `bottom`
+- `end` alignment is now `bottom-right`
+- New properties `enter-delay-ms` and `leave-delay-ms` to affect tooltip open/exit delay on hover
 
 ### ui-shell
 


### PR DESCRIPTION
### Related Ticket(s)
Part of https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/10733

### Description
Added migration docs for: 

* Data-table
* Dropdown
* Modal
* Tile
* Combo-box
* Tag
* Button
* Search
* Layer
* Toggle
* Tooltip
* Pagination

### Changelog

**New**

- added migration docs for more components 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
