### PR TITLE
fix(combo-box): outline/hover issues

### DIFF
--- a/packages/carbon-web-components/src/components/combo-box/combo-box-story.ts
+++ b/packages/carbon-web-components/src/components/combo-box/combo-box-story.ts
@@ -74,7 +74,7 @@ export const Default = () => {
 export const WithLayer = () => {
   return html`
     <sb-template-layers>
-      <div style="width:400px">
+      <div style="width:300px">
         <cds-combo-box
           title-text="ComboBox label"
           helper-text="Combobox helper text"
@@ -178,7 +178,7 @@ export default {
   },
   decorators: [
     (story, { name }) => {
-      const width = !name.toLowerCase().includes('layer') ? `width:400px` : ``;
+      const width = !name.toLowerCase().includes('layer') ? `width:300px` : ``;
       return html` <div style="${width}">${story()}</div> `;
     },
   ],

--- a/packages/carbon-web-components/src/components/combo-box/combo-box.scss
+++ b/packages/carbon-web-components/src/components/combo-box/combo-box.scss
@@ -11,13 +11,15 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/utilities' as *;
-@use '@carbon/styles/scss/components/combo-box/combo-box';
+@use '@carbon/styles/scss/layout' as *;
+@use '@carbon/styles/scss/components/combo-box' as *;
 @use '@carbon/styles/scss/components/form';
 @use '@carbon/styles/scss/components/text-input/text-input';
 @use '../dropdown/dropdown.scss';
 
 :host(#{$prefix}-combo-box) {
   @extend :host(#{$prefix}-dropdown);
+  @include emit-layout-tokens();
 
   outline: none;
 
@@ -25,6 +27,10 @@ $css--plex: true !default;
     // Hides screen reader cursor
     left: -100%;
     top: -100%;
+  }
+
+  .#{$prefix}--list-box__field {
+    padding: 0;
   }
 
   .#{$prefix}--list-box__menu {
@@ -47,6 +53,12 @@ $css--plex: true !default;
   }
 }
 
+:host(#{$prefix}-combo-box[invalid]) {
+  .#{$prefix}--form__helper-text {
+    color: $text-error;
+  }
+}
+
 :host(#{$prefix}-combo-box[read-only]) {
   .#{$prefix}--list-box__selection svg {
     fill: $icon-disabled;
@@ -60,6 +72,10 @@ $css--plex: true !default;
 
   .#{$prefix}--list-box__menu-item__option {
     height: auto;
+  }
+
+  &:hover {
+    background-color: $layer-hover;
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

Closes #10901 

### Description

combox fix outline and hover on items
<img width="397" alt="Screenshot 2023-09-14 at 10 17 58 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/20210594/2ae7b878-c83b-4cf3-a7ce-db99eb468300">

<img width="504" alt="Screenshot 2023-09-14 at 10 18 04 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/20210594/e1a2e67a-e7bc-4b6a-ba9c-0d9370a4d37f">


### Changelog

**Changed**

- storybook update to use width: 300px
- update padding for outline
- add hover fix


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
