### PR TITLE
fix(masthead-a11y): navigation role do not have unique labels

### DIFF
--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -89,7 +89,7 @@ const MastheadL1 = ({ navigationL1, ...rest }) => {
           <HeaderNavContainer>
             <HeaderNavigation
               className={`${prefix}--masthead__l1-nav`}
-              aria-label="">
+              aria-label="Main Navigation">
               {mastheadL1Links}
             </HeaderNavigation>
           </HeaderNavContainer>

--- a/packages/web-components/src/components/masthead/top-nav.ts
+++ b/packages/web-components/src/components/masthead/top-nav.ts
@@ -595,7 +595,7 @@ class DDSTopNav extends StableSelectorMixin(HostListenerMixin(BXHeaderNav)) {
                 </div>
                 <div class="${ddsPrefix}-ce--header__nav-content-container">
                   <div class="${prefix}--header__nav-content">
-                    <nav part="nav" class="${prefix}--header__nav">
+                    <nav part="nav" class="${prefix}--header__nav" aria-label="Main Navigation">
                       <div class="${prefix}--sub-content-left"></div>
                       <div
                         part="menubar"


### PR DESCRIPTION
### Related Ticket(s)

Closes #9680

### Description

Multiple elements with navigation role do not have unique labels

### Changelog

**New**

- Added aria-label to nav in Masthead L1 for both react and web components 


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
