### PR TITLE
fix(content-item-horizontal): fix media overflow on mobile

### DIFF
--- a/packages/styles/scss/components/content-item-horizontal-media/_content-item-horizontal-media.scss
+++ b/packages/styles/scss/components/content-item-horizontal-media/_content-item-horizontal-media.scss
@@ -164,7 +164,10 @@
     }
 
     ::slotted([slot='media']) {
-      grid-column: 1 / span 12;
+      grid-column: 1 / span 4;
+      @include carbon--breakpoint(lg) {
+        grid-column: 1 / span 12;
+      }
     }
     ::slotted(#{$dds-prefix}-image) {
       max-width: none;


### PR DESCRIPTION
### Related Ticket(s)

Closes #10841

### Description

The Content Item horizontal component with featured media displayed an overflow of its media on mobile (really any breakpoint below large). This was due to the media being set to span 12 cols on larger screens, when the grid is actually 12 cols wide, but then on smaller screens the grid is 4 cols. The media was updated to span 4 cols to match its grid on screens smaller than "lg".

### Changelog

**Changed**

- updates the styles package for Content Item Horizontal Featured Media to set media's column span to match its grid.
