### PR TITLE
fix(prefix): change styles prefix to `c4d`

### DIFF
--- a/packages/styles/scss/components/back-to-top/_back-to-top.scss
+++ b/packages/styles/scss/components/back-to-top/_back-to-top.scss
@@ -13,7 +13,7 @@
 @use '@carbon/styles/scss/components/button' as *;
 
 @mixin back-to-top {
-  :host(#{$cds-prefix}-back-to-top) {
+  :host(#{$c4d-prefix}-back-to-top) {
     position: sticky;
     bottom: 0;
     display: flex;
@@ -44,7 +44,7 @@
   }
 
   @media print {
-    :host(#{$cds-prefix}-back-to-top) {
+    :host(#{$c4d-prefix}-back-to-top) {
       display: none;
     }
   }

--- a/packages/styles/scss/components/background-media/_background-media.scss
+++ b/packages/styles/scss/components/background-media/_background-media.scss
@@ -15,7 +15,7 @@
 @use '../image';
 
 @mixin background-media {
-  :host(#{$cds-prefix}-background-media) {
+  :host(#{$c4d-prefix}-background-media) {
     position: relative;
     height: 100%;
     display: block;

--- a/packages/styles/scss/components/button-group/_button-group.scss
+++ b/packages/styles/scss/components/button-group/_button-group.scss
@@ -18,9 +18,9 @@
   @include button;
 
   .#{$prefix}--button-group,
-  :host(#{$cds-prefix}-button-group),
-  :host(#{$cds-prefix}-leadspace-block-cta) {
-    --#{$cds-prefix}--button-group--item-count: 3;
+  :host(#{$c4d-prefix}-button-group),
+  :host(#{$c4d-prefix}-leadspace-block-cta) {
+    --#{$c4d-prefix}--button-group--item-count: 3;
 
     display: grid;
     grid-template-columns: 1fr;
@@ -30,7 +30,7 @@
     @include breakpoint(md) {
       display: inline-grid;
       grid-template-columns: repeat(
-        var(--#{$cds-prefix}--button-group--item-count),
+        var(--#{$c4d-prefix}--button-group--item-count),
         1fr
       );
     }
@@ -41,8 +41,8 @@
   }
 
   .#{$prefix}--button-group-item,
-  :host(#{$cds-prefix}-button-group-item),
-  :host(#{$cds-prefix}-button-cta) {
+  :host(#{$c4d-prefix}-button-group-item),
+  :host(#{$c4d-prefix}-button-cta) {
     max-width: 100%;
     min-width: 0;
 
@@ -100,7 +100,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-button-group-item) {
+  :host(#{$c4d-prefix}-button-group-item) {
     ::slotted([slot='icon']) {
       position: absolute;
       right: $spacing-05;

--- a/packages/styles/scss/components/callout-quote/_callout-quote.scss
+++ b/packages/styles/scss/components/callout-quote/_callout-quote.scss
@@ -16,7 +16,7 @@
 
 @mixin callout-quote {
   .#{$prefix}--callout-quote,
-  :host(#{$cds-prefix}-callout-quote) {
+  :host(#{$c4d-prefix}-callout-quote) {
     .#{$prefix}--quote {
       background-color: $background-inverse;
       .#{$prefix}--link {
@@ -39,7 +39,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-callout-quote) {
+  :host(#{$c4d-prefix}-callout-quote) {
     @extend .#{$prefix}--callout__container;
 
     @include breakpoint(md) {
@@ -48,7 +48,7 @@
 
     padding-bottom: $spacing-10;
 
-    ::slotted(#{$cds-prefix}-callout-link-with-icon) {
+    ::slotted(#{$c4d-prefix}-callout-link-with-icon) {
       padding-left: $spacing-07;
       outline: transparent;
     }

--- a/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
+++ b/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
@@ -18,7 +18,7 @@
 @use '../content-block-simple/content-block-simple';
 
 @mixin callout-with-media {
-  :host(#{$cds-prefix}-callout-with-media),
+  :host(#{$c4d-prefix}-callout-with-media),
   .#{$prefix}--callout-with-media {
     display: block;
     background-color: $background-inverse;
@@ -34,22 +34,22 @@
     }
   }
 
-  :host(#{$cds-prefix}-callout-with-media) ::slotted([slot='heading']),
+  :host(#{$c4d-prefix}-callout-with-media) ::slotted([slot='heading']),
   .#{$prefix}--callout-with-media .#{$prefix}--content-block__heading,
-  :host(#{$cds-prefix}-callout-with-media-copy)
-    ::slotted(#{$cds-prefix}-content-block-paragraph),
+  :host(#{$c4d-prefix}-callout-with-media-copy)
+    ::slotted(#{$c4d-prefix}-content-block-paragraph),
   .#{$prefix}--callout-with-media .#{$prefix}--content-item__copy p,
-  :host(#{$cds-prefix}-callout-with-media-image) .#{$prefix}--image__caption,
-  :host(#{$cds-prefix}-callout-with-media-video)
-    ::slotted(#{$cds-prefix}-video-player),
+  :host(#{$c4d-prefix}-callout-with-media-image) .#{$prefix}--image__caption,
+  :host(#{$c4d-prefix}-callout-with-media-video)
+    ::slotted(#{$c4d-prefix}-video-player),
   .#{$prefix}--callout-with-media .#{$prefix}--video-player__video-caption,
   .#{$prefix}--callout-with-media .#{$prefix}--image__caption {
     color: $icon-inverse;
   }
 
-  :host(#{$cds-prefix}-callout-with-media) ::slotted([slot='heading']),
+  :host(#{$c4d-prefix}-callout-with-media) ::slotted([slot='heading']),
   .#{$prefix}--callout-with-media .#{$prefix}--content-block__heading,
-  :host(#{$cds-prefix}-callout-with-media) ::slotted([slot='copy']),
+  :host(#{$c4d-prefix}-callout-with-media) ::slotted([slot='copy']),
   .#{$prefix}--callout-with-media .#{$prefix}--callout-with-media-copy {
     padding-right: $spacing-07;
     max-width: rem(640px);
@@ -59,7 +59,7 @@
   .#{$prefix}--callout-with-media .#{$prefix}--callout__content {
     padding-top: 0;
   }
-  :host(#{$cds-prefix}-callout-with-media-video),
+  :host(#{$c4d-prefix}-callout-with-media-video),
   .#{$prefix}--callout-with-media
     .#{$prefix}--callout__content
     .#{$prefix}--content-block-simple__media-video {
@@ -70,7 +70,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-callout-with-media-image),
+  :host(#{$c4d-prefix}-callout-with-media-image),
   .#{$prefix}--callout-with-media
     .#{$prefix}--callout__content
     .#{$prefix}--content-block-simple__media-image {
@@ -81,14 +81,14 @@
     }
   }
 
-  :host(#{$cds-prefix}-callout-with-media) .#{$prefix}--callout__content,
+  :host(#{$c4d-prefix}-callout-with-media) .#{$prefix}--callout__content,
   .#{$prefix}--callout-with-media
     .#{$prefix}--callout__content
     .#{$prefix}--content-block {
     padding-bottom: $spacing-10;
   }
 
-  :host(#{$cds-prefix}-callout-with-media-image),
+  :host(#{$c4d-prefix}-callout-with-media-image),
   .#{$prefix}--callout-with-media
     .#{$prefix}--callout__content
     .#{$prefix}--content-block {
@@ -102,7 +102,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-callout-with-media-image) .#{$prefix}--image__img {
+  :host(#{$c4d-prefix}-callout-with-media-image) .#{$prefix}--image__img {
     max-width: 100%;
   }
 }

--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -51,12 +51,12 @@
 }
 
 @mixin card-group {
-  :host(#{$cds-prefix}-card-group),
+  :host(#{$c4d-prefix}-card-group),
   .#{$prefix}--card-group {
     @include card-group-themed-items;
   }
 
-  :host(#{$cds-prefix}-card-group-item),
+  :host(#{$c4d-prefix}-card-group-item),
   .#{$prefix}--card-group__card {
     // FIXME: CardLink is being used as Card in React, need to separate this
     .#{$prefix}--card-link .#{$prefix}--card__heading {
@@ -86,14 +86,14 @@
   }
 
   // FIXME: WC only override
-  :host(#{$cds-prefix}-card-group-item)
+  :host(#{$c4d-prefix}-card-group-item)
     .#{$prefix}--card-link
     .#{$prefix}--card__heading {
     @include type-style('heading-02', true);
   }
 
-  :host(#{$cds-prefix}-card-group-item),
-  :host(#{$cds-prefix}-card-group-card-link-item) {
+  :host(#{$c4d-prefix}-card-group-item),
+  :host(#{$c4d-prefix}-card-group-card-link-item) {
     padding-bottom: 1px;
     padding-right: 1px;
 
@@ -170,10 +170,10 @@
     }
   }
 
-  :host(#{$cds-prefix}-card-group),
+  :host(#{$c4d-prefix}-card-group),
   .#{$prefix}--card-group__row,
   .#{$prefix}--card-group__cards__row {
-    --#{$cds-prefix}--card-group--cards-in-row: 1;
+    --#{$c4d-prefix}--card-group--cards-in-row: 1;
 
     display: grid;
     grid-template-columns: 1fr;
@@ -184,7 +184,7 @@
 
     @include breakpoint(lg) {
       grid-template-columns: repeat(
-        var(--#{$cds-prefix}--card-group--cards-in-row),
+        var(--#{$c4d-prefix}--card-group--cards-in-row),
         1fr
       );
     }
@@ -229,7 +229,7 @@
   }
 
   // Add Grid Mode Narrow (16px gutter) style.
-  :host(#{$cds-prefix}-card-group)[grid-mode='narrow'],
+  :host(#{$c4d-prefix}-card-group)[grid-mode='narrow'],
   .#{$prefix}--card-group--narrow {
     @include breakpoint(sm) {
       padding-top: $spacing-03;
@@ -248,8 +248,8 @@
       );
     }
 
-    ::slotted(#{$cds-prefix}-card-group-item),
-    ::slotted(#{$cds-prefix}-card-group-card-link-item),
+    ::slotted(#{$c4d-prefix}-card-group-item),
+    ::slotted(#{$c4d-prefix}-card-group-card-link-item),
     .#{$prefix}--card-group__cards__col {
       border: 0;
       padding: 0;
@@ -257,7 +257,7 @@
   }
 
   // card with video focus outline
-  :host(#{$cds-prefix}-card-group-item)[cta-type='video'] {
+  :host(#{$c4d-prefix}-card-group-item)[cta-type='video'] {
     &:focus-within {
       .#{$prefix}--tile {
         outline: none;
@@ -364,14 +364,14 @@
 
   // Print styles
   @media print {
-    :host(#{$cds-prefix}-card-group),
+    :host(#{$c4d-prefix}-card-group),
     .#{$prefix}--card-group__row,
     .#{$prefix}--card-group__cards__row {
       display: flex;
       flex-wrap: nowrap;
 
-      ::slotted(#{$cds-prefix}-card-group-item),
-      ::slotted(#{$cds-prefix}-card-group-card-link-item),
+      ::slotted(#{$c4d-prefix}-card-group-item),
+      ::slotted(#{$c4d-prefix}-card-group-card-link-item),
       .#{$prefix}--card {
         /* stylelint-disable declaration-no-important */
         // need important since it gets overriden in WC Card Group without it
@@ -383,8 +383,8 @@
       }
     }
 
-    :host(#{$cds-prefix}-card-group-item),
-    :host(#{$cds-prefix}-card-group-card-link-item) {
+    :host(#{$c4d-prefix}-card-group-item),
+    :host(#{$c4d-prefix}-card-group-card-link-item) {
       background-color: transparent;
 
       &[empty] {

--- a/packages/styles/scss/components/card-in-card/_card-in-card.scss
+++ b/packages/styles/scss/components/card-in-card/_card-in-card.scss
@@ -17,7 +17,7 @@
 @use '../card';
 
 @mixin card-in-card {
-  :host(#{$cds-prefix}-card-in-card),
+  :host(#{$c4d-prefix}-card-in-card),
   .#{$prefix}--card-in-card {
     height: auto;
 
@@ -33,7 +33,7 @@
 
     &:hover {
       ::slotted([slot='image']),
-      #{$cds-prefix}-card-in-card-image {
+      #{$c4d-prefix}-card-in-card-image {
         &::before {
           opacity: 0.2;
         }
@@ -64,8 +64,8 @@
 
       .#{$prefix}--card__eyebrow,
       .#{$prefix}--card__heading,
-      ::slotted(#{$cds-prefix}-card-eyebrow),
-      ::slotted(#{$cds-prefix}-card-heading) {
+      ::slotted(#{$c4d-prefix}-card-eyebrow),
+      ::slotted(#{$c4d-prefix}-card-heading) {
         @include breakpoint(md) {
           width: 90%;
         }
@@ -76,14 +76,14 @@
       }
 
       .#{$prefix}--card__eyebrow,
-      ::slotted(#{$cds-prefix}-card-eyebrow) {
+      ::slotted(#{$c4d-prefix}-card-eyebrow) {
         margin-bottom: $spacing-03;
         color: $text-secondary;
       }
     }
   }
 
-  :host(#{$cds-prefix}-card-in-card-image) {
+  :host(#{$c4d-prefix}-card-in-card-image) {
     @extend .#{$prefix}--image;
 
     position: relative;
@@ -96,7 +96,7 @@
     }
 
     ::slotted(svg[slot='icon']) {
-      @extend :host(#{$cds-prefix}-image::slotted(svg[slot='icon']));
+      @extend :host(#{$c4d-prefix}-image::slotted(svg[slot='icon']));
 
       @include breakpoint(md) {
         right: calc(75% - #{$spacing-07});
@@ -128,7 +128,7 @@
   }
 
   // Adjust the card width when grid mode is equal to "narrow".
-  :host(#{$cds-prefix}-card-in-card)[grid-mode='narrow'],
+  :host(#{$c4d-prefix}-card-in-card)[grid-mode='narrow'],
   .#{$prefix}--card-in-card--narrow {
     @include breakpoint(lg) {
       width: calc(100% - #{carbon--mini-units(2)});
@@ -146,7 +146,7 @@
   }
 
   // Add a $layer-accent-01 border line color when the grid mode is equal "collapsed".
-  :host(#{$cds-prefix}-card-in-card)[grid-mode='collapsed'],
+  :host(#{$c4d-prefix}-card-in-card)[grid-mode='collapsed'],
   .#{$prefix}--card-in-card--narrow {
     .#{$prefix}--card__wrapper {
       &::after {

--- a/packages/styles/scss/components/card-link/_card-link.scss
+++ b/packages/styles/scss/components/card-link/_card-link.scss
@@ -16,7 +16,7 @@
     cursor: not-allowed;
   }
 
-  :host(#{$cds-prefix}-card-link[disabled]),
+  :host(#{$c4d-prefix}-card-link[disabled]),
   .#{$prefix}--card__CTA--disabled {
     .#{$prefix}--card__heading,
     ::slotted([slot='heading']),
@@ -39,12 +39,12 @@
     }
   }
 
-  :host(#{$cds-prefix}-card-link-heading),
+  :host(#{$c4d-prefix}-card-link-heading),
   .#{$prefix}--card-link .#{$prefix}--card__heading {
     @include type-style('heading-02');
   }
 
-  :host(#{$cds-prefix}-card-link-heading) {
+  :host(#{$c4d-prefix}-card-link-heading) {
     margin-bottom: 0;
   }
 }

--- a/packages/styles/scss/components/card-section-offset/_card-section-offset.scss
+++ b/packages/styles/scss/components/card-section-offset/_card-section-offset.scss
@@ -16,7 +16,7 @@
 @use '../card-group/card-group';
 
 @mixin card-section-offset {
-  :host(#{$cds-prefix}-card-section-offset) {
+  :host(#{$c4d-prefix}-card-section-offset) {
     display: block;
     position: relative;
     width: 100%;
@@ -25,7 +25,7 @@
     /* stylelint-disable-next-line property-no-unknown */
     aspect-ratio: 16 / 9;
 
-    ::slotted(#{$cds-prefix}-background-media) {
+    ::slotted(#{$c4d-prefix}-background-media) {
       height: auto;
 
       /* stylelint-disable-next-line property-no-unknown */
@@ -33,7 +33,7 @@
     }
 
     /* remove when the `mobile-position` attribute is removed */
-    #{$cds-prefix}-background-media {
+    #{$c4d-prefix}-background-media {
       height: auto;
 
       /* stylelint-disable-next-line property-no-unknown */
@@ -41,7 +41,7 @@
     }
 
     @include breakpoint(md) {
-      ::slotted(#{$cds-prefix}-background-media) {
+      ::slotted(#{$c4d-prefix}-background-media) {
         top: 0;
         position: absolute;
         height: 100%;
@@ -52,7 +52,7 @@
       }
 
       /* remove when the `mobile-position` attribute is removed */
-      #{$cds-prefix}-background-media {
+      #{$c4d-prefix}-background-media {
         position: absolute;
         height: 100%;
         width: 100%;
@@ -66,7 +66,7 @@
       display: flex;
     }
 
-    ::slotted(:not(#{$cds-prefix}-background-media)) {
+    ::slotted(:not(#{$c4d-prefix}-background-media)) {
       z-index: 1;
     }
 
@@ -106,14 +106,14 @@
   // Print styles
   @media print {
     .#{$prefix}--card-section-offset__content,
-    :host(#{$cds-prefix}-card-section-offset) {
+    :host(#{$c4d-prefix}-card-section-offset) {
       background-color: $background;
       flex-wrap: wrap;
 
       /* stylelint-disable-next-line property-no-unknown */
       aspect-ratio: auto;
 
-      #{$cds-prefix}-background-media {
+      #{$c4d-prefix}-background-media {
         display: none;
       }
 

--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -21,15 +21,15 @@
 
 @mixin card {
   .#{$prefix}--card,
-  :host(#{$cds-prefix}-card),
-  :host(#{$cds-prefix}-link-list-item-card),
-  :host(#{$cds-prefix}-card-group-item),
-  :host(#{$cds-prefix}-card-group-item) .#{$prefix}--card,
-  :host(#{$cds-prefix}-card-cta),
-  :host(#{$cds-prefix}-link-list-item-card-cta),
-  :host(#{$cds-prefix}-card-in-card),
-  :host(#{$cds-prefix}-content-group-cards-item),
-  :host(#{$cds-prefix}-content-group-cards-item) .#{$prefix}--card {
+  :host(#{$c4d-prefix}-card),
+  :host(#{$c4d-prefix}-link-list-item-card),
+  :host(#{$c4d-prefix}-card-group-item),
+  :host(#{$c4d-prefix}-card-group-item) .#{$prefix}--card,
+  :host(#{$c4d-prefix}-card-cta),
+  :host(#{$c4d-prefix}-link-list-item-card-cta),
+  :host(#{$c4d-prefix}-card-in-card),
+  :host(#{$c4d-prefix}-content-group-cards-item),
+  :host(#{$c4d-prefix}-content-group-cards-item) .#{$prefix}--card {
     position: relative;
     display: flex;
     flex-direction: column;
@@ -56,8 +56,8 @@
         }
       }
 
-      ::slotted(#{$cds-prefix}-image),
-      ::slotted(#{$cds-prefix}-card-cta-image),
+      ::slotted(#{$c4d-prefix}-image),
+      ::slotted(#{$c4d-prefix}-card-cta-image),
       .#{$prefix}--card__img,
       .#{$prefix}--card__image_img,
       .#{$prefix}--image,
@@ -88,8 +88,8 @@
       position: relative;
       z-index: 2;
 
-      ::slotted(#{$cds-prefix}-image),
-      ::slotted(#{$cds-prefix}-card-cta-image),
+      ::slotted(#{$c4d-prefix}-image),
+      ::slotted(#{$c4d-prefix}-card-cta-image),
       .#{$prefix}--card__img,
       .#{$prefix}--image {
         z-index: -1;
@@ -103,14 +103,14 @@
       z-index: 2;
       text-decoration: none;
 
-      ::slotted(#{$cds-prefix}-image),
+      ::slotted(#{$c4d-prefix}-image),
       .#{$prefix}--image {
         z-index: -1;
       }
     }
 
-    ::slotted(#{$cds-prefix}-image),
-    ::slotted(#{$cds-prefix}-card-cta-image),
+    ::slotted(#{$c4d-prefix}-image),
+    ::slotted(#{$c4d-prefix}-card-cta-image),
     .#{$prefix}--card__img,
     .#{$prefix}--card__image_img,
     .#{$prefix}--image,
@@ -236,7 +236,7 @@
   }
 
   // static card
-  :host(#{$cds-prefix}-card) {
+  :host(#{$c4d-prefix}-card) {
     // Outlined/Border card
     &[border] {
       .#{$prefix}--card {
@@ -245,8 +245,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-card),
-  :host(#{$cds-prefix}-card-group-item) {
+  :host(#{$c4d-prefix}-card),
+  :host(#{$c4d-prefix}-card-group-item) {
     &:not([href]) {
       &,
       &:hover {
@@ -260,7 +260,7 @@
         outline: none;
       }
 
-      ::slotted(#{$cds-prefix}-card-footer) {
+      ::slotted(#{$c4d-prefix}-card-footer) {
         display: inline-flex;
         &::after {
           position: relative;
@@ -311,7 +311,7 @@
         border-color: $border-inverse;
       }
 
-      ::slotted(#{$cds-prefix}-card-footer) {
+      ::slotted(#{$c4d-prefix}-card-footer) {
         height: 0;
       }
     }
@@ -325,13 +325,13 @@
     }
   }
 
-  :host(#{$cds-prefix}-card-cta),
-  :host(#{$cds-prefix}-card-link-cta),
-  :host(#{$cds-prefix}-card-link) {
+  :host(#{$c4d-prefix}-card-cta),
+  :host(#{$c4d-prefix}-card-link-cta),
+  :host(#{$c4d-prefix}-card-link) {
     outline: none;
   }
 
-  :host(#{$cds-prefix}-card-eyebrow),
+  :host(#{$c4d-prefix}-card-eyebrow),
   .#{$prefix}--card__eyebrow {
     @include content-width;
     @include type-style('label-02');
@@ -343,27 +343,27 @@
   .#{$prefix}--card .#{$prefix}--card__cta,
   .#{$prefix}--card .#{$prefix}--card__cta a,
   .#{$prefix}--card .#{$prefix}--card__cta a:visited,
-  :host(#{$cds-prefix}-card-footer)
-    .#{$cds-prefix}-ce--card__footer
+  :host(#{$c4d-prefix}-card-footer)
+    .#{$c4d-prefix}-ce--card__footer
     ::slotted(svg[slot='icon']),
-  :host(#{$cds-prefix}-card-cta-footer)
-    .#{$cds-prefix}-ce--card__footer
+  :host(#{$c4d-prefix}-card-cta-footer)
+    .#{$c4d-prefix}-ce--card__footer
     ::slotted(svg[slot='icon']) {
     margin-left: 0;
     color: $link-primary;
   }
 
-  :host(#{$cds-prefix}-card-footer[disabled])
-    .#{$cds-prefix}-ce--card__footer
+  :host(#{$c4d-prefix}-card-footer[disabled])
+    .#{$c4d-prefix}-ce--card__footer
     ::slotted(svg[slot='icon']) {
     color: $text-disabled;
   }
 
-  :host(#{$cds-prefix}-card-footer),
-  :host(#{$cds-prefix}-card-cta-footer),
-  :host(#{$cds-prefix}-card-in-card-footer),
-  :host(#{$cds-prefix}-feature-card-footer),
-  :host(#{$cds-prefix}-feature-cta-footer) {
+  :host(#{$c4d-prefix}-card-footer),
+  :host(#{$c4d-prefix}-card-cta-footer),
+  :host(#{$c4d-prefix}-card-in-card-footer),
+  :host(#{$c4d-prefix}-feature-card-footer),
+  :host(#{$c4d-prefix}-feature-cta-footer) {
     margin-top: auto;
     display: flex;
     align-items: flex-end;
@@ -373,7 +373,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-card-footer) {
+  :host(#{$c4d-prefix}-card-footer) {
     .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon {
       display: flex;
 
@@ -385,11 +385,11 @@
   }
 
   .#{$prefix}--card .#{$prefix}--card__footer,
-  :host(#{$cds-prefix}-card-footer) a,
-  :host(#{$cds-prefix}-card-cta-footer) a,
-  :host(#{$cds-prefix}-card-in-card-footer) a,
-  :host(#{$cds-prefix}-feature-card-footer) a,
-  :host(#{$cds-prefix}-feature-cta-footer) a {
+  :host(#{$c4d-prefix}-card-footer) a,
+  :host(#{$c4d-prefix}-card-cta-footer) a,
+  :host(#{$c4d-prefix}-card-in-card-footer) a,
+  :host(#{$c4d-prefix}-feature-card-footer) a,
+  :host(#{$c4d-prefix}-feature-cta-footer) a {
     /* Moves the footer down to the bottom in the card */
     margin-top: auto;
     text-decoration: none;
@@ -436,15 +436,15 @@
     }
   }
 
-  :host(#{$cds-prefix}-card-footer) a,
-  :host(#{$cds-prefix}-card-cta-footer) a,
-  :host(#{$cds-prefix}-card-in-card-footer) a {
+  :host(#{$c4d-prefix}-card-footer) a,
+  :host(#{$c4d-prefix}-card-cta-footer) a,
+  :host(#{$c4d-prefix}-card-in-card-footer) a {
     @include breakpoint(md) {
       padding-right: $spacing-07;
     }
   }
 
-  :host(#{$cds-prefix}-feature-cta-footer) a {
+  :host(#{$c4d-prefix}-feature-cta-footer) a {
     svg,
     ::slotted(svg[slot='icon']) {
       fill: $link-inverse;
@@ -457,7 +457,7 @@
   }
 
   // static card footer
-  :host(#{$cds-prefix}-card-footer):not([parent-href]) {
+  :host(#{$c4d-prefix}-card-footer):not([parent-href]) {
     .#{$prefix}--card__footer {
       &::after {
         content: none;
@@ -480,20 +480,20 @@
   }
 
   .#{$prefix}--card .#{$prefix}--card__footer,
-  .#{$cds-prefix}-ce--card__footer {
+  .#{$c4d-prefix}-ce--card__footer {
     display: flex;
   }
 
   .#{$prefix}--card .#{$prefix}--card__footer svg,
-  .#{$cds-prefix}-ce--card__footer ::slotted(svg[slot='icon']) {
+  .#{$c4d-prefix}-ce--card__footer ::slotted(svg[slot='icon']) {
     fill: currentColor;
     align-self: center;
   }
 
   .#{$prefix}--card--inverse,
   .#{$prefix}--card.#{$prefix}--card--inverse,
-  :host(#{$cds-prefix}-card)[color-scheme='inverse'],
-  :host(#{$cds-prefix}-card-group-item)[color-scheme='inverse']
+  :host(#{$c4d-prefix}-card)[color-scheme='inverse'],
+  :host(#{$c4d-prefix}-card-group-item)[color-scheme='inverse']
     .#{$prefix}--card {
     background-color: $background-inverse;
 
@@ -513,8 +513,8 @@
     &:hover {
       background-color: $background-inverse-hover;
 
-      ::slotted(#{$cds-prefix}-image),
-      ::slotted(#{$cds-prefix}-card-cta-image),
+      ::slotted(#{$c4d-prefix}-image),
+      ::slotted(#{$c4d-prefix}-card-cta-image),
       .#{$prefix}--card__img,
       .#{$prefix}--card__image_img,
       .#{$prefix}--image {
@@ -539,40 +539,40 @@
     }
   }
 
-  :host(#{$cds-prefix}-card-heading),
-  :host(#{$cds-prefix}-card-link-heading) {
+  :host(#{$c4d-prefix}-card-heading),
+  :host(#{$c4d-prefix}-card-link-heading) {
     @include content-width;
 
     color: $text-primary;
     margin-bottom: $spacing-10;
   }
 
-  :host(#{$cds-prefix}-card-heading) {
+  :host(#{$c4d-prefix}-card-heading) {
     @include type-style('fluid-heading-03', true);
   }
 
-  :host(#{$cds-prefix}-card-link-heading) {
+  :host(#{$c4d-prefix}-card-link-heading) {
     @include type-style('heading-02', true);
 
     margin-bottom: 0;
   }
 
-  :host(#{$cds-prefix}-card)[color-scheme='inverse'],
-  :host(#{$cds-prefix}-card-group-item)[color-scheme='inverse'],
-  :host(#{$cds-prefix}-feature-section-card-link)[color-scheme='inverse'],
+  :host(#{$c4d-prefix}-card)[color-scheme='inverse'],
+  :host(#{$c4d-prefix}-card-group-item)[color-scheme='inverse'],
+  :host(#{$c4d-prefix}-feature-section-card-link)[color-scheme='inverse'],
   .#{$prefix}--card-group__card {
-    ::slotted(#{$cds-prefix}-card-eyebrow) {
+    ::slotted(#{$c4d-prefix}-card-eyebrow) {
       color: $text-placeholder;
     }
 
-    ::slotted(#{$cds-prefix}-card-heading),
-    ::slotted(#{$cds-prefix}-card-link-heading) {
+    ::slotted(#{$c4d-prefix}-card-heading),
+    ::slotted(#{$c4d-prefix}-card-link-heading) {
       color: $icon-inverse;
     }
 
     &:hover {
-      ::slotted(#{$cds-prefix}-image),
-      ::slotted(#{$cds-prefix}-card-cta-image),
+      ::slotted(#{$c4d-prefix}-image),
+      ::slotted(#{$c4d-prefix}-card-cta-image),
       .#{$prefix}--card__img,
       .#{$prefix}--card__image_img,
       .#{$prefix}--image {
@@ -587,27 +587,27 @@
   .#{$prefix}--card--inverse
     .#{$prefix}--card__footer
     .#{$prefix}--card__cta__copy,
-  :host(#{$cds-prefix}-card-cta-footer[color-scheme='inverse'])
-    .#{$cds-prefix}-ce--card__footer
+  :host(#{$c4d-prefix}-card-cta-footer[color-scheme='inverse'])
+    .#{$c4d-prefix}-ce--card__footer
     ::slotted(svg[slot='icon']),
-  :host(#{$cds-prefix}-card-cta-footer[color-scheme='inverse'])
+  :host(#{$c4d-prefix}-card-cta-footer[color-scheme='inverse'])
     .#{$prefix}--card__cta__copy,
-  :host(#{$cds-prefix}-card-footer[color-scheme='inverse'])
-    .#{$cds-prefix}-ce--card__footer
+  :host(#{$c4d-prefix}-card-footer[color-scheme='inverse'])
+    .#{$c4d-prefix}-ce--card__footer
     ::slotted(svg[slot='icon']),
-  :host(#{$cds-prefix}-card-footer[color-scheme='inverse'])
+  :host(#{$c4d-prefix}-card-footer[color-scheme='inverse'])
     .#{$prefix}--card__cta__copy {
     color: $link-inverse;
   }
 
   @media print {
-    :host(#{$cds-prefix}-card),
-    :host(#{$cds-prefix}-link-list-item-card),
-    :host(#{$cds-prefix}-card-group-item),
-    :host(#{$cds-prefix}-card-cta),
-    :host(#{$cds-prefix}-link-list-item-card-cta),
-    :host(#{$cds-prefix}-card-in-card),
-    :host(#{$cds-prefix}-content-group-cards-item) {
+    :host(#{$c4d-prefix}-card),
+    :host(#{$c4d-prefix}-link-list-item-card),
+    :host(#{$c4d-prefix}-card-group-item),
+    :host(#{$c4d-prefix}-card-cta),
+    :host(#{$c4d-prefix}-link-list-item-card-cta),
+    :host(#{$c4d-prefix}-card-in-card),
+    :host(#{$c4d-prefix}-content-group-cards-item) {
       border: 1px solid $layer-accent-01;
 
       .#{$prefix}--card {
@@ -615,9 +615,9 @@
         border: none;
       }
 
-      ::slotted(#{$cds-prefix}-image),
-      ::slotted(#{$cds-prefix}-card-cta-image),
-      ::slotted(#{$cds-prefix}-tag-group),
+      ::slotted(#{$c4d-prefix}-image),
+      ::slotted(#{$c4d-prefix}-card-cta-image),
+      ::slotted(#{$c4d-prefix}-tag-group),
       .#{$prefix}--image {
         display: none;
       }
@@ -637,16 +637,16 @@
   }
 
   // Card with pictogram placement style
-  :host(#{$cds-prefix}-card-group-item),
-  :host(#{$cds-prefix}-card-in-card),
-  :host(#{$cds-prefix}-card-cta),
-  :host(#{$cds-prefix}-card) {
+  :host(#{$c4d-prefix}-card-group-item),
+  :host(#{$c4d-prefix}-card-in-card),
+  :host(#{$c4d-prefix}-card-cta),
+  :host(#{$c4d-prefix}-card) {
     outline: none;
 
     .#{$prefix}--card__pictogram {
       display: flex;
 
-      ::slotted(#{$cds-prefix}-card-heading) {
+      ::slotted(#{$c4d-prefix}-card-heading) {
         padding-top: $spacing-07;
         margin-bottom: 0;
 
@@ -661,7 +661,7 @@
     &[pictogram-placement='top'] .#{$prefix}--card,
     &[pictogram-placement='bottom'] .#{$prefix}--card {
       .#{$prefix}--card__motion {
-        ::slotted(#{$cds-prefix}-card-heading) {
+        ::slotted(#{$c4d-prefix}-card-heading) {
           padding-top: 0;
 
           @include breakpoint(md) {
@@ -704,7 +704,7 @@
       &:hover,
       &:focus {
         .#{$prefix}--card__motion {
-          ::slotted(#{$cds-prefix}-card-heading) {
+          ::slotted(#{$c4d-prefix}-card-heading) {
             @include breakpoint(md) {
               opacity: 0;
               transform: translate3d(0, $spacing-05, 0);
@@ -728,7 +728,7 @@
 
     &[pictogram-placement='top'] .#{$prefix}--card {
       .#{$prefix}--card__motion {
-        ::slotted(#{$cds-prefix}-card-heading) {
+        ::slotted(#{$c4d-prefix}-card-heading) {
           align-items: flex-end;
           margin-bottom: 0;
           margin-top: auto;
@@ -757,7 +757,7 @@
 
     &[pictogram-placement='bottom'] .#{$prefix}--card {
       .#{$prefix}--card__motion {
-        ::slotted(#{$cds-prefix}-card-heading) {
+        ::slotted(#{$c4d-prefix}-card-heading) {
           align-items: flex-start;
 
           @include breakpoint(md) {

--- a/packages/styles/scss/components/carousel/_carousel.scss
+++ b/packages/styles/scss/components/carousel/_carousel.scss
@@ -16,16 +16,16 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
 @mixin carousel {
-  :host(#{$cds-prefix}-carousel),
+  :host(#{$c4d-prefix}-carousel),
   .#{$prefix}--carousel {
-    --#{$cds-prefix}--carousel--page-size: 1;
+    --#{$c4d-prefix}--carousel--page-size: 1;
 
     @include breakpoint(md) {
-      --#{$cds-prefix}--carousel--page-size: 2;
+      --#{$c4d-prefix}--carousel--page-size: 2;
     }
 
     @include breakpoint(lg) {
-      --#{$cds-prefix}--carousel--page-size: 3;
+      --#{$c4d-prefix}--carousel--page-size: 3;
     }
 
     [role='region'] {
@@ -37,14 +37,14 @@
 
     overflow: hidden;
     width: calc(
-      100% + var(--#{$cds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+      100% + var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
     );
     margin-right: calc(
-      -1 * var(--#{$cds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+      -1 * var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
     );
     padding-left: $spacing-05;
     padding-right: calc(
-      #{$spacing-05} + var(--#{$cds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+      #{$spacing-05} + var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
     );
 
     @include breakpoint(md) {
@@ -55,8 +55,8 @@
       flex: 0 0
         calc(
           (
-              100% - (var(--#{$cds-prefix}--carousel--page-size, 1) - 1) * #{$spacing-05}
-            ) / var(--#{$cds-prefix}--carousel--page-size, 1)
+              100% - (var(--#{$c4d-prefix}--carousel--page-size, 1) - 1) * #{$spacing-05}
+            ) / var(--#{$c4d-prefix}--carousel--page-size, 1)
         );
       height: auto;
       margin-right: $spacing-05;
@@ -68,14 +68,14 @@
       position: relative;
       overflow: hidden;
       margin-right: calc(
-        -1 * (#{$spacing-05} + var(--#{$cds-prefix}--carousel--overflow-hint-size, #{$spacing-05}))
+        -1 * (#{$spacing-05} + var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05}))
       );
     }
 
     .#{$prefix}--carousel__scroll-contents {
       position: relative;
       margin-right: calc(
-        #{$spacing-05} + var(--#{$cds-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+        #{$spacing-05} + var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
       );
       display: flex;
       // Achieves `sameHeight` effect for card group.
@@ -111,7 +111,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-carousel[in-modal]) {
+  :host(#{$c4d-prefix}-carousel[in-modal]) {
     padding: 0 0 $spacing-05;
     width: 100%;
     height: 100%;
@@ -131,9 +131,9 @@
 }
 
 @media print {
-  :host(#{$cds-prefix}-carousel),
+  :host(#{$c4d-prefix}-carousel),
   .#{$prefix}--carousel {
-    --#{$cds-prefix}--carousel--page-size: 4;
+    --#{$c4d-prefix}--carousel--page-size: 4;
 
     flex-flow: row wrap;
     margin: 0;

--- a/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
+++ b/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
@@ -14,7 +14,7 @@
 @use '../card-group/card-group';
 
 @mixin content-block-cards {
-  :host(#{$cds-prefix}-content-block-cards),
+  :host(#{$c4d-prefix}-content-block-cards),
   .#{$prefix}--content-block-cards .#{$prefix}--content-block {
     display: block;
     padding-top: $spacing-07;
@@ -31,7 +31,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-block-cards) ::slotted([slot='heading']),
+  :host(#{$c4d-prefix}-content-block-cards) ::slotted([slot='heading']),
   .#{$prefix}--content-block-cards .#{$prefix}--content-block__heading {
     margin-bottom: $spacing-07;
 
@@ -44,14 +44,14 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-block-cards) .#{$prefix}--content-block__cta,
+  :host(#{$c4d-prefix}-content-block-cards) .#{$prefix}--content-block__cta,
   .#{$prefix}--content-block-cards .#{$prefix}--content-block__cta {
     @include breakpoint(lg) {
       @include make-col(4, 12);
     }
   }
 
-  :host(#{$cds-prefix}-content-block-cards) .#{$prefix}--content-block__cta {
+  :host(#{$c4d-prefix}-content-block-cards) .#{$prefix}--content-block__cta {
     padding: 0;
   }
 

--- a/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
+++ b/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
@@ -17,7 +17,7 @@
 @use '../link-with-icon';
 
 @mixin content-block-headlines {
-  :host(#{$cds-prefix}-content-block-headlines),
+  :host(#{$c4d-prefix}-content-block-headlines),
   .#{$prefix}--content-block-headlines {
     .#{$prefix}--content-block {
       @include breakpoint(md) {
@@ -38,7 +38,7 @@
       }
     }
 
-    ::slotted(#{$cds-prefix}-content-block-copy),
+    ::slotted(#{$c4d-prefix}-content-block-copy),
     .#{$prefix}--content-block__copy {
       margin-bottom: $spacing-12;
       p {
@@ -86,7 +86,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-block-headlines-item),
+  :host(#{$c4d-prefix}-content-block-headlines-item),
   .#{$prefix}--content-block-headlines__item {
     display: flex;
     flex-direction: column;
@@ -109,7 +109,7 @@
       margin: $spacing-05 0 0;
     }
 
-    :host(#{$cds-prefix}-content-block-headlines-heading),
+    :host(#{$c4d-prefix}-content-block-headlines-heading),
     .#{$prefix}--content-block-headlines__heading {
       @include type-style('display-02', true);
     }

--- a/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
+++ b/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
@@ -13,8 +13,8 @@
 @use '../../globals/vars' as *;
 
 @mixin content-block-horizontal {
-  :host(#{$cds-prefix}-content-block-horizontal),
-  :host(#{$cds-prefix}-content-group-horizontal) {
+  :host(#{$c4d-prefix}-content-block-horizontal),
+  :host(#{$c4d-prefix}-content-group-horizontal) {
     padding-top: $spacing-07;
     padding-bottom: $spacing-07;
 
@@ -46,14 +46,14 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-block-horizontal) ::slotted([slot='heading']),
-  :host(#{$cds-prefix}-content-group-horizontal) ::slotted([slot='heading']),
+  :host(#{$c4d-prefix}-content-block-horizontal) ::slotted([slot='heading']),
+  :host(#{$c4d-prefix}-content-group-horizontal) ::slotted([slot='heading']),
   .#{$prefix}--content-block-horizontal .#{$prefix}--content-block__heading,
   .#{$prefix}--content-group-horizontal .#{$prefix}--content-block__heading {
     margin-bottom: $spacing-07;
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal):last-child,
+  :host(#{$c4d-prefix}-content-item-horizontal):last-child,
   .#{$prefix}--content-block-horizontal
     .#{$prefix}--content-item-horizontal__item:last-child,
   .#{$prefix}--content-group-horizontal

--- a/packages/styles/scss/components/content-block-media/_content-block-media.scss
+++ b/packages/styles/scss/components/content-block-media/_content-block-media.scss
@@ -29,7 +29,7 @@
 
 @mixin content-block-media {
   .#{$prefix}--content-block-media,
-  :host(#{$cds-prefix}-content-block-media) {
+  :host(#{$c4d-prefix}-content-block-media) {
     @include themed-items;
 
     .#{$prefix}--content-group:last-child {

--- a/packages/styles/scss/components/content-block-segmented/_content-block-segmented.scss
+++ b/packages/styles/scss/components/content-block-segmented/_content-block-segmented.scss
@@ -15,7 +15,7 @@
 @use '../image';
 
 @mixin content-block-segmented {
-  :host(#{$cds-prefix}-content-block-segmented),
+  :host(#{$c4d-prefix}-content-block-segmented),
   .#{$prefix}--content-block-segmented {
     .#{$prefix}--row {
       &.#{$prefix}--layout--border {
@@ -67,7 +67,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-block-segmented)
+  :host(#{$c4d-prefix}-content-block-segmented)
     .#{$prefix}--content-block__children
     .#{$prefix}--content-block-segmented__media
     ::slotted(:not([slot])) {
@@ -76,7 +76,7 @@
     margin-bottom: $spacing-10;
   }
 
-  :host(#{$cds-prefix}-content-block-segmented)
+  :host(#{$c4d-prefix}-content-block-segmented)
     .#{$prefix}--content-block__children
     .#{$prefix}--content-block-segmented__media
     ::slotted(:not([slot]):last-of-type) {

--- a/packages/styles/scss/components/content-group-banner/_content-group-banner.scss
+++ b/packages/styles/scss/components/content-group-banner/_content-group-banner.scss
@@ -13,7 +13,7 @@
 @use '../../internal/content-group';
 
 @mixin content-group-banner {
-  :host(#{$cds-prefix}-content-group-banner),
+  :host(#{$c4d-prefix}-content-group-banner),
   .#{$prefix}--content-group-banner {
     background: $background;
     padding-top: $spacing-07;
@@ -23,7 +23,7 @@
       padding-bottom: $spacing-09;
     }
 
-    ::slotted(#{$cds-prefix}-content-group-heading),
+    ::slotted(#{$c4d-prefix}-content-group-heading),
     .#{$prefix}--content-layout ::slotted([slot='heading']),
     .#{$prefix}--content-group__title {
       margin-bottom: 0;
@@ -37,7 +37,7 @@
       }
     }
 
-    ::slotted(#{$cds-prefix}-link-list),
+    ::slotted(#{$c4d-prefix}-link-list),
     .#{$prefix}--content-layout ::slotted([slot='complementary']),
     .#{$prefix}--link-list__list {
       position: relative;

--- a/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
+++ b/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
@@ -22,7 +22,7 @@
 }
 
 @mixin content-group-cards {
-  :host(#{$cds-prefix}-content-group-cards),
+  :host(#{$c4d-prefix}-content-group-cards),
   .#{$prefix}--content-group-cards {
     ::slotted([slot='copy']),
     .#{$prefix}--content-group__copy {
@@ -48,7 +48,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-group-cards-item),
+  :host(#{$c4d-prefix}-content-group-cards-item),
   .#{$prefix}--content-group-cards-item__col {
     margin-top: list.slash($grid-gutter, 2);
     margin-bottom: list.slash($grid-gutter, 2);
@@ -60,7 +60,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-group-cards-item) {
+  :host(#{$c4d-prefix}-content-group-cards-item) {
     padding: list.slash($grid-gutter, 2);
     background: none;
   }

--- a/packages/styles/scss/components/content-group-horizontal/_content-group-horizontal.scss
+++ b/packages/styles/scss/components/content-group-horizontal/_content-group-horizontal.scss
@@ -10,7 +10,7 @@
 @use '../content-block-horizontal';
 
 @mixin content-group-horizontal {
-  :host(#{$cds-prefix}-content-group-horizontal) ::slotted([slot='heading']),
+  :host(#{$c4d-prefix}-content-group-horizontal) ::slotted([slot='heading']),
   .#{$prefix}--content-group-horizontal .#{$prefix}--content-block__heading {
     margin-bottom: $spacing-10;
     @include breakpoint(lg) {
@@ -18,7 +18,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal):last-child,
+  :host(#{$c4d-prefix}-content-item-horizontal):last-child,
   .#{$prefix}--content-group-horizontal
     .#{$prefix}--content-item-horizontal__item:last-child {
     @include breakpoint(max) {

--- a/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
+++ b/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
@@ -12,8 +12,8 @@
 @use '../pictogram-item';
 
 @mixin content-group-pictograms {
-  :host(#{$cds-prefix}-content-group-pictograms)
-    ::slotted(#{$cds-prefix}-content-group-copy),
+  :host(#{$c4d-prefix}-content-group-pictograms)
+    ::slotted(#{$c4d-prefix}-content-group-copy),
   .#{$prefix}--content-group-pictograms .#{$prefix}--content-group__copy {
     margin-bottom: $spacing-05;
     margin-left: $spacing-05;

--- a/packages/styles/scss/components/content-group-simple/_content-group-simple.scss
+++ b/packages/styles/scss/components/content-group-simple/_content-group-simple.scss
@@ -12,8 +12,8 @@
 @use '../../internal/content-group';
 
 @mixin content-group-simple {
-  :host(#{$cds-prefix}-content-group-simple)
-    ::slotted(#{$cds-prefix}-content-group-copy),
+  :host(#{$c4d-prefix}-content-group-simple)
+    ::slotted(#{$c4d-prefix}-content-group-copy),
   .#{$prefix}--content-group-simple .#{$prefix}--content-group__copy {
     margin-bottom: $spacing-07;
   }

--- a/packages/styles/scss/components/content-item-horizontal-media/_content-item-horizontal-media.scss
+++ b/packages/styles/scss/components/content-item-horizontal-media/_content-item-horizontal-media.scss
@@ -14,7 +14,7 @@
 @use '../link-list';
 
 @mixin content-item-horizontal-media {
-  :host(#{$cds-prefix}-content-item-horizontal-media) {
+  :host(#{$c4d-prefix}-content-item-horizontal-media) {
     padding: $spacing-07 $spacing-05 $spacing-10;
     display: block;
 
@@ -28,12 +28,12 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-media),
-  :host(#{$cds-prefix}-content-item-horizontal-media-featured)
+  :host(#{$c4d-prefix}-content-item-horizontal-media),
+  :host(#{$c4d-prefix}-content-item-horizontal-media-featured)
     ::slotted([slot='heading']),
-  :host(#{$cds-prefix}-content-item-horizontal-media-copy)
+  :host(#{$c4d-prefix}-content-item-horizontal-media-copy)
     ::slotted(:not([slot])),
-  :host(#{$cds-prefix}-content-item-horizontal-eyebrow),
+  :host(#{$c4d-prefix}-content-item-horizontal-eyebrow),
   .#{$prefix}--content-item-horizontal__item--eyebrow,
   .#{$prefix}--content-item-horizontal__item--heading,
   .#{$prefix}--content-item-horizontal__item--copy {
@@ -42,16 +42,16 @@
     min-width: 0;
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-eyebrow),
+  :host(#{$c4d-prefix}-content-item-horizontal-eyebrow),
   .#{$prefix}--content-item-horizontal__item--eyebrow {
     color: $text-helper;
     padding-bottom: $spacing-03;
     @include type-style('label-01');
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-media)
+  :host(#{$c4d-prefix}-content-item-horizontal-media)
     ::slotted([slot='heading']),
-  :host(#{$cds-prefix}-content-item-horizontal-media-featured)
+  :host(#{$c4d-prefix}-content-item-horizontal-media-featured)
     ::slotted([slot='heading']),
   .#{$prefix}--content-item-horizontal__item--heading {
     display: block;
@@ -60,7 +60,7 @@
     @include type-style('fluid-heading-03', true);
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-media-copy)
+  :host(#{$c4d-prefix}-content-item-horizontal-media-copy)
     ::slotted(:not([slot])) {
     margin-bottom: $spacing-07;
     max-width: rem(640px);
@@ -69,14 +69,14 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-media-video) {
+  :host(#{$c4d-prefix}-content-item-horizontal-media-video) {
     position: relative;
     text-align: left;
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-media)
+  :host(#{$c4d-prefix}-content-item-horizontal-media)
     .#{$prefix}--content-item__cta,
-  :host(#{$cds-prefix}-content-item-horizontal-media-featured)
+  :host(#{$c4d-prefix}-content-item-horizontal-media-featured)
     .#{$prefix}--content-item__cta,
   .#{$prefix}--content-item-horizontal__item--cta {
     margin-top: auto;
@@ -142,7 +142,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-media-featured) {
+  :host(#{$c4d-prefix}-content-item-horizontal-media-featured) {
     display: block;
     position: relative;
     padding-block-start: $spacing-07;
@@ -174,7 +174,7 @@
         grid-column: 1 / span 12;
       }
     }
-    ::slotted(#{$cds-prefix}-image) {
+    ::slotted(#{$c4d-prefix}-image) {
       max-width: none;
       margin-top: 0;
     }

--- a/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
@@ -16,7 +16,7 @@
 
 @mixin content-item-horizontal {
   // Web component
-  :host(#{$cds-prefix}-content-item-horizontal),
+  :host(#{$c4d-prefix}-content-item-horizontal),
   // React
   .#{$prefix}--content-item-horizontal__item {
     @include make-row;
@@ -50,7 +50,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal) {
+  :host(#{$c4d-prefix}-content-item-horizontal) {
     margin: 0;
   }
 
@@ -63,7 +63,7 @@
       flex-direction: row;
     }
 
-    :host(#{$cds-prefix}-content-item-horizontal)[thumbnail] & {
+    :host(#{$c4d-prefix}-content-item-horizontal)[thumbnail] & {
       justify-content: space-between;
       min-height: auto;
     }
@@ -90,7 +90,7 @@
         width: auto;
       }
 
-      :host(#{$cds-prefix}-content-item-horizontal)[thumbnail] & {
+      :host(#{$c4d-prefix}-content-item-horizontal)[thumbnail] & {
         @include breakpoint(md) {
           @include make-col(4, 8);
         }
@@ -115,7 +115,7 @@
         grid-column: 9 / span 4;
         grid-row: 1 / span 1;
       }
-      :host(#{$cds-prefix}-content-item-horizontal)[thumbnail] & {
+      :host(#{$c4d-prefix}-content-item-horizontal)[thumbnail] & {
         @include breakpoint(md) {
           @include make-col(3, 8);
         }
@@ -133,7 +133,7 @@
   // React
   .#{$prefix}--content-item-horizontal__col:first-of-type,
   .#{$prefix}--content-item-horizontal__col:last-of-type {
-    :host(#{$cds-prefix}-content-item-horizontal)[thumbnail] & {
+    :host(#{$c4d-prefix}-content-item-horizontal)[thumbnail] & {
       @include make-col(4, 4);
 
       @include breakpoint(lg) {
@@ -186,14 +186,14 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal) ::slotted([slot='media']) {
+  :host(#{$c4d-prefix}-content-item-horizontal) ::slotted([slot='media']) {
     display: block;
     padding-top: $spacing-07;
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal) ::slotted([slot='heading']),
-  :host(#{$cds-prefix}-content-item-horizontal-copy) ::slotted(:not([slot])),
-  :host(#{$cds-prefix}-content-item-horizontal-eyebrow),
+  :host(#{$c4d-prefix}-content-item-horizontal) ::slotted([slot='heading']),
+  :host(#{$c4d-prefix}-content-item-horizontal-copy) ::slotted(:not([slot])),
+  :host(#{$c4d-prefix}-content-item-horizontal-eyebrow),
   .#{$prefix}--content-item-horizontal__item--eyebrow,
   .#{$prefix}--content-item-horizontal__item--heading,
   .#{$prefix}--content-item-horizontal__item--copy {
@@ -202,18 +202,18 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-copy) ::slotted(:not([slot])) {
+  :host(#{$c4d-prefix}-content-item-horizontal-copy) ::slotted(:not([slot])) {
     max-width: rem(640px);
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-eyebrow),
+  :host(#{$c4d-prefix}-content-item-horizontal-eyebrow),
   .#{$prefix}--content-item-horizontal__item--eyebrow {
     color: $text-helper;
     padding-bottom: $spacing-03;
     @include type-style('label-02');
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal) ::slotted([slot='heading']),
+  :host(#{$c4d-prefix}-content-item-horizontal) ::slotted([slot='heading']),
   .#{$prefix}--content-item-horizontal__item--heading {
     display: block;
     color: $text-primary;
@@ -230,7 +230,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal)[thumbnail] {
+  :host(#{$c4d-prefix}-content-item-horizontal)[thumbnail] {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     grid-auto-flow: dense;
@@ -244,12 +244,12 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal[thumbnail])
+  :host(#{$c4d-prefix}-content-item-horizontal[thumbnail])
     .#{$prefix}--content-item-horizontal__heading-wrapper {
     max-width: 100%;
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal[thumbnail])
+  :host(#{$c4d-prefix}-content-item-horizontal[thumbnail])
     .#{$prefix}--content-item-horizontal__content-wrapper {
     @include breakpoint-down(md) {
       margin-bottom: $spacing-07;
@@ -259,7 +259,7 @@
     padding-left: 0;
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal[thumbnail]) {
+  :host(#{$c4d-prefix}-content-item-horizontal[thumbnail]) {
     .#{$prefix}--content-item-horizontal__body-wrapper {
       grid-column: 1 / span 4;
       max-width: 100%;
@@ -287,17 +287,17 @@
     padding-right: 0;
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-copy) ::slotted(:not([slot])),
+  :host(#{$c4d-prefix}-content-item-horizontal-copy) ::slotted(:not([slot])),
   .#{$prefix}--content-item-horizontal__item--copy {
     margin-bottom: $spacing-07;
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal-thumbnail-copy)
-    ::slotted(#{$cds-prefix}-content-item-paragraph) {
+  :host(#{$c4d-prefix}-content-item-horizontal-thumbnail-copy)
+    ::slotted(#{$c4d-prefix}-content-item-paragraph) {
     margin-bottom: $spacing-07;
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal) .#{$prefix}--content-item__cta,
+  :host(#{$c4d-prefix}-content-item-horizontal) .#{$prefix}--content-item__cta,
   .#{$prefix}--content-item-horizontal__item--cta {
     .#{$prefix}--link-list {
       padding: 0;
@@ -312,7 +312,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-horizontal) ::slotted([slot='thumbnail']) {
+  :host(#{$c4d-prefix}-content-item-horizontal) ::slotted([slot='thumbnail']) {
     @include breakpoint(md) {
       @include make-col(3, 3);
 

--- a/packages/styles/scss/components/cta-block/_cta-block.scss
+++ b/packages/styles/scss/components/cta-block/_cta-block.scss
@@ -37,7 +37,7 @@
 }
 
 @mixin cta-block {
-  :host(#{$cds-prefix}-cta-block),
+  :host(#{$c4d-prefix}-cta-block),
   .#{$prefix}--cta-block {
     padding-top: $spacing-07;
     padding-bottom: $spacing-10;

--- a/packages/styles/scss/components/cta-section/_cta-section.scss
+++ b/packages/styles/scss/components/cta-section/_cta-section.scss
@@ -37,7 +37,7 @@
 }
 
 @mixin cta-section {
-  :host(#{$cds-prefix}-cta-section),
+  :host(#{$c4d-prefix}-cta-section),
   .#{$prefix}--cta-section {
     .#{$prefix}--cta-section__cta {
       padding-bottom: $spacing-10;

--- a/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
+++ b/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
@@ -12,7 +12,7 @@
 @use '../masthead';
 
 @mixin dotcom-shell {
-  :host(#{$cds-prefix}-dotcom-shell),
+  :host(#{$c4d-prefix}-dotcom-shell),
   .#{$prefix}--dotcom-shell {
     display: flex;
     flex-direction: column;

--- a/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
+++ b/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
@@ -26,7 +26,7 @@
   $icon-size: rem(20px);
   $offset-close-icon: $spacing-07 - list.slash($button-size - $icon-size, 2);
 
-  :host(#{$cds-prefix}-expressive-modal),
+  :host(#{$c4d-prefix}-expressive-modal),
   #{$modal}--expressive {
     color: $text-primary;
 
@@ -48,23 +48,23 @@
     }
   }
 
-  :host(#{$cds-prefix}-expressive-modal-footer) #{$modal}-footer {
+  :host(#{$c4d-prefix}-expressive-modal-footer) #{$modal}-footer {
     justify-content: flex-start;
     height: $spacing-09;
   }
 
-  :host(#{$cds-prefix}-expressive-modal-close-button) {
+  :host(#{$c4d-prefix}-expressive-modal-close-button) {
     #{$modal}-close {
       position: fixed;
     }
   }
 
-  :host(#{$cds-prefix}-expressive-modal-heading),
+  :host(#{$c4d-prefix}-expressive-modal-heading),
   #{$modal}--expressive #{$modal}-content h1 {
     @include type-style('heading-04');
   }
 
-  :host(#{$cds-prefix}-expressive-modal)[expressive-size='full-width'],
+  :host(#{$c4d-prefix}-expressive-modal)[expressive-size='full-width'],
   #{$modal}--expressive--fullwidth {
     @include breakpoint(md) {
       #{$modal}-container {
@@ -76,10 +76,10 @@
     }
   }
 
-  :host(#{$cds-prefix}-expressive-modal[size='full-width'])
-    ::slotted(#{$cds-prefix}-expressive-modal-body),
-  :host(#{$cds-prefix}-expressive-modal[size='full-width'])
-    ::slotted(#{$cds-prefix}-lightbox-media-viewer-body),
+  :host(#{$c4d-prefix}-expressive-modal[size='full-width'])
+    ::slotted(#{$c4d-prefix}-expressive-modal-body),
+  :host(#{$c4d-prefix}-expressive-modal[size='full-width'])
+    ::slotted(#{$c4d-prefix}-lightbox-media-viewer-body),
   #{$modal}--expressive--fullwidth #{$modal}-content {
     padding-right: 0;
     height: auto;

--- a/packages/styles/scss/components/feature-card-block-large/_feature-card-block-large.scss
+++ b/packages/styles/scss/components/feature-card-block-large/_feature-card-block-large.scss
@@ -26,7 +26,7 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
   rem(1px);
 
 @mixin feature-card-block-large {
-  :host(#{$cds-prefix}-feature-card-block-large),
+  :host(#{$c4d-prefix}-feature-card-block-large),
   .#{$prefix}--feature-card-block-large {
     margin-bottom: $spacing-07;
 
@@ -113,8 +113,8 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
       .#{$prefix}--card__eyebrow,
       .#{$prefix}--card__heading,
       .#{$prefix}--card__copy,
-      ::slotted(#{$cds-prefix}-card-eyebrow),
-      ::slotted(#{$cds-prefix}-card-heading) {
+      ::slotted(#{$c4d-prefix}-card-eyebrow),
+      ::slotted(#{$c4d-prefix}-card-heading) {
         width: 100%;
         max-width: rem(480px);
         @include breakpoint(md) {
@@ -127,12 +127,12 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
       }
 
       .#{$prefix}--card__eyebrow,
-      ::slotted(#{$cds-prefix}-card-eyebrow) {
+      ::slotted(#{$c4d-prefix}-card-eyebrow) {
         margin: 0 0 $spacing-05 0;
       }
 
       .#{$prefix}--card__heading,
-      ::slotted(#{$cds-prefix}-card-heading) {
+      ::slotted(#{$c4d-prefix}-card-heading) {
         @include type-style('fluid-heading-04', true);
 
         margin-bottom: $spacing-07;
@@ -175,8 +175,8 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
     }
   }
 
-  :host(#{$cds-prefix}-feature-card-block-large-footer)
-    .#{$cds-prefix}-ce--card__footer
+  :host(#{$c4d-prefix}-feature-card-block-large-footer)
+    .#{$c4d-prefix}-ce--card__footer
     ::slotted(svg[slot='icon']),
   .#{$prefix}--feature-card-block-large
     .#{$prefix}--feature-card-block-large__card.#{$prefix}--tile

--- a/packages/styles/scss/components/feature-card-block-medium/_feature-card-block-medium.scss
+++ b/packages/styles/scss/components/feature-card-block-medium/_feature-card-block-medium.scss
@@ -16,7 +16,7 @@
 
 @mixin feature-card-block-medium {
   .#{$prefix}--feature-card-block-medium,
-  :host(#{$cds-prefix}-feature-card-block-medium) {
+  :host(#{$c4d-prefix}-feature-card-block-medium) {
     color: $text-primary;
     background: $background;
     margin: $spacing-10 0;
@@ -35,14 +35,14 @@
   .#{$prefix}--feature-card-block-medium
     .#{$prefix}--card
     .#{$prefix}--card__heading,
-  :host(#{$cds-prefix}-feature-card-block-medium)
+  :host(#{$c4d-prefix}-feature-card-block-medium)
     .#{$prefix}--card
-    ::slotted(#{$cds-prefix}-card-heading) {
+    ::slotted(#{$c4d-prefix}-card-heading) {
     margin-bottom: 0;
   }
 
   .#{$prefix}--feature-card-block-medium__heading,
-  ::slotted(#{$cds-prefix}-feature-card-block-medium-block-heading) {
+  ::slotted(#{$c4d-prefix}-feature-card-block-medium-block-heading) {
     @include type-style('fluid-heading-04', true);
 
     display: block;

--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -42,7 +42,7 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
   }
 
   .#{$prefix}--card__heading,
-  ::slotted(#{$cds-prefix}-card-heading) {
+  ::slotted(#{$c4d-prefix}-card-heading) {
     margin-bottom: $spacing-07;
     color: $icon-inverse;
   }
@@ -73,15 +73,15 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
 
 @mixin feature-card {
   // all feature cards
-  :host(#{$cds-prefix}-feature-card),
-  :host(#{$cds-prefix}-feature-cta),
+  :host(#{$c4d-prefix}-feature-card),
+  :host(#{$c4d-prefix}-feature-cta),
   .#{$prefix}--feature-card-large,
   .#{$prefix}--feature-card {
     position: relative;
 
     &:hover {
       ::slotted([slot='image']),
-      #{$cds-prefix}-image,
+      #{$c4d-prefix}-image,
       .#{$prefix}--image {
         &::before {
           opacity: 0.08;
@@ -103,7 +103,7 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
     }
 
     ::slotted([slot='image']),
-    #{$cds-prefix}-image,
+    #{$c4d-prefix}-image,
     .#{$prefix}--image {
       width: 100%;
       height: aspect-ratio(2, 1);
@@ -123,8 +123,8 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
     }
   }
 
-  :host(#{$cds-prefix}-feature-card),
-  :host(#{$cds-prefix}-feature-cta) {
+  :host(#{$c4d-prefix}-feature-card),
+  :host(#{$c4d-prefix}-feature-cta) {
     @include breakpoint-down(md) {
       display: flex;
     }
@@ -132,8 +132,8 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
 
   // feature cards that are not size large
   .#{$prefix}--feature-card,
-  :host(#{$cds-prefix}-feature-card:not([size='large'])),
-  :host(#{$cds-prefix}-feature-cta:not([size='large'])) {
+  :host(#{$c4d-prefix}-feature-card:not([size='large'])),
+  :host(#{$c4d-prefix}-feature-cta:not([size='large'])) {
     @include breakpoint-down(md) {
       padding-top: aspect-ratio(1, 1);
 
@@ -202,7 +202,7 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
     // image
 
     ::slotted([slot='image']),
-    #{$cds-prefix}-image,
+    #{$c4d-prefix}-image,
     .#{$prefix}--image {
       @include breakpoint(md) {
         width: 50%;
@@ -245,8 +245,8 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
   }
 
   // feature cards that are size large
-  :host(#{$cds-prefix}-feature-card[size='large']),
-  :host(#{$cds-prefix}-feature-cta[size='large']),
+  :host(#{$c4d-prefix}-feature-card[size='large']),
+  :host(#{$c4d-prefix}-feature-cta[size='large']),
   .#{$prefix}--feature-card-large {
     margin-bottom: $spacing-07;
     color: $text-primary;
@@ -285,7 +285,7 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
       }
 
       ::slotted([slot='image']),
-      #{$cds-prefix}-image,
+      #{$c4d-prefix}-image,
       &__wrapper,
       .#{$prefix}--image {
         @include breakpoint(xlg) {
@@ -315,8 +315,8 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
       .#{$prefix}--card__eyebrow,
       .#{$prefix}--card__heading,
       .#{$prefix}--card__copy,
-      ::slotted(#{$cds-prefix}-card-eyebrow),
-      ::slotted(#{$cds-prefix}-card-heading) {
+      ::slotted(#{$c4d-prefix}-card-eyebrow),
+      ::slotted(#{$c4d-prefix}-card-heading) {
         width: 100%;
         color: $icon-inverse;
         max-width: rem(480px);
@@ -339,13 +339,13 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
       }
 
       .#{$prefix}--card__eyebrow,
-      ::slotted(#{$cds-prefix}-card-eyebrow) {
+      ::slotted(#{$c4d-prefix}-card-eyebrow) {
         margin: 0 0 $spacing-05 0;
         color: $icon-inverse;
       }
 
       .#{$prefix}--card__heading,
-      ::slotted(#{$cds-prefix}-card-heading) {
+      ::slotted(#{$c4d-prefix}-card-heading) {
         color: $icon-inverse;
         margin-bottom: $spacing-07;
         @include type-style('fluid-heading-04', true);
@@ -392,8 +392,8 @@ $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
     }
   }
 
-  :host(#{$cds-prefix}-feature-card-footer)
-    .#{$cds-prefix}-ce--card__footer
+  :host(#{$c4d-prefix}-feature-card-footer)
+    .#{$c4d-prefix}-ce--card__footer
     ::slotted(svg[slot='icon']),
   .#{$prefix}--feature-card-large
     .#{$prefix}--feature-card-large__card.#{$prefix}--tile

--- a/packages/styles/scss/components/feature-section/_feature-section.scss
+++ b/packages/styles/scss/components/feature-section/_feature-section.scss
@@ -33,7 +33,7 @@
     &:focus-within {
       outline: none;
 
-      ::slotted(#{$cds-prefix}-image),
+      ::slotted(#{$c4d-prefix}-image),
       .#{$prefix}--image {
         z-index: 0;
       }
@@ -60,7 +60,7 @@
     }
 
     .#{$prefix}--content-item__copy p,
-    ::slotted(#{$cds-prefix}-content-item-paragraph) {
+    ::slotted(#{$c4d-prefix}-content-item-paragraph) {
       margin-bottom: $spacing-07;
 
       @include breakpoint(md) {
@@ -69,7 +69,7 @@
     }
 
     .#{$prefix}--card-link,
-    ::slotted(#{$cds-prefix}-feature-section-card-link) {
+    ::slotted(#{$c4d-prefix}-feature-section-card-link) {
       position: relative;
       display: inline-block;
       margin-left: 25%;
@@ -91,7 +91,7 @@
     padding-right: 0;
 
     .#{$prefix}--image,
-    ::slotted(#{$cds-prefix}-image) {
+    ::slotted(#{$c4d-prefix}-image) {
       overflow: hidden;
 
       @include breakpoint(sm) {
@@ -109,13 +109,13 @@
   }
 
   .#{$prefix}--card__eyebrow,
-  ::slotted(#{$cds-prefix}-card-eyebrow) {
+  ::slotted(#{$c4d-prefix}-card-eyebrow) {
     display: inline-block;
     margin-bottom: $spacing-05;
   }
 
   .#{$prefix}--card-link,
-  ::slotted(#{$cds-prefix}-feature-section-card-link) {
+  ::slotted(#{$c4d-prefix}-feature-section-card-link) {
     position: absolute;
     right: 0;
     bottom: 0;

--- a/packages/styles/scss/components/filter-panel/_filter-panel.scss
+++ b/packages/styles/scss/components/filter-panel/_filter-panel.scss
@@ -120,7 +120,7 @@
     justify-content: space-between;
   }
 
-  :host(#{$cds-prefix}-filter-panel) {
+  :host(#{$c4d-prefix}-filter-panel) {
     .#{$prefix}--clear {
       display: block;
 
@@ -146,7 +146,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-filter-panel-composite) {
+  :host(#{$c4d-prefix}-filter-panel-composite) {
     .#{$prefix}--filter-button {
       @include type-style('body-compact-01');
 
@@ -169,7 +169,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-filter-panel-checkbox) {
+  :host(#{$c4d-prefix}-filter-panel-checkbox) {
     padding-left: rem(14px);
     padding-bottom: rem(6px);
     @extend .#{$prefix}--checkbox;
@@ -196,7 +196,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-filter-panel-input-select) {
+  :host(#{$c4d-prefix}-filter-panel-input-select) {
     display: block;
 
     &:hover {
@@ -208,7 +208,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-filter-panel-input-select-item) {
+  :host(#{$c4d-prefix}-filter-panel-input-select-item) {
     @include type-style('body-compact-01');
 
     background-color: $layer-01;
@@ -239,7 +239,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-filter-panel-heading) {
+  :host(#{$c4d-prefix}-filter-panel-heading) {
     @include type-style('heading-01');
     @include breakpoint(sm) {
       margin-left: $spacing-05;
@@ -254,7 +254,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-filter-group:first-of-type) {
+  :host(#{$c4d-prefix}-filter-group:first-of-type) {
     ::slotted(#{$prefix}-filter-group-item:first-of-type) {
       @include breakpoint-down(md) {
         margin-top: $spacing-05;
@@ -262,7 +262,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-filter-group-item) {
+  :host(#{$c4d-prefix}-filter-group-item) {
     @extend .#{$prefix}--accordion__item;
 
     display: block;
@@ -288,7 +288,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-filter-group-item[open]:not([disabled])) {
+  :host(#{$c4d-prefix}-filter-group-item[open]:not([disabled])) {
     @extend .#{$prefix}--accordion__item--active;
 
     .#{$prefix}--accordion__content {
@@ -297,7 +297,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-filter-modal-footer) {
+  :host(#{$c4d-prefix}-filter-modal-footer) {
     z-index: 999;
     position: absolute;
     bottom: 0;
@@ -305,7 +305,7 @@
     overflow: auto;
   }
 
-  :host(#{$cds-prefix}-filter-modal-heading) {
+  :host(#{$c4d-prefix}-filter-modal-heading) {
     @include type-style('heading-01');
 
     display: block;

--- a/packages/styles/scss/components/footer/_footer-logo.scss
+++ b/packages/styles/scss/components/footer/_footer-logo.scss
@@ -20,7 +20,7 @@
 /// @group footer
 
 @mixin footer-logo {
-  :host(#{$cds-prefix}-footer-logo),
+  :host(#{$c4d-prefix}-footer-logo),
   .#{$prefix}--footer-logo {
     @include theme($g90, feature-flag-enabled('enable-css-custom-properties'));
 

--- a/packages/styles/scss/components/footer/_footer-nav-group.scss
+++ b/packages/styles/scss/components/footer/_footer-nav-group.scss
@@ -19,7 +19,7 @@
 /// @group footer
 
 @mixin footer-nav-group {
-  :host(#{$cds-prefix}-footer-nav-group),
+  :host(#{$c4d-prefix}-footer-nav-group),
   .#{$prefix}--footer-nav-group,
   .#{$prefix}--footer-nav-group.#{$prefix}--accordion__item {
     @include theme($g90, feature-flag-enabled('enable-css-custom-properties'));
@@ -70,7 +70,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-footer-nav-item),
+  :host(#{$c4d-prefix}-footer-nav-item),
   .#{$prefix}--footer-nav-group {
     .#{$prefix}--link {
       @include breakpoint-down(md) {
@@ -114,7 +114,7 @@
       display: block;
     }
 
-    :host(#{$cds-prefix}-footer-nav-item),
+    :host(#{$c4d-prefix}-footer-nav-item),
     .#{$prefix}--footer-nav-group__item {
       margin-top: carbon--mini-units(1);
     }

--- a/packages/styles/scss/components/footer/_footer-nav.scss
+++ b/packages/styles/scss/components/footer/_footer-nav.scss
@@ -22,7 +22,7 @@
 /// @group footer
 
 @mixin footer-nav {
-  :host(#{$cds-prefix}-footer-nav),
+  :host(#{$c4d-prefix}-footer-nav),
   .#{$prefix}--footer-nav {
     @include theme($g90, feature-flag-enabled('enable-css-custom-properties'));
 
@@ -55,7 +55,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-footer-nav[disable-locale-button]),
+  :host(#{$c4d-prefix}-footer-nav[disable-locale-button]),
   nav.#{$prefix}--footer-nav__locale-button--disabled {
     border-top: none;
     @include breakpoint(lg) {
@@ -81,8 +81,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-footer[size='short'])
-    ::slotted(#{$cds-prefix}-footer-nav),
+  :host(#{$c4d-prefix}-footer[size='short'])
+    ::slotted(#{$c4d-prefix}-footer-nav),
   .#{$prefix}--footer--short .#{$prefix}--footer-nav {
     display: none;
   }

--- a/packages/styles/scss/components/footer/_footer.scss
+++ b/packages/styles/scss/components/footer/_footer.scss
@@ -20,7 +20,7 @@
 /// @group footer
 
 @mixin footer {
-  :host(#{$cds-prefix}-footer),
+  :host(#{$c4d-prefix}-footer),
   .#{$prefix}--footer {
     width: 100%;
     padding-block: $spacing-09;
@@ -41,7 +41,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-footer[size='short']),
+  :host(#{$c4d-prefix}-footer[size='short']),
   .#{$prefix}--footer--short {
     padding-block: carbon--mini-units(4);
 
@@ -56,7 +56,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-footer[size='micro']),
+  :host(#{$c4d-prefix}-footer[size='micro']),
   .#{$prefix}--footer--micro {
     padding-top: 0;
     padding-bottom: 0;
@@ -81,9 +81,9 @@
     }
   }
 
-  :host(#{$cds-prefix}-footer-nav-item),
-  :host(#{$cds-prefix}-legal-nav-item),
-  :host(#{$cds-prefix}-legal-nav-cookie-preferences-placeholder),
+  :host(#{$c4d-prefix}-footer-nav-item),
+  :host(#{$c4d-prefix}-legal-nav-item),
+  :host(#{$c4d-prefix}-legal-nav-cookie-preferences-placeholder),
   .#{$prefix}--footer {
     @include theme($g90, feature-flag-enabled('enable-css-custom-properties'));
 
@@ -110,7 +110,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-legal-nav),
+  :host(#{$c4d-prefix}-legal-nav),
   .#{$prefix}--footer {
     @include theme($g90, feature-flag-enabled('enable-css-custom-properties'));
 
@@ -136,7 +136,7 @@
 
     flex-direction: column;
 
-    :host(#{$cds-prefix}-footer[size='short']) &,
+    :host(#{$c4d-prefix}-footer[size='short']) &,
     .#{$prefix}--footer--short & {
       flex-direction: row;
     }
@@ -169,7 +169,7 @@
   }
 
   @media print {
-    :host(#{$cds-prefix}-footer),
+    :host(#{$c4d-prefix}-footer),
     .#{$prefix}--footer {
       /* stylelint-disable declaration-no-important */
       // need important since it gets overriden in WC Footer without it

--- a/packages/styles/scss/components/footer/_legal-nav.scss
+++ b/packages/styles/scss/components/footer/_legal-nav.scss
@@ -19,7 +19,7 @@
 /// @group footer
 
 @mixin legal-nav {
-  :host(#{$cds-prefix}-legal-nav),
+  :host(#{$c4d-prefix}-legal-nav),
   .#{$prefix}--legal-nav__container {
     @include make-container;
   }
@@ -184,8 +184,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-legal-nav-item),
-  :host(#{$cds-prefix}-legal-nav-cookie-preferences-placeholder),
+  :host(#{$c4d-prefix}-legal-nav-item),
+  :host(#{$c4d-prefix}-legal-nav-cookie-preferences-placeholder),
   .#{$prefix}--legal-nav__list-item {
     margin-right: carbon--mini-units(4);
     padding: carbon--mini-units(2) 0 0 0;

--- a/packages/styles/scss/components/footer/_locale-button.scss
+++ b/packages/styles/scss/components/footer/_locale-button.scss
@@ -20,7 +20,7 @@
 /// @group footer
 
 @mixin locale-button {
-  :host(#{$cds-prefix}-locale-button),
+  :host(#{$c4d-prefix}-locale-button),
   .#{$prefix}--locale-btn__container {
     @include theme($g90, feature-flag-enabled('enable-css-custom-properties'));
     @include button;
@@ -56,8 +56,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-footer[size='short'])
-    ::slotted(#{$cds-prefix}-locale-button),
+  :host(#{$c4d-prefix}-footer[size='short'])
+    ::slotted(#{$c4d-prefix}-locale-button),
   .#{$prefix}--footer--short .#{$prefix}--locale-btn__container {
     margin-top: $spacing-09;
 

--- a/packages/styles/scss/components/horizontal-rule/_horizontal-rule.scss
+++ b/packages/styles/scss/components/horizontal-rule/_horizontal-rule.scss
@@ -16,29 +16,29 @@
   $high-contrast: $border-inverse;
   $thin-weight: rem(1px);
 
-  :host(#{$cds-prefix}-hr)[size='small'] {
+  :host(#{$c4d-prefix}-hr)[size='small'] {
     @extend .#{$prefix}--hr--small;
   }
-  :host(#{$cds-prefix}-hr)[size='medium'] {
+  :host(#{$c4d-prefix}-hr)[size='medium'] {
     @extend .#{$prefix}--hr--medium;
   }
-  :host(#{$cds-prefix}-hr)[size='large'] {
+  :host(#{$c4d-prefix}-hr)[size='large'] {
     @extend .#{$prefix}--hr--large;
   }
-  :host(#{$cds-prefix}-hr)[weight='thick'] {
+  :host(#{$c4d-prefix}-hr)[weight='thick'] {
     @extend .#{$prefix}--hr--thick;
   }
-  :host(#{$cds-prefix}-hr)[type='dashed'] {
+  :host(#{$c4d-prefix}-hr)[type='dashed'] {
     @extend .#{$prefix}--hr--dashed;
   }
-  :host(#{$cds-prefix}-hr)[contrast='low-contrast'] {
+  :host(#{$c4d-prefix}-hr)[contrast='low-contrast'] {
     @extend .#{$prefix}--hr--low-contrast;
   }
-  :host(#{$cds-prefix}-hr)[contrast='high-contrast'] {
+  :host(#{$c4d-prefix}-hr)[contrast='high-contrast'] {
     @extend .#{$prefix}--hr--high-contrast;
   }
 
-  :host(#{$cds-prefix}-hr),
+  :host(#{$c4d-prefix}-hr),
   .#{$prefix}--hr {
     margin: $spacing-05 0;
     border: none;

--- a/packages/styles/scss/components/image/_image.scss
+++ b/packages/styles/scss/components/image/_image.scss
@@ -17,25 +17,25 @@
 @use '../lightbox-media-viewer/lightbox-media-viewer';
 
 @mixin image {
-  :host(#{$cds-prefix}-card-cta-image),
-  :host(#{$cds-prefix}-image) {
+  :host(#{$c4d-prefix}-card-cta-image),
+  :host(#{$c4d-prefix}-image) {
     position: relative;
     display: block;
   }
 
-  :host(#{$cds-prefix}-card-cta-image::slotted(svg[slot='icon'])),
-  :host(#{$cds-prefix}-image::slotted(svg[slot='icon'])) {
+  :host(#{$c4d-prefix}-card-cta-image::slotted(svg[slot='icon'])),
+  :host(#{$c4d-prefix}-image::slotted(svg[slot='icon'])) {
     position: absolute;
     top: calc(50% - #{$spacing-07});
     right: calc(50% - #{$spacing-07});
   }
 
-  :host(#{$cds-prefix}-image-item) {
+  :host(#{$c4d-prefix}-image-item) {
     display: none;
   }
 
-  :host(#{$cds-prefix}-image)[card-group-item],
-  :host(#{$cds-prefix}-card-cta-image) {
+  :host(#{$c4d-prefix}-image)[card-group-item],
+  :host(#{$c4d-prefix}-card-cta-image) {
     @include ratio-base(4, 3, true);
 
     padding-top: 75%;
@@ -67,7 +67,7 @@
     overflow: hidden;
   }
 
-  :host(#{$cds-prefix}-image)[heading] {
+  :host(#{$c4d-prefix}-image)[heading] {
     display: block;
     margin-top: $spacing-07;
     margin-bottom: $spacing-07;
@@ -148,7 +148,7 @@
     color: $text-helper;
   }
 
-  :host(#{$cds-prefix}-image[lightbox-contrast='dark']) {
+  :host(#{$c4d-prefix}-image[lightbox-contrast='dark']) {
     .#{$prefix}--image-with-caption__zoom-button {
       background-color: rgba($white, 0.85);
 
@@ -173,7 +173,7 @@
   }
 
   // cds-image-logo style.
-  :host(#{$cds-prefix}-image-logo) {
+  :host(#{$c4d-prefix}-image-logo) {
     background-color: $layer-02;
     margin: $spacing-05 $spacing-05 $spacing-03 $spacing-05;
     max-width: $spacing-13;

--- a/packages/styles/scss/components/leadspace-block/_leadspace-block.scss
+++ b/packages/styles/scss/components/leadspace-block/_leadspace-block.scss
@@ -31,8 +31,8 @@
 }
 
 @mixin leadspace-block {
-  :host(#{$cds-prefix}-leadspace-block)
-    ::slotted(#{$cds-prefix}-leadspace-block-content) {
+  :host(#{$c4d-prefix}-leadspace-block)
+    ::slotted(#{$c4d-prefix}-leadspace-block-content) {
     @extend %leadspace-block-padding;
   }
 
@@ -68,8 +68,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-leadspace-with-search-heading),
-  :host(#{$cds-prefix}-leadspace-block-heading),
+  :host(#{$c4d-prefix}-leadspace-with-search-heading),
+  :host(#{$c4d-prefix}-leadspace-block-heading),
   .#{$prefix}--leadspace-block__title {
     width: 90%;
     color: $text-primary;
@@ -91,8 +91,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-leadspace-block-content)
-    ::slotted(#{$cds-prefix}-link-list),
+  :host(#{$c4d-prefix}-leadspace-block-content)
+    ::slotted(#{$c4d-prefix}-link-list),
   .#{$prefix}--leadspace-block .#{$prefix}--link-list {
     display: block;
     padding-top: $spacing-09;
@@ -112,12 +112,12 @@
     max-width: none;
   }
 
-  :host(#{$cds-prefix}-leadspace-block-content)
-    ::slotted(#{$cds-prefix}-content-block-copy) {
+  :host(#{$c4d-prefix}-leadspace-block-content)
+    ::slotted(#{$c4d-prefix}-content-block-copy) {
     display: block;
   }
 
-  :host(#{$cds-prefix}-leadspace-block-media),
+  :host(#{$c4d-prefix}-leadspace-block-media),
   .#{$prefix}--leadspace-block .#{$prefix}--leadspace-block__media {
     display: block;
     max-width: carbon--mini-units(80);
@@ -126,18 +126,18 @@
       padding-top: $spacing-05;
     }
 
-    ::slotted(#{$cds-prefix}-image),
+    ::slotted(#{$c4d-prefix}-image),
     .#{$prefix}--image-with-caption {
       margin-top: 0;
       margin-bottom: 0;
     }
   }
 
-  :host(#{$cds-prefix}-leadspace-block-cta),
+  :host(#{$c4d-prefix}-leadspace-block-cta),
   .#{$prefix}--leadspace-block .#{$prefix}--buttongroup {
     padding-top: 0;
 
-    ::slotted(#{$cds-prefix}-button-group-item),
+    ::slotted(#{$c4d-prefix}-button-group-item),
     .#{$prefix}--buttongroup-item {
       margin-top: 0;
       padding-top: 0;

--- a/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
+++ b/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
@@ -100,7 +100,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-leadspace-with-search) {
+  :host(#{$c4d-prefix}-leadspace-with-search) {
     display: block;
     position: relative;
 
@@ -118,7 +118,7 @@
       }
     }
 
-    #{$cds-prefix}-background-media {
+    #{$c4d-prefix}-background-media {
       display: block;
       height: auto;
 
@@ -141,7 +141,7 @@
       }
     }
 
-    ::slotted(#{$cds-prefix}-leadspace-block-heading) {
+    ::slotted(#{$c4d-prefix}-leadspace-block-heading) {
       @include breakpoint(md) {
         width: calc(75% - $spacing-07);
         max-width: rem(640px);
@@ -244,7 +244,7 @@
       }
     }
 
-    ::slotted(#{$cds-prefix}-search-with-typeahead) {
+    ::slotted(#{$c4d-prefix}-search-with-typeahead) {
       @include breakpoint(md) {
         width: 75%;
       }
@@ -254,7 +254,7 @@
       }
     }
 
-    ::slotted(#{$cds-prefix}-hr) {
+    ::slotted(#{$c4d-prefix}-hr) {
       margin: 0 calc(50% - 50vw);
       position: relative;
       background: $layer-accent-01;
@@ -267,14 +267,14 @@
     }
 
     &[adjacent-theme='g10-and-white'] {
-      ::slotted(#{$cds-prefix}-background-media),
+      ::slotted(#{$c4d-prefix}-background-media),
       .#{$prefix}--content-layout {
         @include theme($g10, true);
       }
     }
 
     &[adjacent-theme='g90-and-g100'] {
-      ::slotted(#{$cds-prefix}-background-media),
+      ::slotted(#{$c4d-prefix}-background-media),
       .#{$prefix}--content-layout {
         @include theme($g90, true);
       }
@@ -285,7 +285,7 @@
     }
 
     &[adjacent-theme='g100-and-g90'] {
-      ::slotted(#{$cds-prefix}-background-media),
+      ::slotted(#{$c4d-prefix}-background-media),
       .#{$prefix}--content-layout {
         @include theme($g100, true);
       }
@@ -320,7 +320,7 @@
         }
       }
 
-      ::slotted(#{$cds-prefix}-search-with-typeahead) {
+      ::slotted(#{$c4d-prefix}-search-with-typeahead) {
         @include make-col(4, 4);
 
         @include breakpoint(lg) {
@@ -338,8 +338,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-leadspace-with-search-heading),
-  :host(#{$cds-prefix}-leadspace-with-search-content) {
+  :host(#{$c4d-prefix}-leadspace-with-search-heading),
+  :host(#{$c4d-prefix}-leadspace-with-search-content) {
     display: block;
     padding: 0;
 
@@ -350,8 +350,8 @@
     /* stylelint-enable declaration-no-important */
   }
 
-  :host(#{$cds-prefix}-leadspace-with-search-content-heading) {
-    @extend :host(#{$cds-prefix}-content-block-heading);
+  :host(#{$c4d-prefix}-leadspace-with-search-content-heading) {
+    @extend :host(#{$c4d-prefix}-content-block-heading);
 
     @include breakpoint-down(lg) {
       display: block;
@@ -374,8 +374,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-leadspace-with-search-content-copy) {
-    @extend :host(#{$cds-prefix}-content-block-paragraph);
+  :host(#{$c4d-prefix}-leadspace-with-search-content-copy) {
+    @extend :host(#{$c4d-prefix}-content-block-paragraph);
     @include type-style('fluid-heading-03', true);
 
     display: block;

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -47,7 +47,7 @@ $btn-min-width: 26;
     background-color: $background;
   }
 
-  ::slotted(#{$cds-prefix}-leadspace-heading),
+  ::slotted(#{$c4d-prefix}-leadspace-heading),
   .#{$prefix}--leadspace__title,
   .#{$prefix}--leadspace__desc {
     color: $text-primary;
@@ -78,7 +78,7 @@ $btn-min-width: 26;
     padding-top: $spacing-07;
   }
 
-  :host(#{$cds-prefix}-leadspace),
+  :host(#{$c4d-prefix}-leadspace),
   .#{$prefix}--leadspace {
     .#{$prefix}--image {
       /* stylelint-disable-next-line comment-whitespace-inside */
@@ -109,14 +109,14 @@ $btn-min-width: 26;
     }
 
     .#{$prefix}--buttongroup,
-    ::slotted(#{$cds-prefix}-button-group),
-    ::slotted(#{$cds-prefix}-leadspace-block-cta) {
+    ::slotted(#{$c4d-prefix}-button-group),
+    ::slotted(#{$c4d-prefix}-leadspace-block-cta) {
       padding-bottom: $spacing-07;
 
       @include breakpoint(md) {
         display: grid;
         grid-template-columns: repeat(
-          var(--#{$cds-prefix}--button-group--item-count),
+          var(--#{$c4d-prefix}--button-group--item-count),
           1fr
         );
         @media print {
@@ -143,7 +143,7 @@ $btn-min-width: 26;
     }
 
     .#{$prefix}--leadspace--productive {
-      ::slotted(#{$cds-prefix}-leadspace-heading),
+      ::slotted(#{$c4d-prefix}-leadspace-heading),
       .#{$prefix}--leadspace__title {
         @include type-style(fluid-heading-06, true);
       }
@@ -189,7 +189,7 @@ $btn-min-width: 26;
         height: 100%;
       }
 
-      ::slotted(#{$cds-prefix}-leadspace-heading),
+      ::slotted(#{$c4d-prefix}-leadspace-heading),
       .#{$prefix}--leadspace__title {
         width: percentage(math.div(6, 8));
 
@@ -221,7 +221,7 @@ $btn-min-width: 26;
         width: 100%;
       }
 
-      ::slotted(#{$cds-prefix}-leadspace-heading),
+      ::slotted(#{$c4d-prefix}-leadspace-heading),
       .#{$prefix}--leadspace__title {
         width: percentage(math.div(8, 16));
       }
@@ -232,7 +232,7 @@ $btn-min-width: 26;
       }
 
       .#{$prefix}--leadspace--productive {
-        ::slotted(#{$cds-prefix}-leadspace-heading),
+        ::slotted(#{$c4d-prefix}-leadspace-heading),
         .#{$prefix}--leadspace__title {
           @include make-col(7, 16);
         }
@@ -247,7 +247,7 @@ $btn-min-width: 26;
       background-size: cover;
       background-position: center top;
 
-      ::slotted(#{$cds-prefix}-button-group),
+      ::slotted(#{$c4d-prefix}-button-group),
       ::slotted([slot='action']),
       .#{$prefix}--buttongroup {
         padding-top: $spacing-05;
@@ -278,14 +278,14 @@ $btn-min-width: 26;
         @include type-style(fluid-heading-03, true);
       }
 
-      ::slotted(#{$cds-prefix}-leadspace-heading),
+      ::slotted(#{$c4d-prefix}-leadspace-heading),
       .#{$prefix}--leadspace__title {
         margin-bottom: 0;
         @include type-style(fluid-heading-05, true);
       }
 
       .#{$prefix}--leadspace__desc,
-      ::slotted(#{$cds-prefix}-leadspace-heading),
+      ::slotted(#{$c4d-prefix}-leadspace-heading),
       .#{$prefix}--leadspace__title {
         flex: none;
       }
@@ -311,7 +311,7 @@ $btn-min-width: 26;
           }
         }
 
-        ::slotted(#{$cds-prefix}-leadspace-heading),
+        ::slotted(#{$c4d-prefix}-leadspace-heading),
         .#{$prefix}--leadspace__title,
         .#{$prefix}--leadspace__desc {
           @include content-width;
@@ -439,18 +439,18 @@ $btn-min-width: 26;
     }
   }
 
-  :host(#{$cds-prefix}-leadspace) ::slotted([slot='navigation']) {
+  :host(#{$c4d-prefix}-leadspace) ::slotted([slot='navigation']) {
     z-index: 1;
     padding-left: $spacing-05;
     padding-right: $spacing-05;
     max-width: rem(640px);
   }
 
-  :host(#{$cds-prefix}-leadspace) ::slotted(#{$cds-prefix}-tag-group) {
+  :host(#{$c4d-prefix}-leadspace) ::slotted(#{$c4d-prefix}-tag-group) {
     padding-bottom: $spacing-03;
   }
 
-  :host(#{$cds-prefix}-breadcrumb-link[aria-current='page']) .#{$prefix}--link {
+  :host(#{$c4d-prefix}-breadcrumb-link[aria-current='page']) .#{$prefix}--link {
     color: $text-primary;
     cursor: auto;
 
@@ -459,13 +459,13 @@ $btn-min-width: 26;
     }
   }
 
-  :host(#{$cds-prefix}-leadspace) ::slotted(#{$cds-prefix}-leadspace-image) {
+  :host(#{$c4d-prefix}-leadspace) ::slotted(#{$c4d-prefix}-leadspace-image) {
     @include breakpoint(lg) {
       height: 100%;
     }
   }
 
-  :host(#{$cds-prefix}-leadspace-heading),
+  :host(#{$c4d-prefix}-leadspace-heading),
   .#{$prefix}--leadspace__title {
     padding-top: 0;
     margin-bottom: $spacing-09;
@@ -482,17 +482,17 @@ $btn-min-width: 26;
     /* stylelint-enable declaration-no-important */
   }
 
-  :host(#{$cds-prefix}-leadspace)[size='tall'],
-  :host(#{$cds-prefix}-leadspace)[size='super'] {
-    ::slotted(#{$cds-prefix}-leadspace-heading) {
+  :host(#{$c4d-prefix}-leadspace)[size='tall'],
+  :host(#{$c4d-prefix}-leadspace)[size='super'] {
+    ::slotted(#{$c4d-prefix}-leadspace-heading) {
       @include breakpoint(lg) {
         margin-bottom: $spacing-12;
       }
     }
   }
 
-  :host(#{$cds-prefix}-leadspace)[size='tall'],
-  :host(#{$cds-prefix}-leadspace)[size] {
+  :host(#{$c4d-prefix}-leadspace)[size='tall'],
+  :host(#{$c4d-prefix}-leadspace)[size] {
     .#{$prefix}--leadspace__section {
       height: auto;
 
@@ -502,8 +502,8 @@ $btn-min-width: 26;
     }
   }
 
-  :host(#{$cds-prefix}-leadspace)[size='short'] {
-    ::slotted(#{$cds-prefix}-leadspace-heading) {
+  :host(#{$c4d-prefix}-leadspace)[size='short'] {
+    ::slotted(#{$c4d-prefix}-leadspace-heading) {
       margin-bottom: $spacing-07;
       @include type-style(fluid-heading-06, true);
 
@@ -519,7 +519,7 @@ $btn-min-width: 26;
     }
   }
 
-  :host-context(#{$cds-prefix}-leadspace[size='short']) {
+  :host-context(#{$c4d-prefix}-leadspace[size='short']) {
     @include breakpoint(lg) {
       .#{$prefix}--image__img {
         object-position: left top;
@@ -527,8 +527,8 @@ $btn-min-width: 26;
     }
   }
 
-  :host(#{$cds-prefix}-leadspace)[size='medium'] {
-    ::slotted(#{$cds-prefix}-leadspace-heading) {
+  :host(#{$c4d-prefix}-leadspace)[size='medium'] {
+    ::slotted(#{$c4d-prefix}-leadspace-heading) {
       @include type-style(fluid-heading-05, true);
 
       @include breakpoint(lg) {
@@ -543,8 +543,8 @@ $btn-min-width: 26;
     }
   }
 
-  :host(#{$cds-prefix}-leadspace)[size='super'] {
-    ::slotted(#{$cds-prefix}-leadspace-heading) {
+  :host(#{$c4d-prefix}-leadspace)[size='super'] {
+    ::slotted(#{$c4d-prefix}-leadspace-heading) {
       @include type-style(display-01, true);
     }
 
@@ -555,7 +555,7 @@ $btn-min-width: 26;
     }
   }
 
-  :host(#{$cds-prefix}-leadspace-image),
+  :host(#{$c4d-prefix}-leadspace-image),
   .#{$prefix}--leadspace .#{$prefix}--image {
     @include ratio-base(4, 3, false);
 

--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -57,7 +57,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-lightbox-media-viewer-body),
+  :host(#{$c4d-prefix}-lightbox-media-viewer-body),
   .#{$prefix}--lightbox-media-viewer__container {
     display: block;
     width: 100%;
@@ -195,7 +195,7 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-video-player-container) {
+  ::slotted(#{$c4d-prefix}-video-player-container) {
     width: 100%;
   }
 }

--- a/packages/styles/scss/components/link-list/_link-list.scss
+++ b/packages/styles/scss/components/link-list/_link-list.scss
@@ -25,8 +25,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-link-list-item-card),
-  :host(#{$cds-prefix}-link-list-item-card-cta),
+  :host(#{$c4d-prefix}-link-list-item-card),
+  :host(#{$c4d-prefix}-link-list-item-card-cta),
   .#{$prefix}--link-list {
     .#{$prefix}--card {
       max-width: none;
@@ -93,15 +93,15 @@
     }
   }
 
-  :host(#{$cds-prefix}-link-list-item-card-cta) {
-    ::slotted(#{$cds-prefix}-card-cta-footer) {
+  :host(#{$c4d-prefix}-link-list-item-card-cta) {
+    ::slotted(#{$c4d-prefix}-card-cta-footer) {
       @include breakpoint-down(lg) {
         margin-top: 0;
       }
     }
   }
 
-  :host(#{$cds-prefix}-link-list-item-card-cta)[cta-type='video'],
+  :host(#{$c4d-prefix}-link-list-item-card-cta)[cta-type='video'],
   .#{$prefix}--card__video {
     [slot='heading'],
     .#{$prefix}--card__heading {
@@ -114,7 +114,7 @@
       }
     }
   }
-  :host(#{$cds-prefix}-link-list-item-card-cta)[cta-type='video'] {
+  :host(#{$c4d-prefix}-link-list-item-card-cta)[cta-type='video'] {
     [slot='heading'],
     .#{$prefix}--card__heading {
       color: $link-primary;
@@ -122,7 +122,7 @@
   }
 
   .#{$prefix}--link-list__heading,
-  :host(#{$cds-prefix}-link-list-heading) {
+  :host(#{$c4d-prefix}-link-list-heading) {
     margin-bottom: $spacing-05;
 
     @include type-style('heading-02');
@@ -136,10 +136,10 @@
   }
 
   .#{$prefix}--link-list__list--horizontal {
-    ::slotted(#{$cds-prefix}-link-list-item),
-    ::slotted(#{$cds-prefix}-link-list-item-card),
-    ::slotted(#{$cds-prefix}-link-list-item-cta),
-    ::slotted(#{$cds-prefix}-link-list-item-card-cta),
+    ::slotted(#{$c4d-prefix}-link-list-item),
+    ::slotted(#{$c4d-prefix}-link-list-item-card),
+    ::slotted(#{$c4d-prefix}-link-list-item-cta),
+    ::slotted(#{$c4d-prefix}-link-list-item-card-cta),
     .#{$prefix}--link-list__list__CTA {
       float: left;
       padding-right: $spacing-07;
@@ -180,8 +180,8 @@
   }
 
   .#{$prefix}--link-list__list--vertical-end {
-    ::slotted(#{$cds-prefix}-link-list-item),
-    ::slotted(#{$cds-prefix}-link-list-item-cta),
+    ::slotted(#{$c4d-prefix}-link-list-item),
+    ::slotted(#{$c4d-prefix}-link-list-item-cta),
     .#{$prefix}--link-list__list__CTA .#{$prefix}--link-with-icon__container {
       @include make-col-ready;
 
@@ -228,8 +228,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-link-list-item-card),
-  :host(#{$cds-prefix}-link-list-item-card-cta),
+  :host(#{$c4d-prefix}-link-list-item-card),
+  :host(#{$c4d-prefix}-link-list-item-card-cta),
   .#{$prefix}--link-list__list__CTA {
     &.#{$prefix}--link-list__list--video .#{$prefix}--card__footer span {
       color: $link-primary;
@@ -241,8 +241,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-link-list-item-card),
-  :host(#{$cds-prefix}-link-list-item-card-cta),
+  :host(#{$c4d-prefix}-link-list-item-card),
+  :host(#{$c4d-prefix}-link-list-item-card-cta),
   .#{$prefix}--link-list__list--card .#{$prefix}--link-list__list__CTA {
     max-width: carbon--mini-units(80);
     border-top: 1px solid $layer-accent-01;
@@ -252,8 +252,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-link-list-item-card),
-  :host(#{$cds-prefix}-link-list-item-card-cta),
+  :host(#{$c4d-prefix}-link-list-item-card),
+  :host(#{$c4d-prefix}-link-list-item-card-cta),
   .#{$prefix}--link-list__list--card .#{$prefix}--link-list__list__CTA div {
     .#{$prefix}--tile {
       margin-left: 0;

--- a/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
+++ b/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
@@ -16,10 +16,10 @@
 
 @mixin link-with-icon {
   .#{$prefix}--link-with-icon,
-  :host(#{$cds-prefix}-link-with-icon),
-  :host(#{$cds-prefix}-link-list-item),
-  :host(#{$cds-prefix}-link-list-item-cta),
-  :host(#{$cds-prefix}-text-cta) {
+  :host(#{$c4d-prefix}-link-with-icon),
+  :host(#{$c4d-prefix}-link-list-item),
+  :host(#{$c4d-prefix}-link-list-item-cta),
+  :host(#{$c4d-prefix}-text-cta) {
     display: flex;
 
     span {
@@ -64,13 +64,13 @@
   }
 
   .#{$prefix}--link-with-icon__container,
-  :host(#{$cds-prefix}-callout-link-with-icon),
-  :host(#{$cds-prefix}-card-cta-footer),
-  :host(#{$cds-prefix}-card-footer),
-  :host(#{$cds-prefix}-link-with-icon),
-  :host(#{$cds-prefix}-link-list-item),
-  :host(#{$cds-prefix}-link-list-item-cta),
-  :host(#{$cds-prefix}-text-cta) {
+  :host(#{$c4d-prefix}-callout-link-with-icon),
+  :host(#{$c4d-prefix}-card-cta-footer),
+  :host(#{$c4d-prefix}-card-footer),
+  :host(#{$c4d-prefix}-link-with-icon),
+  :host(#{$c4d-prefix}-link-list-item),
+  :host(#{$c4d-prefix}-link-list-item-cta),
+  :host(#{$c4d-prefix}-text-cta) {
     .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon {
       display: inline-block;
 
@@ -87,7 +87,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-card-cta-footer)[mode='link-list'][cta-type='video'] {
+  :host(#{$c4d-prefix}-card-cta-footer)[mode='link-list'][cta-type='video'] {
     .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon span {
       display: none;
 
@@ -98,8 +98,8 @@
   }
 
   .#{$prefix}--link-with-icon,
-  :host(#{$cds-prefix}-link-with-icon),
-  :host(#{$cds-prefix}-text-cta) {
+  :host(#{$c4d-prefix}-link-with-icon),
+  :host(#{$c4d-prefix}-text-cta) {
     &:not(:first-of-type) {
       margin-left: $spacing-07;
     }
@@ -123,14 +123,14 @@
     }
   }
 
-  :host(#{$cds-prefix}-link-with-icon),
-  :host(#{$cds-prefix}-text-cta) {
+  :host(#{$c4d-prefix}-link-with-icon),
+  :host(#{$c4d-prefix}-text-cta) {
     &:focus {
       outline: none;
     }
   }
 
-  :host(#{$cds-prefix}-link-with-icon),
+  :host(#{$c4d-prefix}-link-with-icon),
   .#{$prefix}--link-with-icon__container {
     display: table;
   }

--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -22,7 +22,7 @@
 /// @group locale-modal
 
 @mixin locale-modal {
-  :host(#{$cds-prefix}-locale-modal),
+  :host(#{$c4d-prefix}-locale-modal),
   .#{$prefix}--locale-modal-container {
     @include theme(
       $white,
@@ -157,7 +157,7 @@
   }
 }
 
-:host(#{$cds-prefix}-region-item) .#{$prefix}--link,
+:host(#{$c4d-prefix}-region-item) .#{$prefix}--link,
 .#{$prefix}--locale-modal-container
   .#{$prefix}--locale-modal__regions
   .#{$prefix}--card {
@@ -180,14 +180,14 @@
   }
 }
 
-:host(#{$cds-prefix}-region-item),
+:host(#{$c4d-prefix}-region-item),
 .#{$prefix}--modal-container {
   svg.#{$prefix}--card__cta {
     color: $border-inverse;
   }
 }
 
-:host(#{$cds-prefix}-locale-item) a.#{$prefix}--link,
+:host(#{$c4d-prefix}-locale-item) a.#{$prefix}--link,
 .#{$prefix}--locale-modal-container .#{$prefix}--locale-modal__locales {
   text-decoration: none;
   border: $spacing-01 solid transparent;
@@ -208,7 +208,7 @@
   }
 }
 
-:host(#{$cds-prefix}-locale-item),
+:host(#{$c4d-prefix}-locale-item),
 .#{$prefix}--locale-modal-container {
   .#{$prefix}--locale-modal__locales__name {
     width: 50%;
@@ -222,7 +222,7 @@
   }
 }
 
-:host(#{$cds-prefix}-locale-search),
+:host(#{$c4d-prefix}-locale-search),
 .#{$prefix}--locale-modal-container .#{$prefix}--locale-modal__filtering {
   display: flex;
   flex-direction: column;
@@ -249,7 +249,7 @@
   }
 }
 
-:host(#{$cds-prefix}-locale-search),
+:host(#{$c4d-prefix}-locale-search),
 .#{$prefix}--locale-modal-container {
   .#{$prefix}--locale-modal__search {
     position: sticky;

--- a/packages/styles/scss/components/logo-grid/_logo-grid.scss
+++ b/packages/styles/scss/components/logo-grid/_logo-grid.scss
@@ -21,7 +21,7 @@
 
 @mixin logo-grid {
   .#{$prefix}--logo-grid,
-  :host(#{$cds-prefix}-logo-grid) {
+  :host(#{$c4d-prefix}-logo-grid) {
     .#{$prefix}--content-block {
       padding-top: 0;
       padding-bottom: 0;
@@ -82,7 +82,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-logo-grid) {
+  :host(#{$c4d-prefix}-logo-grid) {
     .#{$prefix}--content-block__cta-row[hidden] {
       display: none;
     }
@@ -124,7 +124,7 @@
   }
 
   .#{$prefix}--logo-grid__col,
-  :host(#{$cds-prefix}-logo-grid-item) {
+  :host(#{$c4d-prefix}-logo-grid-item) {
     /* stylelint-disable */
     aspect-ratio: var(--logo-ratio, '16/9');
     /* stylelint-enable */
@@ -136,7 +136,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-logo-grid-item) {
+  :host(#{$c4d-prefix}-logo-grid-item) {
     display: flex;
     align-items: stretch;
     justify-content: center;
@@ -173,7 +173,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-logo-grid-link) ::slotted(svg) {
+  :host(#{$c4d-prefix}-logo-grid-link) ::slotted(svg) {
     margin-top: auto;
     fill: $link-primary;
   }

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -19,7 +19,7 @@
 
 @mixin masthead-l1 {
   .#{$prefix}--masthead__l1,
-  :host(#{$cds-prefix}-masthead-l1) {
+  :host(#{$c4d-prefix}-masthead-l1) {
     @include theme($white, true);
 
     display: flex;
@@ -68,7 +68,7 @@
   }
 
   .#{$prefix}--masthead__l1-name,
-  :host(#{$cds-prefix}-masthead-l1-name) {
+  :host(#{$c4d-prefix}-masthead-l1-name) {
     display: flex;
     height: 100%;
     z-index: 1;

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -167,7 +167,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-left-nav-menu-section),
+  :host(#{$c4d-prefix}-left-nav-menu-section),
   .#{$prefix}--side-nav__menu-section {
     @include theme($white, true);
 
@@ -331,23 +331,23 @@
     color: $link-primary;
   }
 
-  :host(#{$cds-prefix}-left-nav-menu-section)[expanded],
+  :host(#{$c4d-prefix}-left-nav-menu-section)[expanded],
   .#{$prefix}--side-nav__menu-section--expanded {
     z-index: 1;
     inset-inline-start: 0;
   }
 
-  :host(#{$cds-prefix}-left-nav-menu-section)[is-submenu],
+  :host(#{$c4d-prefix}-left-nav-menu-section)[is-submenu],
   .#{$prefix}--side-nav__menu-section-submenu {
     inset-inline-start: 100%;
   }
 
-  :host(#{$cds-prefix}-left-nav-menu-section)[is-submenu][expanded],
+  :host(#{$c4d-prefix}-left-nav-menu-section)[is-submenu][expanded],
   .#{$prefix}--side-nav__menu-section-submenu.#{$prefix}--side-nav__menu-section--expanded {
     inset-inline-start: 0;
   }
 
-  :host(#{$cds-prefix}-left-nav-menu-section)[is-submenu][transition],
+  :host(#{$c4d-prefix}-left-nav-menu-section)[is-submenu][transition],
   .#{$prefix}--side-nav__menu-section-submenu--expanded {
     inset-inline-start: -100%;
   }
@@ -408,7 +408,7 @@
   }
 
   .#{$prefix}--masthead__side-nav--submemu-heading,
-  :host(#{$cds-prefix}-left-nav-menu-category-heading) {
+  :host(#{$c4d-prefix}-left-nav-menu-category-heading) {
     @include type-style('body-01');
 
     font-size: $spacing-05;
@@ -446,11 +446,11 @@
   .#{$prefix}--side-nav__item .#{$prefix}--side-nav__link,
   .#{$prefix}--side-nav__menu-item
     .#{$prefix}--side-nav__link:not([isbackbutton='true']),
-  :host(#{$cds-prefix}-left-nav-item-highlighted) a.#{$prefix}--side-nav__link,
-  :host(#{$cds-prefix}-left-nav-menu-item-highlighted)
+  :host(#{$c4d-prefix}-left-nav-item-highlighted) a.#{$prefix}--side-nav__link,
+  :host(#{$c4d-prefix}-left-nav-menu-item-highlighted)
     a.#{$prefix}--side-nav__link,
-  :host(#{$cds-prefix}-left-nav-item) a.#{$prefix}--side-nav__link,
-  :host(#{$cds-prefix}-left-nav-menu-item) a.#{$prefix}--side-nav__link {
+  :host(#{$c4d-prefix}-left-nav-item) a.#{$prefix}--side-nav__link,
+  :host(#{$c4d-prefix}-left-nav-menu-item) a.#{$prefix}--side-nav__link {
     display: flex;
     padding-left: $spacing-05;
     height: auto;
@@ -459,12 +459,12 @@
   }
 
   .#{$prefix}--masthead__side-nav__last-highlighted,
-  :host(#{$cds-prefix}-left-nav-menu-item[last-highlighted]),
-  :host(#{$cds-prefix}-left-nav-menu[last-highlighted]) {
+  :host(#{$c4d-prefix}-left-nav-menu-item[last-highlighted]),
+  :host(#{$c4d-prefix}-left-nav-menu[last-highlighted]) {
     border-bottom: 1px solid $toggle-off;
   }
 
-  :host(#{$cds-prefix}-left-nav-menu[last-highlighted])
+  :host(#{$c4d-prefix}-left-nav-menu[last-highlighted])
     .#{$prefix}--side-nav__submenu
     .#{$prefix}--side-nav__submenu-content,
   .#{$prefix}--masthead__side-nav__last-highlighted
@@ -475,7 +475,7 @@
     .#{$prefix}--masthead__side-nav--submemu-back
     .#{$prefix}--side-nav__link
     .#{$prefix}--side-nav__link-text,
-  :host(#{$cds-prefix}-left-nav-menu-item[last-highlighted])
+  :host(#{$c4d-prefix}-left-nav-menu-item[last-highlighted])
     .#{$prefix}--side-nav__link {
     border-bottom: none;
   }

--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -40,7 +40,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-megamenu-top-nav-menu)
+  :host(#{$c4d-prefix}-megamenu-top-nav-menu)
     .#{$prefix}--header__menu-title[aria-expanded='true']
     + .#{$prefix}--header__menu,
   .#{$prefix}--header__nav
@@ -56,7 +56,7 @@
     box-shadow: none;
   }
 
-  :host(#{$cds-prefix}-megamenu-top-nav-menu),
+  :host(#{$c4d-prefix}-megamenu-top-nav-menu),
   .#{$prefix}--masthead__megamenu__l0-nav,
   .#{$prefix}--masthead__megamenu__l1-nav {
     .#{$prefix}--header__menu {
@@ -72,8 +72,8 @@
 
     .#{$prefix}--header__menu-title[aria-expanded='false']
       + .#{$prefix}--header__menu {
-      ::slotted(#{$cds-prefix}-megamenu),
-      ::slotted(#{$cds-prefix}-cloud-megamenu),
+      ::slotted(#{$c4d-prefix}-megamenu),
+      ::slotted(#{$c4d-prefix}-cloud-megamenu),
       .#{$prefix}--masthead__megamenu {
         animation: $transition-expansion motion(standard, expressive) collapse;
       }
@@ -90,18 +90,18 @@
       margin-bottom: $spacing-10;
       // `100vw` in Shadow DOM causes delayed rendering bug in Safari
       // https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/4493
-      width: var(--#{$cds-prefix}-ce--viewport-width, 100vw);
+      width: var(--#{$c4d-prefix}-ce--viewport-width, 100vw);
       min-height: carbon--mini-units(40);
 
-      ::slotted(#{$cds-prefix}-megamenu),
-      ::slotted(#{$cds-prefix}-cloud-megamenu),
+      ::slotted(#{$c4d-prefix}-megamenu),
+      ::slotted(#{$c4d-prefix}-cloud-megamenu),
       .#{$prefix}--masthead__megamenu {
         animation: $transition-expansion motion(standard, expressive) expand;
       }
     }
   }
 
-  :host(#{$cds-prefix}-megamenu-top-nav-menu),
+  :host(#{$c4d-prefix}-megamenu-top-nav-menu),
   .#{$prefix}--masthead__megamenu__l0-nav {
     .#{$prefix}--header__menu-title[aria-expanded='true']
       + .#{$prefix}--header__menu {
@@ -115,8 +115,8 @@
     top: $l1-nav-height;
   }
 
-  :host(#{$cds-prefix}-megamenu),
-  :host(#{$cds-prefix}-cloud-megamenu),
+  :host(#{$c4d-prefix}-megamenu),
+  :host(#{$c4d-prefix}-cloud-megamenu),
   .#{$prefix}--masthead__megamenu {
     display: block;
     overflow-y: overlay;
@@ -141,7 +141,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-megamenu-right-navigation),
+  :host(#{$c4d-prefix}-megamenu-right-navigation),
   .#{$prefix}--masthead__megamenu__categories-section {
     display: flex;
     flex-direction: column;
@@ -164,7 +164,7 @@
   }
 
   .#{$prefix}--masthead__megamenu__copy,
-  :host(#{$cds-prefix}-megamenu-category-group-copy) {
+  :host(#{$c4d-prefix}-megamenu-category-group-copy) {
     display: block;
     @include type-style('body-01');
 
@@ -172,7 +172,7 @@
     padding: rem(6px) $spacing-05 rem(10px);
   }
 
-  :host(#{$cds-prefix}-megamenu-category-group),
+  :host(#{$c4d-prefix}-megamenu-category-group),
   .#{$prefix}--masthead__megamenu__category-group {
     display: block;
 
@@ -183,7 +183,7 @@
     }
 
     .#{$prefix}--masthead__megamenu__copy,
-    ::slotted(#{$cds-prefix}-megamenu-category-group-copy) {
+    ::slotted(#{$c4d-prefix}-megamenu-category-group-copy) {
       @include type-style('body-01');
 
       color: $text-primary;
@@ -192,7 +192,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-megamenu-link-with-icon) {
+  :host(#{$c4d-prefix}-megamenu-link-with-icon) {
     span {
       flex: inherit;
     }
@@ -207,7 +207,7 @@
   }
 
   :host(
-      #{$cds-prefix}-megamenu-link-with-icon
+      #{$c4d-prefix}-megamenu-link-with-icon
     )[style-scheme='category-headline'],
   .#{$prefix}--masthead__megamenu__category-headline {
     width: 100%;
@@ -240,7 +240,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-megamenu-category-link) a,
+  :host(#{$c4d-prefix}-megamenu-category-link) a,
   .#{$prefix}--masthead__megamenu__category-sublink {
     @include type-style('body-01');
 
@@ -257,7 +257,7 @@
 
   .#{$prefix}--masthead__megamenu__category-sublink--highlighted,
   :host(
-      #{$cds-prefix}-megamenu-link-with-icon
+      #{$c4d-prefix}-megamenu-link-with-icon
     )[style-scheme='category-sublink'] {
     @include type-style('body-compact-01');
 
@@ -269,13 +269,13 @@
   }
 
   .#{$prefix}--masthead__megamenu__category-sublink--highlighted,
-  :host(#{$cds-prefix}-megamenu-link-with-icon)[style-scheme='category-sublink']
+  :host(#{$c4d-prefix}-megamenu-link-with-icon)[style-scheme='category-sublink']
     a {
     width: 100%;
     padding: 7px $spacing-05;
   }
 
-  :host(#{$cds-prefix}-megamenu-link-with-icon)[style-scheme='view-all'],
+  :host(#{$c4d-prefix}-megamenu-link-with-icon)[style-scheme='view-all'],
   .#{$prefix}--masthead__megamenu__view-all-cta {
     margin-top: auto;
     display: flex;
@@ -313,8 +313,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-megamenu-category-link) a,
-  :host(#{$cds-prefix}-megamenu-link-with-icon) a,
+  :host(#{$c4d-prefix}-megamenu-category-link) a,
+  :host(#{$c4d-prefix}-megamenu-link-with-icon) a,
   .#{$prefix}--masthead__megamenu__category-headline
     .#{$prefix}--link-with-icon,
   .#{$prefix}--masthead__megamenu__category-sublink--highlighted,
@@ -343,7 +343,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-megamenu-left-navigation),
+  :host(#{$c4d-prefix}-megamenu-left-navigation),
   .#{$prefix}--masthead__megamenu__highlight-section {
     min-height: 100%;
     padding-top: rem(18px);
@@ -356,7 +356,7 @@
       flex-direction: column;
     }
 
-    :host(#{$cds-prefix}-megamenu-left-navigation),
+    :host(#{$c4d-prefix}-megamenu-left-navigation),
     .#{$prefix}--masthead__megamenu__highlight-section {
       border-right: none;
       border-bottom: rem(1px) solid $layer-accent-01;
@@ -365,7 +365,7 @@
       @include make-col(8, 8);
     }
 
-    :host(#{$cds-prefix}-megamenu-right-navigation),
+    :host(#{$c4d-prefix}-megamenu-right-navigation),
     .#{$prefix}--masthead__megamenu__categories-section {
       .#{$prefix}--masthead__megamenu__categories {
         column-count: 2;

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -62,7 +62,7 @@
 @mixin masthead-search {
   // main nav/search container excluding
   // profile and logo icons - TODO rename this
-  :host(#{$cds-prefix}-top-nav),
+  :host(#{$c4d-prefix}-top-nav),
   .#{$prefix}--header__search {
     display: flex;
     flex: 1;
@@ -155,7 +155,7 @@
 
   // search container
   .#{$prefix}--masthead__search,
-  :host(#{$cds-prefix}-masthead-search) {
+  :host(#{$c4d-prefix}-masthead-search) {
     height: $spacing-09;
     margin-left: $spacing-09;
 

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -175,14 +175,14 @@
 
 /// @access private
 @mixin masthead {
-  :host(#{$cds-prefix}-masthead-composite),
-  :host(#{$cds-prefix}-cloud-masthead-container) {
+  :host(#{$c4d-prefix}-masthead-composite),
+  :host(#{$c4d-prefix}-cloud-masthead-container) {
     z-index: 900;
     padding-top: $spacing-09;
   }
 
   .#{$prefix}--masthead,
-  :host(#{$cds-prefix}-masthead) {
+  :host(#{$c4d-prefix}-masthead) {
     @include theme($white, true);
 
     position: fixed;
@@ -200,7 +200,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-megamenu-overlay),
+  :host(#{$c4d-prefix}-megamenu-overlay),
   .#{$prefix}--masthead__overlay {
     position: fixed;
     left: 0;
@@ -216,7 +216,7 @@
       background-color $transition-expansion $standard-easing;
   }
 
-  :host(#{$cds-prefix}-megamenu-overlay)[active],
+  :host(#{$c4d-prefix}-megamenu-overlay)[active],
   .#{$prefix}--masthead__overlay-show {
     background-color: $overlay;
     visibility: visible;
@@ -224,7 +224,7 @@
     height: 100vh;
   }
 
-  :host(#{$cds-prefix}-megamenu-link-with-icon) {
+  :host(#{$c4d-prefix}-megamenu-link-with-icon) {
     @extend .#{$prefix}--link-with-icon;
   }
 
@@ -337,15 +337,15 @@
   }
 
   .#{$prefix}--header__submenu,
-  :host(#{$cds-prefix}-top-nav-menu-item) {
+  :host(#{$c4d-prefix}-top-nav-menu-item) {
     .#{$prefix}--text-truncate--end {
       white-space: normal;
     }
   }
 
-  :host(#{$cds-prefix}-top-nav-item),
-  :host(#{$cds-prefix}-top-nav-menu),
-  :host(#{$cds-prefix}-megamenu-top-nav-menu),
+  :host(#{$c4d-prefix}-top-nav-item),
+  :host(#{$c4d-prefix}-top-nav-menu),
+  :host(#{$c4d-prefix}-megamenu-top-nav-menu),
   .#{$prefix}--header__nav {
     a.#{$prefix}--header__menu-item {
       @include masthead-top-nav-link;
@@ -385,15 +385,15 @@
     }
   }
 
-  :host(#{$cds-prefix}-top-nav-menu),
-  :host(#{$cds-prefix}-megamenu-top-nav-menu) {
+  :host(#{$c4d-prefix}-top-nav-menu),
+  :host(#{$c4d-prefix}-megamenu-top-nav-menu) {
     a.#{$prefix}--header__menu-item {
       border-bottom: $spacing-01 solid transparent;
       padding: rem(13px) $spacing-05 rem(11px);
     }
   }
 
-  :host(#{$cds-prefix}-top-nav-menu),
+  :host(#{$c4d-prefix}-top-nav-menu),
   .#{$prefix}--header__nav {
     .#{$prefix}--header__menu-title[aria-expanded='true'] {
       z-index: 0;
@@ -714,7 +714,7 @@
   }
 
   @media print {
-    :host(#{$cds-prefix}-masthead),
+    :host(#{$c4d-prefix}-masthead),
     .#{$prefix}--masthead {
       display: none;
     }

--- a/packages/styles/scss/components/pictogram-item/_pictogram-item.scss
+++ b/packages/styles/scss/components/pictogram-item/_pictogram-item.scss
@@ -16,7 +16,7 @@
 
 @mixin pictogram-item {
   .#{$prefix}--pictogram-item,
-  :host(#{$cds-prefix}-pictogram-item) {
+  :host(#{$c4d-prefix}-pictogram-item) {
     .#{$prefix}--pictogram-item__row {
       @include make-row;
 

--- a/packages/styles/scss/components/pricing-table/_pricing-table.scss
+++ b/packages/styles/scss/components/pricing-table/_pricing-table.scss
@@ -25,18 +25,18 @@
     top: -100%;
   }
   to {
-    top: var(--#{$cds-prefix}-sticky-header-height);
+    top: var(--#{$c4d-prefix}-sticky-header-height);
   }
 }
 
 @mixin pricing-table {
-  .#{$cds-prefix}--pricing-table,
-  :host(#{$cds-prefix}-pricing-table) {
-    @extend .#{$cds-prefix}--structured-list;
+  .#{$c4d-prefix}--pricing-table,
+  :host(#{$c4d-prefix}-pricing-table) {
+    @extend .#{$c4d-prefix}--structured-list;
 
     overflow-y: hidden;
 
-    .#{$cds-prefix}-pricing-table-sentinel {
+    .#{$c4d-prefix}-pricing-table-sentinel {
       display: block;
       height: 1px;
       margin-top: -1px;
@@ -45,12 +45,12 @@
   }
 
   .#{$prefix}--pricing-table-group,
-  :host(#{$cds-prefix}-pricing-table-group) {
+  :host(#{$c4d-prefix}-pricing-table-group) {
     @extend .#{$prefix}--structured-list-group;
   }
 
   .#{$prefix}--pricing-table-header-row,
-  :host(#{$cds-prefix}-pricing-table-header-row) {
+  :host(#{$c4d-prefix}-pricing-table-header-row) {
     @extend .#{$prefix}--structured-list-header-row;
 
     box-shadow: none;
@@ -73,7 +73,7 @@
       position: sticky;
       animation: sticky-header-slide-in $duration-slow-01
         motion(standard, productive);
-      top: var(--#{$cds-prefix}-sticky-header-height);
+      top: var(--#{$c4d-prefix}-sticky-header-height);
       background-color: $background;
       z-index: 1;
 
@@ -98,9 +98,9 @@
   .#{$prefix}--pricing-table-header-row,
   .#{$prefix}--pricing-table-row,
   .#{$prefix}--pricing-table-group tr,
-  :host(#{$cds-prefix}-pricing-table-header-row),
-  :host(#{$cds-prefix}-pricing-table-row),
-  :host(#{$cds-prefix}-pricing-table-group) tr {
+  :host(#{$c4d-prefix}-pricing-table-header-row),
+  :host(#{$c4d-prefix}-pricing-table-row),
+  :host(#{$c4d-prefix}-pricing-table-group) tr {
     @extend .#{$prefix}--structured-list-all-rows;
 
     position: relative;
@@ -123,8 +123,8 @@
 
   .#{$prefix}--pricing-table-header-row,
   .#{$prefix}--pricing-table-row,
-  :host(#{$cds-prefix}-pricing-table-header-row),
-  :host(#{$cds-prefix}-pricing-table-row) {
+  :host(#{$c4d-prefix}-pricing-table-header-row),
+  :host(#{$c4d-prefix}-pricing-table-row) {
     ::slotted(:last-child) {
       flex-grow: none;
       max-width: var(--width);
@@ -134,9 +134,9 @@
   .#{$prefix}--pricing-table-header-cell,
   .#{$prefix}--pricing-table-cell,
   .#{$prefix}--pricing-table-group th,
-  :host(#{$cds-prefix}-pricing-table-header-cell),
-  :host(#{$cds-prefix}-pricing-table-cell),
-  :host(#{$cds-prefix}-pricing-table-group) th {
+  :host(#{$c4d-prefix}-pricing-table-header-cell),
+  :host(#{$c4d-prefix}-pricing-table-cell),
+  :host(#{$c4d-prefix}-pricing-table-group) th {
     @extend .#{$prefix}--structured-list-all-cells;
 
     padding-block-end: $spacing-05;
@@ -144,8 +144,8 @@
 
   .#{$prefix}--pricing-table-header-cell,
   .#{$prefix}--pricing-table-cell,
-  :host(#{$cds-prefix}-pricing-table-header-cell),
-  :host(#{$cds-prefix}-pricing-table-cell) {
+  :host(#{$c4d-prefix}-pricing-table-header-cell),
+  :host(#{$c4d-prefix}-pricing-table-cell) {
     position: relative;
     background-color: $background;
 
@@ -161,12 +161,12 @@
   }
 
   .#{$prefix}--pricing-table-header-cell,
-  :host(#{$cds-prefix}-pricing-table-header-cell) {
+  :host(#{$c4d-prefix}-pricing-table-header-cell) {
     @extend .#{$prefix}--structured-list-header-cell;
   }
 
   .#{$prefix}--pricing-table-header-cell:not([scope='row']),
-  :host(#{$cds-prefix}-pricing-table-header-cell:not([scope='row'])) {
+  :host(#{$c4d-prefix}-pricing-table-header-cell:not([scope='row'])) {
     padding-block-end: $spacing-12;
     transition: padding-block-end $duration-slow-01 motion(standard, productive);
 
@@ -202,7 +202,7 @@
       }
 
       .#{$prefix}--pricing-table-header-cell-cta,
-      ::slotted(#{$cds-prefix}-pricing-table-header-cell-cta) {
+      ::slotted(#{$c4d-prefix}-pricing-table-header-cell-cta) {
         margin-block-start: $spacing-05;
       }
     }
@@ -216,7 +216,7 @@
     &.highlighted {
       position: relative;
 
-      ::slotted(#{$cds-prefix}-pricing-table-highlight-label) {
+      ::slotted(#{$c4d-prefix}-pricing-table-highlight-label) {
         display: block;
       }
     }
@@ -230,11 +230,11 @@
   }
 
   .#{$prefix}--pricing-table-cell,
-  :host(#{$cds-prefix}-pricing-table-cell) {
+  :host(#{$c4d-prefix}-pricing-table-cell) {
     @extend .#{$prefix}--structured-list-cell;
 
     &.annotation-visible {
-      ::slotted(#{$cds-prefix}-pricing-table-cell-annotation) {
+      ::slotted(#{$c4d-prefix}-pricing-table-cell-annotation) {
         display: block;
         height: auto;
         opacity: 1;
@@ -244,20 +244,20 @@
     }
 
     &.annotation-visible.no-cell-content {
-      ::slotted(#{$cds-prefix}-pricing-table-cell-annotation) {
+      ::slotted(#{$c4d-prefix}-pricing-table-cell-annotation) {
         margin-top: 0;
       }
     }
   }
 
-  :host(#{$cds-prefix}-pricing-table-cell[icon]) {
+  :host(#{$c4d-prefix}-pricing-table-cell[icon]) {
     &[icon='checkmark'] {
       color: $support-success;
     }
   }
 
   .#{$prefix}--pricing-table-highlight-label,
-  :host(#{$cds-prefix}-pricing-table-highlight-label) {
+  :host(#{$c4d-prefix}-pricing-table-highlight-label) {
     @include type-style('body-compact-01');
 
     display: none;
@@ -271,14 +271,14 @@
   }
 
   .#{$prefix}--pricing-table-header-cell-headline,
-  :host(#{$cds-prefix}-pricing-table-header-cell-headline) {
+  :host(#{$c4d-prefix}-pricing-table-header-cell-headline) {
     // @include type-style('fluid-heading-03');
     color: $text-primary;
     display: block;
   }
 
   .#{$prefix}--pricing-table-header-cell-caption,
-  :host(#{$cds-prefix}-pricing-table-header-cell-caption) {
+  :host(#{$c4d-prefix}-pricing-table-header-cell-caption) {
     @include type-style('heading-compact-01');
 
     color: $text-primary;
@@ -286,7 +286,7 @@
   }
 
   .#{$prefix}--pricing-table-header-cell-tag,
-  :host(#{$cds-prefix}-pricing-table-header-cell-tag) a {
+  :host(#{$c4d-prefix}-pricing-table-header-cell-tag) a {
     @extend .#{$prefix}--tag;
     @extend .#{$prefix}--tag--green;
     @extend .#{$prefix}--tag--sm;
@@ -300,7 +300,7 @@
   }
 
   .#{$prefix}--pricing-table-header-cell-description,
-  :host(#{$cds-prefix}-pricing-table-header-cell-description) {
+  :host(#{$c4d-prefix}-pricing-table-header-cell-description) {
     @include type-style('body-01');
 
     display: block;
@@ -309,7 +309,7 @@
   }
 
   .#{$prefix}--pricing-table-header-cell-cta,
-  :host(#{$cds-prefix}-pricing-table-header-cell-cta) {
+  :host(#{$c4d-prefix}-pricing-table-header-cell-cta) {
     @extend .#{$prefix}--button-group-item;
 
     display: block;
@@ -324,7 +324,7 @@
   }
 
   .#{$prefix}--pricing-table-annotation-toggle,
-  :host(#{$cds-prefix}-pricing-table-annotation-toggle) {
+  :host(#{$c4d-prefix}-pricing-table-annotation-toggle) {
     padding-inline-end: $spacing-03;
 
     button {
@@ -339,7 +339,7 @@
   }
 
   .#{$prefix}--pricing-table-cell-annotation,
-  :host(#{$cds-prefix}-pricing-table-cell-annotation) {
+  :host(#{$c4d-prefix}-pricing-table-cell-annotation) {
     display: block;
     color: $text-secondary;
     transition: $duration-fast-02 motion(standard, productive);

--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -18,7 +18,7 @@
 
 @mixin quote {
   .#{$prefix}--quote,
-  :host(#{$cds-prefix}-quote) {
+  :host(#{$c4d-prefix}-quote) {
     background: $background;
     padding-bottom: $spacing-10;
     display: block;
@@ -100,19 +100,19 @@
     padding-bottom: $spacing-09;
   }
 
-  :host(#{$cds-prefix}-quote-source-heading),
+  :host(#{$c4d-prefix}-quote-source-heading),
   .#{$prefix}--quote__source-heading {
     padding-left: $spacing-05;
     @include type-style(heading-02, true);
   }
 
-  :host(#{$cds-prefix}-quote-source-copy),
+  :host(#{$c4d-prefix}-quote-source-copy),
   .#{$prefix}--quote__source-body {
     padding-left: $spacing-05;
     @include type-style(body-02, true);
   }
 
-  :host(#{$cds-prefix}-quote-source-bottom-copy),
+  :host(#{$c4d-prefix}-quote-source-bottom-copy),
   .#{$prefix}--quote__source-optional-copy {
     padding-left: $spacing-05;
     @include type-style(body-02, true);
@@ -126,16 +126,16 @@
     }
   }
 
-  :host(#{$cds-prefix}-quote) .#{$prefix}--quote__footer {
+  :host(#{$c4d-prefix}-quote) .#{$prefix}--quote__footer {
     padding-left: $spacing-05;
     padding-right: $spacing-05;
 
-    ::slotted(#{$cds-prefix}-quote-link-with-icon) {
+    ::slotted(#{$c4d-prefix}-quote-link-with-icon) {
       margin-left: $spacing-05;
     }
   }
 
-  :host(#{$cds-prefix}-quote)[color-scheme='inverse'] {
+  :host(#{$c4d-prefix}-quote)[color-scheme='inverse'] {
     background: $background-inverse;
     color: $icon-inverse;
 
@@ -147,7 +147,7 @@
       padding-left: 0;
       padding-right: 0;
 
-      ::slotted(#{$cds-prefix}-quote-link-with-icon) {
+      ::slotted(#{$c4d-prefix}-quote-link-with-icon) {
         margin-left: 0;
         padding-left: $spacing-07;
         outline: transparent;
@@ -156,7 +156,7 @@
   }
 
   .#{$prefix}--callout__container,
-  :host(#{$cds-prefix}-callout) {
+  :host(#{$c4d-prefix}-callout) {
     @include make-row;
   }
 

--- a/packages/styles/scss/components/scroll-into-view/_scroll-into-view.scss
+++ b/packages/styles/scss/components/scroll-into-view/_scroll-into-view.scss
@@ -12,7 +12,7 @@
 
 @mixin scroll-into-view {
   :root {
-    --#{$cds-prefix}--fade-in-out-delay: 0s;
+    --#{$c4d-prefix}--fade-in-out-delay: 0s;
   }
 
   $cds--slide-distance: $spacing-07;
@@ -20,7 +20,7 @@
   .#{$prefix}--fade-in {
     transition-timing-function: motion(entrance, expressive);
     transition-duration: $duration-slow-01;
-    transition-delay: var(--#{$cds-prefix}--fade-in-out-delay);
+    transition-delay: var(--#{$c4d-prefix}--fade-in-out-delay);
     opacity: 1;
   }
 
@@ -37,7 +37,7 @@
 
       transition-timing-function: motion(entrance, expressive);
       transition-duration: $duration-slow-01;
-      transition-delay: var(--#{$cds-prefix}--fade-in-out-delay);
+      transition-delay: var(--#{$c4d-prefix}--fade-in-out-delay);
     }
 
     &-up {

--- a/packages/styles/scss/components/search-with-typeahead/_search-with-typeahead.scss
+++ b/packages/styles/scss/components/search-with-typeahead/_search-with-typeahead.scss
@@ -61,7 +61,7 @@
 @mixin search-with-typeahead {
   // main nav/search container excluding
   // profile and logo icons for masthead use
-  :host(#{$cds-prefix}-top-nav),
+  :host(#{$c4d-prefix}-top-nav),
   .#{$prefix}--header__search {
     display: flex;
     flex: 1;
@@ -189,19 +189,19 @@
     width: $spacing-09;
   }
 
-  :host(#{$cds-prefix}-search-with-typeahead) {
+  :host(#{$c4d-prefix}-search-with-typeahead) {
     display: block;
     position: relative;
     outline: none;
     height: $spacing-09;
     margin-left: rem($spacing-09);
 
-    .#{$cds-prefix}-ce__search__list {
+    .#{$c4d-prefix}-ce__search__list {
       height: 0;
       overflow: hidden;
     }
 
-    &[open] .#{$cds-prefix}-ce__search__list {
+    &[open] .#{$c4d-prefix}-ce__search__list {
       height: auto;
     }
 
@@ -481,7 +481,7 @@
   }
 }
 
-:host(#{$cds-prefix}-search-with-typeahead-item) {
+:host(#{$c4d-prefix}-search-with-typeahead-item) {
   @extend %react-autosuggest-suggestion;
 
   span {
@@ -510,8 +510,8 @@
   }
 }
 
-:host(#{$cds-prefix}-scoped-search-dropdown),
-:host(#{$cds-prefix}-scoped-search-dropdown-mobile) {
+:host(#{$c4d-prefix}-scoped-search-dropdown),
+:host(#{$c4d-prefix}-scoped-search-dropdown-mobile) {
   display: flex;
   border-right: 1px solid $layer-accent-01;
 
@@ -525,7 +525,7 @@
   }
 }
 
-:host(#{$cds-prefix}-scoped-search-dropdown) {
+:host(#{$c4d-prefix}-scoped-search-dropdown) {
   @include breakpoint-down(lg) {
     display: none;
   }
@@ -535,7 +535,7 @@
   }
 }
 
-:host(#{$cds-prefix}-scoped-search-dropdown-mobile) {
+:host(#{$c4d-prefix}-scoped-search-dropdown-mobile) {
   width: $spacing-09;
 
   .#{$prefix}--select-input {

--- a/packages/styles/scss/components/structured-list/_structured-list.scss
+++ b/packages/styles/scss/components/structured-list/_structured-list.scss
@@ -71,12 +71,12 @@
 @mixin structured-list {
   // Inherited Table Styles
   .#{$prefix}--structured-list-header-row,
-  :host(#{$cds-prefix}-structured-list-header-row) {
+  :host(#{$c4d-prefix}-structured-list-header-row) {
     border-bottom: none;
   }
 
   .#{$prefix}--structured-list-header-cell,
-  :host(#{$cds-prefix}-structured-list-header-cell) {
+  :host(#{$c4d-prefix}-structured-list-header-cell) {
     @extend .#{$prefix}--structured-list-th;
 
     padding-inline: $spacing-05;
@@ -85,7 +85,7 @@
   }
 
   .#{$prefix}--structured-list-group,
-  :host(#{$cds-prefix}-structured-list-group) {
+  :host(#{$c4d-prefix}-structured-list-group) {
     display: contents;
 
     tr {
@@ -112,7 +112,7 @@
   }
 
   .#{$prefix}--structured-list-cell,
-  :host(#{$cds-prefix}-structured-list-cell) {
+  :host(#{$c4d-prefix}-structured-list-cell) {
     @extend .#{$prefix}--structured-list-td;
 
     padding-inline: $spacing-05;
@@ -121,9 +121,9 @@
 
   // Default Carbon Rows/Columns
   .#{$prefix}--structured-list-all-rows,
-  :host(#{$cds-prefix}-structured-list-header-row),
-  :host(#{$cds-prefix}-structured-list-row),
-  :host(#{$cds-prefix}-structured-list-group) tr {
+  :host(#{$c4d-prefix}-structured-list-header-row),
+  :host(#{$c4d-prefix}-structured-list-row),
+  :host(#{$c4d-prefix}-structured-list-group) tr {
     --max-cols: 4;
 
     @include breakpoint(sm) {
@@ -151,9 +151,9 @@
   }
 
   .#{$prefix}--structured-list-all-cells,
-  :host(#{$cds-prefix}-structured-list-header-cell),
-  :host(#{$cds-prefix}-structured-list-cell),
-  :host(#{$cds-prefix}-structured-list-group) td {
+  :host(#{$c4d-prefix}-structured-list-header-cell),
+  :host(#{$c4d-prefix}-structured-list-cell),
+  :host(#{$c4d-prefix}-structured-list-group) td {
     height: auto;
     scroll-snap-align: start;
 
@@ -171,8 +171,8 @@
   }
 
   // Internal components
-  .#{$cds-prefix}--structured-list,
-  :host(#{$cds-prefix}-structured-list) {
+  .#{$c4d-prefix}--structured-list,
+  :host(#{$c4d-prefix}-structured-list) {
     display: flex;
     flex-wrap: nowrap;
     padding-left: $spacing-05;
@@ -239,7 +239,7 @@
   }
 
   .#{$prefix}--structured-list-cell-tooltip-icon,
-  :host(#{$cds-prefix}-structured-list-cell) #{$prefix}-tooltip-icon {
+  :host(#{$c4d-prefix}-structured-list-cell) #{$prefix}-tooltip-icon {
     display: inline-flex;
     vertical-align: sub;
 
@@ -249,7 +249,7 @@
   }
 
   .#{$prefix}--structured-list-cell[icon],
-  :host(#{$cds-prefix}-structured-list-cell[icon]) {
+  :host(#{$c4d-prefix}-structured-list-cell[icon]) {
     &[icon='checkmark'] {
       color: $support-success;
     }

--- a/packages/styles/scss/components/tableofcontents/_table-of-contents.scss
+++ b/packages/styles/scss/components/tableofcontents/_table-of-contents.scss
@@ -83,7 +83,7 @@ $hover-transition-timing: 95ms;
 }
 
 @mixin table-of-contents {
-  :host(#{$cds-prefix}-table-of-contents),
+  :host(#{$c4d-prefix}-table-of-contents),
   .#{$prefix}--tableofcontents {
     text-size-adjust: 100%;
     @extend .#{$prefix}--grid;
@@ -95,8 +95,8 @@ $hover-transition-timing: 95ms;
     @include themed-items;
   }
 
-  .#{$cds-prefix}-ce--table-of-contents__container,
-  .#{$cds-prefix}-ce--table-of-contents-horizontal__container {
+  .#{$c4d-prefix}-ce--table-of-contents__container,
+  .#{$c4d-prefix}-ce--table-of-contents-horizontal__container {
     @include make-row();
   }
 
@@ -220,7 +220,7 @@ $hover-transition-timing: 95ms;
       padding-bottom: $spacing-05;
     }
 
-    hr[data-autoid='#{$cds-prefix}--hr'] {
+    hr[data-autoid='#{$c4d-prefix}--hr'] {
       margin-top: 0;
     }
   }
@@ -436,7 +436,7 @@ $hover-transition-timing: 95ms;
   }
 
   @media print {
-    :host(#{$cds-prefix}-table-of-contents),
+    :host(#{$c4d-prefix}-table-of-contents),
     .#{$prefix}--tableofcontents {
       .#{$prefix}--tableofcontents__sidebar {
         position: relative;
@@ -459,7 +459,7 @@ $hover-transition-timing: 95ms;
         }
       }
 
-      ::slotted(#{$cds-prefix}-image) {
+      ::slotted(#{$c4d-prefix}-image) {
         width: 25%;
       }
     }

--- a/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
+++ b/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
@@ -14,7 +14,7 @@
 @use '../../globals/vars' as *;
 
 @mixin tabs-extended-media {
-  :host(#{$cds-prefix}-tabs-extended-media) {
+  :host(#{$c4d-prefix}-tabs-extended-media) {
     margin: 0;
     display: flex;
     overflow-x: hidden;

--- a/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
+++ b/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
@@ -22,8 +22,8 @@
 @use '@carbon/styles/scss/components/accordion';
 
 @mixin tabs-extended {
-  :host(#{$cds-prefix}-tabs-extended),
-  :host(#{$cds-prefix}-tabs-extended-media) {
+  :host(#{$c4d-prefix}-tabs-extended),
+  :host(#{$c4d-prefix}-tabs-extended-media) {
     .#{$prefix}--tabs {
       display: none;
 
@@ -209,8 +209,8 @@
   }
 
   @media print {
-    :host(#{$cds-prefix}-tabs-extended),
-    :host(#{$cds-prefix}-tabs-extended-media) {
+    :host(#{$c4d-prefix}-tabs-extended),
+    :host(#{$c4d-prefix}-tabs-extended-media) {
       .#{$prefix}--accordion__content {
         display: block;
       }

--- a/packages/styles/scss/components/tag-group/_tag-group.scss
+++ b/packages/styles/scss/components/tag-group/_tag-group.scss
@@ -10,12 +10,12 @@
 @use '../../globals/vars' as *;
 
 @mixin tag-group {
-  :host(#{$cds-prefix}-tag-group) {
+  :host(#{$c4d-prefix}-tag-group) {
     display: flex;
     flex-flow: row wrap;
     gap: $spacing-03;
 
-    ::slotted(#{$cds-prefix}-tag-link) {
+    ::slotted(#{$c4d-prefix}-tag-link) {
       display: flex;
     }
 

--- a/packages/styles/scss/components/tag-link/_tag-link.scss
+++ b/packages/styles/scss/components/tag-link/_tag-link.scss
@@ -11,7 +11,7 @@
 @use '../../globals/vars' as *;
 
 @mixin tag-link {
-  :host(#{$cds-prefix}-tag-link) a {
+  :host(#{$c4d-prefix}-tag-link) a {
     @include type-style(body-01, true);
 
     padding: rem(6px) $spacing-05;

--- a/packages/styles/scss/components/universal-banner/_universal-banner.scss
+++ b/packages/styles/scss/components/universal-banner/_universal-banner.scss
@@ -15,7 +15,7 @@
 @use '../../globals/vars' as *;
 
 @mixin universal-banner {
-  :host(#{$cds-prefix}-universal-banner) {
+  :host(#{$c4d-prefix}-universal-banner) {
     @include theme($g100, true);
 
     display: block;
@@ -66,7 +66,7 @@
       padding-inline-end: $spacing-05;
       position: relative;
 
-      ::slotted(#{$cds-prefix}-universal-banner-image) {
+      ::slotted(#{$c4d-prefix}-universal-banner-image) {
         position: absolute;
         width: calc(100% + #{$spacing-05});
         height: 100%;
@@ -183,7 +183,7 @@
       }
     }
 
-    ::slotted(#{$cds-prefix}-button-cta) {
+    ::slotted(#{$c4d-prefix}-button-cta) {
       @include theme($g100, true);
 
       width: 100%;
@@ -195,14 +195,14 @@
       }
     }
 
-    #{$cds-prefix}-link-with-icon {
+    #{$c4d-prefix}-link-with-icon {
       @include breakpoint(md) {
         display: none;
       }
     }
   }
 
-  :host(#{$cds-prefix}-universal-banner-heading) {
+  :host(#{$c4d-prefix}-universal-banner-heading) {
     @include type-style('heading-02', true);
 
     display: block;
@@ -222,14 +222,14 @@
     }
   }
 
-  :host(#{$cds-prefix}-universal-banner-copy) {
+  :host(#{$c4d-prefix}-universal-banner-copy) {
     @include type-style('body-compact-02', true);
 
     display: block;
     color: $text-primary;
   }
 
-  :host(#{$cds-prefix}-universal-banner-image) {
+  :host(#{$c4d-prefix}-universal-banner-image) {
     .#{$prefix}--image__img {
       object-fit: cover;
     }

--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -16,9 +16,9 @@
 $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
 
 @mixin video-player {
-  :host(#{$cds-prefix}-video-player),
+  :host(#{$c4d-prefix}-video-player),
   .#{$prefix}--video-player {
-    color: var(--#{$cds-prefix}--video-caption--color, $text-secondary);
+    color: var(--#{$c4d-prefix}--video-caption--color, $text-secondary);
 
     .#{$prefix}--image__img {
       width: 100%;
@@ -43,7 +43,7 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
     }
   }
 
-  :host(#{$cds-prefix}-video-player[background-mode='true']),
+  :host(#{$c4d-prefix}-video-player[background-mode='true']),
   .#{$prefix}--video-player[background-mode='true'] {
     .#{$prefix}--video-player__video-container {
       height: 100%;
@@ -64,7 +64,7 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
     outline: $spacing-01 solid $focus;
   }
 
-  :host(#{$cds-prefix}-video-player) #{$cds-prefix}-image,
+  :host(#{$c4d-prefix}-video-player) #{$c4d-prefix}-image,
   .#{$prefix}--video-player .#{$prefix}--image {
     position: relative;
     width: 100%;
@@ -123,7 +123,7 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
   .#{$prefix}--video-player__video-caption {
     @include type-style('caption-02');
 
-    padding-top: var(--#{$cds-prefix}--video-caption--padding, $spacing-03);
+    padding-top: var(--#{$c4d-prefix}--video-caption--padding, $spacing-03);
     max-width: 90%;
   }
 
@@ -166,10 +166,10 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
     }
   }
 
-  :host(#{$cds-prefix}-video-player) .#{$prefix}--video-player__image-overlay,
+  :host(#{$c4d-prefix}-video-player) .#{$prefix}--video-player__image-overlay,
   .#{$prefix}--video-player .#{$prefix}--video-player__image-overlay {
     &:active {
-      #{$cds-prefix}-image::before,
+      #{$c4d-prefix}-image::before,
       .#{$prefix}--image::before {
         opacity: 0.12;
       }

--- a/packages/styles/scss/globals/_vars.scss
+++ b/packages/styles/scss/globals/_vars.scss
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-$cds-prefix: 'c4d' !default;
+$c4d-prefix: 'c4d' !default;

--- a/packages/styles/scss/internal/callout/_callout.scss
+++ b/packages/styles/scss/internal/callout/_callout.scss
@@ -15,7 +15,7 @@
 
 @mixin callout {
   .#{$prefix}--callout__container,
-  :host(#{$cds-prefix}-callout) {
+  :host(#{$c4d-prefix}-callout) {
     background-color: $focus-inset;
     @include make-row;
   }
@@ -49,9 +49,9 @@
     .#{$prefix}--quote__source-heading,
     .#{$prefix}--quote__source-body,
     .#{$prefix}--quote__source-optional-copy,
-    ::slotted(#{$cds-prefix}-quote-source-bottom-copy),
-    ::slotted(#{$cds-prefix}-quote-source-copy),
-    ::slotted(#{$cds-prefix}-quote-source-heading),
+    ::slotted(#{$c4d-prefix}-quote-source-bottom-copy),
+    ::slotted(#{$c4d-prefix}-quote-source-copy),
+    ::slotted(#{$c4d-prefix}-quote-source-heading),
     .#{$prefix}--quote__mark {
       color: $icon-inverse;
     }

--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -16,16 +16,16 @@
 @use '../../globals/utils/hang' as *;
 
 @mixin content-block {
-  :host(#{$cds-prefix}-content-block),
-  :host(#{$cds-prefix}-content-block-simple),
-  :host(#{$cds-prefix}-content-block-media),
-  :host(#{$cds-prefix}-content-block-mixed),
-  :host(#{$cds-prefix}-content-block-horizontal),
-  :host(#{$cds-prefix}-content-group-horizontal),
-  :host(#{$cds-prefix}-leadspace-block-content),
-  :host(#{$cds-prefix}-leadspace-with-search-content),
-  :host(#{$cds-prefix}-content-block-segmented),
-  :host(#{$cds-prefix}-content-block-headlines),
+  :host(#{$c4d-prefix}-content-block),
+  :host(#{$c4d-prefix}-content-block-simple),
+  :host(#{$c4d-prefix}-content-block-media),
+  :host(#{$c4d-prefix}-content-block-mixed),
+  :host(#{$c4d-prefix}-content-block-horizontal),
+  :host(#{$c4d-prefix}-content-group-horizontal),
+  :host(#{$c4d-prefix}-leadspace-block-content),
+  :host(#{$c4d-prefix}-leadspace-with-search-content),
+  :host(#{$c4d-prefix}-content-block-segmented),
+  :host(#{$c4d-prefix}-content-block-headlines),
   .#{$prefix}--content-block {
     display: block;
     padding-top: $spacing-07;
@@ -87,9 +87,9 @@
 
     // Cards and link lists are the exceptions of above
     // TODO: Remove negative margin adjustment from `<cds-link-list-item*>` and add `<cds-link-list>` here
-    ::slotted(#{$cds-prefix}-card[slot]),
-    ::slotted(#{$cds-prefix}-card-cta[slot]),
-    ::slotted(#{$cds-prefix}-card-link-cta[slot]) {
+    ::slotted(#{$c4d-prefix}-card[slot]),
+    ::slotted(#{$c4d-prefix}-card-cta[slot]),
+    ::slotted(#{$c4d-prefix}-card-link-cta[slot]) {
       margin-left: 0;
       margin-right: 0;
     }
@@ -123,7 +123,7 @@
       margin-top: $spacing-07;
     }
 
-    ::slotted(#{$cds-prefix}-video-player-container) {
+    ::slotted(#{$c4d-prefix}-video-player-container) {
       // Ensures the margin gets effective
       display: block;
     }
@@ -162,8 +162,8 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-block-horizontal) #{$cds-prefix}-hr,
-  :host(#{$cds-prefix}-content-group-horizontal) #{$cds-prefix}-hr {
+  :host(#{$c4d-prefix}-content-block-horizontal) #{$c4d-prefix}-hr,
+  :host(#{$c4d-prefix}-content-group-horizontal) #{$c4d-prefix}-hr {
     margin: 0;
     margin-top: $layout-03;
 
@@ -190,15 +190,15 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-block-heading),
-  :host(#{$cds-prefix}-content-block-copy),
-  :host(#{$cds-prefix}-callout-with-media-copy),
+  :host(#{$c4d-prefix}-content-block-heading),
+  :host(#{$c4d-prefix}-content-block-copy),
+  :host(#{$c4d-prefix}-callout-with-media-copy),
   .#{$prefix}--content-block__heading,
   .#{$prefix}--content-block__copy {
     @include content-width;
   }
 
-  :host(#{$cds-prefix}-content-block-heading),
+  :host(#{$c4d-prefix}-content-block-heading),
   .#{$prefix}--content-block__heading {
     @include type-style('fluid-heading-05', true);
 
@@ -206,7 +206,7 @@
     margin-bottom: $spacing-07;
   }
 
-  :host(#{$cds-prefix}-content-block-paragraph),
+  :host(#{$c4d-prefix}-content-block-paragraph),
   .#{$prefix}--content-block__copy p {
     @include type-style('fluid-heading-03', true);
 

--- a/packages/styles/scss/internal/content-group/_content-group.scss
+++ b/packages/styles/scss/internal/content-group/_content-group.scss
@@ -15,21 +15,21 @@
 @use '../../globals/utils/hang' as *;
 
 @mixin themed-items {
-  :host(#{$cds-prefix}-content-group-heading),
+  :host(#{$c4d-prefix}-content-group-heading),
   .#{$prefix}--content-group__title {
     color: $text-primary;
   }
 }
 @mixin content-group {
-  :host(#{$cds-prefix}-content-group) ::slotted(:not([slot])) {
+  :host(#{$c4d-prefix}-content-group) ::slotted(:not([slot])) {
     margin-left: $spacing-05;
     margin-right: $spacing-05;
   }
 
-  :host(#{$cds-prefix}-content-group),
-  :host(#{$cds-prefix}-content-group-simple),
-  :host(#{$cds-prefix}-content-group-cards),
-  :host(#{$cds-prefix}-content-group-pictograms),
+  :host(#{$c4d-prefix}-content-group),
+  :host(#{$c4d-prefix}-content-group-simple),
+  :host(#{$c4d-prefix}-content-group-cards),
+  :host(#{$c4d-prefix}-content-group-pictograms),
   .#{$prefix}--content-group {
     display: block;
     margin-top: $spacing-07;
@@ -47,7 +47,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-group-heading),
+  :host(#{$c4d-prefix}-content-group-heading),
   .#{$prefix}--content-group__title {
     @include type-style('fluid-heading-04', true);
 
@@ -55,19 +55,19 @@
     margin-bottom: $spacing-07;
   }
 
-  :host(#{$cds-prefix}-content-group-heading),
-  :host(#{$cds-prefix}-content-group-copy),
+  :host(#{$c4d-prefix}-content-group-heading),
+  :host(#{$c4d-prefix}-content-group-copy),
   .#{$prefix}--content-group__title,
   .#{$prefix}--content-group__copy {
     @include content-width;
   }
 
-  :host(#{$cds-prefix}-content-group-copy),
+  :host(#{$c4d-prefix}-content-group-copy),
   .#{$prefix}--content-group__copy {
     margin-bottom: $layout-03;
   }
 
-  :host(#{$cds-prefix}-content-group) ::slotted([slot='footer']),
+  :host(#{$c4d-prefix}-content-group) ::slotted([slot='footer']),
   .#{$prefix}--content-group__cta {
     margin-top: $spacing-09;
 
@@ -77,7 +77,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-group) ::slotted([slot='footer']) {
+  :host(#{$c4d-prefix}-content-group) ::slotted([slot='footer']) {
     @include breakpoint(md) {
       margin-left: -$spacing-05;
     }

--- a/packages/styles/scss/internal/content-item/_content-item.scss
+++ b/packages/styles/scss/internal/content-item/_content-item.scss
@@ -29,15 +29,15 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item),
+  :host(#{$c4d-prefix}-content-item),
   .#{$prefix}--content-item {
     display: block;
     margin-top: $spacing-07;
     margin-bottom: $spacing-07;
   }
 
-  :host(#{$cds-prefix}-content-item)
-    ::slotted(#{$cds-prefix}-video-player-container),
+  :host(#{$c4d-prefix}-content-item)
+    ::slotted(#{$c4d-prefix}-video-player-container),
   .#{$prefix}--content-item .#{$prefix}--video-player {
     margin-top: $spacing-05;
     margin-bottom: $spacing-07;
@@ -48,8 +48,8 @@
     margin-top: $spacing-05;
   }
 
-  :host(#{$cds-prefix}-content-item-heading),
-  :host(#{$cds-prefix}-content-item-copy),
+  :host(#{$c4d-prefix}-content-item-heading),
+  :host(#{$c4d-prefix}-content-item-copy),
   .#{$prefix}--content-item__heading,
   .#{$prefix}--content-item__copy {
     @include breakpoint(md) {
@@ -59,14 +59,14 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-item-heading),
+  :host(#{$c4d-prefix}-content-item-heading),
   .#{$prefix}--content-item__heading {
     @include type-style('heading-02');
 
     color: $text-primary;
   }
 
-  :host(#{$cds-prefix}-content-item-paragraph),
+  :host(#{$c4d-prefix}-content-item-paragraph),
   .#{$prefix}--content-item__copy p {
     @include type-style('body-02');
 

--- a/packages/styles/scss/internal/content-section/_content-section.scss
+++ b/packages/styles/scss/internal/content-section/_content-section.scss
@@ -20,7 +20,7 @@
 }
 
 @mixin content-section {
-  :host(#{$cds-prefix}-link-list-section),
+  :host(#{$c4d-prefix}-link-list-section),
   .#{$prefix}--content-section {
     padding-top: $spacing-09;
     padding-bottom: $spacing-10;
@@ -55,7 +55,7 @@
   }
 
   .#{$prefix}--content-section__grid,
-  :host(#{$cds-prefix}-cta-section) {
+  :host(#{$c4d-prefix}-cta-section) {
     @include make-container;
   }
 
@@ -76,7 +76,7 @@
     }
   }
 
-  :host(#{$cds-prefix}-content-section-heading),
+  :host(#{$c4d-prefix}-content-section-heading),
   .#{$prefix}--content-section__heading {
     margin-top: 0;
     margin-bottom: 0;
@@ -85,7 +85,7 @@
     @include type-style('heading-02');
   }
 
-  :host(#{$cds-prefix}-content-section-copy),
+  :host(#{$c4d-prefix}-content-section-copy),
   .#{$prefix}--content-section__copy p {
     @include type-style('body-compact-02');
 
@@ -93,11 +93,11 @@
     margin-bottom: $spacing-06;
   }
 
-  :host(#{$cds-prefix}-content-section-heading),
+  :host(#{$c4d-prefix}-content-section-heading),
   .#{$prefix}--content-section__heading,
-  :host(#{$cds-prefix}-content-section-copy),
+  :host(#{$c4d-prefix}-content-section-copy),
   .#{$prefix}--content-section__copy p,
-  :host(#{$cds-prefix}-content-section) ::slotted([slot='footer']),
+  :host(#{$c4d-prefix}-content-section) ::slotted([slot='footer']),
   .#{$prefix}--content-section__cta {
     @include breakpoint(md) {
       padding-right: $spacing-07;

--- a/packages/web-components/.storybook/container.scss
+++ b/packages/web-components/.storybook/container.scss
@@ -62,7 +62,7 @@ html {
   }
 }
 
-.cds-story-padding {
+.c4d-story-padding {
   padding-top: $spacing-05;
   padding-bottom: $spacing-05;
 }

--- a/packages/web-components/src/components/button-group/button-group.scss
+++ b/packages/web-components/src/components/button-group/button-group.scss
@@ -9,9 +9,9 @@
 @use '@carbon/ibmdotcom-styles/scss/components/button-group';
 @use '../button/button.scss';
 
-:host(#{$cds-prefix}-button-group-item),
-:host(#{$cds-prefix}-button-cta) {
-  @extend :host(#{$cds-prefix}-button);
+:host(#{$c4d-prefix}-button-group-item),
+:host(#{$c4d-prefix}-button-cta) {
+  @extend :host(#{$c4d-prefix}-button);
 
   outline: none;
 }

--- a/packages/web-components/src/components/button/button.scss
+++ b/packages/web-components/src/components/button/button.scss
@@ -11,7 +11,7 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 @use '../../../../carbon-web-components/src/components/button/button';
 //
-:host(#{$cds-prefix}-button) {
+:host(#{$c4d-prefix}-button) {
   @extend :host(#{$prefix}-button);
 
   svg {

--- a/packages/web-components/src/components/callout-quote/callout-quote.scss
+++ b/packages/web-components/src/components/callout-quote/callout-quote.scss
@@ -13,7 +13,7 @@
 @use '@carbon/ibmdotcom-styles/scss/components/callout-quote';
 @use '@carbon/ibmdotcom-styles/scss/components/link-with-icon';
 
-:host(#{$cds-prefix}-callout-link-with-icon) {
+:host(#{$c4d-prefix}-callout-link-with-icon) {
   @extend .#{$prefix}--link-with-icon;
 
   display: inline-block;
@@ -34,7 +34,7 @@
   }
 }
 
-:host(#{$cds-prefix}-callout-quote) #{$cds-prefix}-hr {
+:host(#{$c4d-prefix}-callout-quote) #{$c4d-prefix}-hr {
   margin: $spacing-05;
   @include breakpoint(md) {
     margin: $spacing-05 0;

--- a/packages/web-components/src/components/card-group/card-group.scss
+++ b/packages/web-components/src/components/card-group/card-group.scss
@@ -15,37 +15,37 @@
 @use '@carbon/ibmdotcom-styles/scss/components/card-group';
 @use '../card/card';
 
-:host(#{$cds-prefix}-card-group) {
+:host(#{$c4d-prefix}-card-group) {
   background: none;
 
-  ::slotted(#{$cds-prefix}-card-group-item) {
+  ::slotted(#{$c4d-prefix}-card-group-item) {
     background-color: $border-subtle-02;
   }
 
-  ::slotted(#{$cds-prefix}-card-group-card-link-item) {
+  ::slotted(#{$c4d-prefix}-card-group-card-link-item) {
     @include breakpoint(md) {
       padding-right: $spacing-05;
     }
   }
 
-  ::slotted(#{$cds-prefix}-card-group-item[empty]),
-  ::slotted(#{$cds-prefix}-card-group-card-link-item[empty]) {
+  ::slotted(#{$c4d-prefix}-card-group-item[empty]),
+  ::slotted(#{$c4d-prefix}-card-group-card-link-item[empty]) {
     background-color: transparent;
     outline: none;
   }
 }
 
-:host(#{$cds-prefix}-card-group)[grid-mode='border'] {
+:host(#{$c4d-prefix}-card-group)[grid-mode='border'] {
   background: $border-subtle-02;
 
   /* stylelint-disable-next-line selector-type-no-unknown */
-  #{$cds-prefix}-card-group-item[empty],
-  #{$cds-prefix}-card-group-card-link-item[empty] {
+  #{$c4d-prefix}-card-group-item[empty],
+  #{$c4d-prefix}-card-group-card-link-item[empty] {
     outline: none;
   }
 
-  ::slotted(#{$cds-prefix}-card-group-item),
-  ::slotted(#{$cds-prefix}-card-group-card-link-item) {
+  ::slotted(#{$c4d-prefix}-card-group-item),
+  ::slotted(#{$c4d-prefix}-card-group-card-link-item) {
     background-color: transparent;
   }
 }

--- a/packages/web-components/src/components/card-in-card/card-in-card.scss
+++ b/packages/web-components/src/components/card-in-card/card-in-card.scss
@@ -11,6 +11,6 @@
 @use '../card/card';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-card-in-card) {
+:host(#{$c4d-prefix}-card-in-card) {
   display: block;
 }

--- a/packages/web-components/src/components/card-link/card-link.scss
+++ b/packages/web-components/src/components/card-link/card-link.scss
@@ -14,10 +14,10 @@
 @use '@carbon/ibmdotcom-styles/scss/components/card';
 @use '@carbon/ibmdotcom-styles/scss/components/card-link';
 
-:host(#{$cds-prefix}-card-link),
-:host(#{$cds-prefix}-card-link-cta),
-:host(#{$cds-prefix}-link-list-item-card),
-:host(#{$cds-prefix}-link-list-item-card-cta) {
+:host(#{$c4d-prefix}-card-link),
+:host(#{$c4d-prefix}-card-link-cta),
+:host(#{$c4d-prefix}-link-list-item-card),
+:host(#{$c4d-prefix}-link-list-item-card-cta) {
   max-width: rem(364px);
 
   .#{$prefix}--card__wrapper {
@@ -27,11 +27,11 @@
   }
 }
 
-:host(#{$cds-prefix}-card-link-cta) {
+:host(#{$c4d-prefix}-card-link-cta) {
   display: flex;
 }
 
-:host(#{$cds-prefix}-feature-section-card-link) {
+:host(#{$c4d-prefix}-feature-section-card-link) {
   .#{$prefix}--card {
     max-width: inherit;
   }
@@ -43,9 +43,9 @@
   }
 }
 
-:host(#{$cds-prefix}-link-list-item-card),
-:host(#{$cds-prefix}-link-list-item-card-cta) {
-  ::slotted(#{$cds-prefix}-card-footer) {
+:host(#{$c4d-prefix}-link-list-item-card),
+:host(#{$c4d-prefix}-link-list-item-card-cta) {
+  ::slotted(#{$c4d-prefix}-card-footer) {
     margin-block: $spacing-01;
     margin-inline-start: $spacing-07;
     @include breakpoint(lg) {

--- a/packages/web-components/src/components/card-section-carousel/card-section-carousel.scss
+++ b/packages/web-components/src/components/card-section-carousel/card-section-carousel.scss
@@ -10,7 +10,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-card-section-carousel) {
+:host(#{$c4d-prefix}-card-section-carousel) {
   @include breakpoint(lg) {
     .#{$prefix}--content-section__body {
       max-width: 75%;

--- a/packages/web-components/src/components/card-section-images/card-section-images.scss
+++ b/packages/web-components/src/components/card-section-images/card-section-images.scss
@@ -11,7 +11,7 @@
 @use '@carbon/ibmdotcom-styles/scss/components/layout';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-card-section-images) {
+:host(#{$c4d-prefix}-card-section-images) {
   display: block;
 
   padding-top: $spacing-09;

--- a/packages/web-components/src/components/card-section-simple/card-section-simple.scss
+++ b/packages/web-components/src/components/card-section-simple/card-section-simple.scss
@@ -11,7 +11,7 @@
 @use '@carbon/ibmdotcom-styles/scss/components/layout';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-card-section-simple) {
+:host(#{$c4d-prefix}-card-section-simple) {
   display: block;
 
   padding-top: $spacing-09;

--- a/packages/web-components/src/components/card/card.scss
+++ b/packages/web-components/src/components/card/card.scss
@@ -13,8 +13,8 @@
 @use '@carbon/ibmdotcom-styles/scss/components/card';
 @use '@carbon/ibmdotcom-styles/scss/components/link-with-icon';
 
-:host(#{$cds-prefix}-card-footer),
-:host(#{$cds-prefix}-card-cta-footer) {
+:host(#{$c4d-prefix}-card-footer),
+:host(#{$c4d-prefix}-card-cta-footer) {
   align-self: flex-start;
   max-width: 90%;
 
@@ -22,11 +22,11 @@
     max-width: calc(100% - #{$spacing-07});
   }
 
-  .#{$cds-prefix}-ce--card__footer--static {
+  .#{$c4d-prefix}-ce--card__footer--static {
     color: $link-primary;
   }
 
-  &[color-scheme='inverse'] .#{$cds-prefix}-ce--card__footer--static {
+  &[color-scheme='inverse'] .#{$c4d-prefix}-ce--card__footer--static {
     color: $link-inverse;
   }
 
@@ -46,6 +46,6 @@
   }
 }
 
-:host(#{$cds-prefix}-card-footer[href])::after {
+:host(#{$c4d-prefix}-card-footer[href])::after {
   position: relative;
 }

--- a/packages/web-components/src/components/content-block-card-static/content-block-card-static.scss
+++ b/packages/web-components/src/components/content-block-card-static/content-block-card-static.scss
@@ -9,7 +9,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-content-block-card-static) {
+:host(#{$c4d-prefix}-content-block-card-static) {
   display: block;
   margin-bottom: $spacing-10;
 
@@ -21,7 +21,7 @@
     margin-bottom: $spacing-13;
   }
 
-  ::slotted(#{$cds-prefix}-content-block-heading) {
+  ::slotted(#{$c4d-prefix}-content-block-heading) {
     margin-top: $spacing-07;
 
     @include breakpoint(max) {
@@ -29,7 +29,7 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-content-item) {
+  ::slotted(#{$c4d-prefix}-content-item) {
     margin-top: $spacing-10;
     margin-left: $spacing-05;
     margin-bottom: $spacing-07;

--- a/packages/web-components/src/components/content-block-headlines/content-block-headlines.scss
+++ b/packages/web-components/src/components/content-block-headlines/content-block-headlines.scss
@@ -8,7 +8,7 @@
 @use '@carbon/ibmdotcom-styles/scss/components/content-block-headlines';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-content-block-headlines-item) {
+:host(#{$c4d-prefix}-content-block-headlines-item) {
   display: flex;
   flex-direction: column;
   ::slotted([slot='footer']) {

--- a/packages/web-components/src/components/content-block-media/content-block-media.scss
+++ b/packages/web-components/src/components/content-block-media/content-block-media.scss
@@ -12,21 +12,21 @@
 @use '@carbon/ibmdotcom-styles/scss/components/content-group-simple';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-content-block-media),
-:host(#{$cds-prefix}-content-block-media-content) {
+:host(#{$c4d-prefix}-content-block-media),
+:host(#{$c4d-prefix}-content-block-media-content) {
   display: block;
 }
 
-:host(#{$cds-prefix}-content-block-media-content) {
-  @extend :host(#{$cds-prefix}-content-group-simple);
+:host(#{$c4d-prefix}-content-block-media-content) {
+  @extend :host(#{$c4d-prefix}-content-group-simple);
 
-  &::slotted(#{$cds-prefix}-card-link) {
+  &::slotted(#{$c4d-prefix}-card-link) {
     margin-left: -$spacing-05;
     margin-right: -$spacing-05;
     display: block;
   }
 
-  ::slotted(#{$cds-prefix}-content-block-complementary) {
+  ::slotted(#{$c4d-prefix}-content-block-complementary) {
     @include breakpoint-down(lg) {
       margin: $spacing-10 0;
     }

--- a/packages/web-components/src/components/content-block-segmented/content-block-segmented.scss
+++ b/packages/web-components/src/components/content-block-segmented/content-block-segmented.scss
@@ -11,7 +11,7 @@
 @use '@carbon/ibmdotcom-styles/scss/components/content-block-segmented';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-content-block-segmented) {
+:host(#{$c4d-prefix}-content-block-segmented) {
   ::slotted(:not([slot])) {
     display: block;
     margin-top: $spacing-10;
@@ -26,21 +26,21 @@
     margin-top: 0;
   }
 
-  ::slotted(#{$cds-prefix}-content-block-complementary) {
+  ::slotted(#{$c4d-prefix}-content-block-complementary) {
     @include breakpoint-down(lg) {
       margin: $spacing-10 0;
     }
   }
 }
 
-:host(#{$cds-prefix}-content-block-segmented-item) ::slotted(*) {
+:host(#{$c4d-prefix}-content-block-segmented-item) ::slotted(*) {
   margin-left: $spacing-05;
   margin-right: $spacing-05;
 }
 
 // TODO: Consider applying this rule in general
-:host(#{$cds-prefix}-content-block-segmented-item) {
-  ::slotted(#{$cds-prefix}-content-item-copy) {
+:host(#{$c4d-prefix}-content-block-segmented-item) {
+  ::slotted(#{$c4d-prefix}-content-item-copy) {
     @include breakpoint(md) {
       width: calc((100% - 2 * #{$spacing-05}) * 0.9);
     }
@@ -51,7 +51,7 @@
   }
 }
 
-.#{$cds-prefix}-ce--content-layout--with-adjacent-heading-content
+.#{$c4d-prefix}-ce--content-layout--with-adjacent-heading-content
   ::slotted([slot='heading']) {
   // In this condition, given the heading content and child content are in different grid area, both margins will be in effect.
   // Uses the margin of child content and cancels one of the heading to get the right margin.

--- a/packages/web-components/src/components/content-block-simple/content-block-simple.scss
+++ b/packages/web-components/src/components/content-block-simple/content-block-simple.scss
@@ -12,22 +12,22 @@
 @use '@carbon/ibmdotcom-styles/scss/components/video-player';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-content-block-simple) {
+:host(#{$c4d-prefix}-content-block-simple) {
   display: block;
 
-  ::slotted(#{$cds-prefix}-content-block-complementary) {
+  ::slotted(#{$c4d-prefix}-content-block-complementary) {
     @include breakpoint-down(lg) {
       margin: $spacing-10 0;
     }
   }
 
-  ::slotted(#{$cds-prefix}-card-cta[slot]),
-  ::slotted(#{$cds-prefix}-card-link-cta[slot]) {
+  ::slotted(#{$c4d-prefix}-card-cta[slot]),
+  ::slotted(#{$c4d-prefix}-card-link-cta[slot]) {
     width: auto;
   }
 
-  ::slotted(#{$cds-prefix}-card-cta),
-  ::slotted(#{$cds-prefix}-card-link-cta) {
+  ::slotted(#{$c4d-prefix}-card-cta),
+  ::slotted(#{$c4d-prefix}-card-link-cta) {
     width: auto;
     max-width: 320px;
   }

--- a/packages/web-components/src/components/content-block/content-block.scss
+++ b/packages/web-components/src/components/content-block/content-block.scss
@@ -16,28 +16,28 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/utils/flex-grid' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-content-block),
-:host(#{$cds-prefix}-callout-with-media-copy),
-:host(#{$cds-prefix}-content-block-copy),
-:host(#{$cds-prefix}-content-block-heading),
-:host(#{$cds-prefix}-content-block-complementary),
-:host(#{$cds-prefix}-content-block-paragraph) {
+:host(#{$c4d-prefix}-content-block),
+:host(#{$c4d-prefix}-callout-with-media-copy),
+:host(#{$c4d-prefix}-content-block-copy),
+:host(#{$c4d-prefix}-content-block-heading),
+:host(#{$c4d-prefix}-content-block-complementary),
+:host(#{$c4d-prefix}-content-block-paragraph) {
   display: block;
 }
 
 // TODO: Consider applying this rule in general
-:host(#{$cds-prefix}-content-block-simple),
-:host(#{$cds-prefix}-content-block-segmented) {
-  ::slotted(#{$cds-prefix}-callout-with-media-copy),
-  ::slotted(#{$cds-prefix}-content-block-copy) {
+:host(#{$c4d-prefix}-content-block-simple),
+:host(#{$c4d-prefix}-content-block-segmented) {
+  ::slotted(#{$c4d-prefix}-callout-with-media-copy),
+  ::slotted(#{$c4d-prefix}-content-block-copy) {
     @include breakpoint(md) {
       width: calc((100% - 2 * #{$spacing-05}) * 0.9);
     }
   }
 }
 
-:host(#{$cds-prefix}-callout-with-media-copy[size='sm']),
-:host(#{$cds-prefix}-content-block-copy[size='sm']) {
+:host(#{$c4d-prefix}-callout-with-media-copy[size='sm']),
+:host(#{$c4d-prefix}-content-block-copy[size='sm']) {
   width: auto;
   max-width: none;
 
@@ -45,18 +45,18 @@
     @include content-width;
   }
 
-  ::slotted(#{$cds-prefix}-content-block-paragraph) {
+  ::slotted(#{$c4d-prefix}-content-block-paragraph) {
     @include type-style('body-02');
 
     margin-bottom: $spacing-06;
   }
 }
 
-.#{$cds-prefix}--content-block-footer {
-  @extend :host(#{$cds-prefix}-card-group);
+.#{$c4d-prefix}--content-block-footer {
+  @extend :host(#{$c4d-prefix}-card-group);
 }
 
 // TODO: Apply `cds--make-col(2, 3)` to React version, too, so we can merge the style to React version
-.#{$cds-prefix}-ce--content-block__col {
+.#{$c4d-prefix}-ce--content-block__col {
   @include make-col(2, 3);
 }

--- a/packages/web-components/src/components/content-group-banner/content-group-banner.scss
+++ b/packages/web-components/src/components/content-group-banner/content-group-banner.scss
@@ -9,6 +9,6 @@
 @use '@carbon/ibmdotcom-styles/scss/internal/content-block';
 @use '@carbon/ibmdotcom-styles/scss/components/content-group-banner';
 
-:host(#{$cds-prefix}-content-group-banner) {
+:host(#{$c4d-prefix}-content-group-banner) {
   display: block;
 }

--- a/packages/web-components/src/components/content-group-pictograms/content-group-pictograms.scss
+++ b/packages/web-components/src/components/content-group-pictograms/content-group-pictograms.scss
@@ -9,6 +9,6 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 @use '@carbon/ibmdotcom-styles/scss/components/content-group-pictograms';
 
-:host(#{$cds-prefix}-content-group-pictograms) {
+:host(#{$c4d-prefix}-content-group-pictograms) {
   display: block;
 }

--- a/packages/web-components/src/components/content-group-simple/content-group-simple.scss
+++ b/packages/web-components/src/components/content-group-simple/content-group-simple.scss
@@ -10,11 +10,11 @@
 @use '@carbon/ibmdotcom-styles/scss/internal/content-block';
 @use '@carbon/ibmdotcom-styles/scss/components/content-group-simple';
 
-:host(#{$cds-prefix}-content-group-simple) {
+:host(#{$c4d-prefix}-content-group-simple) {
   display: block;
 
   // TODO: Define the padding on `<cds-content-item>` by default
-  ::slotted(#{$cds-prefix}-content-item) {
+  ::slotted(#{$c4d-prefix}-content-item) {
     margin-left: $spacing-05;
     margin-right: $spacing-05;
   }

--- a/packages/web-components/src/components/content-group/content-group.scss
+++ b/packages/web-components/src/components/content-group/content-group.scss
@@ -10,12 +10,12 @@
 @use '@carbon/ibmdotcom-styles/scss/internal/content-group';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-content-group),
-:host(#{$cds-prefix}-content-group-copy),
-:host(#{$cds-prefix}-content-group-paragraph) {
+:host(#{$c4d-prefix}-content-group),
+:host(#{$c4d-prefix}-content-group-copy),
+:host(#{$c4d-prefix}-content-group-paragraph) {
   display: block;
 }
 
-:host(#{$cds-prefix}-content-group-copy) {
+:host(#{$c4d-prefix}-content-group-copy) {
   @include type-style('body-02');
 }

--- a/packages/web-components/src/components/content-item-horizontal/content-item-horizontal.scss
+++ b/packages/web-components/src/components/content-item-horizontal/content-item-horizontal.scss
@@ -8,6 +8,6 @@
 @use '@carbon/ibmdotcom-styles/scss/components/content-item-horizontal';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-content-item-horizontal-eyebrow) {
+:host(#{$c4d-prefix}-content-item-horizontal-eyebrow) {
   display: block;
 }

--- a/packages/web-components/src/components/content-item/content-item.scss
+++ b/packages/web-components/src/components/content-item/content-item.scss
@@ -9,14 +9,14 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 @use '@carbon/ibmdotcom-styles/scss/internal/content-item';
 
-:host(#{$cds-prefix}-content-item-copy),
-:host(#{$cds-prefix}-content-item-paragraph) {
+:host(#{$c4d-prefix}-content-item-copy),
+:host(#{$c4d-prefix}-content-item-paragraph) {
   display: block;
 }
 
-:host(#{$cds-prefix}-content-item) ::slotted(#{$cds-prefix}-image),
-:host(#{$cds-prefix}-content-item)
-  ::slotted(#{$cds-prefix}-video-player-container) {
+:host(#{$c4d-prefix}-content-item) ::slotted(#{$c4d-prefix}-image),
+:host(#{$c4d-prefix}-content-item)
+  ::slotted(#{$c4d-prefix}-video-player-container) {
   display: block;
   margin-top: $spacing-05;
   margin-bottom: $spacing-07;

--- a/packages/web-components/src/components/content-section/content-section.scss
+++ b/packages/web-components/src/components/content-section/content-section.scss
@@ -11,26 +11,26 @@
 @use '@carbon/ibmdotcom-styles/scss/internal/content-section';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-content-section),
-:host(#{$cds-prefix}-card-section-carousel),
-:host(#{$cds-prefix}-content-section-heading),
-:host(#{$cds-prefix}-content-section-copy) {
+:host(#{$c4d-prefix}-content-section),
+:host(#{$c4d-prefix}-card-section-carousel),
+:host(#{$c4d-prefix}-content-section-heading),
+:host(#{$c4d-prefix}-content-section-copy) {
   display: block;
   overflow-x: hidden;
 }
 
-:host(#{$cds-prefix}-content-section) {
+:host(#{$c4d-prefix}-content-section) {
   &[with-link-list] {
     .#{$prefix}--content-section__body {
       padding: 0 $spacing-05;
     }
   }
 
-  ::slotted(#{$cds-prefix}-content-block-simple) {
+  ::slotted(#{$c4d-prefix}-content-block-simple) {
     padding-bottom: $spacing-10;
   }
 
-  ::slotted(#{$cds-prefix}-link-list) {
+  ::slotted(#{$c4d-prefix}-link-list) {
     @include breakpoint-down(md) {
       display: block;
       margin: 0 $spacing-05;

--- a/packages/web-components/src/components/cta-block/cta-block.scss
+++ b/packages/web-components/src/components/cta-block/cta-block.scss
@@ -16,7 +16,7 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/utils/flex-grid' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-cta-block) {
+:host(#{$c4d-prefix}-cta-block) {
   display: block;
 
   .#{$prefix}--content-layout {
@@ -43,7 +43,7 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-content-block-heading) {
+  ::slotted(#{$c4d-prefix}-content-block-heading) {
     @include make-col(8, 12);
 
     margin-left: 0;
@@ -62,7 +62,7 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-content-block-copy) {
+  ::slotted(#{$c4d-prefix}-content-block-copy) {
     @include make-col(8, 12);
     @include type-style('fluid-heading-03', true);
 
@@ -78,7 +78,7 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-button-group[slot='action']) {
+  ::slotted(#{$c4d-prefix}-button-group[slot='action']) {
     margin-block-end: 0;
 
     @include breakpoint(lg) {
@@ -86,7 +86,7 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-button-group:last-child) {
+  ::slotted(#{$c4d-prefix}-button-group:last-child) {
     margin-block-end: 0;
   }
 
@@ -98,7 +98,7 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-link-list) {
+  ::slotted(#{$c4d-prefix}-link-list) {
     display: block;
     padding-bottom: 0;
 
@@ -112,7 +112,7 @@
   }
 }
 
-:host(#{$cds-prefix}-cta-section-item-heading) {
+:host(#{$c4d-prefix}-cta-section-item-heading) {
   @include type-style('heading-02', true);
 
   display: block;
@@ -123,7 +123,7 @@
   }
 }
 
-:host(#{$cds-prefix}-cta-block-item-row) {
+:host(#{$c4d-prefix}-cta-block-item-row) {
   width: 100%;
   display: grid;
   grid-template-columns: 1fr;
@@ -145,11 +145,11 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-cta-block-item) {
+  ::slotted(#{$c4d-prefix}-cta-block-item) {
     border-bottom: 1px solid $border-subtle-01;
   }
 
-  ::slotted(#{$cds-prefix}-cta-block-item:last-of-type) {
+  ::slotted(#{$c4d-prefix}-cta-block-item:last-of-type) {
     @include breakpoint-down(md) {
       border: 0;
       padding-bottom: 0;
@@ -165,11 +165,11 @@
   }
 }
 
-.#{$cds-prefix}-ce--cta-block__col {
+.#{$c4d-prefix}-ce--cta-block__col {
   @include make-col(2, 3);
 }
 
-:host(#{$cds-prefix}-cta-block-item) {
+:host(#{$c4d-prefix}-cta-block-item) {
   @include make-col-ready;
 
   width: 100%;
@@ -180,12 +180,12 @@
   display: flex;
   flex-direction: column;
 
-  ::slotted(#{$cds-prefix}-text-cta) {
+  ::slotted(#{$c4d-prefix}-text-cta) {
     margin-left: 0;
     margin-bottom: $spacing-03;
   }
 
-  ::slotted(#{$cds-prefix}-text-cta:last-child) {
+  ::slotted(#{$c4d-prefix}-text-cta:last-child) {
     margin-bottom: 0;
   }
 
@@ -211,7 +211,7 @@
     margin-top: 0;
   }
 
-  ::slotted(#{$cds-prefix}-image-logo) {
+  ::slotted(#{$c4d-prefix}-image-logo) {
     /* stylelint-disable */
     aspect-ratio: var(--logo-ratio);
     /* stylelint-enable */

--- a/packages/web-components/src/components/cta-section/cta-section.scss
+++ b/packages/web-components/src/components/cta-section/cta-section.scss
@@ -13,7 +13,7 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/utils/hang' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-cta-section) {
+:host(#{$c4d-prefix}-cta-section) {
   display: block;
   background-color: $background;
 
@@ -48,7 +48,7 @@
     padding-top: $spacing-09;
   }
 
-  ::slotted(#{$cds-prefix}-content-section-heading) {
+  ::slotted(#{$c4d-prefix}-content-section-heading) {
     margin-bottom: $spacing-07;
 
     @include breakpoint(md) {
@@ -56,7 +56,7 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-cta-block) {
+  ::slotted(#{$c4d-prefix}-cta-block) {
     padding-top: 0;
 
     @include breakpoint(md) {

--- a/packages/web-components/src/components/cta/cta.scss
+++ b/packages/web-components/src/components/cta/cta.scss
@@ -12,17 +12,17 @@
 @use '../card-link/card-link';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-.#{$cds-prefix}-ce--cta__icon {
+.#{$c4d-prefix}-ce--cta__icon {
   flex-shrink: 0;
 }
 
-:host(#{$cds-prefix}-button-cta) .#{$cds-prefix}-ce--cta__icon {
+:host(#{$c4d-prefix}-button-cta) .#{$c4d-prefix}-ce--cta__icon {
   position: absolute;
   right: $spacing-05;
   top: 50%;
   transform: translateY(-50%);
 }
 
-:host(#{$cds-prefix}-cta) {
+:host(#{$c4d-prefix}-cta) {
   display: block;
 }

--- a/packages/web-components/src/components/cta/video-cta-composite.scss
+++ b/packages/web-components/src/components/cta/video-cta-composite.scss
@@ -7,7 +7,7 @@
 
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-video-cta-composite),
-:host(#{$cds-prefix}-video-cta-container) {
+:host(#{$c4d-prefix}-video-cta-composite),
+:host(#{$c4d-prefix}-video-cta-container) {
   display: block;
 }

--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.scss
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.scss
@@ -7,7 +7,7 @@
 
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-dotcom-shell-container),
-:host(#{$cds-prefix}-dotcom-shell-composite) {
+:host(#{$c4d-prefix}-dotcom-shell-container),
+:host(#{$c4d-prefix}-dotcom-shell-composite) {
   display: contents;
 }

--- a/packages/web-components/src/components/expressive-modal/expressive-modal.scss
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal.scss
@@ -13,7 +13,7 @@
 @use '@carbon/ibmdotcom-styles/scss/components/expressive-modal';
 @use '../../../../carbon-web-components/src/components/modal/modal';
 
-:host(#{$cds-prefix}-expressive-modal) {
+:host(#{$c4d-prefix}-expressive-modal) {
   @extend :host(#{$prefix}-modal);
 
   &[expressive-size='full-width'] {
@@ -40,44 +40,44 @@
     grid-template-rows: auto 1fr auto;
   }
 
-  .#{$cds-prefix}-ce--modal__header--with-body {
+  .#{$c4d-prefix}-ce--modal__header--with-body {
     margin-bottom: $spacing-05;
   }
 
-  .#{$cds-prefix}-ce--modal__body {
+  .#{$c4d-prefix}-ce--modal__body {
     width: 100%;
   }
 
-  .#{$cds-prefix}-ce--modal__body--with-footer {
+  .#{$c4d-prefix}-ce--modal__body--with-footer {
     margin-bottom: $spacing-09;
   }
 }
 
-:host(#{$cds-prefix}-expressive-modal[open]) {
+:host(#{$c4d-prefix}-expressive-modal[open]) {
   @extend .#{$prefix}--modal;
   @extend .is-visible;
 }
 
-:host(#{$cds-prefix}-expressive-modal-header),
-:host(#{$cds-prefix}-expressive-modal-heading),
-:host(#{$cds-prefix}-expressive-modal-footer) {
+:host(#{$c4d-prefix}-expressive-modal-header),
+:host(#{$c4d-prefix}-expressive-modal-heading),
+:host(#{$c4d-prefix}-expressive-modal-footer) {
   display: block;
 }
 
-:host(#{$cds-prefix}-expressive-modal-header) {
+:host(#{$c4d-prefix}-expressive-modal-header) {
   padding: 0;
 }
 
-:host(#{$cds-prefix}-expressive-modal-close-button) {
+:host(#{$c4d-prefix}-expressive-modal-close-button) {
   display: inline;
 }
 
-:host(#{$cds-prefix}-expressive-modal-body),
-:host(#{$cds-prefix}-lightbox-media-viewer-body) {
+:host(#{$c4d-prefix}-expressive-modal-body),
+:host(#{$c4d-prefix}-lightbox-media-viewer-body) {
   @include type-style('body-02');
 }
 
-:host(#{$cds-prefix}-expressive-modal)[mode='lightbox'] {
+:host(#{$c4d-prefix}-expressive-modal)[mode='lightbox'] {
   .#{$prefix}--modal-container {
     @include breakpoint-down(md) {
       padding: 0 $spacing-05;

--- a/packages/web-components/src/components/feature-card-block-large/feature-card-block-large.scss
+++ b/packages/web-components/src/components/feature-card-block-large/feature-card-block-large.scss
@@ -10,11 +10,11 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 @use '@carbon/ibmdotcom-styles/scss/components/feature-card-block-large';
 
-:host(#{$cds-prefix}-feature-card-block-large) {
+:host(#{$c4d-prefix}-feature-card-block-large) {
   display: block;
 }
 
-:host(#{$cds-prefix}-feature-card-block-large-footer) {
+:host(#{$c4d-prefix}-feature-card-block-large-footer) {
   display: flex;
   justify-content: flex-start;
 }

--- a/packages/web-components/src/components/feature-card-block-medium/feature-card-block-medium.scss
+++ b/packages/web-components/src/components/feature-card-block-medium/feature-card-block-medium.scss
@@ -11,7 +11,7 @@
 @use '@carbon/ibmdotcom-styles/scss/components/feature-card-block-medium';
 @use '../feature-card/feature-card';
 
-:host(#{$cds-prefix}-feature-card-block-medium) {
+:host(#{$c4d-prefix}-feature-card-block-medium) {
   display: block;
 
   @include breakpoint-down(md) {

--- a/packages/web-components/src/components/feature-card/feature-card.scss
+++ b/packages/web-components/src/components/feature-card/feature-card.scss
@@ -15,11 +15,11 @@
 @use '../card/card';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-feature-card),
-:host(#{$cds-prefix}-feature-cta) {
+:host(#{$c4d-prefix}-feature-card),
+:host(#{$c4d-prefix}-feature-cta) {
   display: block;
   outline: none;
-  ::slotted(#{$cds-prefix}-card-heading) {
+  ::slotted(#{$c4d-prefix}-card-heading) {
     color: $focus-inset;
   }
 
@@ -41,14 +41,14 @@
   }
 }
 
-:host(#{$cds-prefix}-feature-card[size='large']) {
+:host(#{$c4d-prefix}-feature-card[size='large']) {
   &:hover {
     .#{$prefix}--card__wrapper {
       background-color: $background-inverse-hover;
     }
   }
 
-  ::slotted(#{$cds-prefix}-feature-card-footer) {
+  ::slotted(#{$c4d-prefix}-feature-card-footer) {
     display: flex;
     justify-content: flex-start;
 
@@ -58,8 +58,8 @@
   }
 }
 
-:host(#{$cds-prefix}-feature-card-footer),
-:host(#{$cds-prefix}-feature-cta-footer) {
+:host(#{$c4d-prefix}-feature-card-footer),
+:host(#{$c4d-prefix}-feature-cta-footer) {
   display: flex;
   justify-content: flex-start;
 

--- a/packages/web-components/src/components/feature-section/feature-section.scss
+++ b/packages/web-components/src/components/feature-section/feature-section.scss
@@ -13,13 +13,13 @@
 @use '@carbon/ibmdotcom-styles/scss/components/card';
 @use '@carbon/ibmdotcom-styles/scss/components/feature-section';
 
-:host(#{$cds-prefix}-feature-section) {
+:host(#{$c4d-prefix}-feature-section) {
   display: block;
   outline: none;
 
   &[media-alignment='left'] {
     .#{$prefix}--card-link,
-    ::slotted(#{$cds-prefix}-feature-section-card-link) {
+    ::slotted(#{$c4d-prefix}-feature-section-card-link) {
       @include breakpoint-down(lg) {
         position: relative;
         right: 0;

--- a/packages/web-components/src/components/filter-panel/filter-panel.scss
+++ b/packages/web-components/src/components/filter-panel/filter-panel.scss
@@ -18,7 +18,7 @@
 @use '@carbon/ibmdotcom-styles/scss/components/filter-panel';
 @use '../../../../carbon-web-components/src/components/modal/modal';
 
-:host(#{$cds-prefix}-filter-panel-modal) {
+:host(#{$c4d-prefix}-filter-panel-modal) {
   @extend :host(#{$prefix}-modal);
 
   left: 0;
@@ -58,8 +58,8 @@
   }
 }
 
-:host(#{$cds-prefix}-filter-group-item) {
-  .#{$cds-prefix}-filter-group-item__view-all {
+:host(#{$c4d-prefix}-filter-group-item) {
+  .#{$c4d-prefix}-filter-group-item__view-all {
     width: 100%;
     padding: $spacing-03 $spacing-05;
     text-align: left;
@@ -74,7 +74,7 @@
   }
 }
 
-:host(#{$cds-prefix}-filter-modal-footer-button) {
+:host(#{$c4d-prefix}-filter-modal-footer-button) {
   @extend :host(#{$prefix}-modal-footer-button);
 
   outline: 0;

--- a/packages/web-components/src/components/footer/footer.scss
+++ b/packages/web-components/src/components/footer/footer.scss
@@ -20,8 +20,8 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/utils/flex-grid' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-footer),
-:host(#{$cds-prefix}-legal-nav) {
+:host(#{$c4d-prefix}-footer),
+:host(#{$c4d-prefix}-legal-nav) {
   display: block;
   .#{$prefix}--adjunct-links__container {
     list-style: none;
@@ -33,7 +33,7 @@
       margin-right: 0;
       @include make-row;
       .#{$prefix}--adjunct-links__col {
-        ::slotted(#{$cds-prefix}-legal-nav-item) {
+        ::slotted(#{$c4d-prefix}-legal-nav-item) {
           padding-top: 0;
           padding-bottom: $spacing-03;
         }
@@ -54,7 +54,7 @@
   }
 }
 
-:host(#{$cds-prefix}-footer).#{$prefix}--adjunct-links__container
+:host(#{$c4d-prefix}-footer).#{$prefix}--adjunct-links__container
   .#{$prefix}--adjunct-links__row
   .#{$prefix}--adjunct-links__col,
 :host(cds-legal-nav)
@@ -67,23 +67,23 @@
   }
 }
 
-:host(#{$cds-prefix}-footer-nav-group[open]) {
+:host(#{$c4d-prefix}-footer-nav-group[open]) {
   @extend .#{$prefix}--accordion__item--active;
 }
 
-:host(#{$cds-prefix}-footer-nav-item),
-:host(#{$cds-prefix}-legal-nav-item),
-:host(#{$cds-prefix}-legal-nav-cookie-preferences-placeholder) {
+:host(#{$c4d-prefix}-footer-nav-item),
+:host(#{$c4d-prefix}-legal-nav-item),
+:host(#{$c4d-prefix}-legal-nav-cookie-preferences-placeholder) {
   display: list-item;
   outline: none;
 }
 
-:host(#{$cds-prefix}-footer-nav-group[open]) .#{$prefix}--accordion__content {
+:host(#{$c4d-prefix}-footer-nav-group[open]) .#{$prefix}--accordion__content {
   display: block;
   padding-top: 0;
 }
 
-:host(#{$cds-prefix}-footer-nav-group) {
+:host(#{$c4d-prefix}-footer-nav-group) {
   .#{$prefix}--accordion__heading {
     border-top: 1px solid $border-subtle-01;
     padding: 0;
@@ -92,7 +92,7 @@
   }
 }
 
-:host(#{$cds-prefix}-locale-button) {
+:host(#{$c4d-prefix}-locale-button) {
   outline: none;
 
   .#{$prefix}--btn {
@@ -103,7 +103,7 @@
 
 // The style of legal nav deviates from the one of React, so we can make the markup simpler.
 // FIXME: Once the style is stabilized, change the markup of React, too, so we can share the style
-:host(#{$cds-prefix}-legal-nav):not([size='micro']) {
+:host(#{$c4d-prefix}-legal-nav):not([size='micro']) {
   .#{$prefix}--legal-nav__list {
     padding-bottom: 0;
     padding-top: 0;
@@ -131,16 +131,16 @@
   }
 }
 
-:host(#{$cds-prefix}-footer[size='micro']) {
-  ::slotted(#{$cds-prefix}-footer-nav),
-  ::slotted(#{$cds-prefix}-footer-logo) {
+:host(#{$c4d-prefix}-footer[size='micro']) {
+  ::slotted(#{$c4d-prefix}-footer-nav),
+  ::slotted(#{$c4d-prefix}-footer-logo) {
     display: none;
   }
 }
 
-:host(#{$cds-prefix}-legal-nav[size='micro']) {
-  ::slotted(#{$cds-prefix}-legal-nav-item),
-  ::slotted(#{$cds-prefix}-legal-nav-cookie-preferences-placeholder) {
+:host(#{$c4d-prefix}-legal-nav[size='micro']) {
+  ::slotted(#{$c4d-prefix}-legal-nav-item),
+  ::slotted(#{$c4d-prefix}-legal-nav-cookie-preferences-placeholder) {
     display: flex;
     align-items: center;
     padding: 0;
@@ -177,7 +177,7 @@
   }
 }
 
-:host(#{$cds-prefix}-locale-button[size='micro']) {
+:host(#{$c4d-prefix}-locale-button[size='micro']) {
   margin: 0;
   flex-shrink: 1;
   padding: 0;
@@ -245,8 +245,8 @@
   }
 }
 
-:host(#{$cds-prefix}-language-selector-desktop),
-:host(#{$cds-prefix}-language-selector-mobile) {
+:host(#{$c4d-prefix}-language-selector-desktop),
+:host(#{$c4d-prefix}-language-selector-mobile) {
   position: relative;
   outline: none;
   margin-top: $spacing-09;
@@ -290,7 +290,7 @@
   }
 }
 
-:host(#{$cds-prefix}-language-selector-desktop) {
+:host(#{$c4d-prefix}-language-selector-desktop) {
   .#{$prefix}--list-box__menu-icon {
     right: $spacing-04;
   }
@@ -305,7 +305,7 @@
   }
 }
 
-:host(#{$cds-prefix}-language-selector-desktop[size='micro']) {
+:host(#{$c4d-prefix}-language-selector-desktop[size='micro']) {
   margin: 0;
   padding: 0;
   border-left: 1px solid $border-subtle-01;
@@ -359,7 +359,7 @@
   }
 }
 
-:host(#{$cds-prefix}-language-selector-mobile[size='micro']) {
+:host(#{$c4d-prefix}-language-selector-mobile[size='micro']) {
   align-self: flex-end;
   border-left: 1px solid $border-subtle-01;
   width: 100%;
@@ -383,7 +383,7 @@
   }
 }
 
-:host(#{$cds-prefix}-language-selector-mobile) {
+:host(#{$c4d-prefix}-language-selector-mobile) {
   .#{$prefix}--select-input__wrapper {
     height: $spacing-09;
     margin-top: -#{$spacing-05};

--- a/packages/web-components/src/components/horizontal-rule/horizontal-rule.scss
+++ b/packages/web-components/src/components/horizontal-rule/horizontal-rule.scss
@@ -8,6 +8,6 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 @use '@carbon/ibmdotcom-styles/scss/components/horizontal-rule';
 
-:host(#{$cds-prefix}-hr) {
+:host(#{$c4d-prefix}-hr) {
   display: block;
 }

--- a/packages/web-components/src/components/leadspace-block/leadspace-block.scss
+++ b/packages/web-components/src/components/leadspace-block/leadspace-block.scss
@@ -12,13 +12,13 @@
 @use '@carbon/ibmdotcom-styles/scss/components/leadspace-block';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-leadspace-with-search-heading),
-:host(#{$cds-prefix}-leadspace-block-heading) {
+:host(#{$c4d-prefix}-leadspace-with-search-heading),
+:host(#{$c4d-prefix}-leadspace-block-heading) {
   display: block;
 }
 
-:host(#{$cds-prefix}-leadspace-with-search-content),
-:host(#{$cds-prefix}-leadspace-block-content) {
+:host(#{$c4d-prefix}-leadspace-with-search-content),
+:host(#{$c4d-prefix}-leadspace-block-content) {
   ::slotted(*) {
     margin-left: $spacing-05;
     margin-right: $spacing-05;

--- a/packages/web-components/src/components/leadspace/leadspace.scss
+++ b/packages/web-components/src/components/leadspace/leadspace.scss
@@ -12,7 +12,7 @@
 @use '../../../../carbon-web-components/src/components/breadcrumb/breadcrumb';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-leadspace) {
+:host(#{$c4d-prefix}-leadspace) {
   display: block;
   position: relative;
 
@@ -36,7 +36,7 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-background-media) {
+  ::slotted(#{$c4d-prefix}-background-media) {
     height: auto;
     aspect-ratio: 4 / 3; /* stylelint-disable-line property-no-unknown */
 
@@ -49,21 +49,21 @@
   }
 }
 
-:host(#{$cds-prefix}-breadcrumb) {
+:host(#{$c4d-prefix}-breadcrumb) {
   // @extend :host(#{$prefix}-breadcrumb);
   padding-bottom: $spacing-05;
 }
 
-:host(#{$cds-prefix}-breadcrumb-item) {
+:host(#{$c4d-prefix}-breadcrumb-item) {
   // @extend :host(#{$prefix}-breadcrumb-item);
   display: inline;
 }
 
-:host(#{$cds-prefix}-breadcrumb-item:last-of-type)::after {
+:host(#{$c4d-prefix}-breadcrumb-item:last-of-type)::after {
   // @extend :host(#{$prefix}-breadcrumb-item:last-of-type)::after;
 }
 
-:host(#{$cds-prefix}-breadcrumb-link) {
+:host(#{$c4d-prefix}-breadcrumb-link) {
   // @extend :host(#{$prefix}-breadcrumb-link);
 }
 

--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm.scss
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm.scss
@@ -12,12 +12,12 @@
 @use '../../../../carbon-web-components/src/components/modal/modal';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-leaving-ibm-composite),
-:host(#{$cds-prefix}-leaving-ibm-container) {
+:host(#{$c4d-prefix}-leaving-ibm-composite),
+:host(#{$c4d-prefix}-leaving-ibm-container) {
   width: 100%;
 }
 
-:host(#{$cds-prefix}-leaving-ibm-modal) {
+:host(#{$c4d-prefix}-leaving-ibm-modal) {
   // @extend :host(#{$prefix}-modal);
   max-height: 100%;
 
@@ -26,15 +26,15 @@
   }
 }
 
-:host(#{$cds-prefix}-leaving-ibm-modal-heading) {
+:host(#{$c4d-prefix}-leaving-ibm-modal-heading) {
   // @include type-style('fluid-heading-04');
 }
 
-:host(#{$cds-prefix}-leaving-ibm-modal-body) {
+:host(#{$c4d-prefix}-leaving-ibm-modal-body) {
   // @extend :host(#{$prefix}-modal-body);
   padding-right: 20%;
 
-  ::slotted(#{$cds-prefix}-leaving-ibm-modal-supplemental),
+  ::slotted(#{$c4d-prefix}-leaving-ibm-modal-supplemental),
   ::slotted(slot[name='supplemental']) {
     display: block;
     margin-top: $spacing-07;

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer.scss
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer.scss
@@ -11,13 +11,13 @@
 @use '../expressive-modal/expressive-modal';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-lightbox-image-viewer),
-:host(#{$cds-prefix}-lightbox-video-player) {
-  @extend :host(#{$cds-prefix}-expressive-modal-body);
+:host(#{$c4d-prefix}-lightbox-image-viewer),
+:host(#{$c4d-prefix}-lightbox-video-player) {
+  @extend :host(#{$c4d-prefix}-expressive-modal-body);
   @extend .#{$prefix}--lightbox-media-viewer;
 }
 
-:host(#{$cds-prefix}-lightbox-video-player) .#{$prefix}--video-player {
+:host(#{$c4d-prefix}-lightbox-video-player) .#{$prefix}--video-player {
   width: 100%;
 
   ::slotted(.#{$prefix}--video-player__video) {

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.scss
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.scss
@@ -7,7 +7,7 @@
 
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-lightbox-video-player-container),
-:host(#{$cds-prefix}-lightbox-video-player-composite) {
+:host(#{$c4d-prefix}-lightbox-video-player-container),
+:host(#{$c4d-prefix}-lightbox-video-player-composite) {
   display: contents;
 }

--- a/packages/web-components/src/components/link-list-section/link-list-section.scss
+++ b/packages/web-components/src/components/link-list-section/link-list-section.scss
@@ -11,7 +11,7 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/utils/flex-grid' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-link-list-section) {
+:host(#{$c4d-prefix}-link-list-section) {
   display: block;
 
   .#{$prefix}--content-section__left {
@@ -26,7 +26,7 @@
     }
   }
 
-  ::slotted(#{$cds-prefix}-content-section-heading) {
+  ::slotted(#{$c4d-prefix}-content-section-heading) {
     margin-bottom: 0;
   }
 }

--- a/packages/web-components/src/components/link-list/link-list.scss
+++ b/packages/web-components/src/components/link-list/link-list.scss
@@ -15,8 +15,8 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/utils/hang';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-link-list-heading),
-:host(#{$cds-prefix}-link-list-item) {
+:host(#{$c4d-prefix}-link-list-heading),
+:host(#{$c4d-prefix}-link-list-item) {
   display: block;
 
   .#{$prefix}--link {
@@ -24,29 +24,29 @@
   }
 }
 
-:host(#{$cds-prefix}-link-list-item) {
+:host(#{$c4d-prefix}-link-list-item) {
   &:focus {
     outline: none;
   }
 }
 
-:host(#{$cds-prefix}-link-list-item-card) .#{$prefix}--link:focus {
+:host(#{$c4d-prefix}-link-list-item-card) .#{$prefix}--link:focus {
   outline: $spacing-01 solid $focus;
   outline-offset: -#{$spacing-01};
 }
 
-:host(#{$cds-prefix}-link-list-item)
+:host(#{$c4d-prefix}-link-list-item)
   .cds--link-with-icon__icon-left
   ::slotted(svg[slot='icon']),
-:host(#{$cds-prefix}-link-list-item-cta)
+:host(#{$c4d-prefix}-link-list-item-cta)
   .cds--link-with-icon__icon-left
   ::slotted(svg[slot='icon']) {
   min-width: 20px;
   min-height: 20px;
 }
 
-:host(#{$cds-prefix}-link-list-item)[type='end'],
-:host(#{$cds-prefix}-link-list-item-cta)[type='end'] {
+:host(#{$c4d-prefix}-link-list-item)[type='end'],
+:host(#{$c4d-prefix}-link-list-item-cta)[type='end'] {
   outline: none;
 
   &:hover {
@@ -58,26 +58,26 @@
 
   .#{$prefix}--link {
     // TODO: See if there is a better solution than an internal custom property
-    padding: var(--#{$cds-prefix}--link-list-item--anchor-padding, 0);
+    padding: var(--#{$c4d-prefix}--link-list-item--anchor-padding, 0);
     display: flex;
   }
 }
 
-:host(#{$cds-prefix}-link-list):last-of-type {
+:host(#{$c4d-prefix}-link-list):last-of-type {
   padding-bottom: $spacing-10;
 }
 
-:host(#{$cds-prefix}-link-list) {
+:host(#{$c4d-prefix}-link-list) {
   padding-bottom: 0;
 
   .#{$prefix}--link-list__list--card,
   .#{$prefix}--link-list__list--vertical,
-  .#{$cds-prefix}-ce--link-list__list--end {
+  .#{$c4d-prefix}-ce--link-list__list--end {
     display: grid;
     grid-auto-rows: 1fr;
 
-    ::slotted(#{$cds-prefix}-link-list-item),
-    ::slotted(#{$cds-prefix}-link-list-item-cta) {
+    ::slotted(#{$c4d-prefix}-link-list-item),
+    ::slotted(#{$c4d-prefix}-link-list-item-cta) {
       outline: none;
     }
   }
@@ -87,26 +87,26 @@
   }
 
   .#{$prefix}--link-list__list--card,
-  .#{$cds-prefix}-ce--link-list__list--end {
-    ::slotted(#{$cds-prefix}-link-list-item),
-    ::slotted(#{$cds-prefix}-link-list-item-cta) {
+  .#{$c4d-prefix}-ce--link-list__list--end {
+    ::slotted(#{$c4d-prefix}-link-list-item),
+    ::slotted(#{$c4d-prefix}-link-list-item-cta) {
       display: grid;
     }
   }
 
   .#{$prefix}--link-list__list--vertical
-    ::slotted(#{$cds-prefix}-link-list-item) {
+    ::slotted(#{$c4d-prefix}-link-list-item) {
     display: flex;
   }
 
-  .#{$cds-prefix}-ce--link-list__list--end {
-    ::slotted(#{$cds-prefix}-link-list-item),
-    ::slotted(#{$cds-prefix}-link-list-item-cta) {
+  .#{$c4d-prefix}-ce--link-list__list--end {
+    ::slotted(#{$c4d-prefix}-link-list-item),
+    ::slotted(#{$c4d-prefix}-link-list-item-cta) {
       border-top: 1px solid $border-subtle-01;
       border-bottom: 1px solid $border-subtle-01;
       margin-top: -1px;
       margin-left: -$spacing-05;
-      --#{$cds-prefix}--link-list-item--anchor-padding: #{$spacing-05};
+      --#{$c4d-prefix}--link-list-item--anchor-padding: #{$spacing-05};
 
       @include breakpoint(md) {
         margin-right: -$spacing-05;
@@ -114,21 +114,21 @@
     }
   }
 
-  .#{$cds-prefix}-ce--link-list__heading__wrapper {
+  .#{$c4d-prefix}-ce--link-list__heading__wrapper {
     display: contents;
   }
 
   @include breakpoint(md) {
-    .#{$cds-prefix}-ce--link-list__heading--split
-      ::slotted(#{$cds-prefix}-link-list-heading) {
+    .#{$c4d-prefix}-ce--link-list__heading--split
+      ::slotted(#{$c4d-prefix}-link-list-heading) {
       width: 33.3%;
       padding-right: 10%;
     }
   }
 
-  .#{$cds-prefix}-ce--link-list__list--split,
-  .#{$cds-prefix}-ce--link-list__list--three-columns {
-    ::slotted(#{$cds-prefix}-link-list-item) {
+  .#{$c4d-prefix}-ce--link-list__list--split,
+  .#{$c4d-prefix}-ce--link-list__list--three-columns {
+    ::slotted(#{$c4d-prefix}-link-list-item) {
       display: grid;
       align-items: stretch;
       margin-right: -$spacing-05;
@@ -138,20 +138,20 @@
       display: grid;
       grid-column-gap: $spacing-07;
 
-      ::slotted(#{$cds-prefix}-link-list-item) {
+      ::slotted(#{$c4d-prefix}-link-list-item) {
         margin-left: -$spacing-05;
         margin-right: 0;
       }
     }
   }
 
-  .#{$cds-prefix}-ce--link-list__list--split {
+  .#{$c4d-prefix}-ce--link-list__list--split {
     @include breakpoint(md) {
       grid-template-columns: 1fr 1fr;
     }
   }
 
-  .#{$cds-prefix}-ce--link-list__list--three-columns {
+  .#{$c4d-prefix}-ce--link-list__list--three-columns {
     @include breakpoint(md) {
       grid-template-columns: 1fr 1fr 1fr;
     }

--- a/packages/web-components/src/components/link-with-icon/link-with-icon.scss
+++ b/packages/web-components/src/components/link-with-icon/link-with-icon.scss
@@ -12,17 +12,17 @@
 @use '@carbon/ibmdotcom-styles/scss/components/link-with-icon';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-link-with-icon),
-:host(#{$cds-prefix}-link-list-item),
-:host(#{$cds-prefix}-text-cta),
-:host(#{$cds-prefix}-link-list-item-cta) {
+:host(#{$c4d-prefix}-link-with-icon),
+:host(#{$c4d-prefix}-link-list-item),
+:host(#{$c4d-prefix}-text-cta),
+:host(#{$c4d-prefix}-link-list-item-cta) {
   // Re-define the ruleset so this wins over `.cds--link:visited`, etc.
   .#{$prefix}--link--disabled {
     color: $text-disabled;
   }
 }
 
-:host(#{$cds-prefix}-link-list-item) {
+:host(#{$c4d-prefix}-link-list-item) {
   .#{$prefix}--link {
     align-content: flex-start;
 
@@ -33,7 +33,7 @@
   }
 }
 
-:host(#{$cds-prefix}-link-list-item)[type='end'] {
+:host(#{$c4d-prefix}-link-list-item)[type='end'] {
   .#{$prefix}--link-with-icon__icon-left ::slotted(svg[slot='icon']) {
     margin-right: $spacing-07;
   }

--- a/packages/web-components/src/components/locale-modal/locale-modal-composite.scss
+++ b/packages/web-components/src/components/locale-modal/locale-modal-composite.scss
@@ -7,7 +7,7 @@
 
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-locale-modal-composite),
-:host(#{$cds-prefix}-locale-modal-container) {
+:host(#{$c4d-prefix}-locale-modal-composite),
+:host(#{$c4d-prefix}-locale-modal-container) {
   display: contents;
 }

--- a/packages/web-components/src/components/locale-modal/locale-modal.scss
+++ b/packages/web-components/src/components/locale-modal/locale-modal.scss
@@ -17,10 +17,10 @@
 @use '@carbon/ibmdotcom-styles/scss/globals/utils/flex-grid' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-// :host(#{$cds-prefix}-locale-modal) {
-//   @extend :host(#{$cds-prefix}-expressive-modal);
+// :host(#{$c4d-prefix}-locale-modal) {
+//   @extend :host(#{$c4d-prefix}-expressive-modal);
 
-//   #{$cds-prefix}-expressive-modal-header {
+//   #{$c4d-prefix}-expressive-modal-header {
 //     padding: 0 20% 0 $spacing-05;
 //     margin-bottom: $spacing-03;
 //   }
@@ -46,15 +46,15 @@
 //   }
 // }
 
-// :host(#{$cds-prefix}-locale-modal) #{$cds-prefix}-expressive-modal-heading {
+// :host(#{$c4d-prefix}-locale-modal) #{$c4d-prefix}-expressive-modal-heading {
 //   width: fit-content;
 // }
 
-// :host(#{$cds-prefix}-locale-search) {
+// :host(#{$c4d-prefix}-locale-search) {
 //   padding-top: $spacing-03;
 // }
 
-// :host(#{$cds-prefix}-region-item) {
+// :host(#{$c4d-prefix}-region-item) {
 //   @include breakpoint('sm', $grid-breakpoints) {
 //     @include make-col(4, map.get(map.get($grid-breakpoints, 'sm'), 'columns'));
 //   }

--- a/packages/web-components/src/components/markdown/markdown.scss
+++ b/packages/web-components/src/components/markdown/markdown.scss
@@ -9,7 +9,7 @@ $css--reset: false !default;
 
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-markdown) {
+:host(#{$c4d-prefix}-markdown) {
   // shouldn't be needed
   // p {
   //   @include reset;

--- a/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
+++ b/packages/web-components/src/components/masthead/cloud/cloud-masthead.scss
@@ -19,28 +19,28 @@
 
 // Cloud Masthead.
 
-:host(#{$cds-prefix}-cloud-masthead-container),
-#{$cds-prefix}-cloud-masthead-container {
+:host(#{$c4d-prefix}-cloud-masthead-container),
+#{$c4d-prefix}-cloud-masthead-container {
   position: relative;
 }
 
-:host(#{$cds-prefix}-cloud-masthead-global-bar) {
-  @extend :host(#{$cds-prefix}-masthead-global-bar);
+:host(#{$c4d-prefix}-cloud-masthead-global-bar) {
+  @extend :host(#{$c4d-prefix}-masthead-global-bar);
 
   background-color: $background;
   flex: none;
   z-index: 0;
 }
 
-:host(#{$cds-prefix}-cloud-masthead-global-bar)
-  ::slotted(#{$cds-prefix}-cloud-button-cta) {
+:host(#{$c4d-prefix}-cloud-masthead-global-bar)
+  ::slotted(#{$c4d-prefix}-cloud-button-cta) {
   @include breakpoint-down(md) {
     display: none;
   }
 }
 
-:host(#{$cds-prefix}-cloud-button-cta) {
-  @extend :host(#{$cds-prefix}-button-cta);
+:host(#{$c4d-prefix}-cloud-button-cta) {
+  @extend :host(#{$c4d-prefix}-button-cta);
 
   margin: 0;
   padding-right: 0;
@@ -64,7 +64,7 @@
   }
 }
 
-:host(#{$cds-prefix}-cloud-top-nav-name) {
+:host(#{$c4d-prefix}-cloud-top-nav-name) {
   outline: none;
   position: relative;
   z-index: 1;
@@ -95,7 +95,7 @@
 
 // Cloud Megamenu.
 
-:host(#{$cds-prefix}-cloud-megamenu),
+:host(#{$c4d-prefix}-cloud-megamenu),
 .#{$prefix}--masthead__megamenu {
   position: relative;
 
@@ -125,7 +125,7 @@
   }
 }
 
-:host(#{$cds-prefix}-cloud-megamenu-left-navigation) {
+:host(#{$c4d-prefix}-cloud-megamenu-left-navigation) {
   @include make-col(4, 16);
 
   display: flex;
@@ -142,7 +142,7 @@
   }
 }
 
-:host(#{$cds-prefix}-cloud-megamenu-right-navigation) {
+:host(#{$c4d-prefix}-cloud-megamenu-right-navigation) {
   @include make-col(12, 16);
 
   display: flex;
@@ -151,7 +151,7 @@
   margin-bottom: $spacing-07;
 }
 
-:host(#{$cds-prefix}-cloud-megamenu-tabs) {
+:host(#{$c4d-prefix}-cloud-megamenu-tabs) {
   display: flex;
   flex-direction: column;
   margin-top: rem(18px);
@@ -162,7 +162,7 @@
   }
 }
 
-:host(#{$cds-prefix}-cloud-megamenu-tab) {
+:host(#{$c4d-prefix}-cloud-megamenu-tab) {
   outline: 0;
 
   button {
@@ -192,18 +192,18 @@
   }
 }
 
-:host(#{$cds-prefix}-cloud-megamenu-tab)[selected] button {
+:host(#{$c4d-prefix}-cloud-megamenu-tab)[selected] button {
   background-color: $background-selected;
   color: $text-primary;
 }
 
-:host(#{$cds-prefix}-cloud-megamenu-category-link-group) {
+:host(#{$c4d-prefix}-cloud-megamenu-category-link-group) {
   display: flex;
   flex-flow: wrap;
   justify-content: flex-start;
 }
 
-:host(#{$cds-prefix}-cloud-megamenu-category-link) {
+:host(#{$c4d-prefix}-cloud-megamenu-category-link) {
   width: 100%;
   max-width: 50%;
   outline: 0;
@@ -247,7 +247,7 @@
   }
 }
 
-:host(#{$cds-prefix}-cloud-megamenu-category-heading) {
+:host(#{$c4d-prefix}-cloud-megamenu-category-heading) {
   display: block;
   padding: 0 $spacing-05;
   margin-bottom: $spacing-07;
@@ -300,8 +300,8 @@
   }
 }
 
-:host(#{$cds-prefix}-cloud-left-nav-item) {
-  @extend :host(#{$cds-prefix}-left-nav-item);
+:host(#{$c4d-prefix}-cloud-left-nav-item) {
+  @extend :host(#{$c4d-prefix}-left-nav-item);
 
   a.#{$prefix}--side-nav__link .#{$prefix}--side-nav__link-text {
     color: $text-secondary;
@@ -324,7 +324,7 @@
   }
 }
 
-:host(#{$cds-prefix}-cloud-masthead-profile)
+:host(#{$c4d-prefix}-cloud-masthead-profile)
   .#{$prefix}--header__menu-title[aria-expanded='true']
   + .#{$prefix}--header__menu {
   @include breakpoint-down(md) {
@@ -332,7 +332,7 @@
   }
 }
 
-:host(#{$cds-prefix}-cloud-masthead-profile) a.#{$prefix}--header__menu-item {
+:host(#{$c4d-prefix}-cloud-masthead-profile) a.#{$prefix}--header__menu-item {
   svg {
     fill: $icon-secondary;
   }

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -18,7 +18,7 @@
 @use '@carbon/ibmdotcom-styles/scss/components/masthead' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-masthead-menu-button) {
+:host(#{$c4d-prefix}-masthead-menu-button) {
   // @extend :host(#{$prefix}-header-menu-button);
   position: relative;
   width: mini-units(6);
@@ -30,18 +30,18 @@
     }
   }
 
-  .#{$cds-prefix}-ce--header__menu-trigger__container {
+  .#{$c4d-prefix}-ce--header__menu-trigger__container {
     display: contents;
   }
 
-  .#{$cds-prefix}-ce--header__menu-trigger__container--has-search-active {
+  .#{$c4d-prefix}-ce--header__menu-trigger__container--has-search-active {
     @include breakpoint-down(md) {
       display: none;
     }
   }
 }
 
-:host(#{$cds-prefix}-masthead-logo) {
+:host(#{$c4d-prefix}-masthead-logo) {
   // @extend :host(#{$prefix}-header-name);
   @include masthead-logo;
 
@@ -55,7 +55,7 @@
     height: 23px;
   }
 
-  .#{$cds-prefix}-ce--header__logo--has-search-active {
+  .#{$c4d-prefix}-ce--header__logo--has-search-active {
     @include breakpoint-down(md) {
       display: none;
     }
@@ -68,7 +68,7 @@
   }
 }
 
-:host(#{$cds-prefix}-top-nav-name) {
+:host(#{$c4d-prefix}-top-nav-name) {
   outline: none;
   z-index: 1;
   background: $background;
@@ -78,26 +78,26 @@
   }
 }
 
-:host(#{$cds-prefix}-masthead-search) {
+:host(#{$c4d-prefix}-masthead-search) {
   outline: none;
 
-  .#{$cds-prefix}-ce--masthead__search__list {
+  .#{$c4d-prefix}-ce--masthead__search__list {
     height: 0;
     overflow: hidden;
   }
 
-  &[open] .#{$cds-prefix}-ce--masthead__search__list {
+  &[open] .#{$c4d-prefix}-ce--masthead__search__list {
     height: auto;
   }
 }
 
-:host(#{$cds-prefix}-masthead-search-item) {
+:host(#{$c4d-prefix}-masthead-search-item) {
   @extend .react-autosuggest__suggestion;
 
   font-size: $spacing-05;
 }
 
-:host(#{$cds-prefix}-masthead-global-bar) {
+:host(#{$c4d-prefix}-masthead-global-bar) {
   @extend .#{$prefix}--header__global;
 
   &[has-search-active] {
@@ -106,19 +106,19 @@
     }
   }
 
-  .#{$cds-prefix}-ce--header__global__container {
+  .#{$c4d-prefix}-ce--header__global__container {
     display: contents;
   }
 
-  .#{$cds-prefix}-ce--header__global__container--has-search-active {
+  .#{$c4d-prefix}-ce--header__global__container--has-search-active {
     @include breakpoint-down(md) {
       display: none;
     }
   }
 }
 
-:host(#{$cds-prefix}-masthead-profile),
-:host(#{$cds-prefix}-cloud-masthead-profile) {
+:host(#{$c4d-prefix}-masthead-profile),
+:host(#{$c4d-prefix}-cloud-masthead-profile) {
   background-color: $background;
   width: $spacing-09;
   a.#{$prefix}--header__menu-item {
@@ -137,8 +137,8 @@
   }
 }
 
-:host(#{$cds-prefix}-top-nav),
-:host(#{$cds-prefix}-top-nav-l1) {
+:host(#{$c4d-prefix}-top-nav),
+:host(#{$c4d-prefix}-top-nav-l1) {
   display: none;
   background-color: $background;
 
@@ -159,7 +159,7 @@
     padding-left: 0;
   }
 
-  .#{$cds-prefix}-ce--header__nav-content-container {
+  .#{$c4d-prefix}-ce--header__nav-content-container {
     flex: 1;
     position: relative;
   }
@@ -195,14 +195,14 @@
     height: $spacing-09;
   }
 
-  .#{$cds-prefix}-ce--header__nav-caret-container--hidden {
+  .#{$c4d-prefix}-ce--header__nav-caret-container--hidden {
     position: absolute;
     visibility: hidden;
   }
 }
 
-:host(#{$cds-prefix}-top-nav)[cloud],
-:host(#{$cds-prefix}-top-nav-l1)[cloud] {
+:host(#{$c4d-prefix}-top-nav)[cloud],
+:host(#{$c4d-prefix}-top-nav-l1)[cloud] {
   @include breakpoint(800px) {
     display: none;
   }
@@ -225,18 +225,18 @@
   }
 }
 
-:host(#{$cds-prefix}-top-nav-l1) {
+:host(#{$c4d-prefix}-top-nav-l1) {
   overflow: visible;
 }
 
-:host(#{$cds-prefix}-top-nav-item) {
+:host(#{$c4d-prefix}-top-nav-item) {
   // @extend :host(#{$prefix}-header-nav-item);
 }
 
-:host(#{$cds-prefix}-top-nav-menu),
-:host(#{$cds-prefix}-megamenu-top-nav-menu),
-:host(#{$cds-prefix}-masthead-profile),
-:host(#{$cds-prefix}-cloud-masthead-profile) {
+:host(#{$c4d-prefix}-top-nav-menu),
+:host(#{$c4d-prefix}-megamenu-top-nav-menu),
+:host(#{$c4d-prefix}-masthead-profile),
+:host(#{$c4d-prefix}-cloud-masthead-profile) {
   // @extend :host(#{$prefix}-header-menu);
 
   .#{$prefix}--header__menu-title[aria-expanded='true'] {
@@ -245,9 +245,9 @@
   }
 }
 
-:host(#{$cds-prefix}-top-nav-menu),
-:host(#{$cds-prefix}-masthead-profile),
-:host(#{$cds-prefix}-cloud-masthead-profile) {
+:host(#{$c4d-prefix}-top-nav-menu),
+:host(#{$c4d-prefix}-masthead-profile),
+:host(#{$c4d-prefix}-cloud-masthead-profile) {
   .#{$prefix}--header__menu-title[aria-expanded='true']
     + .#{$prefix}--header__menu {
     background-color: $background;
@@ -256,8 +256,8 @@
   }
 }
 
-:host(#{$cds-prefix}-top-nav-menu-item),
-:host(#{$cds-prefix}-masthead-profile-item) {
+:host(#{$c4d-prefix}-top-nav-menu-item),
+:host(#{$c4d-prefix}-masthead-profile-item) {
   // @extend :host(#{$prefix}-header-menu-item);
   @include masthead-top-nav-menu-item;
 
@@ -266,11 +266,11 @@
   }
 }
 
-:host(#{$cds-prefix}-top-nav-item),
-:host(#{$cds-prefix}-top-nav-menu),
-:host(#{$cds-prefix}-megamenu-top-nav-menu),
-:host(#{$cds-prefix}-top-nav-menu-item),
-:host(#{$cds-prefix}-masthead-profile-item) {
+:host(#{$c4d-prefix}-top-nav-item),
+:host(#{$c4d-prefix}-top-nav-menu),
+:host(#{$c4d-prefix}-megamenu-top-nav-menu),
+:host(#{$c4d-prefix}-top-nav-menu-item),
+:host(#{$c4d-prefix}-masthead-profile-item) {
   .#{$prefix}--header__menu-arrow {
     fill: $text-primary;
     width: 20px;
@@ -286,7 +286,7 @@
   }
 }
 
-:host(#{$cds-prefix}-megamenu-top-nav-menu) {
+:host(#{$c4d-prefix}-megamenu-top-nav-menu) {
   .#{$prefix}--header__menu-title[aria-expanded='true']
     + .#{$prefix}--header__menu {
     bottom: auto;
@@ -296,7 +296,7 @@
   }
 }
 
-:host(#{$cds-prefix}-left-nav) {
+:host(#{$c4d-prefix}-left-nav) {
   // @extend :host(#{$prefix}-side-nav);
   display: block;
   overflow: hidden;
@@ -345,14 +345,14 @@
     position: relative;
   }
 
-  ::slotted(#{$cds-prefix}-left-nav-menu-section) {
+  ::slotted(#{$c4d-prefix}-left-nav-menu-section) {
     overflow: hidden;
     height: auto;
   }
 }
 
-:host(#{$cds-prefix}-masthead-menu-button),
-:host(#{$cds-prefix}-left-nav) {
+:host(#{$c4d-prefix}-masthead-menu-button),
+:host(#{$c4d-prefix}-left-nav) {
   @include breakpoint(md) {
     display: block;
   }
@@ -362,8 +362,8 @@
   }
 }
 
-:host(#{$cds-prefix}-masthead-menu-button)[cloud],
-:host(#{$cds-prefix}-left-nav)[cloud] {
+:host(#{$c4d-prefix}-masthead-menu-button)[cloud],
+:host(#{$c4d-prefix}-left-nav)[cloud] {
   @include breakpoint(md) {
     display: block;
   }
@@ -373,7 +373,7 @@
   }
 }
 
-:host(#{$cds-prefix}-left-nav-name) {
+:host(#{$c4d-prefix}-left-nav-name) {
   .#{$prefix}--side-nav__submenu-platform {
     display: flex;
     align-items: center;
@@ -392,27 +392,27 @@
   }
 }
 
-:host(#{$cds-prefix}-left-nav-items) {
+:host(#{$c4d-prefix}-left-nav-items) {
   // @extend :host(#{$prefix}-side-nav-items);
 }
 
-:host(#{$cds-prefix}-left-nav-item) {
+:host(#{$c4d-prefix}-left-nav-item) {
   // @extend :host(#{$prefix}-side-nav-link);
 }
 
-:host(#{$cds-prefix}-left-nav-menu) {
+:host(#{$c4d-prefix}-left-nav-menu) {
   // @extend :host(#{$prefix}-side-nav-menu);
 }
 
-:host(#{$cds-prefix}-left-nav-menu-item) {
+:host(#{$c4d-prefix}-left-nav-menu-item) {
   // @extend :host(#{$prefix}-side-nav-menu-item);
 }
 
-:host(#{$cds-prefix}-left-nav-item-highlighted) a.#{$prefix}--side-nav__link,
-:host(#{$cds-prefix}-left-nav-menu-item-highlighted)
+:host(#{$c4d-prefix}-left-nav-item-highlighted) a.#{$prefix}--side-nav__link,
+:host(#{$c4d-prefix}-left-nav-menu-item-highlighted)
   a.#{$prefix}--side-nav__link,
-:host(#{$cds-prefix}-left-nav-item) a.#{$prefix}--side-nav__link,
-:host(#{$cds-prefix}-left-nav-menu-item) a.#{$prefix}--side-nav__link {
+:host(#{$c4d-prefix}-left-nav-item) a.#{$prefix}--side-nav__link,
+:host(#{$c4d-prefix}-left-nav-menu-item) a.#{$prefix}--side-nav__link {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -421,18 +421,18 @@
   width: 100%;
 }
 
-:host(#{$cds-prefix}-left-nav-item),
-:host(#{$cds-prefix}-left-nav-menu),
-:host(#{$cds-prefix}-left-nav-menu-item) {
+:host(#{$c4d-prefix}-left-nav-item),
+:host(#{$c4d-prefix}-left-nav-menu),
+:host(#{$c4d-prefix}-left-nav-menu-item) {
   .#{$prefix}--side-nav__link:hover {
     background-color: $background-hover;
     color: $text-primary;
   }
 }
 
-:host(#{$cds-prefix}-left-nav-menu),
-:host(#{$cds-prefix}-left-nav-menu-item),
-:host(#{$cds-prefix}-left-nav-menu-section) {
+:host(#{$c4d-prefix}-left-nav-menu),
+:host(#{$c4d-prefix}-left-nav-menu-item),
+:host(#{$c4d-prefix}-left-nav-menu-section) {
   .#{$prefix}--side-nav__link,
   .#{$prefix}--side-nav__submenu,
   a.#{$prefix}--side-nav__link,
@@ -476,7 +476,7 @@
     mini-units(6) + ' + 1px), 100% 100%, 0 100%)*/'};
 }
 
-:host(#{$cds-prefix}-left-nav-overlay) {
+:host(#{$c4d-prefix}-left-nav-overlay) {
   // @extend .#{$prefix}--side-nav__overlay;
 
   &[active] {
@@ -486,7 +486,7 @@
   }
 }
 
-:host(#{$cds-prefix}-left-nav-overlay)[cloud] {
+:host(#{$c4d-prefix}-left-nav-overlay)[cloud] {
   &[active] {
     @include breakpoint-down(960px) {
       @include left-nav-overlay;
@@ -494,7 +494,7 @@
   }
 }
 
-:host(#{$cds-prefix}-left-nav-overlay[dir='rtl']) {
+:host(#{$c4d-prefix}-left-nav-overlay[dir='rtl']) {
   clip-path: polygon(
     0 0,
     calc(100% - #{mini-units(6)}) 0,
@@ -505,12 +505,12 @@
   );
 }
 
-:host(#{$cds-prefix}-megamenu-link-with-icon):focus,
-:host(#{$cds-prefix}-megamenu-category-link):focus {
+:host(#{$c4d-prefix}-megamenu-link-with-icon):focus,
+:host(#{$c4d-prefix}-megamenu-category-link):focus {
   outline: none;
 }
 
-:host(#{$cds-prefix}-masthead-search-composite),
-:host(#{$cds-prefix}-masthead-search-container) {
+:host(#{$c4d-prefix}-masthead-search-composite),
+:host(#{$c4d-prefix}-masthead-search-container) {
   display: contents;
 }

--- a/packages/web-components/src/components/pictogram-item/pictogram-item.scss
+++ b/packages/web-components/src/components/pictogram-item/pictogram-item.scss
@@ -9,6 +9,6 @@
 @use '@carbon/ibmdotcom-styles/scss/internal/content-item';
 @use '@carbon/ibmdotcom-styles/scss/components/pictogram-item';
 
-:host(#{$cds-prefix}-pictogram-item) {
+:host(#{$c4d-prefix}-pictogram-item) {
   display: block;
 }

--- a/packages/web-components/src/components/quote/quote.scss
+++ b/packages/web-components/src/components/quote/quote.scss
@@ -13,13 +13,13 @@
 @use '@carbon/ibmdotcom-styles/scss/components/link-with-icon';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-quote-source-bottom-copy),
-:host(#{$cds-prefix}-quote-source-copy),
-:host(#{$cds-prefix}-quote-source-heading) {
+:host(#{$c4d-prefix}-quote-source-bottom-copy),
+:host(#{$c4d-prefix}-quote-source-copy),
+:host(#{$c4d-prefix}-quote-source-heading) {
   display: block;
 }
 
-:host(#{$cds-prefix}-quote) #{$cds-prefix}-hr {
+:host(#{$c4d-prefix}-quote) #{$c4d-prefix}-hr {
   margin: $spacing-05;
   @include breakpoint(md) {
     margin: $spacing-05 0;
@@ -29,13 +29,13 @@
   }
 }
 
-:host(#{$cds-prefix}-quote-link-with-icon) {
+:host(#{$c4d-prefix}-quote-link-with-icon) {
   @extend .#{$prefix}--link-with-icon;
 
   display: inline-block;
 }
 
-:host-context(#{$cds-prefix}-quote[color-scheme='inverse'])
+:host-context(#{$c4d-prefix}-quote[color-scheme='inverse'])
   a.#{$prefix}--link-with-icon.#{$prefix}--link.#{$prefix}--link-with-icon__icon-right {
   color: $link-inverse;
   outline-color: $focus-inverse;

--- a/packages/web-components/src/components/search/search.scss
+++ b/packages/web-components/src/components/search/search.scss
@@ -11,7 +11,7 @@
 // @use '@carbon/styles/scss/components/search/search';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 //
-:host(#{$cds-prefix}-search) {
+:host(#{$c4d-prefix}-search) {
   @extend :host(#{$prefix}-search);
 
   &[size='sm'] {

--- a/packages/web-components/src/components/table-of-contents/table-of-contents.scss
+++ b/packages/web-components/src/components/table-of-contents/table-of-contents.scss
@@ -12,7 +12,7 @@
 @use '@carbon/ibmdotcom-styles/scss/components/layout';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-table-of-contents[toc-layout='horizontal'])
+:host(#{$c4d-prefix}-table-of-contents[toc-layout='horizontal'])
   .#{$prefix}--tableofcontents__navbar {
   @include breakpoint(lg) {
     &::before {
@@ -41,7 +41,7 @@
   }
 }
 
-:host(#{$cds-prefix}-table-of-contents[toc-layout='horizontal'])
+:host(#{$c4d-prefix}-table-of-contents[toc-layout='horizontal'])
   .#{$prefix}--tableofcontents__desktop-container {
   @include breakpoint(lg) {
     position: relative;
@@ -50,21 +50,21 @@
   }
 }
 
-:host(#{$cds-prefix}-table-of-contents[toc-layout='horizontal'])
+:host(#{$c4d-prefix}-table-of-contents[toc-layout='horizontal'])
   .#{$prefix}--tableofcontents__mobile {
   margin: 0;
 }
 
-:host(#{$cds-prefix}-table-of-contents[toc-layout='horizontal'])
+:host(#{$c4d-prefix}-table-of-contents[toc-layout='horizontal'])
   .#{$prefix}--tableofcontents__content {
   max-width: none;
   flex: 1;
 }
 
-.#{$cds-prefix}-ce--table-of-contents__container {
+.#{$c4d-prefix}-ce--table-of-contents__container {
   // TODO: Make the layout CSS grid-based so we can remove this ruleset
-  ::slotted(#{$cds-prefix}-content-block-simple),
-  ::slotted(#{$cds-prefix}-content-block-segmented) {
+  ::slotted(#{$c4d-prefix}-content-block-simple),
+  ::slotted(#{$c4d-prefix}-content-block-segmented) {
     margin-left: calc(-1 * #{$spacing-05});
     margin-right: calc(-1 * #{$spacing-05});
   }
@@ -98,7 +98,7 @@
   height: $spacing-09;
 }
 
-.#{$cds-prefix}-ce--toc__navbar-caret-container--hidden {
+.#{$c4d-prefix}-ce--toc__navbar-caret-container--hidden {
   position: absolute;
   visibility: hidden;
 }

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.scss
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.scss
@@ -9,11 +9,11 @@
 @use '@carbon/ibmdotcom-styles/scss/components/tabs-extended';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$cds-prefix}-tabs-extended) {
+:host(#{$c4d-prefix}-tabs-extended) {
   margin: 0;
 }
 
-:host(#{$cds-prefix}-tab) {
+:host(#{$c4d-prefix}-tab) {
   display: contents;
 
   .#{$prefix}--accordion__item:last-of-type {

--- a/packages/web-components/src/globals/scss/themes.scss
+++ b/packages/web-components/src/globals/scss/themes.scss
@@ -9,22 +9,22 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/themes' as *;
 
-:host(.#{$cds-prefix}-theme-zone-white),
-.#{$cds-prefix}-theme-zone-white {
+:host(.#{$c4d-prefix}-theme-zone-white),
+.#{$c4d-prefix}-theme-zone-white {
   @include theme($white, true);
 }
 
-:host(.#{$cds-prefix}-theme-zone-g10),
-.#{$cds-prefix}-theme-zone-g10 {
+:host(.#{$c4d-prefix}-theme-zone-g10),
+.#{$c4d-prefix}-theme-zone-g10 {
   @include theme($g10, true);
 }
 
-:host(.#{$cds-prefix}-theme-zone-g90),
-.#{$cds-prefix}-theme-zone-g90 {
+:host(.#{$c4d-prefix}-theme-zone-g90),
+.#{$c4d-prefix}-theme-zone-g90 {
   @include theme($g90, true);
 }
 
-:host(.#{$cds-prefix}-theme-zone-g100),
-.#{$cds-prefix}-theme-zone-g100 {
+:host(.#{$c4d-prefix}-theme-zone-g100),
+.#{$c4d-prefix}-theme-zone-g100 {
   @include theme($g100, true);
 }


### PR DESCRIPTION
### Description

This updates prefixes in `@carbon/ibmdotcom-styles` to `c4d`.

### Changelog

**New**

- {{new thing}}

**Changed**

- changed `cds-prefix` to `c4d-prefix`

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
