### PR TITLE
[Feature Section]: Expand the availability of CTA types in feature card sections

### DIFF
--- a/packages/web-components/src/components/card/card.scss
+++ b/packages/web-components/src/components/card/card.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2020, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -30,13 +30,6 @@
     svg,
     ::slotted(svg[slot='icon']) {
       color: $inverse-link;
-    }
-  }
-
-  &:hover {
-    ::slotted(svg[slot='icon']),
-    .#{$prefix}--card__cta__copy {
-      color: $hover-primary-text;
     }
   }
 }

--- a/packages/web-components/src/components/cta/card-cta.ts
+++ b/packages/web-components/src/components/cta/card-cta.ts
@@ -61,7 +61,9 @@ class DDSCardCTA extends VideoCTAMixin(CTAMixin(DDSCard)) {
       )
     );
 
-    const heading = this.querySelector('dds-card-heading')
+    const heading = this.querySelector(
+      'dds-card-heading, dds-card-link-heading'
+    )
       ? html``
       : html` <dds-card-heading>${caption}</dds-card-heading> `;
     return html` <slot name="heading"></slot>${heading} `;

--- a/packages/web-components/src/components/feature-section/__stories__/feature-section.stories.ts
+++ b/packages/web-components/src/components/feature-section/__stories__/feature-section.stories.ts
@@ -20,7 +20,7 @@ import imgSm1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x7
 import imgXs1x1 from '../../../../../storybook-images/assets/320/fpo--1x1--320x320--002.jpg';
 import { MEDIA_ALIGNMENT } from '../defs';
 import { CTA_TYPE } from '../../cta/defs';
-import { types, typeOptions } from '../../cta/__stories__/ctaTypeConfig';
+import { typeOptions } from '../../cta/__stories__/ctaTypeConfig';
 
 import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';

--- a/packages/web-components/src/components/feature-section/__stories__/feature-section.stories.ts
+++ b/packages/web-components/src/components/feature-section/__stories__/feature-section.stories.ts
@@ -20,6 +20,7 @@ import imgSm1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x7
 import imgXs1x1 from '../../../../../storybook-images/assets/320/fpo--1x1--320x320--002.jpg';
 import { MEDIA_ALIGNMENT } from '../defs';
 import { CTA_TYPE } from '../../cta/defs';
+import { types, typeOptions } from '../../cta/__stories__/ctaTypeConfig';
 
 import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';
@@ -27,11 +28,6 @@ import textNullable from '../../../../.storybook/knob-text-nullable';
 const mediaAlignment = {
   [`Left`]: MEDIA_ALIGNMENT.LEFT,
   [`Right`]: MEDIA_ALIGNMENT.RIGHT,
-};
-
-const types = {
-  [`Local (${CTA_TYPE.LOCAL})`]: CTA_TYPE.LOCAL,
-  [`External (${CTA_TYPE.EXTERNAL})`]: CTA_TYPE.EXTERNAL,
 };
 
 export const Default = (args) => {
@@ -100,7 +96,7 @@ export default {
           You decide how you want to work and where to focus our expertise.`
         ),
         alt: textNullable('Image Alt Text (alt):', 'Image alt text'),
-        ctaType: select('CTA type (cta-type)', types, CTA_TYPE.LOCAL),
+        ctaType: select('CTA type (cta-type)', typeOptions, CTA_TYPE.LOCAL),
         href: textNullable('CTA Href (href):', 'https://example.com'),
       }),
     },

--- a/packages/web-components/src/components/feature-section/__stories__/feature-section.stories.ts
+++ b/packages/web-components/src/components/feature-section/__stories__/feature-section.stories.ts
@@ -57,7 +57,8 @@ export const Default = (args) => {
         slot="footer"
         href="${href}"
         cta-type="${ifNonNull(ctaType)}"
-        color-scheme="inverse">
+        color-scheme="inverse"
+        no-poster>
         <dds-card-link-heading
           >Try a free virtual business framing session with IBM
           Garage</dds-card-link-heading
@@ -70,7 +71,10 @@ export const Default = (args) => {
 
 export default {
   title: 'Components/Feature section',
-  decorators: [(story) => html` ${story()} `],
+  decorators: [
+    (story) =>
+      html`<dds-video-cta-container>${story()}</dds-video-cta-container>`,
+  ],
   parameters: {
     ...readme.parameters,
     hasStoryPadding: true,


### PR DESCRIPTION
### Related Ticket(s)

Closes #11159
[Jira ticket](https://jsw.ibm.com/browse/ADCMS-4274)

### Description

Expand options in the Feature section story to include all supported CTA types. Fix a bug when using the video CTA type, where a double header would appear.

### Changelog

**Changed**

- Expand options in the Feature section story to include all supported CTA types.
- Fix a bug when using the video CTA type, where a double header would appear.

### Testing

- [ ] Open Feature section > Default
- [ ] All CTA types should be represented in the "CTA type (cta-type)" list. Pick through each and verify the icon on the CTA card updates
- [ ] Select "Video (video)" for the "CTA type(cta-type)"
- [ ] Enter a valid video id into the "CTA Href (href)" field, eg. `1_9h94wo6b`
- [ ] Click on the CTA card in the Feature section
- [ ] It should open a modal and playback the video

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
