### PR TITLE
chore(examples): update grid to cds v2

### DIFF
--- a/packages/web-components/examples/codesandbox/components-react/card-section-simple/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/card-section-simple/src/index.js
@@ -20,9 +20,9 @@ import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20.js';
 import './index.css';
 
 const App = () => (
-  <div className="bx--grid">
-    <div className="bx--row">
-      <div className="bx--col-sm-4">
+  <div className="cds--grid">
+    <div className="cds--row">
+      <div className="cds--col-sm-4">
         <C4DCardSectionSimple>
           <C4DContentSectionHeading>Aliquam condimentum interdum</C4DContentSectionHeading>
           <C4DCardGroup>

--- a/packages/web-components/examples/codesandbox/components-react/content-block-cards/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/content-block-cards/src/index.js
@@ -20,9 +20,9 @@ import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20.js';
 import './index.css';
 
 const App = () => (
-  <div className="bx--grid">
-    <div className="bx--row">
-      <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4 bx--no-gutter">
+  <div className="cds--grid">
+    <div className="cds--row">
+      <div className="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4 cds--no-gutter">
         <C4DContentBlockCards>
           <C4DContentBlockHeading>Lorem ipsum dolor sit amet</C4DContentBlockHeading>
           <C4DCardGroup>

--- a/packages/web-components/examples/codesandbox/components-react/content-block-media/index.html
+++ b/packages/web-components/examples/codesandbox/components-react/content-block-media/index.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     <title>carbon-web-components example with React</title>
   </head>
   <body>

--- a/packages/web-components/examples/codesandbox/components-react/content-block-media/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/content-block-media/src/index.js
@@ -25,9 +25,9 @@ import C4DCardCTAFooter from '@carbon/ibmdotcom-web-components/es/components-rea
 import './index.css';
 
 const App = () => (
-  <div className="bx--grid">
-    <div className="bx--row">
-      <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+  <div className="cds--grid">
+    <div className="cds--row">
+      <div className="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
         <C4DContentBlockMedia>
           <C4DContentBlockHeading>Curabitur malesuada varius mi eu posuere</C4DContentBlockHeading>
           <C4DContentBlockCopy size="lg">

--- a/packages/web-components/examples/codesandbox/components-react/content-block-mixed/index.html
+++ b/packages/web-components/examples/codesandbox/components-react/content-block-mixed/index.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     <title>carbon-web-components example with React</title>
   </head>
   <body>

--- a/packages/web-components/examples/codesandbox/components-react/content-block-mixed/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/content-block-mixed/src/index.js
@@ -34,9 +34,9 @@ import TouchScreen from '@carbon/pictograms-react/es/touch--screen/index.js';
 import './index.css';
 
 const App = () => (
-  <div className="bx--grid">
-    <div className="bx--row">
-      <div className="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+  <div className="cds--grid">
+    <div className="cds--row">
+      <div className="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
         <C4DContentBlockMixed>
           <C4DContentBlockHeading>Lorem ipsum dolor sit amet</C4DContentBlockHeading>
           <C4DContentBlockCopy>

--- a/packages/web-components/examples/codesandbox/components-react/content-block-segmented/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/content-block-segmented/src/index.js
@@ -49,9 +49,9 @@ const contentItemCopy =
 const video = <C4DVideoPlayerContainer slot="media" video-id="0_uka1msg4"></C4DVideoPlayerContainer>;
 
 const App = () => (
-  <div className="bx--grid">
-    <div className="bx--row">
-      <div className="bx--col-lg-8 bx--no-gutter">
+  <div className="cds--grid">
+    <div className="cds--row">
+      <div className="cds--col-lg-8 cds--no-gutter">
         (
         <C4DContentBlockSegmented>
           <C4DContentBlockHeading>Lorem ipsum dolor sit amet.</C4DContentBlockHeading>

--- a/packages/web-components/examples/codesandbox/components-react/content-group-pictograms/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/content-group-pictograms/src/index.js
@@ -48,9 +48,9 @@ const pictogramsItems = [
 ];
 
 const App = () => (
-  <div className="bx--grid">
-    <div className="bx--row">
-      <div className="bx--col-sm-4 bx--col-lg-8 bx--no-gutter">
+  <div className="cds--grid">
+    <div className="cds--row">
+      <div className="cds--col-sm-4 cds--col-lg-8 cds--no-gutter">
         <C4DContentGroupPictograms>
           <C4DContentGroupHeading>{groupHeading}</C4DContentGroupHeading>
           <C4DContentGroupCopy>{groupCopy}</C4DContentGroupCopy>

--- a/packages/web-components/examples/codesandbox/components-react/content-group-simple/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/content-group-simple/src/index.js
@@ -78,9 +78,9 @@ const image = ({ heading: imageHeading } = { heading: undefined }) => (
 );
 
 const App = () => (
-  <div className="bx--grid">
-    <div className="bx--row">
-      <div className="bx--col-lg-12 bx--no-gutter">
+  <div className="cds--grid">
+    <div className="cds--row">
+      <div className="cds--col-lg-12 cds--no-gutter">
         <C4DVideoCTAContainer>
           <C4DContentGroupSimple>
             <C4DContentGroupHeading>'Curabitur malesuada varius mi eu posuere'</C4DContentGroupHeading>

--- a/packages/web-components/examples/codesandbox/components-react/cta-card-link/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/cta-card-link/src/index.js
@@ -16,9 +16,9 @@ import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20.js';
 import './index.css';
 
 const App = () => (
-  <div className="bx--grid">
-    <div className="bx--row">
-      <div className="bx--col-sm-4 bx--col-lg-4 bx--no-gutter">
+  <div className="cds--grid">
+    <div className="cds--row">
+      <div className="cds--col-sm-4 cds--col-lg-4 cds--no-gutter">
         <C4DCardLinkCTA cta-type="local" href="https://www.example.com">
           <C4DCardLinkHeading>Card link heading</C4DCardLinkHeading>
           <C4DCardCTAFooter>

--- a/packages/web-components/examples/codesandbox/components-react/cta-card/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/cta-card/src/index.js
@@ -15,9 +15,9 @@ import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20.js';
 import './index.css';
 
 const App = () => (
-  <div className="bx--grid">
-    <div className="bx--row">
-      <div className="bx--col-sm-4 bx--col-lg-4 bx--no-gutter">
+  <div className="cds--grid">
+    <div className="cds--row">
+      <div className="cds--col-sm-4 cds--col-lg-4 cds--no-gutter">
         <C4DCardCTA cta-type="local" href="https://www.example.com">
           Card CTA Copy
           <C4DCardCTAFooter>

--- a/packages/web-components/examples/codesandbox/components-react/cta-feature/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/cta-feature/src/index.js
@@ -17,9 +17,9 @@ import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20.js';
 import './index.css';
 
 const App = () => (
-  <div className="bx--grid">
-    <div className="bx--row">
-      <div className="bx--col-sm-4 bx--col-lg-8">
+  <div className="cds--grid">
+    <div className="cds--row">
+      <div className="cds--col-sm-4 cds--col-lg-8">
         <C4DFeatureCTA cta-type="local" href="https://www.example.com">
           <C4DCardHeading>Feature CTA Copy</C4DCardHeading>
           <C4DImage

--- a/packages/web-components/examples/codesandbox/components-react/dotcom-shell/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/dotcom-shell/src/index.js
@@ -27,10 +27,10 @@ window.digitalData = {
 
 const App = () => (
   <C4DDotcomShellContainer>
-    <main className="bx--content cds-ce-demo--ui-shell-content">
-      <div className="bx--grid">
-        <div className="bx--row">
-          <div className="bx--offset-lg-3 bx--col-lg-13">
+    <main className="cds--content cds-ce-demo--ui-shell-content">
+      <div className="cds--grid">
+        <div className="cds--row">
+          <div className="cds--offset-lg-3 cds--col-lg-13">
             <h2>Purpose and function</h2>
             <p>
               The shell is perhaps the most crucial piece of any UI built with Carbon. It contains the shared navigation framework

--- a/packages/web-components/examples/codesandbox/components-react/masthead-l1/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/masthead-l1/src/index.js
@@ -15,10 +15,10 @@ import './index.css';
 const App = () => (
   <>
     <C4DMastheadContainer id="masthead-container"></C4DMastheadContainer>
-    <main className="bx--content cds-ce-demo--ui-shell-content">
-      <div className="bx--grid">
-        <div className="bx--row">
-          <div className="bx--offset-lg-3 bx--col-lg-13">
+    <main className="cds--content cds-ce-demo--ui-shell-content">
+      <div className="cds--grid">
+        <div className="cds--row">
+          <div className="cds--offset-lg-3 cds--col-lg-13">
             <h2>Purpose and function</h2>
             <p>
               The shell is perhaps the most crucial piece of any UI built with Carbon. It contains the shared navigation framework

--- a/packages/web-components/examples/codesandbox/components-react/masthead/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/masthead/src/index.js
@@ -15,10 +15,10 @@ import './index.css';
 const App = () => (
   <>
     <C4DMastheadContainer id="masthead-container"></C4DMastheadContainer>
-    <main className="bx--content cds-ce-demo--ui-shell-content">
-      <div className="bx--grid">
-        <div className="bx--row">
-          <div className="bx--offset-lg-3 bx--col-lg-13">
+    <main className="cds--content cds-ce-demo--ui-shell-content">
+      <div className="cds--grid">
+        <div className="cds--row">
+          <div className="cds--offset-lg-3 cds--col-lg-13">
             <h2>Purpose and function</h2>
             <p>
               The shell is perhaps the most crucial piece of any UI built with Carbon. It contains the shared navigation framework

--- a/packages/web-components/examples/codesandbox/components-react/pictogram-item/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/pictogram-item/src/index.js
@@ -30,7 +30,7 @@ const App = () => (
       height="64"
       viewBox="8 8 32 32"
       role="img"
-      class="bx--pictogram-item__pictogram">
+      class="cds--pictogram-item__pictogram">
       <path
         fill="none"
         stroke-linejoin="round"

--- a/packages/web-components/examples/codesandbox/components-react/video-player/src/index.js
+++ b/packages/web-components/examples/codesandbox/components-react/video-player/src/index.js
@@ -14,9 +14,9 @@ import './index.css';
 
 const App = () => (
   <>
-    <div className="bx--grid">
-      <div className="bx--row">
-        <div className="bx--offset-lg-3 bx--col-lg-13">
+    <div className="cds--grid">
+      <div className="cds--row">
+        <div className="cds--offset-lg-3 cds--col-lg-13">
           <C4DVideoPlayerContainer aspectRatio="1x1" videoId="1_9h94wo6b" />
         </div>
       </div>

--- a/packages/web-components/examples/codesandbox/components/back-to-top/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/back-to-top/cdn.html
@@ -12,8 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     #app {
       height: 6000px;
@@ -22,9 +21,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/back-to-top.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <h1>Scroll down! 👋</h1>
       <div id="app"></div>
     </div>

--- a/packages/web-components/examples/codesandbox/components/back-to-top/index.html
+++ b/packages/web-components/examples/codesandbox/components/back-to-top/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     #app {
       height: 6000px;
@@ -23,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <h1>Scroll down! 👋</h1>
       <div id="app"></div>
     </div>

--- a/packages/web-components/examples/codesandbox/components/background-media/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/background-media/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-background-media:not(:defined) {
@@ -23,9 +22,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/background-media.min.js"></script>
 </head>
 <body>
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--col-sm-4 bx--no-gutter">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--col-sm-4 cds--no-gutter">
         <cds-background-media
           alt="alt-text"
           default-src="https://fpoimg.com/672x672?text=1:1&bg_color=ee5396&text_color=161616"

--- a/packages/web-components/examples/codesandbox/components/background-media/index.html
+++ b/packages/web-components/examples/codesandbox/components/background-media/index.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-background-media:not(:defined) {
@@ -22,9 +21,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--col-sm-4 bx--no-gutter">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--col-sm-4 cds--no-gutter">
         <cds-background-media
           alt="alt-text"
           default-src="https://fpoimg.com/672x672?text=1:1&bg_color=ee5396&text_color=161616"

--- a/packages/web-components/examples/codesandbox/components/button-group/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/button-group/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-button-group:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button-group.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-button-group>
         <cds-button-group-item>Lorem ipsum</cds-button-group-item>
         <cds-button-group-item>Dolor sit amet</cds-button-group-item>

--- a/packages/web-components/examples/codesandbox/components/button-group/index.html
+++ b/packages/web-components/examples/codesandbox/components/button-group/index.html
@@ -24,9 +24,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--col-sm-4 bx--col-lg-12">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--col-sm-4 cds--col-lg-12">
         <cds-button-group>
           <cds-button-group-item>Lorem ipsum</cds-button-group-item>
           <cds-button-group-item>Dolor sit amet</cds-button-group-item>

--- a/packages/web-components/examples/codesandbox/components/callout-quote/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/callout-quote/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-callout-quote:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/callout-quote.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-callout-quote>
         Callout Quote: Duis aute irure dolor in reprehenderit
         <cds-quote-source-heading>Lorem ipsum</cds-quote-source-heading>

--- a/packages/web-components/examples/codesandbox/components/callout-quote/index.html
+++ b/packages/web-components/examples/codesandbox/components/callout-quote/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-callout-quote:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-callout-quote>
         Callout Quote: Duis aute irure dolor in reprehenderit
         <cds-quote-source-heading>Lorem ipsum</cds-quote-source-heading>

--- a/packages/web-components/examples/codesandbox/components/callout-with-media/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/callout-with-media/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-callout-with-media:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/callout-with-media.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-callout-with-media>
         <cds-content-block-heading>Curabitur malesuada varius mi eu posuere
         </cds-content-block-heading>

--- a/packages/web-components/examples/codesandbox/components/callout-with-media/index.html
+++ b/packages/web-components/examples/codesandbox/components/callout-with-media/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-callout-with-media:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-callout-with-media>
         <cds-content-block-heading>Curabitur malesuada varius mi eu posuere
         </cds-content-block-heading>

--- a/packages/web-components/examples/codesandbox/components/card-group/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-group/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card-group:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-group.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-card-group>
         <cds-card-group-item href="https://example.com">
           <cds-card-heading>Nunc convallis lobortis</cds-card-heading>

--- a/packages/web-components/examples/codesandbox/components/card-group/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-group/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card-group:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-card-group>
         <cds-card-group-item href="https://example.com">
           <cds-card-heading>Nunc convallis lobortis</cds-card-heading>

--- a/packages/web-components/examples/codesandbox/components/card-in-card/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-in-card/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card-in-card:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-in-card.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <h1>Hello World! 👋</h1>
       <cds-card-in-card href="https://example.com">
         <cds-card-in-card-image slot="image" alt="Image alt text"

--- a/packages/web-components/examples/codesandbox/components/card-in-card/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-in-card/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card-in-card:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <h1>Hello World! 👋</h1>
       <cds-card-in-card cta-type="external" href="https://example.com">
         <cds-card-in-card-image

--- a/packages/web-components/examples/codesandbox/components/card-link/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-link/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card-link:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-link.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-card-link href="https://example.com">
         <p>Explore AI use cases in all industries</p>
         <cds-card-footer slot="footer">

--- a/packages/web-components/examples/codesandbox/components/card-link/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-link/index.html
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-card-link href="https://example.com">
         <p>Explore AI use cases in all industries</p>
         <cds-card-footer slot="footer">

--- a/packages/web-components/examples/codesandbox/components/card-section-carousel/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-carousel/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card-section-carousel:not(:defined) {
@@ -25,8 +24,8 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-section-carousel.min.js"></script>
 </head>
 <body>
-  <div class="bx--grid">
-    <div class="bx--row">
+  <div class="cds--grid">
+    <div class="cds--row">
       <cds-card-section-carousel>
         <cds-content-section-heading>Card Section - Carousel</cds-content-section-heading>
         <cds-content-section-copy

--- a/packages/web-components/examples/codesandbox/components/card-section-carousel/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-carousel/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card-section-carousel:not(:defined) {
@@ -24,8 +23,8 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
+<div class="cds--grid">
+  <div class="cds--row">
     <cds-card-section-carousel>
       <cds-content-section-heading>Card Section - Carousel</cds-content-section-heading>
       <cds-content-section-copy

--- a/packages/web-components/examples/codesandbox/components/card-section-offset/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-offset/cdn.html
@@ -12,8 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card-section-offset:not(:defined) {
@@ -23,8 +22,8 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-section-offset.min.js"></script>
 </head>
 <body>
-  <div class="bx--grid">
-    <div class="bx--row">
+  <div class="cds--grid">
+    <div class="cds--row">
       <cds-card-section-offset>
         <cds-content-block-heading slot="heading">heading</cds-content-block-heading>
         <cds-background-media

--- a/packages/web-components/examples/codesandbox/components/card-section-offset/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-offset/index.html
@@ -23,8 +23,8 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
+    <div class="cds--grid">
+      <div class="cds--row">
         <cds-card-section-offset>
           <cds-background-media
             gradient-direction="left-to-right"

--- a/packages/web-components/examples/codesandbox/components/card-section-simple/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-simple/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card-section-simple:not(:defined) {
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-section-simple.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4">
       <cds-card-section-simple heading="Aliquam condimentum interdum">
         <cds-content-section-heading>Aliquam condimentum interdum</cds-content-section-heading>
         <cds-card-group>

--- a/packages/web-components/examples/codesandbox/components/card-section-simple/index.html
+++ b/packages/web-components/examples/codesandbox/components/card-section-simple/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4">
           <cds-card-section-simple>
             <cds-content-section-heading>Aliquam condimentum interdum</cds-content-section-heading>
             <cds-card-group>

--- a/packages/web-components/examples/codesandbox/components/card/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/card/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card:not(:defined) {
@@ -22,9 +21,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-card href="https://example.com">
         <cds-card-eyebrow>eyebrow text</cds-card-eyebrow>
         <cds-card-heading>Lorem ipsum dolor sit amet</cds-card-heading>

--- a/packages/web-components/examples/codesandbox/components/card/index.html
+++ b/packages/web-components/examples/codesandbox/components/card/index.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8" />
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-card:not(:defined) {
@@ -22,9 +21,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-card href="https://example.com">
         <cds-card-eyebrow>eyebrow text</cds-card-eyebrow>
         <cds-card-heading>Lorem ipsum dolor sit amet</cds-card-heading>

--- a/packages/web-components/examples/codesandbox/components/carousel/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/carousel/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-carousel:not(:defined) {
@@ -27,9 +26,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-16">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-16">
       <cds-carousel>
         <cds-card href="https://example.com">
           <cds-card-heading>Lorem ipsum dolor sit amet</cds-card-heading>

--- a/packages/web-components/examples/codesandbox/components/carousel/index.html
+++ b/packages/web-components/examples/codesandbox/components/carousel/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-carousel:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-16">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-16">
       <cds-carousel>
         <cds-card href="https://example.com">
           <cds-card-heading>Lorem ipsum dolor sit amet</cds-card-heading>

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn-rtl.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-cloud-masthead-container:not(:defined) {
@@ -24,16 +24,16 @@ LICENSE file in the root directory of this source tree.
     }
 
     @media (min-width: 66rem) {
-      .bx--offset-lg-3 {
+      .cds--offset-lg-3 {
         margin-left: 0;
       }
     }
 
-    .bx--content.cds-ce-demo--ui-shell-content h2 {
+    .cds--content.cds-ce-demo--ui-shell-content h2 {
       margin: 30px 0;
     }
 
-    .bx--content.cds-ce-demo--ui-shell-content h2:first-of-type {
+    .cds--content.cds-ce-demo--ui-shell-content h2:first-of-type {
       margin-top: 0;
     }
   </style>
@@ -42,10 +42,10 @@ LICENSE file in the root directory of this source tree.
 </head>
 <body>
 <cds-cloud-masthead-container data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></cds-cloud-masthead-container>
-<main class="bx--content cds-ce-demo--ui-shell-content">
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--offset-lg-3 bx--col-lg-13">
+<main class="cds--content cds-ce-demo--ui-shell-content">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--offset-lg-3 cds--col-lg-13">
         <h2>
           Purpose and function
         </h2>

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-cloud-masthead-container:not(:defined) {
@@ -24,16 +24,16 @@ LICENSE file in the root directory of this source tree.
     }
 
     @media (min-width: 66rem) {
-      .bx--offset-lg-3 {
+      .cds--offset-lg-3 {
         margin-left: 0;
       }
     }
 
-    .bx--content.cds-ce-demo--ui-shell-content h2 {
+    .cds--content.cds-ce-demo--ui-shell-content h2 {
       margin: 30px 0;
     }
 
-    .bx--content.cds-ce-demo--ui-shell-content h2:first-of-type {
+    .cds--content.cds-ce-demo--ui-shell-content h2:first-of-type {
       margin-top: 0;
     }
   </style>
@@ -42,10 +42,10 @@ LICENSE file in the root directory of this source tree.
 </head>
 <body>
 <cds-cloud-masthead-container data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></cds-cloud-masthead-container>
-<main class="bx--content cds-ce-demo--ui-shell-content">
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--offset-lg-3 bx--col-lg-13">
+<main class="cds--content cds-ce-demo--ui-shell-content">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--offset-lg-3 cds--col-lg-13">
         <h2>
           Purpose and function
         </h2>

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/index.html
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/index.html
@@ -22,10 +22,10 @@ LICENSE file in the root directory of this source tree.
   </head>
   <body>
   <cds-cloud-masthead-container data-endpoint="/common/carbon-for-ibm-dotcom/translations/cloud-masthead" id="cloud-masthead-container"></cds-cloud-masthead-container>
-  <main class="bx--content cds-ce-demo--ui-shell-content">
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="bx--offset-lg-3 bx--col-lg-13">
+  <main class="cds--content cds-ce-demo--ui-shell-content">
+      <div class="cds--grid">
+        <div class="cds--row">
+          <div class="cds--offset-lg-3 cds--col-lg-13">
             <h2>
               Purpose and function
             </h2>

--- a/packages/web-components/examples/codesandbox/components/cloud-masthead/src/index.scss
+++ b/packages/web-components/examples/codesandbox/components/cloud-masthead/src/index.scss
@@ -21,12 +21,12 @@ body {
 }
 
 @media (min-width: 66rem) {
-  .bx--offset-lg-3 {
+  .cds--offset-lg-3 {
     margin-left: 0;
   }
 }
 
-.bx--content.cds-ce-demo--ui-shell-content {
+.cds--content.cds-ce-demo--ui-shell-content {
   h2 {
     margin: 30px 0;
 

--- a/packages/web-components/examples/codesandbox/components/content-block-card-static/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-card-static/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-block-card-static:not(:defined) {
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-card-static.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
       <cds-content-block-card-static>
         <cds-content-block-heading>Lorem ipsum dolor sit amet.</cds-content-block-heading>
 

--- a/packages/web-components/examples/codesandbox/components/content-block-card-static/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-card-static/index.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     <script src="src/index.js"></script>
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
@@ -23,9 +23,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-cds--s--offset-lg-4">
           <cds-content-block-card-static>
             <cds-content-block-heading>Morbi consectetur vulputate faucibus. Proin.</cds-content-block-heading>
 

--- a/packages/web-components/examples/codesandbox/components/content-block-cards/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-cards/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-block-cards:not(:defined) {
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-cards.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4 bx--no-gutter">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4 cds--no-gutter">
       <cds-content-block-cards>
         <cds-content-block-heading>Lorem ipsum dolor sit amet</cds-content-block-heading>
         <cds-card-group>

--- a/packages/web-components/examples/codesandbox/components/content-block-cards/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-cards/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4 bx--no-gutter">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4 cds--no-gutter">
           <cds-content-block-cards>
             <cds-content-block-heading>Lorem ipsum dolor sit amet</cds-content-block-heading>
             <cds-card-group>

--- a/packages/web-components/examples/codesandbox/components/content-block-headlines/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-headlines/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-block-headlines:not(:defined) {
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-headlines.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4 bx--no-gutter">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4 cds--no-gutter">
       <cds-content-block-headlines>
         <cds-content-block-heading>Aliquam condimentum</cds-content-block-heading>
         <cds-content-block-copy

--- a/packages/web-components/examples/codesandbox/components/content-block-headlines/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-headlines/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4 bx--no-gutter">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4 cds--no-gutter">
           <cds-content-block-headlines>
             <cds-content-block-heading>Aliquam condimentum</cds-content-block-heading>
             <cds-content-block-copy

--- a/packages/web-components/examples/codesandbox/components/content-block-media/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-media/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-block-media:not(:defined) {
@@ -23,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/image-with-caption.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
       <cds-content-block-media>
         <cds-content-block-heading>
           Curabitur malesuada varius mi eu posuere

--- a/packages/web-components/examples/codesandbox/components/content-block-media/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-media/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     </style>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
           <cds-content-block-media>
             <cds-content-block-heading>
               Curabitur malesuada varius mi eu posuere

--- a/packages/web-components/examples/codesandbox/components/content-block-mixed/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-mixed/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-block-mixed:not(:defined) {
@@ -25,9 +25,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-simple.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
       <cds-content-block-mixed>
         <cds-content-block-heading>Lorem ipsum dolor sit amet</cds-content-block-heading>
         <cds-content-block-copy>
@@ -108,7 +108,7 @@ LICENSE file in the root directory of this source tree.
               height="48"
               viewBox="0 0 48 48"
               role="img"
-              class="bx--pictogram-item__pictogram"
+              class="cds--pictogram-item__pictogram"
             >
               <path
                 fill="none"

--- a/packages/web-components/examples/codesandbox/components/content-block-mixed/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-mixed/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     </style>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
           <cds-content-block-mixed>
             <cds-content-block-heading>Lorem ipsum dolor sit amet</cds-content-block-heading>
             <cds-content-block-copy>
@@ -104,7 +104,7 @@ LICENSE file in the root directory of this source tree.
                   height="48"
                   viewBox="0 0 48 48"
                   role="img"
-                  class="bx--pictogram-item__pictogram"
+                  class="cds--pictogram-item__pictogram"
                 >
                   <path
                     fill="none"

--- a/packages/web-components/examples/codesandbox/components/content-block-segmented/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-segmented/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-block-segmented:not(:defined) {
@@ -24,9 +24,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/video-player.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
       <cds-content-block-segmented>
         <cds-content-block-heading>Lorem ipsum dolor sit amet</cds-content-block-heading>
         <cds-content-block-copy>

--- a/packages/web-components/examples/codesandbox/components/content-block-segmented/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-segmented/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
           <cds-content-block-segmented>
             <cds-content-block-heading>Lorem ipsum dolor sit amet</cds-content-block-heading>
             <cds-content-block-copy>

--- a/packages/web-components/examples/codesandbox/components/content-block-simple/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-simple/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-block-simple:not(:defined) {
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-simple.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
       <cds-content-block-simple>
         <cds-content-block-heading>Curabitur malesuada varius mi eu posuere</cds-content-block-heading>
         <cds-content-block-copy>

--- a/packages/web-components/examples/codesandbox/components/content-block-simple/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block-simple/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
           <cds-content-block-simple>
             <cds-content-block-heading>Curabitur malesuada varius mi eu posuere</cds-content-block-heading>
             <cds-content-block-copy>

--- a/packages/web-components/examples/codesandbox/components/content-block/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-block/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-block:not(:defined) {
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-link-cta.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
       <cds-content-block>
         <cds-content-block-heading>Curabitur malesuada varius mi eu posuere</cds-content-block-heading>
         <cds-content-block-copy>

--- a/packages/web-components/examples/codesandbox/components/content-block/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-block/index.html
@@ -19,9 +19,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
           <cds-content-block>
             <cds-content-block-heading>Curabitur malesuada varius mi eu posuere</cds-content-block-heading>
             <cds-content-block-copy>

--- a/packages/web-components/examples/codesandbox/components/content-group-banner/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-banner/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-group-banner:not(:defined) {
@@ -20,9 +20,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-banner.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-lg-8 cds--col-sm-cds--offset-lg-4">
       <cds-content-group-banner>
         <cds-content-group-heading>Curabitur malesuada varius mi eu posuere</cds-content-group-heading>
         <cds-link-list type="vertical" slot="complementary">

--- a/packages/web-components/examples/codesandbox/components/content-group-banner/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-banner/index.html
@@ -19,9 +19,9 @@ LICENSE file in the root directory of this source tree.
     </style>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-lg-8 cds--col-sm-4 cds--offset-lg-4">
           <cds-content-group-banner>
             <cds-content-group-heading>Curabitur malesuada varius mi eu posuere</cds-content-group-heading>
             <cds-link-list type="vertical" slot="complementary">

--- a/packages/web-components/examples/codesandbox/components/content-group-cards/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-cards/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-group-cards:not(:defined) {
@@ -20,9 +20,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-cards.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-lg-8 cds--col-sm-4 cds--offset-lg-4">
       <cds-content-group-cards>
         <cds-content-group-heading>Curabitur malesuada varius mi eu posuere</cds-content-group-heading>
         <cds-content-group-copy>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</cds-content-group-copy>

--- a/packages/web-components/examples/codesandbox/components/content-group-cards/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-cards/index.html
@@ -19,9 +19,9 @@ LICENSE file in the root directory of this source tree.
     </style>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-lg-8 cds--col-sm-4 cds--offset-lg-4">
           <cds-content-group-cards>
             <cds-content-group-heading>Curabitur malesuada varius mi eu posuere</cds-content-group-heading>
             <cds-content-group-copy>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</cds-content-group-copy>

--- a/packages/web-components/examples/codesandbox/components/content-group-horizontal/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-horizontal/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-group-horizontal:not(:defined) {
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-horizontal.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
       <cds-content-group-horizontal>
         <cds-content-block-heading>Curabitur malesuada varius mi eu posuere</cds-content-block-heading>
         <cds-content-item-horizontal>

--- a/packages/web-components/examples/codesandbox/components/content-group-horizontal/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-horizontal/index.html
@@ -12,6 +12,7 @@ LICENSE file in the root directory of this source tree.
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       cds-content-group-horizontal:not(:defined) {
@@ -21,9 +22,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
           <cds-content-group-horizontal>
             <cds-content-block-heading>Curabitur malesuada varius mi eu posuere</cds-content-block-heading>
             <cds-content-item-horizontal>

--- a/packages/web-components/examples/codesandbox/components/content-group-pictograms/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-pictograms/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-group-pictograms:not(:defined) {
@@ -20,9 +20,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-pictograms.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
       <cds-content-group-pictograms>
         <cds-content-group-heading>Lorem ipsum dolor sit amet</cds-content-group-heading>
         <cds-content-group-copy>
@@ -43,7 +43,7 @@ LICENSE file in the root directory of this source tree.
             height="48"
             viewBox="0 0 48 48"
             role="img"
-            class="bx--pictogram-item__pictogram"
+            class="cds--pictogram-item__pictogram"
           >
             <path
               fill="none"

--- a/packages/web-components/examples/codesandbox/components/content-group-pictograms/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-pictograms/index.html
@@ -19,9 +19,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
           <cds-content-group-pictograms>
             <cds-content-group-heading>Lorem ipsum dolor sit amet</cds-content-group-heading>
             <cds-content-group-copy>
@@ -42,7 +42,7 @@ LICENSE file in the root directory of this source tree.
                 height="48"
                 viewBox="0 0 48 48"
                 role="img"
-                class="bx--pictogram-item__pictogram"
+                class="cds--pictogram-item__pictogram"
               >
                 <path
                   fill="none"

--- a/packages/web-components/examples/codesandbox/components/content-group-simple/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-simple/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-group-simple:not(:defined) {
@@ -20,9 +20,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-simple.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
       <cds-content-group-simple>
         <cds-content-group-heading>Curabitur malesuada varius mi eu posuere</cds-content-group-heading>
         <cds-content-group-copy>

--- a/packages/web-components/examples/codesandbox/components/content-group-simple/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-group-simple/index.html
@@ -19,9 +19,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
           <cds-content-group-simple>
             <cds-content-group-heading>Curabitur malesuada varius mi eu posuere</cds-content-group-heading>
             <cds-content-group-copy>

--- a/packages/web-components/examples/codesandbox/components/content-group/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-group/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-group:not(:defined) {
@@ -20,9 +20,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
       <cds-content-group>
         <cds-content-group-heading>Curabitur malesuada varius mi eu posuere</cds-content-group-heading>
         <cds-content-group-copy>

--- a/packages/web-components/examples/codesandbox/components/content-group/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-group/index.html
@@ -19,9 +19,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
           <cds-content-group>
             <cds-content-group-heading>Curabitur malesuada varius mi eu posuere</cds-content-group-heading>
             <cds-content-group-copy>

--- a/packages/web-components/examples/codesandbox/components/content-item-horizontal/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-item-horizontal/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-item-horizontal:not(:defined) {
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
 </head>
 <body>
 <div id="app">
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--col-lg-12 bx--col-sm-4 bx--offset-lg-4">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--col-lg-12 cds--col-sm-4 cds--offset-lg-4">
         <cds-content-item-horizontal>
           <cds-content-item-horizontal-eyebrow>Lorem ipsum</cds-content-item-horizontal-eyebrow>
           <cds-content-item-heading>Aliquam condimentum</cds-content-item-heading>
@@ -44,8 +44,8 @@ LICENSE file in the root directory of this source tree.
         </cds-content-item-horizontal>
       </div>
     </div>
-    <div class="bx--row">
-      <div class="bx--col-lg-12 bx--col-sm-4 bx--offset-lg-4">
+    <div class="cds--row">
+      <div class="cds--col-lg-12 cds--col-sm-4 cds--offset-lg-4">
         <cds-content-item-horizontal-media-featured>
           <cds-content-item-horizontal-eyebrow>Lorem ipsum</cds-content-item-horizontal-eyebrow>
           <cds-content-item-heading>Aliquam condimentum</cds-content-item-heading>

--- a/packages/web-components/examples/codesandbox/components/content-item-horizontal/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-item-horizontal/index.html
@@ -10,6 +10,8 @@ LICENSE file in the root directory of this source tree.
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
+
     <style>
       /* Suppress custom element until styles are loaded */
       cds-content-item-horizontal:not(:defined) {
@@ -20,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   </head>
   <body>
     <div id="app">
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="bx--col-lg-12 bx--col-sm-4 bx--offset-lg-4">
+      <div class="cds--grid">
+        <div class="cds--row">
+          <div class="cds--col-lg-12 cds--col-sm-4 cds--offset-lg-4">
             <cds-content-item-horizontal>
               <cds-content-item-horizontal-eyebrow>Lorem ipsum</cds-content-item-horizontal-eyebrow>
               <cds-content-item-heading>Aliquam condimentum</cds-content-item-heading>
@@ -43,8 +45,8 @@ LICENSE file in the root directory of this source tree.
             </cds-content-item-horizontal>
           </div>
         </div>
-        <div class="bx--row">
-          <div class="bx--col-lg-12 bx--col-sm-4 bx--offset-lg-4">
+        <div class="cds--row">
+          <div class="cds--col-lg-12 cds--col-sm-4 cds--offset-lg-4">
             <cds-content-item-horizontal-media-featured>
               <cds-content-item-horizontal-eyebrow>Lorem ipsum</cds-content-item-horizontal-eyebrow>
               <cds-content-item-heading>Aliquam condimentum</cds-content-item-heading>

--- a/packages/web-components/examples/codesandbox/components/content-item/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-item/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-item-horizontal:not(:defined) {
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
 </head>
 <body>
 <div id="app">
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--col-lg-12 bx--col-sm-4 bx--offset-lg-4">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--col-lg-12 cds--col-sm-4 cds--offset-lg-4">
         <cds-content-item>
           <cds-content-item-heading>Heading</cds-content-item-heading>
           <cds-content-item-copy>Copy</cds-content-item-copy>

--- a/packages/web-components/examples/codesandbox/components/content-item/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-item/index.html
@@ -10,6 +10,7 @@ LICENSE file in the root directory of this source tree.
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       cds-content-item:not(:defined) {
@@ -20,9 +21,9 @@ LICENSE file in the root directory of this source tree.
   </head>
   <body>
     <div id="app">
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="bx--col-lg-12 bx--col-sm-4 bx--offset-lg-4">
+      <div class="cds--grid">
+        <div class="cds--row">
+          <div class="cds--col-lg-12 cds--col-sm-4 cds--offset-lg-4">
             <cds-content-item>
               <cds-content-item-heading>Heading</cds-content-item-heading>
               <cds-content-item-copy>Copy</cds-content-item-copy>

--- a/packages/web-components/examples/codesandbox/components/content-section/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/content-section/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-content-section:not(:defined) {
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
 </head>
 <body>
 <div id="app">
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--col-lg-12 bx--col-sm-4 bx--offset-lg-4">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--col-lg-12 cds--col-sm-4 cds--offset-lg-4">
         <cds-content-section>
           <cds-content-section-heading>Content section heading</cds-content-section-heading>
           <cds-content-section-copy>Copy text</cds-content-section-copy>

--- a/packages/web-components/examples/codesandbox/components/content-section/index.html
+++ b/packages/web-components/examples/codesandbox/components/content-section/index.html
@@ -10,6 +10,7 @@ LICENSE file in the root directory of this source tree.
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     <style>
       /* Suppress custom element until styles are loaded */
       cds-content-section:not(:defined) {
@@ -20,9 +21,9 @@ LICENSE file in the root directory of this source tree.
   </head>
   <body>
     <div id="app">
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="bx--col-lg-12 bx--col-sm-4 bx--offset-lg-4">
+      <div class="cds--grid">
+        <div class="cds--row">
+          <div class="cds--col-lg-12 cds--col-sm-4 cds--offset-lg-4">
             <cds-content-section>
               <cds-content-section-heading>Content section heading</cds-content-section-heading>
               <cds-content-section-copy>Copy text</cds-content-section-copy>

--- a/packages/web-components/examples/codesandbox/components/cta-block/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-block/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-cta-block:not(:defined) {
@@ -23,9 +23,9 @@ LICENSE file in the root directory of this source tree.
 </head>
 
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-lg-8 cds--col-sm-4 cds--offset-lg-4">
       <cds-cta-block no-border>
         <cds-content-block-heading>Take the next step</cds-content-block-heading>
         <cds-content-block-copy

--- a/packages/web-components/examples/codesandbox/components/cta-block/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-block/index.html
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   </head>
 
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-lg-8 cds--col-sm-4 cds--offset-lg-4">
           <cds-cta-block no-border>
             <cds-content-block-heading>Take the next step</cds-content-block-heading>
             <cds-content-block-copy

--- a/packages/web-components/examples/codesandbox/components/cta-button/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-button/cdn.html
@@ -15,10 +15,7 @@ LICENSE file in the root directory of this source tree.
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"
     />
-    <link
-      rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"
-    />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       cds-button-cta:not(:defined) {
@@ -31,9 +28,9 @@ LICENSE file in the root directory of this source tree.
     ></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12">
           <cds-button-cta
             cta-type="local"
             kind="tertiary"

--- a/packages/web-components/examples/codesandbox/components/cta-button/contact-methods.html
+++ b/packages/web-components/examples/codesandbox/components/cta-button/contact-methods.html
@@ -15,10 +15,7 @@ LICENSE file in the root directory of this source tree.
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"
     />
-    <link
-      rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"
-    />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     <script src="https://www.ibm.com/common/digitaladvisor/cm-app/latest/cm-app.min.js" defer></script>
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
@@ -29,9 +26,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12">
           <cds-button-cta cta-type="call">Call</cds-button-cta>
           <cds-button-cta cta-type="email">Email</cds-button-cta>
           <cds-button-cta cta-type="chat">Chat</cds-button-cta>

--- a/packages/web-components/examples/codesandbox/components/cta-button/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-button/index.html
@@ -15,22 +15,16 @@ LICENSE file in the root directory of this source tree.
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"
     />
-    <link
-      rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"
-    />
-    <style type="text/css">
-      /* Suppress custom element until styles are loaded */
-      cds-button-cta:not(:defined) {
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />cds-button-cta:not(:defined) {
         display: none;
       }
     </style>
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12">
           <cds-button-cta
             cta-type="local"
             kind="tertiary"

--- a/packages/web-components/examples/codesandbox/components/cta-card-link/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-card-link/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-card-link-cta:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-link-cta.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-card-link-cta href="https://www.ibm.com/" cta-type="local">
         <cds-card-link-heading>Lorem ipsum dolor sit amet</cds-card-link-heading>
         <cds-card-cta-footer>

--- a/packages/web-components/examples/codesandbox/components/cta-card-link/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-card-link/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-card-link-cta:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-4">
       <cds-card-link-cta href="https://www.ibm.com/" cta-type="local">
         <cds-card-link-heading>Lorem ipsum dolor sit amet</cds-card-link-heading>
         <cds-card-cta-footer>

--- a/packages/web-components/examples/codesandbox/components/cta-card/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-card/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-card-cta:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-cta.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-4">
       <cds-card-cta href="https://www.ibm.com/" cta-type="local">
         Lorem ipsum dolor sit amet
         <cds-card-cta-footer>

--- a/packages/web-components/examples/codesandbox/components/cta-card/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-card/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-card-cta:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-4">
       <cds-card-cta href="https://www.ibm.com/" cta-type="local">
         Lorem ipsum dolor sit amet
         <cds-card-cta-footer>

--- a/packages/web-components/examples/codesandbox/components/cta-feature/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-feature/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-feature-cta:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/feature-cta.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-feature-cta href="https://www.ibm.com/" cta-type="local">
         Copy text
         <cds-image

--- a/packages/web-components/examples/codesandbox/components/cta-feature/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-feature/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-feature-cta:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-feature-cta href="https://www.ibm.com/" cta-type="local">
         Copy text
         <cds-image

--- a/packages/web-components/examples/codesandbox/components/cta-section/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-section/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-cta-section:not(:defined) {
@@ -23,9 +23,9 @@ LICENSE file in the root directory of this source tree.
 </head>
 
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-lg-12 bx--col-sm-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-lg-12 cds--col-sm-4">
       <cds-cta-section>
         <cds-cta-block>
           <cds-content-block-heading>Curabitur malesuada varius mi eu posuere</cds-content-block-heading>

--- a/packages/web-components/examples/codesandbox/components/cta-section/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-section/index.html
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   </head>
 
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-lg-12 bx--col-sm-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-lg-12 cds--col-sm-4">
           <cds-cta-section>
             <cds-cta-block>
               <cds-content-block-heading>Curabitur malesuada varius mi eu posuere</cds-content-block-heading>

--- a/packages/web-components/examples/codesandbox/components/cta-text/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/cta-text/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-video-cta-container:not(:defined) {
@@ -27,9 +26,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/video-cta-container.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-video-cta-container>
         <cds-text-cta cta-type="video" href="1_9h94wo6b"></cds-text-cta>
       </cds-video-cta-container>

--- a/packages/web-components/examples/codesandbox/components/cta-text/index.html
+++ b/packages/web-components/examples/codesandbox/components/cta-text/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-video-cta-container:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-video-cta-container>
         <cds-text-cta cta-type="video" href="1_9h94wo6b"></cds-text-cta>
       </cds-video-cta-container>

--- a/packages/web-components/examples/codesandbox/components/dotcom-shell/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/dotcom-shell/cdn.html
@@ -146,7 +146,7 @@ LICENSE file in the root directory of this source tree.
   <link rel="alternate" hreflang="en-zm" href="https://www.ibm.com/zm-en" />
   <link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-dotcom-shell-container:not(:defined) {
@@ -158,10 +158,10 @@ LICENSE file in the root directory of this source tree.
 </head>
 <body>
 <cds-dotcom-shell-container>
-  <main class="bx--content cds-ce-demo--ui-shell-content">
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--offset-lg-3 bx--col-lg-13">
+  <main class="cds--content cds-ce-demo--ui-shell-content">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--offset-lg-3 cds--col-lg-13">
           <h2>
             Purpose and function
           </h2>

--- a/packages/web-components/examples/codesandbox/components/dotcom-shell/index.html
+++ b/packages/web-components/examples/codesandbox/components/dotcom-shell/index.html
@@ -156,10 +156,10 @@ LICENSE file in the root directory of this source tree.
   </head>
   <body>
     <cds-dotcom-shell-container>
-      <main class="bx--content cds-ce-demo--ui-shell-content">
-        <div class="bx--grid">
-          <div class="bx--row">
-            <div class="bx--offset-lg-3 bx--col-lg-13">
+      <main class="cds--content cds-ce-demo--ui-shell-content">
+        <div class="cds--grid">
+          <div class="cds--row">
+            <div class="cds--offset-lg-3 cds--col-lg-13">
               <h2>
                 Purpose and function
               </h2>

--- a/packages/web-components/examples/codesandbox/components/dotcom-shell/src/index.scss
+++ b/packages/web-components/examples/codesandbox/components/dotcom-shell/src/index.scss
@@ -17,12 +17,12 @@ $feature-flags: (
 @import 'carbon-components/scss/components/ui-shell/content';
 
 @media (min-width: 66rem) {
-  .bx--offset-lg-3 {
+  .cds--offset-lg-3 {
     margin-left: 0;
   }
 }
 
-.bx--content.cds-ce-demo--ui-shell-content {
+.cds--content.cds-ce-demo--ui-shell-content {
   h2 {
     margin: 30px 0;
 

--- a/packages/web-components/examples/codesandbox/components/expressive-modal/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/expressive-modal/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-expressive-modal:not(:defined), cds-button-expressive:not(:defined) {
@@ -27,9 +26,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/expressive-modal.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-button-expressive id="open-modal-btn">Open modal
       </cds-button-expressive>
     </div>

--- a/packages/web-components/examples/codesandbox/components/expressive-modal/index.html
+++ b/packages/web-components/examples/codesandbox/components/expressive-modal/index.html
@@ -13,9 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
-  <style type="text/css">
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     /* Suppress custom element until styles are loaded */
     cds-expressive-modal:not(:defined), cds-button-expressive:not(:defined) {
       display: none;
@@ -24,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-button-expressive id="open-modal-btn">Open modal
       </cds-button-expressive>
     </div>

--- a/packages/web-components/examples/codesandbox/components/feature-card/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/feature-card/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-feature-card:not(:defined) {
@@ -23,9 +22,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/feature-card.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-feature-card href="https://example.com">
         <cds-image
           slot="image"

--- a/packages/web-components/examples/codesandbox/components/feature-card/index.html
+++ b/packages/web-components/examples/codesandbox/components/feature-card/index.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-feature-card:not(:defined) {
@@ -22,9 +21,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-feature-card href="https://example.com">
         <cds-image
           slot="image"

--- a/packages/web-components/examples/codesandbox/components/filter-panel/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/filter-panel/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-filter-panel:not(:defined) {
@@ -23,9 +23,9 @@ LICENSE file in the root directory of this source tree.
 </head>
 
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-lg-4">
       <cds-filter-panel-composite>
         <cds-filter-panel-heading slot="heading">Filter</cds-filter-panel-heading>
         <cds-filter-group>

--- a/packages/web-components/examples/codesandbox/components/filter-panel/index.html
+++ b/packages/web-components/examples/codesandbox/components/filter-panel/index.html
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   </head>
 
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-lg-4">
           <cds-filter-panel-composite>
         <cds-filter-panel-heading slot="heading">Filter</cds-filter-panel-heading>
         <cds-filter-group>

--- a/packages/web-components/examples/codesandbox/components/horizontal-rule/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/horizontal-rule/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-horizontal-rule:not(:defined) {
@@ -23,9 +22,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/horizontal-rule.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-hr size="fluid"></cds-hr>
     </div>
   </div>

--- a/packages/web-components/examples/codesandbox/components/horizontal-rule/index.html
+++ b/packages/web-components/examples/codesandbox/components/horizontal-rule/index.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-horizontal-rule:not(:defined) {
@@ -22,9 +21,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-hr size="fluid"></cds-hr>
     </div>
   </div>

--- a/packages/web-components/examples/codesandbox/components/image/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/image/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-image:not(:defined) {
@@ -23,9 +22,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/image.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-image
         slot="image"
         alt="Image alt text"

--- a/packages/web-components/examples/codesandbox/components/image/index.html
+++ b/packages/web-components/examples/codesandbox/components/image/index.html
@@ -11,9 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
-  <style type="text/css">
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     /* Suppress custom element until styles are loaded */
     cds-image:not(:defined) {
       display: none;
@@ -22,9 +20,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-image
         slot="image"
         alt="Image alt text"

--- a/packages/web-components/examples/codesandbox/components/leadspace-block/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/leadspace-block/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-leadspace-block:not(:defined) {
@@ -23,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-list.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
       <cds-leadspace-block>
         <cds-leadspace-block-heading>Continuous delivery</cds-leadspace-block-heading>
         <cds-leadspace-block-content>

--- a/packages/web-components/examples/codesandbox/components/leadspace-block/index.html
+++ b/packages/web-components/examples/codesandbox/components/leadspace-block/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12 cds--offset-lg-4">
           <cds-leadspace-block>
             <cds-leadspace-block-heading>Continuous delivery</cds-leadspace-block-heading>
             <cds-leadspace-block-content>

--- a/packages/web-components/examples/codesandbox/components/leadspace-with-search/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/leadspace-with-search/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-leadspace-with-search:not(:defined) {
@@ -23,9 +22,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/leadspace-with-search.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <h1>Hello World! 👋</h1>
 
       <cds-leadspace-with-search>

--- a/packages/web-components/examples/codesandbox/components/leadspace-with-search/index.html
+++ b/packages/web-components/examples/codesandbox/components/leadspace-with-search/index.html
@@ -15,9 +15,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12">
           <cds-leadspace-with-search>
             <cds-leadspace-with-search-heading>Find a product</cds-leadspace-with-search-heading>
             <cds-leadspace-with-search-content>

--- a/packages/web-components/examples/codesandbox/components/leadspace/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/leadspace/cdn.html
@@ -15,10 +15,7 @@ LICENSE file in the root directory of this source tree.
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"
     />
-    <link
-      rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"
-    />
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     <style type="text/css">
       /* Suppress custom element until styles are loaded */
       cds-leadspace:not(:defined) {
@@ -35,9 +32,9 @@ LICENSE file in the root directory of this source tree.
     ></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-8 bx--col-lg-16">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-8 cds--col-lg-16">
           <cds-leadspace
             size="medium"
             alt="Image text"

--- a/packages/web-components/examples/codesandbox/components/leadspace/index.html
+++ b/packages/web-components/examples/codesandbox/components/leadspace/index.html
@@ -24,9 +24,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-8 bx--col-lg-16">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-8 cds--col-lg-16">
           <cds-leadspace
             size="medium"
             alt="Image text"

--- a/packages/web-components/examples/codesandbox/components/leaving-ibm/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/leaving-ibm/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-leaving-ibm-container:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/leaving-ibm.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-leaving-ibm-container open="true"
                                  href="https://www.example.com/"></cds-leaving-ibm-container>
     </div>

--- a/packages/web-components/examples/codesandbox/components/link-list-section/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/link-list-section/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-link-list-section:not(:defined) {
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-list-section.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-8 bx--col-lg-12 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-8 cds--col-lg-12 cds--offset-lg-4">
       <cds-link-list-section>
         <cds-link-list-heading>Lorem ipsum dolor sit amet</cds-link-list-heading>
         <cds-link-list>

--- a/packages/web-components/examples/codesandbox/components/link-list-section/index.html
+++ b/packages/web-components/examples/codesandbox/components/link-list-section/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-8 bx--col-lg-12 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-8 cds--col-lg-12 cds--offset-lg-4">
           <cds-link-list-section>
             <cds-link-list-heading>Lorem ipsum dolor sit amet</cds-link-list-heading>
             <cds-link-list>

--- a/packages/web-components/examples/codesandbox/components/link-list/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/link-list/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-link-list:not(:defined) {
@@ -23,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-8 bx--col-lg-4 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-8 cds--col-lg-4 cds--offset-lg-4">
       <cds-link-list type="default">
         <cds-link-list-heading>Tutorial</cds-link-list-heading>
         <cds-link-list-item-card href="https://example.com">

--- a/packages/web-components/examples/codesandbox/components/link-list/index.html
+++ b/packages/web-components/examples/codesandbox/components/link-list/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-8 bx--col-lg-4 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-8 cds--col-lg-4 cds--offset-lg-4">
           <cds-link-list type="default">
             <cds-link-list-heading>Tutorial</cds-link-list-heading>
             <cds-link-list-item-card href="https://example.com">

--- a/packages/web-components/examples/codesandbox/components/link-with-icon/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/link-with-icon/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-link-with-icon:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-with-icon.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-link-with-icon
         href="https://www.ibm.com/standards/carbon">
         Link text

--- a/packages/web-components/examples/codesandbox/components/link-with-icon/index.html
+++ b/packages/web-components/examples/codesandbox/components/link-with-icon/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-link-with-icon:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-link-with-icon
         href="https://www.ibm.com/standards/carbon">
         Link text

--- a/packages/web-components/examples/codesandbox/components/locale-modal/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/cdn.html
@@ -147,8 +147,7 @@ LICENSE file in the root directory of this source tree.
   <link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-button-expressive:not(:defined), cds-locale-modal-container:not(:defined) {
@@ -161,9 +160,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-button-expressive id="open-modal-btn">Open modal
       </cds-button-expressive>
     </div>

--- a/packages/web-components/examples/codesandbox/components/locale-modal/index.html
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/index.html
@@ -147,8 +147,7 @@ LICENSE file in the root directory of this source tree.
   <link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-button-expressive:not(:defined), cds-locale-modal-container:not(:defined) {
@@ -158,9 +157,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-button-expressive id="open-modal-btn">Open modal
       </cds-button-expressive>
     </div>

--- a/packages/web-components/examples/codesandbox/components/logo-grid/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/logo-grid/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-logo-grid:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/logo-grid.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-logo-grid logo-count="3" logo-ratio="2:1">
         <cds-content-block-heading>
           This is a heading

--- a/packages/web-components/examples/codesandbox/components/logo-grid/index.html
+++ b/packages/web-components/examples/codesandbox/components/logo-grid/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-logo-grid:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-logo-grid logo-count="3" logo-ratio="2:1">
         <cds-content-block-heading>
           This is a heading

--- a/packages/web-components/examples/codesandbox/components/masthead-l1/cdn-rtl.html
+++ b/packages/web-components/examples/codesandbox/components/masthead-l1/cdn-rtl.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <link rel="stylesheet" href="src/index.scss" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
@@ -25,10 +25,10 @@ LICENSE file in the root directory of this source tree.
 </head>
   <body>
     <cds-masthead-composite></cds-masthead-composite>
-    <main class="bx--content cds-ce-demo--ui-shell-content">
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="bx--offset-lg-3 bx--col-lg-13">
+    <main class="cds--content cds-ce-demo--ui-shell-content">
+      <div class="cds--grid">
+        <div class="cds--row">
+          <div class="cds--offset-lg-3 cds--col-lg-13">
             <h2>
               Purpose and function
             </h2>

--- a/packages/web-components/examples/codesandbox/components/masthead-l1/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/masthead-l1/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <link rel="stylesheet" href="src/index.scss" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
@@ -25,10 +25,10 @@ LICENSE file in the root directory of this source tree.
 </head>
   <body>
     <cds-masthead-composite></cds-masthead-composite>
-    <main class="bx--content cds-ce-demo--ui-shell-content">
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="bx--offset-lg-3 bx--col-lg-13">
+    <main class="cds--content cds-ce-demo--ui-shell-content">
+      <div class="cds--grid">
+        <div class="cds--row">
+          <div class="cds--offset-lg-3 cds--col-lg-13">
             <h2>
               Purpose and function
             </h2>

--- a/packages/web-components/examples/codesandbox/components/masthead-l1/index.html
+++ b/packages/web-components/examples/codesandbox/components/masthead-l1/index.html
@@ -22,10 +22,10 @@ LICENSE file in the root directory of this source tree.
   </head>
   <body>
     <cds-masthead-composite></cds-masthead-composite>
-    <main class="bx--content cds-ce-demo--ui-shell-content">
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="bx--offset-lg-3 bx--col-lg-13">
+    <main class="cds--content cds-ce-demo--ui-shell-content">
+      <div class="cds--grid">
+        <div class="cds--row">
+          <div class="cds--offset-lg-3 cds--col-lg-13">
             <h2>
               Purpose and function
             </h2>

--- a/packages/web-components/examples/codesandbox/components/masthead-l1/src/index.scss
+++ b/packages/web-components/examples/codesandbox/components/masthead-l1/src/index.scss
@@ -21,12 +21,12 @@ body {
 }
 
 @media (min-width: 66rem) {
-  .bx--offset-lg-3 {
+  .cds--offset-lg-3 {
     margin-left: 0;
   }
 }
 
-.bx--content.cds-ce-demo--ui-shell-content {
+.cds--content.cds-ce-demo--ui-shell-content {
   h2 {
     margin: 30px 0;
 

--- a/packages/web-components/examples/codesandbox/components/masthead/cdn-rtl.html
+++ b/packages/web-components/examples/codesandbox/components/masthead/cdn-rtl.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-masthead-container:not(:defined) {
@@ -24,10 +24,10 @@ LICENSE file in the root directory of this source tree.
 </head>
 <body>
 <cds-masthead-container id="masthead-container"></cds-masthead-container>
-<main class="bx--content cds-ce-demo--ui-shell-content">
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--offset-lg-3 bx--col-lg-13">
+<main class="cds--content cds-ce-demo--ui-shell-content">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--offset-lg-3 cds--col-lg-13">
         <h2>
           Purpose and function
         </h2>

--- a/packages/web-components/examples/codesandbox/components/masthead/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/masthead/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-masthead-container:not(:defined) {
@@ -24,10 +24,10 @@ LICENSE file in the root directory of this source tree.
 </head>
 <body>
 <cds-masthead-container id="masthead-container"></cds-masthead-container>
-<main class="bx--content cds-ce-demo--ui-shell-content">
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--offset-lg-3 bx--col-lg-13">
+<main class="cds--content cds-ce-demo--ui-shell-content">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--offset-lg-3 cds--col-lg-13">
         <h2>
           Purpose and function
         </h2>

--- a/packages/web-components/examples/codesandbox/components/masthead/index.html
+++ b/packages/web-components/examples/codesandbox/components/masthead/index.html
@@ -22,10 +22,10 @@ LICENSE file in the root directory of this source tree.
   </head>
   <body>
     <cds-masthead-container id="masthead-container"></cds-masthead-container>
-    <main class="bx--content cds-ce-demo--ui-shell-content">
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="bx--offset-lg-3 bx--col-lg-13">
+    <main class="cds--content cds-ce-demo--ui-shell-content">
+      <div class="cds--grid">
+        <div class="cds--row">
+          <div class="cds--offset-lg-3 cds--col-lg-13">
             <h2>
               Purpose and function
             </h2>

--- a/packages/web-components/examples/codesandbox/components/masthead/src/index.scss
+++ b/packages/web-components/examples/codesandbox/components/masthead/src/index.scss
@@ -21,12 +21,12 @@ body {
 }
 
 @media (min-width: 66rem) {
-  .bx--offset-lg-3 {
+  .cds--offset-lg-3 {
     margin-left: 0;
   }
 }
 
-.bx--content.cds-ce-demo--ui-shell-content {
+.cds--content.cds-ce-demo--ui-shell-content {
   h2 {
     margin: 30px 0;
 

--- a/packages/web-components/examples/codesandbox/components/pictogram-item/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/pictogram-item/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-pictogram-item:not(:defined) {
@@ -20,9 +20,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/pictogram-item.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-8 bx--col-lg-12 bx--offset-lg-3">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-8 cds--col-lg-12 cds--offset-lg-3">
       <cds-pictogram-item>
         <svg
           slot="pictogram"
@@ -36,7 +36,7 @@ LICENSE file in the root directory of this source tree.
           height="48"
           viewBox="0 0 48 48"
           role="img"
-          class="bx--pictogram-item__pictogram"
+          class="cds--pictogram-item__pictogram"
         >
           <path
             fill="none"

--- a/packages/web-components/examples/codesandbox/components/pictogram-item/index.html
+++ b/packages/web-components/examples/codesandbox/components/pictogram-item/index.html
@@ -19,9 +19,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-8 bx--col-lg-12 bx--offset-lg-3">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-8 cds--col-lg-12 cds--offset-lg-3">
           <cds-pictogram-item>
             <svg
               slot="pictogram"
@@ -35,7 +35,7 @@ LICENSE file in the root directory of this source tree.
               height="48"
               viewBox="0 0 48 48"
               role="img"
-              class="bx--pictogram-item__pictogram"
+              class="cds--pictogram-item__pictogram"
             >
               <path
                 fill="none"

--- a/packages/web-components/examples/codesandbox/components/pricing-table/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/pricing-table/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-pricing-table:not(:defined) {
@@ -27,9 +26,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/pricing-table.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-pricing-table highlight-column="2" highlight-label="Featured">
         <cds-pricing-table-head>
           <cds-pricing-table-header-row>

--- a/packages/web-components/examples/codesandbox/components/pricing-table/index.html
+++ b/packages/web-components/examples/codesandbox/components/pricing-table/index.html
@@ -11,9 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
-  <style type="text/css">
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
     /* Suppress custom element until styles are loaded */
     cds-pricing-table:not(:defined) {
       display: none;
@@ -26,9 +24,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-pricing-table highlight-column="2" highlight-label="Featured">
         <cds-pricing-table-head>
           <cds-pricing-table-header-row>

--- a/packages/web-components/examples/codesandbox/components/quote/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/quote/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-quote:not(:defined) {
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/quote.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-8 bx--col-lg-8 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-8 cds--col-lg-8 cds--offset-lg-4">
       <cds-quote color-scheme="regular">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus est purus, posuere at est vitae, ornare rhoncus sem.
         Suspendisse vitae tellus fermentum, hendrerit augue eu, placerat magna.

--- a/packages/web-components/examples/codesandbox/components/quote/index.html
+++ b/packages/web-components/examples/codesandbox/components/quote/index.html
@@ -15,9 +15,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-8 bx--col-lg-8 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-8 cds--col-lg-8 cds--offset-lg-4">
           <cds-quote color-scheme="regular">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus est purus, posuere at est vitae, ornare rhoncus sem.
             Suspendisse vitae tellus fermentum, hendrerit augue eu, placerat magna.

--- a/packages/web-components/examples/codesandbox/components/search-with-typeahead/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/search-with-typeahead/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-search-with-typeahead:not(:defined) {
@@ -23,9 +22,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/search-with-typeahead.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <h1>Hello World! 👋</h1>
 
       <cds-search-with-typeahead active>

--- a/packages/web-components/examples/codesandbox/components/search-with-typeahead/index.html
+++ b/packages/web-components/examples/codesandbox/components/search-with-typeahead/index.html
@@ -15,9 +15,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-12">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-12">
           <cds-search-with-typeahead></cds-search-with-typeahead>
         </div>
       </div>

--- a/packages/web-components/examples/codesandbox/components/structured-list/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/structured-list/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-structured-list:not(:defined) {
@@ -27,9 +26,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/structured-list.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-structured-list>
         <cds-structured-list-head>
           <cds-structured-list-header-row>

--- a/packages/web-components/examples/codesandbox/components/structured-list/index.html
+++ b/packages/web-components/examples/codesandbox/components/structured-list/index.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-structured-list:not(:defined) {
@@ -26,9 +25,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-structured-list>
         <cds-structured-list-head>
           <cds-structured-list-header-row>

--- a/packages/web-components/examples/codesandbox/components/table-of-contents/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/table-of-contents/cdn.html
@@ -13,9 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
-  <link rel="stylesheet"
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/table-of-contents.css"/>
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
@@ -32,11 +30,11 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/table-of-contents.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-8 bx--col-lg-16">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-8 cds--col-lg-16">
       <cds-table-of-contents>
-        <div class="bx--tableofcontents__contents">
+        <div class="cds--tableofcontents__contents">
           <a name="1" data-title="Section - 1"></a>
           <h3>Section - 1</h3>
           <p>

--- a/packages/web-components/examples/codesandbox/components/table-of-contents/index.html
+++ b/packages/web-components/examples/codesandbox/components/table-of-contents/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-table-of-contents:not(:defined) {
@@ -44,11 +43,11 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-8 bx--col-lg-16">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-8 cds--col-lg-16">
       <cds-table-of-contents>
-        <div class="bx--tableofcontents__contents">
+        <div class="cds--tableofcontents__contents">
           <a name="1" data-title="Section - 1"></a>
           <h3>Section - 1</h3>
           <p>

--- a/packages/web-components/examples/codesandbox/components/tabs-extended-media/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/tabs-extended-media/cdn.html
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style>
     /* Suppress custom element until styles are loaded */
     cds-tabs-extended-media:not(:defined) {
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
 </head>
 <body>
 <div id="app">
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--col-lg-12 bx--col-sm-4 bx--offset-lg-4">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--col-lg-12 cds--col-sm-4 cds--offset-lg-4">
         <cds-tabs-extended-media>
           <cds-content-section-heading>Section heading</cds-content-section-heading>
           <cds-tab label="First tab">

--- a/packages/web-components/examples/codesandbox/components/tabs-extended-media/index.html
+++ b/packages/web-components/examples/codesandbox/components/tabs-extended-media/index.html
@@ -20,9 +20,9 @@ LICENSE file in the root directory of this source tree.
   </head>
   <body>
     <div id="app">
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="bx--col-lg-12 bx--col-sm-4 bx--offset-lg-4">
+      <div class="cds--grid">
+        <div class="cds--row">
+          <div class="cds--col-lg-12 cds--col-sm-4 cds--offset-lg-4">
             <cds-tabs-extended-media>
               <cds-content-section-heading>Section heading</cds-content-section-heading>
               <cds-tab label="First tab">

--- a/packages/web-components/examples/codesandbox/components/tabs-extended/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/tabs-extended/cdn.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-tabs-extended:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/tabs-extended.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <h1>Hello World! 👋</h1>
 
       <cds-tabs-extended>

--- a/packages/web-components/examples/codesandbox/components/tabs-extended/index.html
+++ b/packages/web-components/examples/codesandbox/components/tabs-extended/index.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-tabs-extended:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <h1>Hello World! 👋</h1>
 
       <cds-tabs-extended>

--- a/packages/web-components/examples/codesandbox/components/tabs-extended/with-cta-block-item-rows.html
+++ b/packages/web-components/examples/codesandbox/components/tabs-extended/with-cta-block-item-rows.html
@@ -13,8 +13,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-tabs-extended:not(:defined) {
@@ -24,9 +23,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/with-cta-block-item-rows.js" type="module"></script>
 </head>
 <body>
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--col-sm-4">
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--col-sm-4">
         <cds-tabs-extended orientation="horizontal">
           <cds-tab label="Relational">
             <cds-cta-block>
@@ -47,7 +46,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/cloud/db2-on-cloud">
-                      <span class="bx--link-text">IBM Db2 on Cloud</span>
+                      <span class="cds--link-text">IBM Db2 on Cloud</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -62,7 +61,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/products/db2-database">
-                      <span class="bx--link-text">IBM Db2 Database</span>
+                      <span class="cds--link-text">IBM Db2 Database</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -78,7 +77,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/cloud/databases-for-postgresql">
-                      <span class="bx--link-text">IBM Cloud Databases for PostgreSQL</span>
+                      <span class="cds--link-text">IBM Cloud Databases for PostgreSQL</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -96,7 +95,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/cloud/databases-for-enterprisedb">
-                      <span class="bx--link-text">IBM Cloud Databases for EnterpriseDB</span>
+                      <span class="cds--link-text">IBM Cloud Databases for EnterpriseDB</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -111,7 +110,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/products/postgres-enterprise">
-                      <span class="bx--link-text">EDB Postgres Enterprise and Standard with IBM</span>
+                      <span class="cds--link-text">EDB Postgres Enterprise and Standard with IBM</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -127,7 +126,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/cloud/databases-for-mysql">
-                      <span class="bx--link-text">IBM Cloud Databases for MySQL</span>
+                      <span class="cds--link-text">IBM Cloud Databases for MySQL</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -145,7 +144,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/products/singlestore">
-                      <span class="bx--link-text">SingleStore DB with IBM</span>
+                      <span class="cds--link-text">SingleStore DB with IBM</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -172,7 +171,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/cloud/db2-warehouse-on-cloud">
-                      <span class="bx--link-text">IBM Db2 Data Warehouse on Cloud</span>
+                      <span class="cds--link-text">IBM Db2 Data Warehouse on Cloud</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -187,7 +186,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/products/db2-warehouse">
-                      <span class="bx--link-text">IBM Db2 Data Warehouse</span>
+                      <span class="cds--link-text">IBM Db2 Data Warehouse</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -203,7 +202,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/products/netezza">
-                      <span class="bx--link-text">IBM Netezza Performance Server</span>
+                      <span class="cds--link-text">IBM Netezza Performance Server</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -230,7 +229,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/cloud/databases-for-mongodb">
-                      <span class="bx--link-text">IBM Cloud Databases for MongoDB</span>
+                      <span class="cds--link-text">IBM Cloud Databases for MongoDB</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -245,7 +244,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/products/mongodb-enterprise-advanced">
-                      <span class="bx--link-text">MongoDB Enterprise Advanced with IBM</span>
+                      <span class="cds--link-text">MongoDB Enterprise Advanced with IBM</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -261,7 +260,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/cloud/cloudant">
-                      <span class="bx--link-text">IBM Cloudant</span>
+                      <span class="cds--link-text">IBM Cloudant</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -288,7 +287,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/cloud/databases-for-etcd">
-                      <span class="bx--link-text">IBM Databases for etcd</span>
+                      <span class="cds--link-text">IBM Databases for etcd</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -315,7 +314,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/cloud/databases-for-datastax?mhsrc=ibmsearch_a&amp;mhq=datastax">
-                      <span class="bx--link-text">IBM Cloud Databases for DataStax</span>
+                      <span class="cds--link-text">IBM Cloud Databases for DataStax</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>
@@ -330,7 +329,7 @@ LICENSE file in the root directory of this source tree.
                   </cds-content-item-copy>
                   <cds-video-cta-container>
                     <a href="https://www.ibm.com/products/datastax-enterprise">
-                      <span class="bx--link-text">DataStax Enterprise with IBM</span>
+                      <span class="cds--link-text">DataStax Enterprise with IBM</span>
                       <span class="ibm_icon_arrowright_local"></span>
                     </a>
                   </cds-video-cta-container>

--- a/packages/web-components/examples/codesandbox/components/tag-group/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/tag-group/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-tag-group:not(:defined) {
@@ -25,9 +24,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/tag-link.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <h1>Hello World! 👋</h1>
 
       <cds-tag-group>

--- a/packages/web-components/examples/codesandbox/components/tag-group/index.html
+++ b/packages/web-components/examples/codesandbox/components/tag-group/index.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-tag-group:not(:defined) {
@@ -22,9 +21,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <h1>Hello World! 👋</h1>
 
       <cds-tag-group>

--- a/packages/web-components/examples/codesandbox/components/tag-link/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/tag-link/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-tag-link:not(:defined) {
@@ -27,9 +26,9 @@ LICENSE file in the root directory of this source tree.
           src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/tag-link.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-tag-link href="https://www.example.com">
         Copy Text
       </cds-tag-link>

--- a/packages/web-components/examples/codesandbox/components/tag-link/index.html
+++ b/packages/web-components/examples/codesandbox/components/tag-link/index.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-tag-link:not(:defined) {
@@ -26,9 +25,9 @@ LICENSE file in the root directory of this source tree.
   <script src="src/index.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
       <cds-tag-link href="https://www.example.com">
         Copy Text
       </cds-tag-link>

--- a/packages/web-components/examples/codesandbox/components/universal-banner/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/universal-banner/cdn.html
@@ -11,8 +11,7 @@ LICENSE file in the root directory of this source tree.
   <meta charset="UTF-8"/>
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-universal-banner:not(:defined) {

--- a/packages/web-components/examples/codesandbox/components/video-player/cdn.html
+++ b/packages/web-components/examples/codesandbox/components/video-player/cdn.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     cds-video-player-container:not(:defined) {
@@ -22,9 +22,9 @@ LICENSE file in the root directory of this source tree.
   <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/video-player.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
       <cds-video-player-container video-id="1_9h94wo6b"></cds-video-player-container>
     </div>
   </div>

--- a/packages/web-components/examples/codesandbox/components/video-player/index.html
+++ b/packages/web-components/examples/codesandbox/components/video-player/index.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+    <div class="cds--grid">
+      <div class="cds--row">
+        <div class="cds--col-sm-4 cds--col-lg-8 cds--offset-lg-4">
           <cds-video-player-container video-id="1_9h94wo6b"></cds-video-player-container>
         </div>
       </div>


### PR DESCRIPTION
### Related Ticket(s)

none
### Description

update all web component examples to use `cds` vs `bx` and update the grid cdn to the v2 cdn


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
