### PR TITLE
feat(github-actions): add workflow for publishing masthead v2 alpha

### DIFF
--- a/.github/workflows/publish-v2alpha-cdn.yml
+++ b/.github/workflows/publish-v2alpha-cdn.yml
@@ -1,0 +1,45 @@
+name: publish-v2alpha-cdn (Publish Canary release to CDN)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
+    runs-on: ubuntu-20.04
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+      - name: Build project
+        run: yarn lerna run --ignore '@carbon/react' build
+      - name: Create CDN artifacts
+        run: yarn build:sass:cdn && yarn build:components
+        working-directory: packages/web-components
+      - name: Publish to COS (Carbon for IBM.com Web Components)
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ${{ secrets.COS_BUCKET_COMMON }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.COS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.COS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.COS_REGION }}
+          AWS_S3_ENDPOINT: https://${{ secrets.COS_ENDPOINT }}
+          SOURCE_DIR: 'packages/web-components/dist'
+          DEST_DIR: 'common/carbon-for-ibm-dotcom/version/2.0.0.alpha.${{ github.run_id }}'
+      - uses: act10ns/slack@v2
+        with:
+          status: ${{ job.status }}
+        if: failure()


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This is a workflow for publishing a v2 alpha CDN of Carbon for IBM.com web components. This is a manually triggered workflow. 

This was created as we were seeing memory issues running on Jenkins.

### Changelog

**New**

- `publish-v2alpha-cdn.yml`
