### PR TITLE
fix(modal): focus trap issue fix in v2

### DIFF
--- a/packages/carbon-web-components/src/components/modal/modal.ts
+++ b/packages/carbon-web-components/src/components/modal/modal.ts
@@ -151,10 +151,18 @@ class CDSModal extends HostListenerMixin(LitElement) {
         relatedTarget === endSentinelNode ||
         comparisonResult & FOLLOWING
       ) {
-        await (this.constructor as typeof CDSModal)._delay();
+        await (this.constructor as typeof CDSModal)._delay(0.25);
         if (!tryFocusElems(this.querySelectorAll(selectorTabbableForModal))) {
           this.focus();
         }
+      }
+    } else if (open && relatedTarget === startSentinelNode && PRECEDING) {
+      await (this.constructor as typeof CDSModal)._delay();
+      if (
+        !tryFocusElems(this.querySelectorAll(selectorTabbableForModal), true) &&
+        relatedTarget !== this
+      ) {
+        this.focus();
       }
     }
   };
@@ -301,11 +309,10 @@ class CDSModal extends HostListenerMixin(LitElement) {
       ...containerClass,
     });
     return html`
-      <a
+      <button
         id="start-sentinel"
         class="${prefix}--visually-hidden"
-        href="javascript:void 0"
-        role="navigation"></a>
+        role="button"></button>
       <div
         aria-label=${ariaLabel}
         part="dialog"
@@ -318,11 +325,10 @@ class CDSModal extends HostListenerMixin(LitElement) {
           ? html` <div class="cds--modal-content--overflow-indicator"></div> `
           : ``}
       </div>
-      <a
+      <button
         id="end-sentinel"
         class="${prefix}--visually-hidden"
-        href="javascript:void 0"
-        role="navigation"></a>
+        role="button"></button>
     `;
   }
 

--- a/packages/carbon-web-components/src/globals/settings.ts
+++ b/packages/carbon-web-components/src/globals/settings.ts
@@ -67,7 +67,8 @@ const selectorTabbable = `
   ${prefix}-header-nav-item,
   ${prefix}-side-nav-link,
   ${prefix}-side-nav-menu,
-  ${prefix}-side-nav-menu-item
+  ${prefix}-side-nav-menu-item,
+  ${prefix}-modal-footer-button
 `;
 
 // Because we're going to have a bunch of exports


### PR DESCRIPTION
### Related Ticket(s)

Closes https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/10966

### Description

Focus trap not working in Modal

### Changelog

**New**

- Added Modal footer button to tabbable items in settings.js

**Changed**

- Updated condition for focus trapping


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
