### PR TITLE
fix(storybook): header theme

### DIFF
--- a/packages/carbon-web-components/.storybook/manager.js
+++ b/packages/carbon-web-components/.storybook/manager.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright IBM Corp. 2020, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { addons } from '@storybook/addons';
+import yourTheme from './theme';
+
+addons.setConfig({
+  theme: yourTheme,
+});

--- a/packages/carbon-web-components/.storybook/preview.js
+++ b/packages/carbon-web-components/.storybook/preview.js
@@ -150,7 +150,7 @@ export const parameters = {
 export const decorators = [
   function decoratorContainer(story, context) {
     const result = story();
-    const { hasMainTag } = result as any;
+    const { hasMainTag } = result;
     const { theme } = context.globals;
 
     document.documentElement.setAttribute('storybook-carbon-theme', theme);

--- a/packages/carbon-web-components/.storybook/theme.js
+++ b/packages/carbon-web-components/.storybook/theme.js
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { create, ThemeVars } from '@storybook/theming';
+import { create } from '@storybook/theming';
 import { version } from '../package.json';
 
 export default create({
@@ -18,4 +18,4 @@ export default create({
   brandTitle: `@carbon/web-components ${version}`,
   brandUrl:
     'https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/carbon-web-components',
-} as ThemeVars);
+});


### PR DESCRIPTION
### Related Ticket(s)

none
### Description

updates cwc storybook v2 so it shows the correct version at the top header
<img width="230" alt="Screenshot 2023-08-24 at 10 42 25 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/20210594/f37fcd32-b1fe-463c-8237-5069a464002c">

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
