### PR TITLE
fix(package): update web components component exports

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install xvfb
         run: sudo apt-get install xvfb
       - name: Run basic checks
-        run: xvfb-run --auto-servernum yarn lerna run --stream --prefix --scope=@carbon/ibmdotcom-web-components ci-check
+        run: xvfb-run --auto-servernum yarn lerna run --stream --prefix --verbose --scope=@carbon/ibmdotcom-web-components ci-check
   a11y:
     runs-on: ubuntu-latest
     steps:

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -5,20 +5,20 @@
   "license": "Apache-2.0",
   "exports": {
     "./dist/": "./dist/",
-    "./es/components-react/": {
-      "node": "./lib/components-react-node/",
-      "default": "./es/components-react/"
+    "./es/components-react/*": {
+      "node": "./lib/components-react-node/*",
+      "default": "./es/components-react/*"
     },
-    "./es/components/": {
-      "node": "./lib/components/",
-      "default": "./es/components/"
+    "./es/components/*": {
+      "node": "./lib/components/*",
+      "default": "./es/components/*"
     },
-    "./es/globals/": {
-      "node": "./lib/globals/",
-      "default": "./es/globals/"
+    "./es/globals/*": {
+      "node": "./lib/globals/*",
+      "default": "./es/globals/*"
     },
-    "./es/": "./es/",
-    "./lib/": "./lib/",
+    "./es/": "./es/*",
+    "./lib/": "./lib/*",
     "./custom-elements.json": "./custom-elements.json",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
### Description

This updates deprecated folder mappings in `@carbon/ibmdotcom-web-components` which was causing applications using Node 18+ to fail builds.

### Changelog

**New**

- {{new thing}}

**Changed**

- update folder mapping exports in `package.json`

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
