### PR TITLE
fix(code-snippet): tooltip-content prop and migration docs

### DIFF
--- a/docs/cwc-v2-migration.md
+++ b/docs/cwc-v2-migration.md
@@ -39,13 +39,16 @@ For Carbon v11 migration guidance, see their
 | multi-select              | View changes [here](#multi-select)       |
 | notification              | View changes [here](#notification)       |
 | number-input              | View changes [here](#number-input)       |
+| ordered-list              | No API changes.                          |
 | overflow-menu             | View changes [here](#overflow-menu)      |
 | pagination                | View changes [here](#pagination)         |
+| popover                   | New component in v2.                     |
 | progress-bar              | New component in v2.                     |
 | progress-indicator        | View changes [here](#progress-indicator) |
 | radio-button              | View changes [here](#radio-button)       |
 | search                    | View changes [here](#search)             |
 | select                    | View changes [here](#select)             |
+| skeleton-placeholder      | No API changes.                          |
 | skeleton-text             | View changes [here](#skeleton-text)      |
 | slider                    | View changes [here](#slider)             |
 | stack                     | New component in v2.                     |
@@ -59,6 +62,7 @@ For Carbon v11 migration guidance, see their
 | toggletip                 | New component in v2.                     |
 | tooltip                   | View changes [here](#tooltip)            |
 | ui-shell                  | View changes [here](#ui-shell)           |
+| unordered-list            | No API changes.                          |
 
 ### accordion
 

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet-story.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet-story.ts
@@ -16,8 +16,8 @@ import './index';
 
 export const inline = () => {
   return html`
-    <cds-code-snippet type="inline"
-      >node -v<span slot="button-description">Copy to clipboard</span>
+    <cds-code-snippet type="inline" tooltip-content="Copy to Clipboard"
+      >node -v
     </cds-code-snippet>
   `;
 };
@@ -25,8 +25,8 @@ export const inline = () => {
 export const inlineWithLayer = () => {
   return html`
     <sb-template-layers>
-      <cds-code-snippet type="inline"
-        >node -v<span slot="button-description">Copy to clipboard</span>
+      <cds-code-snippet type="inline" tooltip-content="Copy to Clipboard"
+        >node -v
       </cds-code-snippet>
     </sb-template-layers>
   `;

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -367,7 +367,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
       return html`
         <cds-copy button-class-name="${classes}" @click="${handleCopyClick}">
           <code slot="icon"><slot></slot></code>
-          <span slot="tooltip-content"><slot name="button-description"></slot> </span>
+          <span slot="tooltip-content">${tooltipContent}</span>
         </cds-copy>
       `;
     }


### PR DESCRIPTION
### Related Ticket(s)

Closes #10839 
Closes #10733

### Description

fix tooltip-content for inline codesnippet, so adopters can just use the property 

Also updated migration docs



<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
