### PR TITLE
fix(ui shell): UI Shell issue with header navigation in Mobile menu

### DIFF
--- a/packages/carbon-web-components/src/components/ui-shell/ui-shell-story.mdx
+++ b/packages/carbon-web-components/src/components/ui-shell/ui-shell-story.mdx
@@ -53,6 +53,28 @@ import '@carbon/web-components/es/components/ui-shell/index.js';
 </cds-header>
 <cds-side-nav aria-label="Side navigation" expanded>
   <cds-side-nav-items>
+    <cds-header-side-nav-items has-divider="" role="list">
+      <cds-side-nav-link href="javascript:void(0)" role="listitem">
+        Link 1
+      </cds-side-nav-link>
+      <cds-side-nav-link href="javascript:void(0)" role="listitem">
+        Link 2
+      </cds-side-nav-link>
+      <cds-side-nav-link href="javascript:void(0)" role="listitem">
+        Link 3
+      </cds-side-nav-link>
+      <cds-side-nav-menu title="Link 4" role="listitem">
+        <cds-side-nav-menu-item href="javascript:void(0)" tabindex="-1">
+          Sub-link 1
+        </cds-side-nav-menu-item>
+        <cds-side-nav-menu-item href="javascript:void(0)" tabindex="-1">
+          Sub-link 2
+        </cds-side-nav-menu-item>
+        <cds-side-nav-menu-item href="javascript:void(0)" tabindex="-1">
+          Sub-link 3
+        </cds-side-nav-menu-item>
+      </cds-side-nav-menu>
+    </cds-header-side-nav-items>
     <cds-side-nav-menu title="L0 menu">
       <cds-side-nav-menu-item href="www.ibm.com">
         L0 menu item


### PR DESCRIPTION
### Related Ticket(s)

Closes #11097 

### Description

Header navigation not showing in mobile menu, when there is both side and header navigation. Issue was related to documentation.

### Changelog

**Changed**

- Updated documentation by adding "cds-header-side-nav-items" component under "cds-side-nav-items".


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
