### PR TITLE
fix(lightbox-video-player): use more reliable reference to video player

### DIFF
--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.react.tsx
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -77,67 +77,119 @@ const textCTAContent = (
   </DDSTextCTA>
 );
 
-const imageContent = <DDSCardCTAImage slot="image" alt="Image alt text" defaultSrc={imgXlg4x3} />;
+const imageContent = (
+  <DDSCardCTAImage slot="image" alt="Image alt text" defaultSrc={imgXlg4x3} />
+);
 
-const cardsDiffLengthPhrase = (index, tagGroup, media, gridMode, cardType, addCta) => {
+const cardsDiffLengthPhrase = (
+  index,
+  tagGroup,
+  media,
+  gridMode,
+  cardType,
+  addCta
+) => {
   const defaultCardGroupItem = (
     <DDSCardGroupItem
       cta-type={cardType === 'Card static' ? '' : 'local'}
       href={cardType === 'Card static' ? '' : 'https://example.com'}
-      colorScheme={cardType === 'Card static' || gridMode === 'border' ? 'light' : null}>
+      colorScheme={
+        cardType === 'Card static' || gridMode === 'border' ? 'light' : null
+      }>
       {media ? imageContent : ''}
       <DDSCardEyebrow>Topic</DDSCardEyebrow>
-      <DDSCardHeading>{index < 5 ? phraseArray[index] : 'Lorem ipsum dolor sit amet'}</DDSCardHeading>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.'</p>
+      <DDSCardHeading>
+        {index < 5 ? phraseArray[index] : 'Lorem ipsum dolor sit amet'}
+      </DDSCardHeading>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
+        ultricies est.'
+      </p>
       {tagGroup ? tagGroupContent : ''}
-      {cardType === 'Card static' && addCta ? textCTAContent : <DDSCardCTAFooter slot="footer"></DDSCardCTAFooter>}
+      {cardType === 'Card static' && addCta ? (
+        textCTAContent
+      ) : (
+        <DDSCardCTAFooter slot="footer"></DDSCardCTAFooter>
+      )}
     </DDSCardGroupItem>
   );
 
-  const videoCardGroupItem = (
-    <DDSCardGroupItem cta-type="video" href="1_9h94wo6b" color-scheme={gridMode === 'border' ? 'light' : null}>
+  const videoCardGroupItem = (videoId = '1_9h94wo6b') => (
+    <DDSCardGroupItem
+      cta-type="video"
+      href={videoId}
+      color-scheme={gridMode === 'border' ? 'light' : null}>
       <DDSCardEyebrow>Topic</DDSCardEyebrow>
       {tagGroup ? tagGroupContent : ''}
-      <DDSCardCTAFooter cta-type="video" href="1_9h94wo6b" slot="footer"></DDSCardCTAFooter>
+      <DDSCardCTAFooter
+        cta-type="video"
+        href={videoId}
+        slot="footer"></DDSCardCTAFooter>
     </DDSCardGroupItem>
   );
 
+  const demoVideoIds = ['1_9h94wo6b', '0_ibuqxqbe', '1_6b6qjovy'];
+
   count = count > 3 ? 0 : count + 1;
-  return media && index % 2 ? videoCardGroupItem : defaultCardGroupItem;
+  return media && index % 2
+    ? videoCardGroupItem(demoVideoIds[index % 3])
+    : defaultCardGroupItem;
 };
 
-const longHeadingCardGroupItem = (tagGroup, media, gridMode, cardType, addCta) => {
+const longHeadingCardGroupItem = (
+  tagGroup,
+  media,
+  gridMode,
+  cardType,
+  addCta
+) => {
   return (
     <DDSCardGroupItem
       cta-type={cardType === 'Card static' ? '' : 'local'}
       href={cardType === 'Card static' ? '' : 'https://example.com'}
-      colorScheme={cardType === 'Card static' || gridMode === 'border' ? 'light' : null}>
+      colorScheme={
+        cardType === 'Card static' || gridMode === 'border' ? 'light' : null
+      }>
       {media ? imageContent : ''}
       <DDSCardEyebrow>Topic</DDSCardEyebrow>
-      <DDSCardHeading>Nunc convallis lobortis Nunc convallis lobortis Nunc convallis lobortis</DDSCardHeading>
+      <DDSCardHeading>
+        Nunc convallis lobortis Nunc convallis lobortis Nunc convallis lobortis
+      </DDSCardHeading>
       <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-        Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
+        ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at
+        elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
       {tagGroup ? tagGroupContent : ''}
-      {cardType === 'Card static' && addCta ? textCTAContent : <DDSCardCTAFooter slot="footer"></DDSCardCTAFooter>}
+      {cardType === 'Card static' && addCta ? (
+        textCTAContent
+      ) : (
+        <DDSCardCTAFooter slot="footer"></DDSCardCTAFooter>
+      )}
     </DDSCardGroupItem>
   );
 };
 
-const pictogramCard = gridMode => (
-  <DDSCardGroupItem href="https://example.com" pictogramPlacement="top" colorScheme={gridMode === 'border' ? 'light' : null}>
+const pictogramCard = (gridMode) => (
+  <DDSCardGroupItem
+    href="https://example.com"
+    pictogramPlacement="top"
+    colorScheme={gridMode === 'border' ? 'light' : null}>
     <DDSCardHeading>Aerospace and defence</DDSCardHeading>
     <p>
-      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Ut enim ad minim
-      veniam, quis nostrud exercitation.
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Ut enim ad minim veniam, quis nostrud
+      exercitation.
     </p>
     <Desktop slot="pictogram" width="48" height="48" />
   </DDSCardGroupItem>
 );
 
 const cardLink = (
-  <DDSCardGroupCardLinkItem cta-type="local" href="https://example.com" pattern-background>
+  <DDSCardGroupCardLinkItem
+    cta-type="local"
+    href="https://example.com"
+    pattern-background>
     <DDSCardLinkHeading>IBM Developer</DDSCardLinkHeading>
     <p>Learn, code and connect with your community</p>
     <DDSCardCTAFooter slot="footer"></DDSCardCTAFooter>
@@ -149,15 +201,24 @@ const emptyCard = <DDSCardGroupItem empty></DDSCardGroupItem>;
 const cardInCardItems = (i, tagGroup, media, gridMode) => {
   if (media) {
     return i % 2 === 0 ? (
-      <DDSCardGroupItem cta-type="local" href="https://example.com" colorScheme={gridMode === 'border' ? 'light' : null}>
+      <DDSCardGroupItem
+        cta-type="local"
+        href="https://example.com"
+        colorScheme={gridMode === 'border' ? 'light' : null}>
         {imageContent}
         <DDSCardEyebrow>Label</DDSCardEyebrow>
-        <DDSCardHeading>The United Nations Environment Program works with IBM to reduce marine litter</DDSCardHeading>
+        <DDSCardHeading>
+          The United Nations Environment Program works with IBM to reduce marine
+          litter
+        </DDSCardHeading>
         {tagGroup ? tagGroupContent : ''}
         <DDSCardCTAFooter slot="footer" />
       </DDSCardGroupItem>
     ) : (
-      <DDSCardGroupItem cta-type="video" href="1_9h94wo6b" colorScheme={gridMode === 'border' ? 'light' : null}>
+      <DDSCardGroupItem
+        cta-type="video"
+        href="1_9h94wo6b"
+        colorScheme={gridMode === 'border' ? 'light' : null}>
         <DDSCardEyebrow>Topic</DDSCardEyebrow>
         {tagGroup ? tagGroupContent : ''}
         <DDSCardCTAFooter cta-type="video" slot="footer" href="1_9h94wo6b" />
@@ -165,17 +226,33 @@ const cardInCardItems = (i, tagGroup, media, gridMode) => {
     );
   }
   return (
-    <DDSCardGroupItem cta-type="local" href="https://example.com" colorScheme={gridMode === 'border' ? 'light' : null}>
+    <DDSCardGroupItem
+      cta-type="local"
+      href="https://example.com"
+      colorScheme={gridMode === 'border' ? 'light' : null}>
       <DDSCardEyebrow>Label</DDSCardEyebrow>
-      <DDSCardHeading>The United Nations Environment Program works with IBM to reduce marine litter</DDSCardHeading>
+      <DDSCardHeading>
+        The United Nations Environment Program works with IBM to reduce marine
+        litter
+      </DDSCardHeading>
       {tagGroup ? tagGroupContent : ''}
       <DDSCardCTAFooter slot="footer" />
     </DDSCardGroupItem>
   );
 };
 
-export const Default = args => {
-  const { cards, cardType, media, tagGroup, cardsPerRow, gridMode, offset, cta, addCta } = args?.CardGroup ?? {};
+export const Default = (args) => {
+  const {
+    cards,
+    cardType,
+    media,
+    tagGroup,
+    cardsPerRow,
+    gridMode,
+    offset,
+    cta,
+    addCta,
+  } = args?.CardGroup ?? {};
 
   const allCards: object[] = [];
 
@@ -184,15 +261,24 @@ export const Default = args => {
   }
 
   if (cardType === 'Card - default') {
-    allCards.push(longHeadingCardGroupItem(tagGroup, media, gridMode, cardType, addCta));
+    allCards.push(
+      longHeadingCardGroupItem(tagGroup, media, gridMode, cardType, addCta)
+    );
     for (let i = 1; i < cards; i++) {
-      allCards.push(cardsDiffLengthPhrase(i, tagGroup, media, gridMode, cardType, addCta));
+      allCards.push(
+        cardsDiffLengthPhrase(i, tagGroup, media, gridMode, cardType, addCta)
+      );
     }
     if (cta) {
       allCards.push(
-        <DDSCardGroupItem cta-type="local" href="https://example.com" colorScheme="inverse">
+        <DDSCardGroupItem
+          cta-type="local"
+          href="https://example.com"
+          colorScheme="inverse">
           <DDSCardHeading>Top level card link</DDSCardHeading>
-          <DDSCardCTAFooter slot="footer" color-scheme="inverse"></DDSCardCTAFooter>
+          <DDSCardCTAFooter
+            slot="footer"
+            color-scheme="inverse"></DDSCardCTAFooter>
         </DDSCardGroupItem>
       );
     }
@@ -205,13 +291,20 @@ export const Default = args => {
   }
 
   if (cardType === 'Card static') {
-    allCards.push(longHeadingCardGroupItem(tagGroup, media, gridMode, cardType, addCta));
+    allCards.push(
+      longHeadingCardGroupItem(tagGroup, media, gridMode, cardType, addCta)
+    );
     for (let i = 1; i < cards; i++) {
-      allCards.push(cardsDiffLengthPhrase(i, tagGroup, media, gridMode, cardType, addCta));
+      allCards.push(
+        cardsDiffLengthPhrase(i, tagGroup, media, gridMode, cardType, addCta)
+      );
     }
     if (cta) {
       allCards.push(
-        <DDSCardGroupItem cta-type="local" href="https://example.com" colorScheme="inverse">
+        <DDSCardGroupItem
+          cta-type="local"
+          href="https://example.com"
+          colorScheme="inverse">
           <DDSCardHeading>Top level card link</DDSCardHeading>
           <DDSCardCTAFooter slot="footer" colorScheme="inverse" />
         </DDSCardGroupItem>
@@ -248,11 +341,22 @@ Default.story = {
           ['Card - default', 'Card - pictogram', 'Card static', 'Card link'],
           'Card - default'
         );
-        const media = cardType === 'Card - default' || cardType === 'Card static' ? boolean('Add media:', false) : '';
-        const tagGroup = cardType === 'Card - default' || cardType === 'Card static' ? boolean('Add tags:', false) : '';
-        const addCta = cardType === 'Card static' ? boolean('Add CTA Links:', false) : '';
+        const media =
+          cardType === 'Card - default' || cardType === 'Card static'
+            ? boolean('Add media:', false)
+            : '';
+        const tagGroup =
+          cardType === 'Card - default' || cardType === 'Card static'
+            ? boolean('Add tags:', false)
+            : '';
+        const addCta =
+          cardType === 'Card static' ? boolean('Add CTA Links:', false) : '';
         const cards = number('Number of cards:', 5, { min: 2, max: 6 });
-        const cardsPerRow = select('Cards per row:', cardsCol, cardsCol['3 cards per row (default)']);
+        const cardsPerRow = select(
+          'Cards per row:',
+          cardsCol,
+          cardsCol['3 cards per row (default)']
+        );
         const gridMode =
           cardType === 'Card static' || cardType === 'Card link'
             ? ''
@@ -275,7 +379,7 @@ Default.story = {
   },
 };
 
-export const withCardInCard = args => {
+export const withCardInCard = (args) => {
   const { cards, tagGroup, media, gridMode } = args?.CardGroup ?? {};
   const allCards: object[] = [];
   for (let i = 0; i < cards; i++) {
@@ -283,14 +387,21 @@ export const withCardInCard = args => {
   }
   return (
     <>
-      <DDSCardInCard href="https://example.com" grid-mode={gridMode || undefined}>
-        <DDSCardInCardImage slot="image" alt="Image alt text" defaultSrc={imgSm4x3}>
+      <DDSCardInCard
+        href="https://example.com"
+        grid-mode={gridMode || undefined}>
+        <DDSCardInCardImage
+          slot="image"
+          alt="Image alt text"
+          defaultSrc={imgSm4x3}>
           <DDSImageItem media="(min-width: 1312px)" srcset={imgXlg16x9} />
           <DDSImageItem media="(min-width: 672px)" srcset={imgMd16x9} />
           <DDSImageItem media="(min-width: 320px)" srcset={imgSm4x3} />
         </DDSCardInCardImage>
         <DDSCardEyebrow>Label</DDSCardEyebrow>
-        <DDSCardHeading>Standard Bank Group prepares to embrace Africa’s AI opportunity</DDSCardHeading>
+        <DDSCardHeading>
+          Standard Bank Group prepares to embrace Africa’s AI opportunity
+        </DDSCardHeading>
         <DDSCardCTAFooter></DDSCardCTAFooter>
       </DDSCardInCard>
       <DDSCardGroup gridMode={gridMode || undefined}>{allCards}</DDSCardGroup>
@@ -317,7 +428,7 @@ withCardInCard.story = {
 export default {
   title: 'Components/Card group',
   decorators: [
-    story => {
+    (story) => {
       return (
         <>
           <style type="text/css">{styles.cssText}</style>

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -410,16 +410,12 @@ withCardInCard.story = {
 };
 
 export const withMultipleVideos = (args) => {
-  const { gridMode, tagGroup, cards: cardCount } = args?.CardGroup ?? {};
+  const { cards: cardCount } = args?.CardGroup ?? {};
 
   const videoCardGroupItem = (videoId = '1_9h94wo6b') =>
     html`
-      <dds-card-group-item
-        cta-type="video"
-        href="${videoId}"
-        color-scheme=${gridMode === 'border' ? 'light' : null}>
+      <dds-card-group-item cta-type="video" href="${videoId}">
         <dds-card-eyebrow>Topic</dds-card-eyebrow>
-        ${tagGroup ? tagGroupContent : ''}
         <dds-card-cta-footer cta-type="video" slot="footer" href="1_9h94wo6b">
         </dds-card-cta-footer>
       </dds-card-group-item>
@@ -432,11 +428,7 @@ export const withMultipleVideos = (args) => {
     cards.push(videoCardGroupItem(demoVideoIds[i % 3]));
   }
 
-  return html`
-    <dds-card-group grid-mode="${ifNonNull(gridMode)}">
-      ${cards}
-    </dds-card-group>
-  `;
+  return html` <dds-card-group> ${cards} </dds-card-group> `;
 };
 
 withMultipleVideos.story = {

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -12,7 +12,7 @@ import '../../card/index';
 import '../../card-in-card/index';
 import '../index';
 import '../../cta/video-cta-container';
-import { html, TemplateResult } from 'lit-element';
+import { html } from 'lit-element';
 import { select, number, boolean } from '@storybook/addon-knobs';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 // eslint-disable-next-line sort-imports
@@ -104,10 +104,10 @@ const cardsDiffLengthPhrase = (
     </dds-card-group-item>
   `;
 
-  const videoCardGroupItem = html`
+  const videoCardGroupItem = (videoId = '1_9h94wo6b') => html`
     <dds-card-group-item
       cta-type="video"
-      href="1_9h94wo6b"
+      href="${videoId}"
       color-scheme=${gridMode === 'border' ? 'light' : null}>
       <dds-card-eyebrow>Topic</dds-card-eyebrow>
       ${tagGroup ? tagGroupContent : ''}
@@ -116,8 +116,12 @@ const cardsDiffLengthPhrase = (
     </dds-card-group-item>
   `;
 
+  const demoVideoIds = ['1_9h94wo6b', '0_ibuqxqbe', '1_6b6qjovy'];
+
   count = count > 3 ? 0 : count + 1;
-  return media && index % 2 ? videoCardGroupItem : defaultCardGroupItem;
+  return media && index % 2
+    ? videoCardGroupItem(demoVideoIds[index % 3])
+    : defaultCardGroupItem;
 };
 
 const longHeadingCardGroupItem = (
@@ -402,48 +406,6 @@ withCardInCard.story = {
           media: false,
           tagGroup: false,
           gridMode: 'narrow',
-          cards: 5,
-        },
-      },
-    },
-  },
-};
-
-export const withMultipleVideos = (args) => {
-  const { cards: cardCount } = args?.CardGroup ?? {};
-
-  const videoCardGroupItem = (videoId = '1_9h94wo6b') =>
-    html`
-      <dds-card-group-item cta-type="video" href="${videoId}">
-        <dds-card-eyebrow>Topic</dds-card-eyebrow>
-        <dds-card-cta-footer cta-type="video" slot="footer" href="1_9h94wo6b">
-        </dds-card-cta-footer>
-      </dds-card-group-item>
-    `;
-
-  const demoVideoIds = ['1_9h94wo6b', '0_ibuqxqbe', '1_6b6qjovy'];
-
-  const cards: TemplateResult[] = [];
-  for (let i = 0; i < cardCount; i++) {
-    cards.push(videoCardGroupItem(demoVideoIds[i % 3]));
-  }
-
-  return html` <dds-card-group> ${cards} </dds-card-group> `;
-};
-
-withMultipleVideos.story = {
-  name: 'With multiple videos',
-  parameters: {
-    ...readme.parameters,
-    hasStoryPadding: true,
-    knobs: {
-      CardGroup: () => ({
-        cards: number('Number of cards', 5, { min: 2, max: 6 }),
-      }),
-    },
-    propsSet: {
-      default: {
-        CardGroup: {
           cards: 5,
         },
       },

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -12,7 +12,7 @@ import '../../card/index';
 import '../../card-in-card/index';
 import '../index';
 import '../../cta/video-cta-container';
-import { html } from 'lit-element';
+import { html, TemplateResult } from 'lit-element';
 import { select, number, boolean } from '@storybook/addon-knobs';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 // eslint-disable-next-line sort-imports
@@ -402,6 +402,56 @@ withCardInCard.story = {
           media: false,
           tagGroup: false,
           gridMode: 'narrow',
+          cards: 5,
+        },
+      },
+    },
+  },
+};
+
+export const withMultipleVideos = (args) => {
+  const { gridMode, tagGroup, cards: cardCount } = args?.CardGroup ?? {};
+
+  const videoCardGroupItem = (videoId = '1_9h94wo6b') =>
+    html`
+      <dds-card-group-item
+        cta-type="video"
+        href="${videoId}"
+        color-scheme=${gridMode === 'border' ? 'light' : null}>
+        <dds-card-eyebrow>Topic</dds-card-eyebrow>
+        ${tagGroup ? tagGroupContent : ''}
+        <dds-card-cta-footer cta-type="video" slot="footer" href="1_9h94wo6b">
+        </dds-card-cta-footer>
+      </dds-card-group-item>
+    `;
+
+  const demoVideoIds = ['1_9h94wo6b', '0_ibuqxqbe', '1_6b6qjovy'];
+
+  const cards: TemplateResult[] = [];
+  for (let i = 0; i < cardCount; i++) {
+    cards.push(videoCardGroupItem(demoVideoIds[i % 3]));
+  }
+
+  return html`
+    <dds-card-group grid-mode="${ifNonNull(gridMode)}">
+      ${cards}
+    </dds-card-group>
+  `;
+};
+
+withMultipleVideos.story = {
+  name: 'With multiple videos',
+  parameters: {
+    ...readme.parameters,
+    hasStoryPadding: true,
+    knobs: {
+      CardGroup: () => ({
+        cards: number('Number of cards', 5, { min: 2, max: 6 }),
+      }),
+    },
+    propsSet: {
+      default: {
+        CardGroup: {
           cards: 5,
         },
       },

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
@@ -46,7 +46,8 @@ class DDSLightboxVideoPlayerComposite extends ModalRenderMixin(
    * Handles aria state depending on the modal's state.
    */
   private _handleAriaAndHiddenState = () => {
-    const iFrame = this._videoPlayer?.querySelector('iframe');
+    const { _videoPlayer: videoPlayer } = this;
+    const iFrame = videoPlayer?.querySelector('iframe');
 
     // Handles edge case where screen reader still reads video title within iFrame
     try {
@@ -69,9 +70,7 @@ class DDSLightboxVideoPlayerComposite extends ModalRenderMixin(
       .constructor as typeof DDSLightboxVideoPlayerComposite;
 
     const elems = Array.prototype.slice.call(
-      document
-        .querySelector('dds-lightbox-video-player')
-        ?.querySelectorAll(selectorEmbeddedVideoContainer)
+      videoPlayer?.querySelectorAll(selectorEmbeddedVideoContainer)
     );
 
     elems.forEach((element) => {


### PR DESCRIPTION
### Related Ticket(s)

none

### Description

`<dds-video-cta-container>` can handle multiple Kaltura video embed requests within the same modal/lightbox by slotting a `<div>` per video into the same `<dds-lightbox-video-player>`. When the modal is activated by user interaction, the current video ID is sent along, and the `<dds-lightbox-video-player-composite>` sets `hidden` on the `<div>`s that don't have a matching ID. This works great when there is only one `<dds-video-cta-container>`.

The problems start when multiple video containers are used throughout the document. Each creates some number modal render root elements depending on the structure of the content, and the lightbox composite uses `document.querySelector('dds-lightbox-video-player')` to find the video player when trying to hide embedded Kaltura videos that are not active. As we know, `querySelector` returns the first matching element, and since we've established there may be multiple of these video players in various modal render roots, sometimes it found the wrong one and failed to hide non-active videos.

Luckily, the fix was pretty simple. Lightbox composites already have an internal reference to their video player, so I swapped out the document query to use that reference, which _should_ guarantee the composite is looking in the right place when hiding inactive videos.

### Changelog

**Changed**

- Ensure `<dds-lightbox-video-player-composite>` hides inactive videos by using an internal reference to modal's video player instead of querying for it from the document root.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
