### PR TITLE
fix(masthead-v2): use more explicit selector in dropdown toggle action

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -678,8 +678,10 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
     const { isMobileVersion } = this;
     const { currentTarget } = event;
     const button = currentTarget as HTMLElement;
-    const dropdown = button.nextElementSibling as HTMLElement;
-    const isOpen = dropdown.classList.contains('is-open');
+    const dropdown = button.parentNode?.querySelector(
+      `.${prefix}--masthead__l1-dropdown`
+    ) as HTMLElement;
+    const isOpen = dropdown?.classList.contains('is-open');
 
     if (!isMobileVersion && dropdown && !isOpen) {
       // Get Button & Dropdown locations & widths


### PR DESCRIPTION
### Related Ticket(s)

### Description

The previous implementation of L1 submenu toggling relied on the toggle button's `nextElementSibling` returning specifically the `div` that contains the menu items. However, some teams are loading analytics and/or testing scripts that modify the markup that is delivered by the component, causing a different element to be returned instead, and thusly preventing the L1 menu items from opening.

### To Test

Visit the deploy preview's Masthead with L1 story and verify the dropdown menus still open and close as expected.

### Changelog

**Changed**

- L1 submenu toggle buttons use a more explicit selector to target the DOM elements necessary for opening and closing their respective submenus.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
