### PR TITLE
fix(pricing-table):  hide component examples

### DIFF
--- a/packages/web-components/.storybook/manager.js
+++ b/packages/web-components/.storybook/manager.js
@@ -24,7 +24,7 @@ addons.setConfig({
  */
 const getCss = (envVar, cssId) => {
   return envVar !== 'true'
-    ? `button[id^="${cssId}"] { display: none !important; }\n`
+    ? `[id^="${cssId}"] { display: none !important; }\n`
     : '';
 };
 


### PR DESCRIPTION
### Related Ticket(s)

Closes # https://jsw.ibm.com/browse/ADCMS-3666

### Description

PR to fix when viewing the Web Components in the Storybook, the Components list does not display "Pricing Table" as one of the listed components. 

### Changelog


**Changed**
Changed the css selector manager.js to also hide the child elements 



- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
