### PR TITLE
fix(language-selector): remove internal decorator

### DIFF
--- a/packages/carbon-web-components/src/components/input/input.ts
+++ b/packages/carbon-web-components/src/components/input/input.ts
@@ -50,6 +50,12 @@ export default class BXInput extends ValidityMixin(FormMixin(LitElement)) {
   protected _value = '';
 
   /**
+   * Set initial value of input
+   */
+  @property({ reflect: true })
+  value = '';
+
+  /**
    * Handles `oninput` event on the `<input>`.
    *
    * @param event The event.
@@ -197,32 +203,6 @@ export default class BXInput extends ValidityMixin(FormMixin(LitElement)) {
    */
   @property({ attribute: 'validity-message' })
   validityMessage = '';
-
-  /**
-   * The value of the input.
-   */
-  @property({ reflect: true })
-  get value() {
-    // FIXME: Figure out how to deal with TS2611
-    // once we have the input we can directly query for the value
-    if (this._input) {
-      return this._input.value;
-    }
-    // but before then _value will work fine
-    return this._value;
-  }
-
-  set value(value) {
-    const oldValue = this._value;
-    this._value = value;
-    // make sure that lit-element updates the right properties
-    this.requestUpdate('value', oldValue);
-    // we set the value directly on the input (when available)
-    // so that programatic manipulation updates the UI correctly
-    if (this._input) {
-      this._input.value = value;
-    }
-  }
 
   createRenderRoot() {
     return this.attachShadow({

--- a/packages/web-components/src/components/footer/combo-box.ts
+++ b/packages/web-components/src/components/footer/combo-box.ts
@@ -12,7 +12,7 @@ import { TemplateResult } from 'lit-html';
 import { html, property, query } from 'lit-element';
 import BXComboBoxItem from '../../internal/vendor/@carbon/web-components/components/combo-box/combo-box-item.js';
 import Close16 from '../../internal/vendor/@carbon/web-components/icons/close/16.js';
-import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
+import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { findIndex, forEach } from '../../globals/internal/collection-helpers';
 import DDSDropdown, { DROPDOWN_KEYBOARD_ACTION } from './dropdown';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
@@ -58,7 +58,7 @@ class DDSComboBox extends DDSDropdown {
    * The `<input>` for filtering.
    */
   @query('input')
-  private _filterInputNode!: HTMLInputElement;
+  protected _filterInputNode!: HTMLInputElement;
 
   /**
    * @param item A combo box item.
@@ -226,7 +226,8 @@ class DDSComboBox extends DDSDropdown {
     return true;
   }
 
-  updated() {
+  updated(changedProperties) {
+    super.updated(changedProperties);
     const { _listBoxNode: listBoxNode } = this;
     if (listBoxNode) {
       listBoxNode.classList.add(`${prefix}--combo-box`);

--- a/packages/web-components/src/components/footer/language-selector-desktop.ts
+++ b/packages/web-components/src/components/footer/language-selector-desktop.ts
@@ -25,7 +25,6 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * The API for language selection is still subject to change.
  *
  * @element dds-language-selector-desktop
- * @internal
  */
 @customElement(`${ddsPrefix}-language-selector-desktop`)
 class DDSLanguageSelectorDesktop extends HostListenerMixin(DDSComboBox) {
@@ -39,7 +38,7 @@ class DDSLanguageSelectorDesktop extends HostListenerMixin(DDSComboBox) {
    * The `<input>` for filtering.
    */
   @query('input')
-  private _filterInputNode!: HTMLInputElement;
+  protected _filterInputNode!: HTMLInputElement;
 
   /**
    * Reverts input value to last chosen valid language.
@@ -134,9 +133,8 @@ class DDSLanguageSelectorDesktop extends HostListenerMixin(DDSComboBox) {
   @property({ reflect: true })
   slot = 'language-selector';
 
-  // @ts-ignore
   updated(changedProperties) {
-    super.updated();
+    super.updated(changedProperties);
     if (changedProperties.has('value')) {
       this._lastValidLang = this.value;
     }

--- a/packages/web-components/src/components/footer/language-selector-mobile.ts
+++ b/packages/web-components/src/components/footer/language-selector-mobile.ts
@@ -20,7 +20,6 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * The API for language selection is still subject to change.
  *
  * @element dds-language-selector-mobile
- * @internal
  */
 @customElement(`${ddsPrefix}-language-selector-mobile`)
 class DDSLanguageSelectorMobile extends BXSelect {


### PR DESCRIPTION
### Related Ticket(s)

Closes #10885 

### Description

Removes the `@internal` decorator from `language-selector` which was preventing output to the `.d.ts`. Also removes unneeded code from `bx-input`.

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- `@internal` decorator
- unused getter/setter from `bx-input`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
