### PR TITLE
docs(codesandboxes): update codesandboxes with theming example

### DIFF
--- a/packages/carbon-web-components/examples/codesandbox/basic/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-accordion:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-
-  <link rel="stylesheet" href="src/styles.scss" />
+  
   <style>
     /* Suppress custom element until styles are loaded */
     cds-accordion:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+        
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-accordion:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/accordion/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-breadcrumb:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-breadcrumb:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-breadcrumb:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/breadcrumb/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/button/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/button/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/button/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/button/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-button:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/button/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/button/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-button:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/button/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/button/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-button:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/button/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/button/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/button/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/button/src/styles.scss
@@ -1,0 +1,13 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+@use '@carbon/styles/scss/components/button/tokens' as button-tokens;
+@include theme.add-component-tokens(button-tokens.$button-tokens);
+
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-checkbox:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  
-  <link rel="stylesheet" href="src/styles.scss" />
+
   <style>
     /* Suppress custom element until styles are loaded */
     cds-checkbox:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-checkbox:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/checkbox/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-code-snippet:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-code-snippet:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-code-snippet:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/code-snippet/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/cdn.html
@@ -13,7 +13,9 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <style>
+ 
+  <link rel="stylesheet" href="src/styles.scss" />
+ <style>
     /* Suppress custom element until styles are loaded */
     cds-combo-box:not(:defined) {
       display: none;

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
- 
-  <link rel="stylesheet" href="src/styles.scss" />
+  
  <style>
     /* Suppress custom element until styles are loaded */
     cds-combo-box:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-combo-box:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/combo-box/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-combo-box:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-combo-box:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-switcher:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/content-switcher/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  
-  <link rel="stylesheet" href="src/styles.scss" /> 
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-copy-buton:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" /> 
   <style>
     /* Suppress custom element until styles are loaded */
     cds-copy-buton:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-copy-button:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/copy-button/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/cdn.html
@@ -13,7 +13,6 @@ LICENSE file in the root directory of this source tree.
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     
-    <link rel="stylesheet" href="src/styles.scss" />
     <style>
       /* Suppress custom element until styles are loaded */
       cds-data-table:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/cdn.html
@@ -12,6 +12,8 @@ LICENSE file in the root directory of this source tree.
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+    
+    <link rel="stylesheet" href="src/styles.scss" />
     <style>
       /* Suppress custom element until styles are loaded */
       cds-data-table:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/index.html
@@ -12,7 +12,9 @@ LICENSE file in the root directory of this source tree.
     <title>carbon-web-components example</title>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-    <style>
+   
+    <link rel="stylesheet" href="src/styles.scss" />
+   <style>
       /* Suppress custom element until styles are loaded */
       cds-table:not(:defined) {
         display: none;

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/data-table/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  
-  <link rel="stylesheet" href="src/styles.scss" /> 
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-date-picker:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" /> 
   <style>
     /* Suppress custom element until styles are loaded */
     cds-date-picker:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" /> 
   <style>
     /* Suppress custom element until styles are loaded */
     cds-date-picker:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/date-picker/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/dropdown/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/dropdown/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/dropdown/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/dropdown/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/dropdown/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/dropdown/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  
-  <link rel="stylesheet" href="src/styles.scss" />  
+      
   <style>
     /* Suppress custom element until styles are loaded */
     cds-file-uploader:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />  
   <style>
     /* Suppress custom element until styles are loaded */
     cds-file-uploader:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-file-uploader:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/file-uploader/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-icon-button:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-icon-button:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-button:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/form-group/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-icon-button:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-icon-button:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-button:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/icon-button/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+        
   <style>
     /* Suppress custom element until styles are loaded */
     cds-inline-loading:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-inline-loading:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+   <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-inline-loading:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/inline-loading/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/input/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/input/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/input/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/input/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" /> 
   <style>
     /* Suppress custom element until styles are loaded */
     cds-form-item:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/input/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/input/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" /> 
+    
   <style>
     /* Suppress custom element until styles are loaded */
     cds-form-item:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/input/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/input/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-form:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/input/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/input/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/input/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/input/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/layer/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/layer/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/layer/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/layer/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     .example-layer-test-component {
       padding: 1rem;

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/layer/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/layer/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     .example-layer-test-component {
       padding: 1rem;

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/layer/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/layer/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     .example-layer-test-component {
       padding: 1rem;

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/layer/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/layer/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/layer/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/layer/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/link/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/link/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/link/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/link/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-link:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/link/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/link/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-link:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/link/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/link/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-link:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/link/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/link/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/link/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/link/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/list/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/list/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/list/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/list/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-ordered-list:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/list/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/list/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-ordered-list:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/list/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/list/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-ordered-list:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/list/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/list/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/list/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/list/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/loading/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/loading/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/loading/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/loading/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-loading:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/loading/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/loading/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-loading:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/loading/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/loading/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-loading:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/loading/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/loading/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/loading/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/loading/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/modal/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/modal/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/modal/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/modal/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-modal:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/modal/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/modal/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-modal:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/modal/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/modal/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-modal:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/modal/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/modal/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/modal/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/modal/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-multi-select:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-multi-select:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-multi-select:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/multi-select/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/notification/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/notification/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/notification/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/notification/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-inline-notification:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/notification/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/notification/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-inline-notification:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/notification/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/notification/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-inline-notification:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/notification/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/notification/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/notification/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/notification/src/styles.scss
@@ -1,0 +1,12 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+@use '@carbon/styles/scss/components/notification/tokens' as notification-tokens;
+@include theme.add-component-tokens(notification-tokens.$notification-tokens);
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-number-input:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-number-input:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/index.html
@@ -13,7 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <style>
+  <link rel="stylesheet" href="src/styles.scss" />
+<style>
     /* Suppress custom element until styles are loaded */
     cds-number-input:not(:defined) {
       display: none;

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/number-input/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-overflow-menu:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-overflow-menu:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-overflow-menu:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/overflow-menu/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-pagination:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-pagination:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-pagination:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/pagination/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/popover/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/popover/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/popover/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/popover/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-pagination:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/popover/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/popover/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-pagination:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/popover/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/popover/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-pagination:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/popover/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/popover/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/popover/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/popover/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-progress-bar:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-progress-bar:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-progress-bar:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-bar/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-progress-indicator:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-progress-indicator:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-progress-indicator:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/progress-indicator/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-radio-button-group:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-radio-button-group:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-radio-button-group:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/radio-button/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/search/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/search/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/search/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/search/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-search:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/search/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/search/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-search:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/search/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/search/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-search:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/search/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/search/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/search/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/search/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/select/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/select/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/select/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/select/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-select:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/select/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/select/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-select:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/select/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/select/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-select:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/select/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/select/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/select/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/select/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-skeleton-placeholder:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-skeleton-placeholder:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-skeleton-placeholder:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-placeholder/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-skeleton-text:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+
   <style>
     /* Suppress custom element until styles are loaded */
     cds-skeleton-text:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/index.html
@@ -13,7 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <style>
+  <link rel="stylesheet" href="src/styles.scss" />
+ <style>
     /* Suppress custom element until styles are loaded */
     cds-skeleton-text:not(:defined) {
       display: none;

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skeleton-text/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-skip-to-content:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-skip-to-content:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-skip-to-content:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/skip-to-content/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/slider/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/slider/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/slider/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/slider/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-slider:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/slider/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/slider/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-slider:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/slider/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/slider/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-slider:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/slider/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/slider/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/slider/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/slider/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/stack/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/stack/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/stack/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/stack/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/stack.min.js"></script>
 </head>
 <body>

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/stack/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/stack/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/stack.min.js"></script>
 </head>
 <body>

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/stack/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/stack/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <style>
-  </style>
+  <link rel="stylesheet" href="src/styles.scss" />
   <script type="module" src="src/index.js"></script>
 </head>
 <body>

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/stack/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/stack/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/stack/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/stack/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-structured-list:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  
-  <link rel="stylesheet" href="src/styles.scss" />
+ 
   <style>
     /* Suppress custom element until styles are loaded */
     cds-structured-list:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/index.html
@@ -13,7 +13,9 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <style>
+ 
+  <link rel="stylesheet" href="src/styles.scss" />
+ <style>
     /* Suppress custom element until styles are loaded */
     cds-structured-list:not(:defined) {
       display: none;

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/structured-list/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  
-  <link rel="stylesheet" href="src/styles.scss" />
+    
   <style>
     /* Suppress custom element until styles are loaded */
     cds-tabs:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-tabs:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-tabs:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tabs/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tag/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tag/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tag/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tag/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-tag:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tag/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tag/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-tag:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tag/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tag/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-tag:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tag/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tag/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tag/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tag/src/styles.scss
@@ -1,0 +1,12 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+@use '@carbon/styles/scss/components/tag/tokens' as tag-tokens;
+@include theme.add-component-tokens(tag-tokens.$tag-tokens);
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-textarea:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-textarea:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+ 
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-textarea:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/textarea/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tile/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tile/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tile/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tile/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
  
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-clickable-tile:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tile/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tile/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+ 
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-clickable-tile:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tile/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tile/index.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-clickable-tile:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tile/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tile/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tile/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tile/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/cdn.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-toggle:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/cdn.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-toggle:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-toggle:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/toggle/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  
-  <link rel="stylesheet" href="src/styles.scss" />
+   
   <style>
     /* Suppress custom element until styles are loaded */
     cds-tooltip:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-tooltip:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-tooltip:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tooltip/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/cdn.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-header:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/cdn.html
@@ -14,7 +14,6 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   
-  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-header:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/index.html
@@ -13,6 +13,8 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+ 
+  <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-header:not(:defined) {

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/package.json
@@ -11,7 +11,9 @@
     "start": "parcel index.html --port=9000 --no-hmr"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/ui-shell/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/index.html
@@ -11,6 +11,7 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>carbon-web-components example</title>
     <meta charset="UTF-8" />
+    <link rel="stylesheet" href="src/styles.scss" />
     <style type="text/css">
       body {
         font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;

--- a/packages/carbon-web-components/examples/codesandbox/basic/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/package.json
@@ -8,7 +8,9 @@
     "start": "webpack serve"
   },
   "dependencies": {
-    "@carbon/web-components": "latest"
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
   },
   "devDependencies": {
     "html-webpack-plugin": "^4.5.0",

--- a/packages/carbon-web-components/examples/codesandbox/basic/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/src/styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/package.json
+++ b/packages/carbon-web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/web-components",
-  "version": "2.0.0-rc.7",
+  "version": "2.0.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### Related Ticket(s)

Closes # {{Provide issue number link(s) to the related ticket(s) that this pull request addresses}}

### Description

CWC v2 components need token values set by the theming package. This means adopters need to utilize and set a carbon theme for the proper token values to be applied to components. This PR updates the codesandboxes to use the carbon theme.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
