### PR TITLE
fix(video-player): v2 alignment

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -69,6 +69,7 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
     position: relative;
     width: 100%;
     height: 100%;
+    padding-top: 0;
 
     &::before {
       content: '';


### PR DESCRIPTION
### Related Ticket(s)

none

### Description

looks like some v2 changes accidentally effected the video-player alignment. This should bring it back centered

before: 
<img width="1016" alt="Screenshot 2023-11-14 at 9 32 39 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/20210594/1eaf3a22-36d2-4729-8657-40e497e073b8">
after:
<img width="737" alt="Screenshot 2023-11-14 at 9 38 17 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/20210594/75e1cd8f-dd1f-42d2-a931-d2bc4c0f32af">

### Changelog



**Changed**

- set padding to 0


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
