### PR TITLE
chore(ci): remove `xvfb` from ci-checks

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -23,40 +23,8 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
       - name: Build project
-        run: yarn lerna run --stream --ignore @carbon/ibmdotcom-web-components --ignore @carbon/ibmdotcom-services-store build
+        run: yarn lerna run --stream build
       - name: Run CI Checks
         run: |
           yarn ci-check
-          yarn lerna run --ignore=@carbon/ibmdotcom-web-components ci-check
-  web-components:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.15
-          cache: 'yarn'
-      - name: Install dependencies
-        run: yarn install --immutable --immutable-cache
-      - name: Build project
-        run: yarn lerna run --stream --ignore @carbon/ibmdotcom-react build
-      - name: Run basic checks
-        run: yarn lerna run --loglevel=verbose --scope=@carbon/ibmdotcom-web-components typecheck
-  a11y:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.15
-          cache: 'yarn'
-      - name: Install dependencies
-        run: yarn install --immutable --immutable-cache
-      - name: Build project
-        run: yarn build
-      - name: Install xvfb
-        run: sudo apt-get install xvfb
-      - name: Run a11y compliance tests
-        run: xvfb-run --auto-servernum --error-file=/dev/stderr yarn test:a11y
+          yarn lerna run ci-check

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   check-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x
@@ -23,8 +23,42 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
       - name: Build project
-        run: yarn lerna run --stream build
+        run: yarn lerna run --stream --ignore @carbon/ibmdotcom-web-components --ignore @carbon/ibmdotcom-services-store build
       - name: Run CI Checks
         run: |
           yarn ci-check
-          yarn lerna run ci-check
+          yarn lerna run --ignore=@carbon/ibmdotcom-web-components ci-check
+  web-components:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.15
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+      - name: Build project
+        run: yarn lerna run --stream --ignore @carbon/ibmdotcom-react build
+      - name: Install xvfb
+        run: sudo apt-get install xvfb
+      - name: Run basic checks
+        run: xvfb-run --auto-servernum yarn lerna run --stream --prefix --verbose --scope=@carbon/ibmdotcom-web-components ci-check
+  a11y:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.15
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+      - name: Build project
+        run: yarn build
+      - name: Install xvfb
+        run: sudo apt-get install xvfb
+      - name: Run a11y compliance tests
+        run: xvfb-run --auto-servernum --error-file=/dev/stderr yarn test:a11y

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build project
         run: yarn lerna run --stream --ignore @carbon/ibmdotcom-react build
       - name: Run basic checks
-        run: yarn lerna run --loglevel=verbose --scope=@carbon/ibmdotcom-web-components ci-check
+        run: yarn lerna run --loglevel=verbose --scope=@carbon/ibmdotcom-web-components typecheck
   a11y:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -41,10 +41,8 @@ jobs:
         run: yarn install --immutable --immutable-cache
       - name: Build project
         run: yarn lerna run --stream --ignore @carbon/ibmdotcom-react build
-      - name: Install xvfb
-        run: sudo apt-get install xvfb
       - name: Run basic checks
-        run: xvfb-run --auto-servernum yarn lerna run --stream --prefix --verbose --scope=@carbon/ibmdotcom-web-components ci-check
+        run: yarn lerna run --loglevel=verbose --scope=@carbon/ibmdotcom-web-components ci-check
   a11y:
     runs-on: ubuntu-latest
     steps:

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -54,7 +54,7 @@
     "build-storybook:experimental": "cross-env NODE_OPTIONS=--openssl-legacy-provider DDS_FLAGS_ALL=true build-storybook -o storybook-static-experimental",
     "build-storybook:react": "gulp build:modules:react && node --openssl-legacy-provider --max-old-space-size=8192 node_modules/@storybook/react/bin/build.js -c .storybook/react -o storybook-static-react",
     "build-storybook:rtl": "cross-env NODE_OPTIONS=--openssl-legacy-provider STORYBOOK_USE_RTL=true build-storybook -o storybook-static-rtl",
-    "ci-check": "yarn wca && yarn typecheck && yarn build && yarn test:unit",
+    "ci-check": "yarn wca && yarn typecheck && yarn test:unit",
     "clean": "gulp clean",
     "clean:dist": "rimraf dist",
     "doctoc": "doctoc --title '## Table of contents' docs && doctoc --title '## Table of contents' README.md",


### PR DESCRIPTION
### Description

This removes `xvfb` from the GH workflow for web components ci-checks.

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
