### PR TITLE
chore(gh): downgrade ubuntu to version 20.04

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   add-to-dotcom-project:
     name: Add issue to Dotcom project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/add-to-project@v0.5.0
         with:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   check-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x
@@ -29,7 +29,7 @@ jobs:
           yarn ci-check
           yarn lerna run --ignore=@carbon/ibmdotcom-web-components ci-check
   web-components:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x
@@ -46,7 +46,7 @@ jobs:
       - name: Run basic checks
         run: xvfb-run --auto-servernum yarn lerna run --stream --prefix --verbose --scope=@carbon/ibmdotcom-web-components ci-check
   a11y:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   DCOAssistant:
     if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: "DCO Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the DCO Document and I hereby sign the DCO') || github.event_name == 'pull_request_target'

--- a/.github/workflows/e2e-tests-parallel.yml
+++ b/.github/workflows/e2e-tests-parallel.yml
@@ -62,11 +62,11 @@ jobs:
         with:
           name: storybook-build
           path: packages/web-components/storybook-static
-      
+
       - name: Clear remnant failure files
         uses: geekyeggo/delete-artifact@v2
         with:
-          name: failure-wc.txt          
+          name: failure-wc.txt
 
   web-components-tests:
     runs-on: macos-latest
@@ -87,7 +87,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'        
+          cache: 'yarn'
 
       - name: Download the build folders
         uses: actions/download-artifact@v3
@@ -106,7 +106,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn
-      
+
       - name: 'Run e2e tests (chromium)'
         if: matrix.browser == 'chromium'
         id: cypress-tests-wc
@@ -132,11 +132,11 @@ jobs:
 
       - name: Exit upon failure
         if: steps.cypress-tests-wc.outcome == 'failure'
-        run: exit 1          
+        run: exit 1
 
   wc-tests-completed:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: web-components-tests
     steps:
       - uses: actions/download-artifact@v3
@@ -158,7 +158,7 @@ jobs:
   install-react:
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
         node-version: [ 18.x ]
         browser: [ chromium ]
     runs-on: ${{ matrix.os }}
@@ -202,10 +202,10 @@ jobs:
       - name: Clear remnant failure files
         uses: geekyeggo/delete-artifact@v2
         with:
-          name: failure-react.txt 
+          name: failure-react.txt
 
   react-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: install-react
     continue-on-error: true
     strategy:
@@ -213,7 +213,7 @@ jobs:
       matrix:
         # run copies of the current job in parallel
         containers: [1, 2, 3, 4, 5]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
         node-version: [ 18.x ]
         browser: [ chromium ]
     steps:
@@ -223,7 +223,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'        
+          cache: 'yarn'
 
       - name: Download the build folders
         uses: actions/download-artifact@v3
@@ -242,7 +242,7 @@ jobs:
           key: ${{ matrix.os }}-yarn-v5${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ matrix.os }}-yarn
-        
+
       - name: 'Run e2e tests (chromium)'
         if: matrix.browser == 'chromium'
         id: cypress-tests-react
@@ -272,7 +272,7 @@ jobs:
 
   react-tests-completed:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: react-tests
     steps:
       - uses: actions/download-artifact@v3
@@ -290,4 +290,3 @@ jobs:
       - name: Failure file exists, exit with error
         if: steps.check_files.outputs.files_exists == 'true'
         run: exit 1
-        

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,7 +47,7 @@ jobs:
   react:
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
         node-version: [ 18.x ]
         browser: [ chromium ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Description

Downgrades the GH action Ubuntu version to `20.04` from `latest`. In the latest version `chrome-headless` binary fails, causing tests to exit prematurely.

### Changelog

**New**

- {{new thing}}

**Changed**

- downgrade `ubuntu-latest` to `ubuntu-20.04` in all GH actions

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
