### PR TITLE
fix(content-block): spacing adjustments

### DIFF
--- a/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
+++ b/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
@@ -81,11 +81,14 @@
     }
   }
 
-  :host(#{$c4d-prefix}-callout-with-media) .#{$prefix}--callout__content,
   .#{$prefix}--callout-with-media
     .#{$prefix}--callout__content
     .#{$prefix}--content-block {
-    padding-bottom: $spacing-10;
+    margin-bottom: $layout-05;
+  }
+
+  :host(#{$c4d-prefix}-callout-with-media) .#{$prefix}--callout__content {
+    padding-bottom: $layout-05;
   }
 
   :host(#{$c4d-prefix}-callout-with-media-image),

--- a/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
+++ b/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,17 +17,17 @@
   :host(#{$c4d-prefix}-content-block-cards),
   .#{$prefix}--content-block-cards .#{$prefix}--content-block {
     display: block;
-    padding-top: $spacing-07;
-    padding-bottom: $spacing-10;
+    margin-top: $carbon--layout-03;
+    margin-bottom: $carbon--layout-05;
 
-    @include breakpoint(md) {
-      padding-top: $spacing-07;
-      padding-bottom: $spacing-12;
+    @include breakpoint('md') {
+      margin-top: $carbon--layout-03;
+      margin-bottom: $carbon--layout-06;
     }
 
-    @include breakpoint(lg) {
-      padding-top: $spacing-10;
-      padding-bottom: $spacing-13;
+    @include breakpoint('lg') {
+      margin-top: $carbon--layout-05;
+      margin-bottom: $carbon--layout-07;
     }
   }
 

--- a/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
+++ b/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
@@ -17,17 +17,17 @@
   :host(#{$c4d-prefix}-content-block-cards),
   .#{$prefix}--content-block-cards .#{$prefix}--content-block {
     display: block;
-    margin-top: $carbon--layout-03;
-    margin-bottom: $carbon--layout-05;
+    margin-top: $layout-03;
+    margin-bottom: $layout-05;
 
     @include breakpoint('md') {
-      margin-top: $carbon--layout-03;
-      margin-bottom: $carbon--layout-06;
+      margin-top: $layout-03;
+      margin-bottom: $layout-06;
     }
 
     @include breakpoint('lg') {
-      margin-top: $carbon--layout-05;
-      margin-bottom: $carbon--layout-07;
+      margin-top: $layout-05;
+      margin-bottom: $layout-07;
     }
   }
 

--- a/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
+++ b/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
@@ -1,5 +1,5 @@
 /**
-* Copyright IBM Corp. 2016, 2021
+* Copyright IBM Corp. 2016, 2022
 *
 * This source code is licensed under the Apache-2.0 license found in the
 * LICENSE file in the root directory of this source tree.
@@ -20,12 +20,12 @@
   :host(#{$c4d-prefix}-content-block-headlines),
   .#{$prefix}--content-block-headlines {
     .#{$prefix}--content-block {
-      @include breakpoint(md) {
-        padding-top: $spacing-07;
+      @include breakpoint('md') {
+        margin-top: $carbon--spacing-07;
       }
 
-      @include breakpoint(lg) {
-        padding-top: $spacing-10;
+      @include breakpoint('lg') {
+        margin-top: $carbon--layout-05;
       }
     }
 

--- a/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
+++ b/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
@@ -21,11 +21,11 @@
   .#{$prefix}--content-block-headlines {
     .#{$prefix}--content-block {
       @include breakpoint('md') {
-        margin-top: $carbon--spacing-07;
+        margin-top: $spacing-07;
       }
 
       @include breakpoint('lg') {
-        margin-top: $carbon--layout-05;
+        margin-top: $layout-05;
       }
     }
 

--- a/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
+++ b/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
@@ -16,13 +16,13 @@
   :host(#{$c4d-prefix}-content-block-horizontal),
   :host(#{$c4d-prefix}-content-group-horizontal) {
     margin-top: $layout-03;
-    margin-bottom: $carbon--layout-03;
+    margin-bottom: $layout-03;
 
-    @include carbon--breakpoint('md') {
+    @include breakpoint('md') {
       margin-bottom: $layout-03;
     }
 
-    @include carbon--breakpoint('lg') {
+    @include breakpoint('lg') {
       margin-top: $layout-05;
       margin-bottom: $layout-05;
     }

--- a/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
+++ b/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
@@ -15,29 +15,23 @@
 @mixin content-block-horizontal {
   :host(#{$c4d-prefix}-content-block-horizontal),
   :host(#{$c4d-prefix}-content-group-horizontal) {
-    padding-top: $spacing-07;
-    padding-bottom: $spacing-07;
+    margin-top: $layout-03;
+    margin-bottom: $carbon--layout-03;
 
-    @include breakpoint(md) {
-      padding-bottom: $spacing-07;
+    @include carbon--breakpoint('md') {
+      margin-bottom: $layout-03;
     }
 
-    @include breakpoint(lg) {
-      padding-top: $spacing-10;
-      padding-bottom: $spacing-10;
+    @include carbon--breakpoint('lg') {
+      margin-top: $layout-05;
+      margin-bottom: $layout-05;
     }
   }
 
   .#{$prefix}--content-block-horizontal,
   .#{$prefix}--content-group-horizontal {
     .#{$prefix}--content-block {
-      padding-top: $spacing-07;
-      padding-bottom: $spacing-05;
-
-      @include breakpoint(lg) {
-        padding-top: $spacing-10;
-        padding-bottom: $spacing-09;
-      }
+      padding: 0;
     }
   }
   .#{$prefix}--content-group-horizontal {

--- a/packages/styles/scss/components/layout/_layout.scss
+++ b/packages/styles/scss/components/layout/_layout.scss
@@ -12,7 +12,7 @@
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
 
-// $carbon--layouts has been replaced by standard spacing tokens
+// $layouts has been replaced by standard spacing tokens
 $layout-spacings: $spacing-05, $spacing-06, $spacing-07, $spacing-09,
   $spacing-10, $spacing-12, $spacing-13;
 

--- a/packages/styles/scss/components/leadspace-block/_leadspace-block.scss
+++ b/packages/styles/scss/components/leadspace-block/_leadspace-block.scss
@@ -18,27 +18,27 @@
 @use '../image';
 @use '../../internal/content-block';
 
-%leadspace-block-padding {
-  padding-top: 0;
-  padding-bottom: $spacing-05;
+%leadspace-block-margin {
+  margin-top: 0;
+  margin-bottom: $layout-01;
 
-  @include breakpoint(md) {
-    padding-bottom: $spacing-12;
+  @include breakpoint('md') {
+    margin-bottom: $layout-06;
   }
-  @include breakpoint(lg) {
-    padding-bottom: $spacing-13;
+  @include breakpoint('lg') {
+    margin-bottom: $layout-07;
   }
 }
 
 @mixin leadspace-block {
   :host(#{$c4d-prefix}-leadspace-block)
     ::slotted(#{$c4d-prefix}-leadspace-block-content) {
-    @extend %leadspace-block-padding;
+    @extend %leadspace-block-margin;
   }
 
   .#{$prefix}--leadspace-block {
     .#{$prefix}--content-block {
-      @extend %leadspace-block-padding;
+      @extend %leadspace-block-margin;
 
       .#{$prefix}--image-with-caption {
         margin-bottom: 0;

--- a/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
+++ b/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
@@ -355,7 +355,7 @@
   }
 
   :host(#{$c4d-prefix}-leadspace-with-search-content-heading) {
-    @extend :host(#{$dds-prefix}-content-block-heading);
+    @extend :host(#{$c4d-prefix}-content-block-heading);
 
     @include breakpoint-down(lg) {
       display: block;

--- a/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
+++ b/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
@@ -350,8 +350,12 @@
     /* stylelint-enable declaration-no-important */
   }
 
+  :host(#{$c4d-prefix}-leadspace-with-search-content) {
+    margin: 0;
+  }
+
   :host(#{$c4d-prefix}-leadspace-with-search-content-heading) {
-    @extend :host(#{$c4d-prefix}-content-block-heading);
+    @extend :host(#{$dds-prefix}-content-block-heading);
 
     @include breakpoint-down(lg) {
       display: block;

--- a/packages/styles/scss/components/logo-grid/_logo-grid.scss
+++ b/packages/styles/scss/components/logo-grid/_logo-grid.scss
@@ -164,6 +164,10 @@
     display: block;
   }
 
+  .#{$prefix}--content-layout__body {
+    display: block;
+  }
+
   .#{$prefix}--logo-grid__wrapper,
   .#{$prefix}--content-layout--logo-grid {
     width: 100%;

--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -28,16 +28,19 @@
   :host(#{$c4d-prefix}-content-block-headlines),
   .#{$prefix}--content-block {
     display: block;
-    padding-top: $spacing-07;
-    padding-bottom: $spacing-10;
+    margin-top: $carbon--spacing-07;
+    margin-bottom: $carbon--spacing-12;
 
-    @include breakpoint(md) {
-      padding-top: $spacing-10;
-      padding-bottom: $spacing-12;
+    @include breakpoint('lg') {
+      margin-top: $carbon--spacing-10;
+      margin-bottom: $carbon--spacing-13;
     }
 
-    @include breakpoint(max) {
-      padding-bottom: $spacing-13;
+    &[complementary-style-scheme='with-border'] {
+      margin-bottom: $carbon--spacing-07;
+      @include breakpoint('lg') {
+        margin-bottom: $carbon--spacing-10;
+      }
     }
 
     .#{$prefix}--card__CTA {
@@ -76,6 +79,11 @@
       margin-right: 0;
       padding-left: 0;
       padding-right: 0;
+      padding-bottom: $carbon--spacing-10;
+
+      @include carbon--breakpoint('lg') {
+        padding-bottom: $carbon--spacing-12;
+      }
     }
 
     // Most slotted contents have margins aligning to Carbon grid gutters.

--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -28,18 +28,18 @@
   :host(#{$c4d-prefix}-content-block-headlines),
   .#{$prefix}--content-block {
     display: block;
-    margin-top: $carbon--spacing-07;
-    margin-bottom: $carbon--spacing-12;
+    margin-top: $spacing-07;
+    margin-bottom: $spacing-12;
 
     @include breakpoint('lg') {
-      margin-top: $carbon--spacing-10;
-      margin-bottom: $carbon--spacing-13;
+      margin-top: $spacing-10;
+      margin-bottom: $spacing-13;
     }
 
     &[complementary-style-scheme='with-border'] {
-      margin-bottom: $carbon--spacing-07;
+      margin-bottom: $spacing-07;
       @include breakpoint('lg') {
-        margin-bottom: $carbon--spacing-10;
+        margin-bottom: $spacing-10;
       }
     }
 
@@ -79,10 +79,10 @@
       margin-right: 0;
       padding-left: 0;
       padding-right: 0;
-      padding-bottom: $carbon--spacing-10;
+      padding-bottom: $spacing-10;
 
-      @include carbon--breakpoint('lg') {
-        padding-bottom: $carbon--spacing-12;
+      @include breakpoint('lg') {
+        padding-bottom: $spacing-12;
       }
     }
 

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -401,6 +401,34 @@ withCardInCard.story = {
           tagGroup: false,
           gridMode: 'narrow',
           cards: 5,
+          cardsPerRow: 'dds-ce-demo-devenv--cards-in-row-3',
+        },
+      },
+    },
+  },
+};
+
+Default.story = {
+  name: 'With card in card',
+  parameters: {
+    ...readme.parameters,
+    hasStoryPadding: true,
+    knobs: {
+      CardGroup: () => ({
+        media: boolean('Add media:', false),
+        tagGroup: boolean('Add tags:', false),
+        gridMode: select('Grid mode:', gridModes, GRID_MODE.NARROW),
+        cards: number('Number of cards', 5, { min: 2, max: 6 }),
+      }),
+    },
+    propsSet: {
+      default: {
+        CardGroup: {
+          media: false,
+          tagGroup: false,
+          gridMode: 'narrow',
+          cards: 5,
+          cardsPerRow: 'dds-ce-demo-devenv--cards-in-row-3',
         },
       },
     },

--- a/packages/web-components/src/components/content-block-headlines/content-block-headlines.scss
+++ b/packages/web-components/src/components/content-block-headlines/content-block-headlines.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2022
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.

--- a/packages/web-components/src/components/content-block-horizontal/content-block-horizontal.scss
+++ b/packages/web-components/src/components/content-block-horizontal/content-block-horizontal.scss
@@ -1,8 +1,8 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2022
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/ibmdotcom-styles/scss/components/content-block-horizontal';
+@use '@carbon/ibmdotcom-styles/scss/components/content-block-horizontal/content-block-horizontal';

--- a/packages/web-components/src/components/content-block-media/content-block-media.scss
+++ b/packages/web-components/src/components/content-block-media/content-block-media.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2022
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.

--- a/packages/web-components/src/components/content-section-playground/playground.stories.ts
+++ b/packages/web-components/src/components/content-section-playground/playground.stories.ts
@@ -1,0 +1,386 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html } from 'lit-element';
+import { select, text } from '@storybook/addon-knobs';
+import ArrowRight20 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import imgLg16x9 from '../../../../storybook-images/assets/720/fpo--16x9--720x405--005.jpg';
+import imgMd16x9 from '../../../../storybook-images/assets/480/fpo--16x9--480x270--005.jpg';
+import imgSm16x9 from '../../../../storybook-images/assets/320/fpo--16x9--320x180--005.jpg';
+
+const currentComponents = [
+  'Callout quote',
+  'Callout with media',
+  'Card group',
+  'Card in card',
+  'Carousel',
+  'Content block',
+  'Content group',
+  'Content item horizontal',
+  'Content item',
+  'CTA block',
+  'Feature card',
+  'Image',
+  'Lightbox media viewer',
+  'Link list',
+  'Logo grid',
+  'Notice Choice',
+  'Pictogram item',
+  'Quote',
+  'Structured list',
+  'Tabs extended',
+  'Tabs extended - with media',
+  'Tag group',
+  'Video player',
+];
+const kitchenSinkComponents = [
+  'Callout quote',
+  'Callout with media',
+  'Card group',
+  'Card in card',
+  'Carousel',
+  'Content block',
+  'Content group',
+  'Content item horizontal',
+  'Content item',
+  'CTA block',
+  'Feature card',
+  'Image',
+  'Link list',
+  'Logo grid',
+  'Notice Choice',
+  'Pictogram item',
+  'Quote',
+  'Structured list',
+  'Tabs extended',
+  'Tabs extended - with media',
+  'Tag group',
+  'Video player',
+];
+
+const card1 = html`
+  <c4d-content-group-cards-item href="https://www.example.com">
+    <c4d-card-heading>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt
+    </c4d-card-heading>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua.
+    </p>
+    <c4d-card-footer icon-placement="left">
+      ${ArrowRight20({ slot: 'icon' })}
+    </c4d-card-footer>
+  </c4d-content-group-cards-item>
+`;
+
+const card2 = html`
+  <c4d-content-group-cards-item href="https://www.example.com">
+    <c4d-card-heading>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt
+    </c4d-card-heading>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
+    <c4d-card-footer icon-placement="left">
+      ${ArrowRight20({ slot: 'icon' })}
+    </c4d-card-footer>
+  </c4d-content-group-cards-item>
+`;
+
+const specContext = require.context('../../', true, /\.stories\.ts$/);
+
+const storyModules = specContext.keys().map(specContext);
+
+const componentStories = {};
+
+storyModules.forEach((e) => {
+  const title = (e as any)?.default?.title || '';
+  componentStories[title.split('/')[1]] = e;
+});
+
+export const Default = (args) => {
+  const { component, childrenCustomClass } = args?.Playground ?? {};
+  const currentStory = componentStories[component];
+
+  const storyParameters = currentStory?.default?.parameters;
+
+  // // setting default props from propSet
+  if (!storyParameters?.props) {
+    storyParameters.props = storyParameters?.propsSet?.default || {};
+  }
+
+  const storyArray = [] as any;
+
+  // setting up Story array to render all
+  // eslint-disable-next-line no-restricted-syntax
+  for (const [key, value] of Object.entries(currentStory)) {
+    if (value instanceof Function) {
+      const defaultObject = (value as any).story?.parameters?.propsSet?.default;
+      const defaultPropsKey = defaultObject && Object.keys(defaultObject)[0];
+
+      // ensure variant story props save to its own key
+      if (defaultPropsKey && (value as any).story) {
+        storyParameters.props[defaultPropsKey] = (
+          value as any
+        ).story?.parameters?.propsSet.default[defaultPropsKey];
+      }
+
+      // set props from current variant propSet if default props aren't defined
+      if (storyParameters?.props) {
+        storyParameters.props[key] = (
+          value as any
+        ).story?.parameters?.propsSet?.default[key];
+      }
+
+      storyArray.push(value);
+    }
+  }
+
+  const returnStory = storyArray.map((story) => {
+    const variationTitle =
+      story?.story?.name ||
+      Object.keys(story?.story?.parameters?.knobs || {})[0];
+
+    return html`
+      ${variationTitle || 'Default'} ${story(storyParameters.props)}
+    `;
+  });
+
+  return html`
+    <c4d-content-section children-custom-class=${childrenCustomClass}>
+      <c4d-content-section-heading>Heading</c4d-content-section-heading>
+      ${component === 'Card group'
+        ? html`
+            <c4d-card-group>
+              ${card1}${card2}${card1}${card2}${card1}${card2}
+            </c4d-card-group>
+          `
+        : ``}
+      ${returnStory}
+    </c4d-content-section>
+  `;
+};
+
+export const MultipleContentSections = () => {
+  return html`
+    <c4d-content-section>
+      <c4d-content-section-heading>Heading</c4d-content-section-heading>
+      <c4d-card-group>
+        ${card1}${card2}${card1}${card2}${card1}${card2}
+      </c4d-card-group>
+    </c4d-content-section>
+
+    <c4d-content-section>
+      <c4d-content-section-heading>Heading</c4d-content-section-heading>
+      <c4d-card-group>
+        ${card1}${card2}${card1}${card2}${card1}${card2}
+      </c4d-card-group>
+      <c4d-content-block-segmented>
+        <c4d-content-block-heading>heading</c4d-content-block-heading>
+        <c4d-content-block-copy>copy</c4d-content-block-copy>
+        <c4d-image
+          slot="media"
+          alt="Image alt text"
+          default-src="https://fpoimg.com/672x378?text=16:9&amp;bg_color=ee5396&amp;text_color=161616"
+          heading="Mauris iaculis eget dolor nec hendrerit.">
+        </c4d-image>
+        <c4d-content-block-segmented-item>
+          <c4d-content-group-heading
+            >Lorem ipsum dolor sit amet.</c4d-content-group-heading
+          >
+          <c4d-content-item-copy
+            >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus
+            sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris
+            finibus efficitur quis ut arcu. Praesent purus turpis, venenatis
+            eget odio et, tincidunt bibendum sem. Curabitur pretium elit non
+            blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed
+            interdum tortor. Sed id pellentesque diam. In ut quam id mauris
+            finibus efficitur quis ut arcu. Praesent purus turpis, venenatis
+            eget odio et, tincidunt bibendum sem. Curabitur pretium elit non
+            blandit lobortis. Donec quis pretium odio, in dignissim
+            sapien.</c4d-content-item-copy
+          >
+          <c4d-text-cta
+            slot="footer"
+            cta-type="local"
+            icon-placement="right"
+            href="https://example.com"
+            >Lorem Ipsum dolor sit</c4d-text-cta
+          >
+        </c4d-content-block-segmented-item>
+        <c4d-content-block-segmented-item>
+          <c4d-content-group-heading
+            >Lorem ipsum dolor sit amet.</c4d-content-group-heading
+          >
+          <c4d-content-item-copy
+            >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus
+            sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris
+            finibus efficitur quis ut arcu. Praesent purus turpis, venenatis
+            eget odio et, tincidunt bibendum sem. Curabitur pretium elit non
+            blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed
+            interdum tortor. Sed id pellentesque diam. In ut quam id mauris
+            finibus efficitur quis ut arcu. Praesent purus turpis, venenatis
+            eget odio et, tincidunt bibendum sem. Curabitur pretium elit non
+            blandit lobortis. Donec quis pretium odio, in dignissim
+            sapien.</c4d-content-item-copy
+          >
+          <c4d-image
+            slot="media"
+            alt="Image alt text"
+            default-src="https://fpoimg.com/672x378?text=16:9&amp;bg_color=ee5396&amp;text_color=161616"
+            heading="Mauris iaculis eget dolor nec hendrerit.">
+          </c4d-image>
+          <c4d-text-cta
+            slot="footer"
+            cta-type="local"
+            icon-placement="right"
+            href="https://example.com"
+            >Lorem Ipsum dolor sit</c4d-text-cta
+          >
+        </c4d-content-block-segmented-item>
+        <c4d-card-link-cta
+          slot="footer"
+          cta-type="local"
+          href="https://example.com">
+          <c4d-card-link-heading>Lorem ipsum dolor</c4d-card-link-heading>
+          <c4d-card-cta-footer></c4d-card-cta-footer>
+        </c4d-card-link-cta>
+      </c4d-content-block-segmented>
+    </c4d-content-section>
+
+    <c4d-content-section>
+      <c4d-content-section-heading>Heading</c4d-content-section-heading>
+      <c4d-image
+        alt="Image alt text"
+        default-src="${imgLg16x9}"
+        heading="Mauris iaculis eget dolor nec hendrerit.">
+        <c4d-image-item media="(min-width: 672px)" srcset="${imgLg16x9}">
+        </c4d-image-item>
+        <c4d-image-item media="(min-width: 400px)" srcset="${imgMd16x9}">
+        </c4d-image-item>
+        <c4d-image-item media="(min-width: 320px)" srcset="${imgSm16x9}">
+        </c4d-image-item>
+      </c4d-image>
+      <c4d-content-item>
+        <c4d-content-item-heading>Heading</c4d-content-item-heading>
+        <c4d-content-item-copy>Copy</c4d-content-item-copy>
+        <c4d-text-cta
+          slot="footer"
+          cta-type="local"
+          href="https://www.example.com">
+          CTA text</c4d-text-cta
+        >
+      </c4d-content-item>
+
+      <c4d-feature-card href="https://example.com">
+        <c4d-image
+          slot="image"
+          alt="Image alt text"
+          default-src="${imgLg16x9}"></c4d-image>
+        <c4d-card-heading>Heading</c4d-card-heading>
+        <c4d-feature-card-footer>
+          ${ArrowRight20({ slot: 'icon' })}
+        </c4d-feature-card-footer>
+      </c4d-feature-card>
+    </c4d-content-section>
+  `;
+};
+
+export const KitchenSink = (args) => {
+  const { childrenCustomClass } = args?.Playground ?? {};
+
+  const storyMappings = {};
+
+  kitchenSinkComponents.forEach((component) => {
+    const currentStory = componentStories[component] as any;
+
+    const storyParameters = currentStory?.default?.parameters;
+
+    // // setting default props from propSet
+    if (!storyParameters?.props) {
+      storyParameters.props = storyParameters?.propsSet?.default || {};
+    }
+
+    const storyArray = [] as any;
+
+    // setting up Story array to render all
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [key, value] of Object.entries(currentStory)) {
+      if (value instanceof Function) {
+        const defaultObject = (value as any).story?.parameters?.propsSet
+          ?.default;
+        const defaultPropsKey = defaultObject && Object.keys(defaultObject)[0];
+
+        // ensure variant story props save to its own key
+        if (defaultPropsKey && (value as any).story) {
+          storyParameters.props[defaultPropsKey] = (
+            value as any
+          ).story?.parameters?.propsSet.default[defaultPropsKey];
+        }
+
+        // set props from current variant propSet if default props aren't defined
+        if (storyParameters?.props) {
+          storyParameters.props[key] = (
+            value as any
+          ).story?.parameters?.propsSet?.default[key];
+        }
+
+        storyArray.push(value);
+      }
+    }
+    storyMappings[component] = storyArray;
+  });
+
+  const storyHtml = [] as any;
+
+  for (const [key, value] of Object.entries(storyMappings)) {
+    const storyParameters = componentStories[key]?.default?.parameters;
+    const returnStory = (value as any).map((story) => {
+      return html` ${story(storyParameters.props)} `;
+    });
+
+    storyHtml.push(returnStory);
+  }
+
+  return html`
+    <c4d-content-section children-custom-class=${childrenCustomClass}>
+      <c4d-content-section-heading>Heading</c4d-content-section-heading>
+      <c4d-card-group>
+        ${card1}${card2}${card1}${card2}${card1}${card2}
+      </c4d-card-group>
+      ${storyHtml.map((e) => e)}
+    </c4d-content-section>
+  `;
+};
+
+KitchenSink.story = {
+  parameters: {
+    knobs: {
+      Playground: () => ({
+        childrenCustomClass: text('Custom class:', ''),
+      }),
+    },
+  },
+};
+
+export default {
+  title: 'Components/Content section playground',
+  decorators: [(story) => html` ${story()} `],
+  parameters: {
+    hasStoryPadding: true,
+    knobs: {
+      Playground: () => ({
+        childrenCustomClass: text('Custom class:', ''),
+        component: select('Component:', currentComponents, 'Callout quote'),
+      }),
+    },
+  },
+};

--- a/packages/web-components/src/components/leadspace-with-search/leadspace-with-search.scss
+++ b/packages/web-components/src/components/leadspace-with-search/leadspace-with-search.scss
@@ -1,5 +1,5 @@
 /*
-* Copyright IBM Corp. 2016, 2021
+* Copyright IBM Corp. 2016, 2022
 *
 * This source code is licensed under the Apache-2.0 license found in the
 * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
### Related Ticket(s)


### Description
In #9819, the spacing for Content Block was adjusted using the [v2 specs](https://www.figma.com/file/Nj4VLq782cvj6mwDb6anfk/v2-Component-audit?type=design&node-id=45%3A8222&mode=design&t=0M6lRtLtY9h2uLfQ-1). 

This PR brings those changes into the Carbon for IBM.com v2 branch, as well as adding the playground story for content section to see the changes in place.

### Changelog

**New**

- playground story for content section containing kitchen sink and content block story

**Changed**

- the spacing styles for content block and other components

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
