### PR TITLE
fix(link-with-icon): remove property set-by-enum

### DIFF
--- a/packages/web-components/src/components/link-with-icon/link-with-icon.ts
+++ b/packages/web-components/src/components/link-with-icon/link-with-icon.ts
@@ -50,7 +50,7 @@ class DDSLinkWithIcon extends StableSelectorMixin(BXLink) {
    * @internal
    */
   @property()
-  size = LINK_SIZE.LARGE;
+  size = 'lg';
 
   /**
    * @returns The main content.


### PR DESCRIPTION
### Related Ticket(s)

Followup to #11071

### Description

This PR removes <dds-link-with-icon>'s use of `LINK_SIZE.LARGE` to set the `size` property.

### Changelog

**Changed**

- Changed component internals to avoid rollup errors in extending projects