### PR TITLE
chore(gulp): fix spread import path

### DIFF
--- a/packages/web-components/gulp-tasks/build/modules/icons.js
+++ b/packages/web-components/gulp-tasks/build/modules/icons.js
@@ -41,10 +41,7 @@ async function icons() {
           const descriptor = await descriptorFromSVG(String(file.contents));
           file.contents = Buffer.from(`
                 import { svg } from 'lit';
-                import spread from '${path.resolve(
-                  __dirname,
-                  '../src/internal/vendor/@carbon/web-components/globals/directives/spread'
-                )}';          
+                import spread from '../internal/vendor/@carbon/web-components/globals/directives/spread.js';
                 const svgResultIBMdotcomIcon = ${createSVGResultFromIconDescriptor(descriptor)};
                 export default svgResultIBMdotcomIcon;
               `);


### PR DESCRIPTION
### Description

Fix `spread.js` import path

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
