### PR TITLE
feat(masthead-v2): add masthead to document flow

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -180,6 +180,7 @@ $search-transition-timing: 95ms;
   :host(#{$dds-prefix}-masthead-composite),
   :host(#{$dds-prefix}-masthead-container),
   :host(#{$dds-prefix}-cloud-masthead-container) {
+    display: block;
     position: relative;
     z-index: 900;
     padding-top: $carbon--layout-04;

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -1336,7 +1336,7 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
   /**
    * Mutation observer
    */
-  private _heightMutationObserver = new MutationObserver(
+  private _heightResizeObserver = new ResizeObserver(
     this._setContainerHeight.bind(this)
   );
 
@@ -1345,8 +1345,10 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
    */
   protected _setContainerHeight() {
     const { mastheadRef } = this;
-    this.style.display = 'block';
-    this.style.height = `${mastheadRef.getBoundingClientRect().height}px`;
+    if (mastheadRef) {
+      this.style.display = 'block';
+      this.style.height = `${mastheadRef.getBoundingClientRect().height}px`;
+    }
   }
 
   createRenderRoot() {
@@ -1373,12 +1375,8 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
       this.requestUpdate();
     });
 
-    // Watch for changes to dds-masthead's immediate children.
-    this._heightMutationObserver.observe(this.mastheadRef, {
-      childList: true,
-      subtree: false,
-      attributes: false,
-    });
+    // Keep render root's height in sync with dds-masthead.
+    this._heightResizeObserver.observe(this.mastheadRef);
   }
 
   updated(changedProperties) {
@@ -1396,7 +1394,7 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this._heightMutationObserver.disconnect();
+    this._heightResizeObserver.disconnect();
   }
 
   render() {

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -1334,7 +1334,9 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
   mastheadRef;
 
   /**
-   * Mutation observer
+   * Resize observer to trigger container height recalculations.
+   *
+   * @private
    */
   private _heightResizeObserver = new ResizeObserver(
     this._setContainerHeight.bind(this)

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -1337,7 +1337,7 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
    * Mutation observer
    */
   private _heightMutationObserver = new MutationObserver(
-    this._setContainerHeight.bind(this),
+    this._setContainerHeight.bind(this)
   );
 
   /**
@@ -1378,7 +1378,7 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
       childList: true,
       subtree: false,
       attributes: false,
-    })
+    });
   }
 
   updated(changedProperties) {

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -1339,8 +1339,25 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
    * @private
    */
   private _heightResizeObserver = new ResizeObserver(
-    this._setContainerHeight.bind(this)
+    this._resizeObserverCallback.bind(this)
   );
+
+  /**
+   * Prevents resize observer from blocking main thread.
+   */
+  private _resizeObserverThrottle?: NodeJS.Timeout;
+
+  /**
+   * Throttled callback for _heightResizeObserver.
+   */
+  protected _resizeObserverCallback() {
+    if (!this._resizeObserverThrottle) {
+      this._setContainerHeight();
+      this._resizeObserverThrottle = setTimeout(() => {
+        this._resizeObserverThrottle = undefined;
+      }, 100);
+    }
+  }
 
   /**
    * Sets root element's height equal to the height of the fixed masthead elements.

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -1351,12 +1351,11 @@ class DDSMastheadComposite extends HostListenerMixin(LitElement) {
    * Throttled callback for _heightResizeObserver.
    */
   protected _resizeObserverCallback() {
-    if (!this._resizeObserverThrottle) {
-      this._setContainerHeight();
-      this._resizeObserverThrottle = setTimeout(() => {
-        this._resizeObserverThrottle = undefined;
-      }, 100);
-    }
+    clearTimeout(this._resizeObserverThrottle);
+    this._resizeObserverThrottle = setTimeout(
+      this._setContainerHeight.bind(this),
+      100
+    );
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)


### Description

The visible parts of the masthead are `position: fixed;`, which prevents them from being in the document flow. This forces adopters to manually add spacing to their page content so the masthead doesn't overlap. We provide the `--dds-sticky-header-height` variable via the StickyHeader utility as a value to use, but this changes as the user scrolls, creating a potentially unwanted parallax effect.

![parallax](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/12532727/982b084d-b195-40eb-9c2b-a5ea84dca525)

To overcome this, we force the masthead's container into the document flow by giving it a height equal to its visible parts' height. This avoids the parallax effect, and adopters should only need to add the spacing they want between their content and the masthead, rather than solving for the masthead's height in some way.

### Testing

Visit deploy preview Stories for the masthead with and without the L1. In each, use the browser dev tools to inspect the element and find the `<dds-masthead-container>` or `<dds-masthead-composite>` (they are mostly analogous). It should have a CSS `height` set on it equal to the `<dds-masthead>` element's height.

### Changelog

**Changed**

- Puts the masthead into the document flow so it naturally takes up space equivalent to its height.


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
