### PR TITLE
feat(package.json): add entry point for cwc scss files

### DIFF
--- a/packages/carbon-web-components/package.json
+++ b/packages/carbon-web-components/package.json
@@ -27,6 +27,7 @@
     "./es/": "./es/",
     "./lib/": "./lib/",
     "./dist/": "./dist/",
+    "./scss/": "./scss/",
     "./custom-elements.json": "./custom-elements.json",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

Working on Carbon for AI, I'm trying to pull in CWC v2 styles and extend them but running into issues accessing them (ie. `@use "@carbon/web-components/scss/components/button/button";`). This PR adds the `scss` files to the `exports` field so they can be pulled in.

### Changelog

**New**

- add `scss` files under exports in package.json



<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
