### PR TITLE
fix(ui-shell): a11y issue with side nav item

### DIFF
--- a/packages/carbon-web-components/src/components/ui-shell/ui-shell-story.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/ui-shell-story.ts
@@ -134,38 +134,39 @@ export const sideNav = (args) => {
       ?expanded=${expanded}>
       <bx-side-nav-items>
         <bx-side-nav-menu title="L0 menu">
-          <bx-side-nav-menu-item href="${ifNonNull(href)}">
+          <bx-side-nav-menu-item href="${ifNonNull(href)}" role="button">
             L0 menu item
           </bx-side-nav-menu-item>
-          <bx-side-nav-menu-item href="${ifNonNull(href)}">
+          <bx-side-nav-menu-item href="${ifNonNull(href)}" role="button">
             L0 menu item
           </bx-side-nav-menu-item>
-          <bx-side-nav-menu-item href="${ifNonNull(href)}">
+          <bx-side-nav-menu-item href="${ifNonNull(href)}" role="button">
             L0 menu item
           </bx-side-nav-menu-item>
         </bx-side-nav-menu>
         <bx-side-nav-menu title="L0 menu">
-          <bx-side-nav-menu-item href="${ifNonNull(href)}">
+          <bx-side-nav-menu-item href="${ifNonNull(href)}" role="button">
             L0 menu item
           </bx-side-nav-menu-item>
           <bx-side-nav-menu-item
             active
             aria-current="page"
-            href="${ifNonNull(href)}">
+            href="${ifNonNull(href)}"
+            role="button">
             L0 menu item
           </bx-side-nav-menu-item>
-          <bx-side-nav-menu-item href="${ifNonNull(href)}">
+          <bx-side-nav-menu-item href="${ifNonNull(href)}" role="button">
             L0 menu item
           </bx-side-nav-menu-item>
         </bx-side-nav-menu>
         <bx-side-nav-menu title="L0 menu">
-          <bx-side-nav-menu-item href="${ifNonNull(href)}">
+          <bx-side-nav-menu-item href="${ifNonNull(href)}" role="button">
             L0 menu item
           </bx-side-nav-menu-item>
-          <bx-side-nav-menu-item href="${ifNonNull(href)}">
+          <bx-side-nav-menu-item href="${ifNonNull(href)}" role="button">
             L0 menu item
           </bx-side-nav-menu-item>
-          <bx-side-nav-menu-item href="${ifNonNull(href)}">
+          <bx-side-nav-menu-item href="${ifNonNull(href)}" role="button">
             L0 menu item
           </bx-side-nav-menu-item>
         </bx-side-nav-menu>


### PR DESCRIPTION
### Related Ticket(s)

Closes #10918

### Description

The bx-side-nav-menu-item tag in UI Shell component throws accessibility error.
 
### Changelog


**Changed**

- Added role attribute value button to the element.


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
<img width="1696" alt="Screenshot 2023-10-17 at 3 51 06 PM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/58620134/e4264482-547e-4bc0-bc18-6bb5dde8b785">

