### PR TITLE
fix(filter panel): Open item behavior

### DIFF
--- a/packages/web-components/src/components/filter-panel/filter-group-item.ts
+++ b/packages/web-components/src/components/filter-panel/filter-group-item.ts
@@ -222,6 +222,7 @@ class DDSFilterGroupItem extends StableSelectorMixin(BXAccordionItem) {
       // Reset `allRevealed` on accordion close.
       if (prevOpen) {
         this.allRevealed = this._hasHiddenActiveFilter() || false;
+        this.removeAttribute('open');
       }
 
       // Respect `allRevealed` attribute.

--- a/packages/web-components/src/components/filter-panel/filter-panel-composite.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-composite.ts
@@ -88,13 +88,19 @@ class DDSFilterPanelComposite extends HostListenerMixin(
 
     // toggle checkbox in filter panel modal
     this.querySelectorAll(`${ddsPrefix}-filter-panel-checkbox`).forEach((e) => {
+      const closestGroupItem = e.closest(`${ddsPrefix}-filter-group-item`);
       if (e.getAttribute('value') === value) {
         e.toggleAttribute('checked');
-        e.closest(`${ddsPrefix}-filter-group-item`)?.setAttribute('open', '');
+        closestGroupItem?.setAttribute('open', '');
 
         const { stableSelector } = DDSFilterPanelCheckbox;
         this._focusElement = `${stableSelector}[value="${value}"]`;
       }
+      if(!closestGroupItem?.querySelector(`${ddsPrefix}-filter-panel-checkbox[checked]`)){
+
+        closestGroupItem?.removeAttribute('open');
+      }
+
     });
 
     const filterGroupItems = this.querySelectorAll(
@@ -161,9 +167,9 @@ class DDSFilterPanelComposite extends HostListenerMixin(
     // toggle checkbox in filter panel modal
     this.querySelectorAll(`${ddsPrefix}-filter-panel-input-select`).forEach(
       (e) => {
+        const currentGroup = e.closest(`${ddsPrefix}-filter-group-item`);
         // capture the element counterpart in Filter Panel Modal
         if (e.getAttribute('header-value') === headerValue) {
-          const currentGroup = e.closest(`${ddsPrefix}-filter-group-item`);
           currentGroup?.setAttribute('open', '');
 
           // Clears all other sibling items in the Filter Group
@@ -180,7 +186,12 @@ class DDSFilterPanelComposite extends HostListenerMixin(
 
           e.toggleAttribute('selected');
           e.toggleAttribute('is-open');
+          
         }
+        if(!currentGroup?.querySelector(`${ddsPrefix}-filter-panel-input-select[selected]`)){
+          currentGroup?.removeAttribute('open');
+        } 
+
       }
     );
 


### PR DESCRIPTION
### Related Ticket(s)

Closes # https://jsw.ibm.com/browse/ADCMS-4084

### Description

Changes how it handles proprieties so it no longer reopens closed sections even if nothing is selected.

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
