### PR TITLE
fix(video-player): move updateThumbnailUrl callback after updateComplete

### DIFF
--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -273,9 +273,13 @@ class DDSVideoPlayer extends FocusMixin(
       }
     }
 
-    if (this.offsetWidth > 0) {
-      this._updateThumbnailUrl();
-    }
+    // Move measurement & API call to callback queue & wait for update to complete.
+    setTimeout(async () => {
+      await this.updateComplete;
+      if (!this.thumbnailUrl.endsWith(`${this.offsetWidth}`)) {
+        this._updateThumbnailUrl();
+      }
+    }, 0);
   }
 
   firstUpdated() {


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-4128](https://jsw.ibm.com/browse/ADCMS-4128)

### Description

As discovered in ADCMS-4128, the video-player component does not always update to the correct kaltura thumbnails. This was found on https://www.ibm.com/think/videos, but replication and diagnosis of the issue has been difficult.

The blurry thumbnails were added in #7914 and are a function of the default thumbnail width [being set to 3px](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/packages/web-components/src/components/video-player/video-player-composite.ts#L230-L234). This allows for a softer, more deliberate blurring effect. These thumbnails are intended to be replaced by thumbnails that are the perfect size to help optimize memory/network requests.

Unfortunately, as we see on the Think Videos page, this isn't always happening correctly. Debugging this issue has been rather difficult as it seems to be some combination of a race condition and function of the number of video players in use on the page. Because of that, there's not a set of replication steps I can offer.

The solution we're trying in this PR is to move the measurement of `this.offsetWidth` and the subsequent call to `this._updateThumbnailUrl` as far as we can down the line. To do this, we're leaning on Lit to resolve `this.updateComplete`. Since that relies on the update actually completing, we need to remove the `await` from that synchronous flow of the update hooks. Using `setTimeout(() => {}, 0)` allows us to move that function to the event callback queue after the entire update lifecycle has run and completed.

### Changelog

**Changed**

- Fixes a problem where video-player thumbnails don't load properly