### PR TITLE
chore(dotcom-v2): various fixes for `rc.2`

### DIFF
--- a/packages/styles/scss/components/button-group/_button-group.scss
+++ b/packages/styles/scss/components/button-group/_button-group.scss
@@ -39,7 +39,7 @@
 
       @media print {
         background: $white-0;
-        border: rem(1px) solid $gray-100;
+        border: to-rem(1px) solid $gray-100;
         color: $gray-100;
         font-weight: 600;
         display: block;

--- a/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
+++ b/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
@@ -129,7 +129,7 @@
   :host(#{$c4d-prefix}-callout-with-media) ::slotted([slot='heading']),
   :host(#{$c4d-prefix}-callout-with-media) ::slotted([slot='copy']) {
     padding-right: $spacing-07;
-    max-width: rem(640px);
+    max-width: to-rem(640px);
     width: auto;
   }
 

--- a/packages/styles/scss/components/card-section-offset/_card-section-offset.scss
+++ b/packages/styles/scss/components/card-section-offset/_card-section-offset.scss
@@ -72,7 +72,7 @@
 
     ::slotted([slot='action']) {
       width: 90%;
-      max-width: rem(640px);
+      max-width: to-rem(640px);
 
       @include breakpoint(md) {
         width: calc(100% - $spacing-07);

--- a/packages/styles/scss/components/content-block-media/_content-block-media.scss
+++ b/packages/styles/scss/components/content-block-media/_content-block-media.scss
@@ -37,7 +37,7 @@
     }
 
     .#{$prefix}--feature-card {
-      max-width: rem(640px);
+      max-width: to-rem(640px);
     }
   }
 

--- a/packages/styles/scss/components/content-block-simple/_content-block-simple.scss
+++ b/packages/styles/scss/components/content-block-simple/_content-block-simple.scss
@@ -13,7 +13,7 @@
 
 @mixin content-block-simple {
   .#{$prefix}--content-block-simple__media-video {
-    max-width: rem(640px);
+    max-width: to-rem(640px);
   }
 
   .#{$prefix}--content-block-simple__content {

--- a/packages/styles/scss/components/content-item-row-media/_content-item-row-media.scss
+++ b/packages/styles/scss/components/content-item-row-media/_content-item-row-media.scss
@@ -67,7 +67,7 @@
   }
 
   :host(#{$c4d-prefix}-content-item-row-media-copy) ::slotted(:not([slot])) {
-    max-width: rem(640px);
+    max-width: to-rem(640px);
     p {
       color: $text-primary;
     }

--- a/packages/styles/scss/components/content-item-row/_content-item-row.scss
+++ b/packages/styles/scss/components/content-item-row/_content-item-row.scss
@@ -161,7 +161,7 @@
   }
 
   :host(#{$c4d-prefix}-content-item-row-copy) ::slotted(:not([slot])) {
-    max-width: rem(640px);
+    max-width: to-rem(640px);
   }
 
   :host(#{$c4d-prefix}-content-item-row-eyebrow) {
@@ -193,18 +193,18 @@
     grid-auto-flow: dense;
 
     @include breakpoint(md) {
-      min-height: rem(306px);
+      min-height: to-rem(306px);
       grid-template-columns: repeat(8, 1fr);
       column-gap: $spacing-07;
     }
 
     @include breakpoint(lg) {
-      min-height: rem(272px);
+      min-height: to-rem(272px);
       grid-template-columns: repeat(12, 1fr);
     }
 
     @include breakpoint(xlg) {
-      min-height: rem(252px);
+      min-height: to-rem(252px);
     }
   }
 

--- a/packages/styles/scss/components/cta-block/_cta-block.scss
+++ b/packages/styles/scss/components/cta-block/_cta-block.scss
@@ -79,7 +79,7 @@
     .#{$prefix}--content-block__heading,
     .#{$prefix}--content-block__copy {
       width: 90%;
-      max-width: rem(640px);
+      max-width: to-rem(640px);
 
       @include breakpoint(sm) {
         width: 100%;

--- a/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
+++ b/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
@@ -15,7 +15,7 @@
 @use '@carbon/styles/scss/utilities' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/components/modal' as *;
-@use '../../../../carbon-web-components/src/components/modal/modal';
+@use '@carbon/web-components/scss/components/modal/modal' as *;
 
 /// Expressive modal
 /// @access private
@@ -23,8 +23,8 @@
 
 @mixin expressive-modal {
   $modal: '.#{$prefix}--modal';
-  $button-size: rem(48px);
-  $icon-size: rem(20px);
+  $button-size: to-rem(48px);
+  $icon-size: to-rem(20px);
   $offset-close-icon: $spacing-07 - math.div($button-size - $icon-size, 2);
 
   :host(#{$c4d-prefix}-expressive-modal) {
@@ -122,6 +122,6 @@
   .#{$prefix}--modal--expressive--fullwidth .#{$prefix}--modal-content {
     padding-right: 0;
     height: auto;
-    min-height: rem(500px);
+    min-height: to-rem(500px);
   }
 }

--- a/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
+++ b/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
@@ -10,12 +10,12 @@
 @use '../../globals/vars' as *;
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/styles/scss/utilities' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/components/modal' as *;
-@use '@carbon/web-components/scss/components/modal/modal' as *;
 
 /// Expressive modal
 /// @access private
@@ -23,12 +23,10 @@
 
 @mixin expressive-modal {
   $modal: '.#{$prefix}--modal';
-  $button-size: to-rem(48px);
   $icon-size: to-rem(20px);
-  $offset-close-icon: $spacing-07 - math.div($button-size - $icon-size, 2);
 
   :host(#{$c4d-prefix}-expressive-modal) {
-    @extend :host(#{$prefix}-modal);
+    @extend .#{$prefix}--modal;
 
     .#{$prefix}--modal-container {
       grid-template-rows: 1fr;
@@ -60,7 +58,21 @@
   }
 
   :host(#{$c4d-prefix}-expressive-modal[open]) {
-    @extend :host(#{$prefix}-modal[open]);
+    @extend .#{$prefix}--modal;
+
+    opacity: 1;
+    transition: opacity $duration-moderate-02 motion(entrance, expressive),
+      visibility 0ms linear;
+    visibility: inherit;
+
+    .#{$prefix}--modal-container {
+      transform: translate3d(0, 0, 0);
+      transition: transform $duration-moderate-02 motion(entrance, expressive);
+    }
+
+    @media screen and (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   }
 
   :host(#{$c4d-prefix}-expressive-modal-footer) .#{$prefix}--modal-footer {

--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -26,7 +26,7 @@
 $fcb-large-custom-bp-copy: 992px;
 $fcb-large-custom-bp-nocopy: 752px;
 $fcb-breakpoint-up--lg: map.get(map.get($grid-breakpoints, 'lg'), 'width') -
-  rem(1px);
+  to-rem(1px);
 
 $feature-flags: (
   enable-experimental-tile-contrast: true,
@@ -235,8 +235,8 @@ $feature-flags: (
 
       svg {
         @include breakpoint(sm) {
-          width: rem(20px);
-          height: rem(20px);
+          width: to-rem(20px);
+          height: to-rem(20px);
         }
 
         @include breakpoint(md) {
@@ -347,7 +347,7 @@ $feature-flags: (
       ::slotted(#{$c4d-prefix}-card-eyebrow),
       ::slotted(#{$c4d-prefix}-card-heading) {
         width: 100%;
-        max-width: rem(480px);
+        max-width: to-rem(480px);
 
         @include breakpoint(md) {
           width: 90%;
@@ -460,8 +460,8 @@ $feature-flags: (
     float: none;
 
     @include breakpoint(sm) {
-      width: rem(20px);
-      height: rem(20px);
+      width: to-rem(20px);
+      height: to-rem(20px);
     }
 
     @include breakpoint(md) {

--- a/packages/styles/scss/components/filter-panel/_filter-panel.scss
+++ b/packages/styles/scss/components/filter-panel/_filter-panel.scss
@@ -28,7 +28,7 @@
   .#{$prefix}--filter-panel__section {
     box-sizing: border-box;
     background-color: $layer-01;
-    padding-bottom: rem(112px);
+    padding-bottom: to-rem(112px);
     margin-top: $spacing-05;
     overflow: initial;
 
@@ -67,14 +67,14 @@
       outline: $spacing-01 solid $focus;
       margin-left: $spacing-01;
       margin-right: $spacing-01;
-      padding-left: rem(14px);
+      padding-left: to-rem(14px);
       z-index: 1;
     }
 
     .#{$prefix}--close__icon {
       position: absolute;
       right: $spacing-05;
-      top: rem(10px);
+      top: to-rem(10px);
     }
   }
 
@@ -161,8 +161,8 @@
   }
 
   :host(#{$c4d-prefix}-filter-panel-checkbox) {
-    padding-left: rem(14px);
-    padding-bottom: rem(6px);
+    padding-left: to-rem(14px);
+    padding-bottom: to-rem(6px);
     @extend .#{$prefix}--checkbox-label;
     @include type-style('body-compact-01');
 
@@ -225,7 +225,7 @@
     .#{$prefix}--close__icon {
       position: absolute;
       right: $spacing-05;
-      top: rem(10px);
+      top: to-rem(10px);
     }
   }
 

--- a/packages/styles/scss/components/footer/_footer-logo.scss
+++ b/packages/styles/scss/components/footer/_footer-logo.scss
@@ -69,7 +69,7 @@
 
     @include breakpoint-between(md, lg) {
       position: absolute;
-      bottom: rem(58.5px);
+      bottom: to-rem(58.5px);
     }
   }
 }

--- a/packages/styles/scss/components/footer/_footer.scss
+++ b/packages/styles/scss/components/footer/_footer.scss
@@ -486,7 +486,7 @@
     }
 
     .#{$prefix}--list-box__menu {
-      bottom: rem($spacing-09);
+      bottom: to-rem($spacing-09);
     }
 
     .#{$prefix}--dropdown,

--- a/packages/styles/scss/components/footer/_language-selector.scss
+++ b/packages/styles/scss/components/footer/_language-selector.scss
@@ -113,7 +113,7 @@
     .#{$prefix}--list-box--up {
       .#{$prefix}--list-box__menu {
         z-index: 1;
-        bottom: rem(47px);
+        bottom: to-rem(47px);
       }
     }
 

--- a/packages/styles/scss/components/global-banner/_global-banner.scss
+++ b/packages/styles/scss/components/global-banner/_global-banner.scss
@@ -46,8 +46,8 @@
 
         &:focus,
         &:active {
-          outline: rem(1px) solid $background;
-          outline-offset: rem(-1px);
+          outline: to-rem(1px) solid $background;
+          outline-offset: to-rem(-1px);
           border-color: $focus;
         }
       }

--- a/packages/styles/scss/components/horizontal-rule/_horizontal-rule.scss
+++ b/packages/styles/scss/components/horizontal-rule/_horizontal-rule.scss
@@ -14,7 +14,7 @@
 @mixin horizontal-rule {
   $subtle-contrast: $border-subtle-01;
   $strong-contrast: $border-strong-01;
-  $thin-weight: rem(1px);
+  $thin-weight: to-rem(1px);
 
   :host(#{$c4d-prefix}-hr) {
     display: block;

--- a/packages/styles/scss/components/leadspace-block/_leadspace-block.scss
+++ b/packages/styles/scss/components/leadspace-block/_leadspace-block.scss
@@ -63,7 +63,7 @@
     width: 100%;
 
     @include breakpoint(md) {
-      max-width: rem(640px);
+      max-width: to-rem(640px);
       padding-right: $spacing-07;
     }
   }

--- a/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
+++ b/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
@@ -105,7 +105,7 @@
       padding-left: 0;
       color: $text-primary;
 
-      max-width: rem(640px);
+      max-width: to-rem(640px);
 
       @include breakpoint(md) {
         width: calc(75% - $spacing-07);
@@ -227,7 +227,7 @@
     display: block;
     padding-top: $spacing-07;
     margin-bottom: 0;
-    max-width: rem(640px);
+    max-width: to-rem(640px);
 
     @include breakpoint(md) {
       width: calc(75% - #{$spacing-07});

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -42,7 +42,7 @@ $btn-min-width: 26;
   $cds--gradient-light: #ffffff;
   $cds--gradient-dark: #161616;
 
-  .#{$prefix}--leadspace__section {
+  .#{$c4d-prefix}--leadspace__section {
     display: flex;
     background-color: $background;
 
@@ -51,43 +51,34 @@ $btn-min-width: 26;
     }
   }
 
-  .#{$prefix}--leadspace__gradient__stops stop {
+  .#{$c4d-prefix}--leadspace__gradient__stops stop {
     stop-color: $background;
   }
 
-  .#{$prefix}--leadspace--centered .#{$prefix}--leadspace__overlay {
+  .#{$c4d-prefix}--leadspace--centered .#{$c4d-prefix}--leadspace__overlay {
     background-color: $background;
   }
 
   ::slotted(#{$c4d-prefix}-leadspace-heading),
-  .#{$prefix}--leadspace__title,
-  .#{$prefix}--leadspace__desc {
+  .#{$c4d-prefix}--leadspace__title,
+  .#{$c4d-prefix}--leadspace__desc {
     color: $text-primary;
     padding-right: 0;
   }
 
-  .#{$prefix}--leadspace--centered .#{$prefix}--leadspace__desc {
+  .#{$c4d-prefix}--leadspace--centered .#{$c4d-prefix}--leadspace__desc {
     width: 100%;
   }
 
-  .#{$prefix}--buttongroup {
-    padding-left: 0;
-
-    @include breakpoint(md) {
-      display: flex;
-    }
-  }
-
   @include breakpoint(md) {
-    .#{$prefix}--leadspace--centered .#{$prefix}--leadspace__overlay {
+    .#{$c4d-prefix}--leadspace--centered .#{$c4d-prefix}--leadspace__overlay {
       background-color: transparent;
     }
   }
 }
 
 @mixin leadspace {
-  ::slotted([slot='action']),
-  .#{$prefix}--buttongroup {
+  ::slotted([slot='action']) {
     padding-top: $spacing-07;
   }
 
@@ -129,7 +120,7 @@ $btn-min-width: 26;
   }
 
   :host(#{$c4d-prefix}-leadspace),
-  .#{$prefix}--leadspace {
+  .#{$c4d-prefix}--leadspace {
     .#{$prefix}--image {
       /* stylelint-disable-next-line comment-whitespace-inside */
       /* !rtl:raw:
@@ -142,7 +133,7 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--leadspace--content__container {
+    .#{$c4d-prefix}--leadspace--content__container {
       display: flex;
       flex-direction: column;
       justify-content: space-between;
@@ -150,7 +141,7 @@ $btn-min-width: 26;
       margin-bottom: $spacing-07;
     }
 
-    .#{$prefix}--leadspace__container {
+    .#{$c4d-prefix}--leadspace__container {
       position: relative;
       width: 100%;
 
@@ -159,7 +150,6 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--buttongroup,
     ::slotted(#{$c4d-prefix}-button-group),
     ::slotted(#{$c4d-prefix}-leadspace-block-cta) {
       @include breakpoint(md) {
@@ -174,7 +164,7 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--leadspace__overlay {
+    .#{$c4d-prefix}--leadspace__overlay {
       @include make-container;
 
       position: relative;
@@ -191,14 +181,14 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--leadspace--productive {
+    .#{$c4d-prefix}--leadspace--productive {
       ::slotted(#{$c4d-prefix}-leadspace-heading),
-      .#{$prefix}--leadspace__title {
+      .#{$c4d-prefix}--leadspace__title {
         @include type-style(fluid-heading-05, true);
       }
     }
 
-    .#{$prefix}--leadspace__desc {
+    .#{$c4d-prefix}--leadspace__desc {
       z-index: 1;
       @include make-col-ready;
       @include type-style(fluid-heading-03, true);
@@ -219,24 +209,20 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--leadspace__row {
+    .#{$c4d-prefix}--leadspace__row {
       @include make-row;
 
       flex-flow: column nowrap;
     }
 
-    .#{$prefix}--leadspace__action {
+    .#{$c4d-prefix}--leadspace__action {
       @include breakpoint(md) {
         display: inline-block;
       }
     }
 
-    .#{$prefix}--btn {
-      min-width: carbon--mini-units($btn-min-width);
-    }
-
     @include breakpoint(md) {
-      .#{$prefix}--leadspace__overlay {
+      .#{$c4d-prefix}--leadspace__overlay {
         padding-top: $spacing-07;
         top: 0;
       }
@@ -246,13 +232,13 @@ $btn-min-width: 26;
       }
 
       ::slotted(#{$c4d-prefix}-leadspace-heading),
-      .#{$prefix}--leadspace__title {
+      .#{$c4d-prefix}--leadspace__title {
         width: percentage(math.div(6, 8));
 
         flex-shrink: 1;
       }
 
-      .#{$prefix}--leadspace__desc {
+      .#{$c4d-prefix}--leadspace__desc {
         @include make-col(6, 8);
       }
     }
@@ -266,35 +252,35 @@ $btn-min-width: 26;
       margin-left: -50vw;
       margin-right: -50vw;
 
-      .#{$prefix}--leadspace__section {
+      .#{$c4d-prefix}--leadspace__section {
         margin-right: auto;
         margin-left: auto;
         position: relative;
         max-width: 99rem;
       }
 
-      .#{$prefix}--leadspace__container {
+      .#{$c4d-prefix}--leadspace__container {
         width: 100%;
       }
 
       ::slotted(#{$c4d-prefix}-leadspace-heading),
-      .#{$prefix}--leadspace__title {
+      .#{$c4d-prefix}--leadspace__title {
         width: percentage(math.div(8, 16));
       }
 
-      .#{$prefix}--leadspace__desc {
+      .#{$c4d-prefix}--leadspace__desc {
         @include make-col(6, 16);
       }
 
-      .#{$prefix}--leadspace--productive {
+      .#{$c4d-prefix}--leadspace--productive {
         ::slotted(#{$c4d-prefix}-leadspace-heading),
-        .#{$prefix}--leadspace__title {
+        .#{$c4d-prefix}--leadspace__title {
           @include make-col(7, 16);
         }
       }
     }
 
-    .#{$prefix}--leadspace--centered {
+    .#{$c4d-prefix}--leadspace--centered {
       margin-right: auto;
       margin-left: auto;
       max-width: 99rem;
@@ -303,8 +289,7 @@ $btn-min-width: 26;
       background-position: center top;
 
       ::slotted(#{$c4d-prefix}-button-group),
-      ::slotted([slot='action']),
-      .#{$prefix}--buttongroup {
+      ::slotted([slot='action']) {
         padding-top: $spacing-05;
         padding-bottom: 0;
 
@@ -313,12 +298,12 @@ $btn-min-width: 26;
         }
       }
 
-      &.#{$prefix}--leadspace__section {
+      &.#{$c4d-prefix}--leadspace__section {
         min-height: to-rem(560px);
         padding-top: 0;
       }
 
-      .#{$prefix}--leadspace--content__container {
+      .#{$c4d-prefix}--leadspace--content__container {
         display: flex;
         flex-direction: column;
         justify-content: space-between;
@@ -328,7 +313,7 @@ $btn-min-width: 26;
         @include make-col(4, 4);
       }
 
-      .#{$prefix}--leadspace__desc {
+      .#{$c4d-prefix}--leadspace__desc {
         width: 95%;
         padding-top: $spacing-09;
 
@@ -336,30 +321,30 @@ $btn-min-width: 26;
       }
 
       ::slotted(#{$c4d-prefix}-leadspace-heading),
-      .#{$prefix}--leadspace__title {
+      .#{$c4d-prefix}--leadspace__title {
         margin-bottom: 0;
       }
 
-      .#{$prefix}--leadspace__desc,
+      .#{$c4d-prefix}--leadspace__desc,
       ::slotted(#{$c4d-prefix}-leadspace-heading),
-      .#{$prefix}--leadspace__title {
+      .#{$c4d-prefix}--leadspace__title {
         flex: none;
       }
 
       @include themed-items;
 
       @include breakpoint(sm) {
-        .#{$prefix}--leadspace__overlay {
+        .#{$c4d-prefix}--leadspace__overlay {
           padding: $spacing-05 0 0 0;
         }
       }
 
       @include breakpoint(md) {
-        .#{$prefix}--leadspace__overlay {
+        .#{$c4d-prefix}--leadspace__overlay {
           padding: $spacing-07 0 0 0;
         }
 
-        .#{$prefix}--leadspace--content__container {
+        .#{$c4d-prefix}--leadspace--content__container {
           margin: 0 auto;
           padding-left: $spacing-06;
           @include breakpoint(lg) {
@@ -368,18 +353,18 @@ $btn-min-width: 26;
         }
 
         ::slotted(#{$c4d-prefix}-leadspace-heading),
-        .#{$prefix}--leadspace__title,
-        .#{$prefix}--leadspace__desc {
+        .#{$c4d-prefix}--leadspace__title,
+        .#{$c4d-prefix}--leadspace__desc {
           @include content-width;
         }
 
-        .#{$prefix}--leadspace__desc {
+        .#{$c4d-prefix}--leadspace__desc {
           padding-top: $spacing-09;
         }
       }
 
       @include breakpoint(lg) {
-        .#{$prefix}--leadspace__overlay {
+        .#{$c4d-prefix}--leadspace__overlay {
           height: 100%;
           padding: $spacing-10 0 0 0;
         }
@@ -388,8 +373,8 @@ $btn-min-width: 26;
 
     @include themed-items;
 
-    .#{$prefix}--leadspace--g100,
-    .#{$prefix}--leadspace--g90 {
+    .#{$c4d-prefix}--leadspace--g100,
+    .#{$c4d-prefix}--leadspace--g90 {
       @include theme(
         $g100,
         feature-flag-enabled('enable-css-custom-properties')
@@ -398,7 +383,7 @@ $btn-min-width: 26;
       @include themed-items(dark);
     }
 
-    .#{$prefix}--leadspace__gradient {
+    .#{$c4d-prefix}--leadspace__gradient {
       display: block;
       position: absolute;
       top: 0;
@@ -412,11 +397,11 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--leadspace__gradient__rect {
+    .#{$c4d-prefix}--leadspace__gradient__rect {
       fill: url(#stops);
     }
 
-    .#{$prefix}--leadspace__gradient__stops stop {
+    .#{$c4d-prefix}--leadspace__gradient__stops stop {
       &:nth-of-type(1) {
         stop-opacity: 1;
         /* stylelint-disable-next-line comment-whitespace-inside */
@@ -446,8 +431,8 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--leadspace--centered
-      .#{$prefix}--leadspace__gradient__stops
+    .#{$c4d-prefix}--leadspace--centered
+      .#{$c4d-prefix}--leadspace__gradient__stops
       stop {
       &:nth-of-type(1) {
         stop-opacity: 1;
@@ -467,33 +452,33 @@ $btn-min-width: 26;
     }
   }
 
-  .#{$prefix}--leadspace__section {
-    height: auto;
-  }
+  // .#{$c4d-prefix}--leadspace__section {
+  //   height: auto;
+  // }
 
-  .#{$prefix}--leadspace--medium {
-    .#{$prefix}--leadspace__section {
-      @include breakpoint(lg) {
-        min-height: carbon--mini-units(60);
-      }
-    }
-  }
+  // .#{$c4d-prefix}--leadspace--medium {
+  //   .#{$c4d-prefix}--leadspace__section {
+  //     @include breakpoint(lg) {
+  //       min-height: 30rem;
+  //     }
+  //   }
+  // }
 
-  .#{$prefix}--leadspace--tall {
-    .#{$prefix}--leadspace__section {
-      @include breakpoint(lg) {
-        min-height: carbon--mini-units(70);
-      }
-    }
-  }
+  // .#{$c4d-prefix}--leadspace--tall {
+  //   .#{$c4d-prefix}--leadspace__section {
+  //     @include breakpoint(lg) {
+  //       min-height: 35rem;
+  //     }
+  //   }
+  // }
 
-  .#{$prefix}--leadspace--super {
-    .#{$prefix}--leadspace__section {
-      @include breakpoint(lg) {
-        min-height: carbon--mini-units(80);
-      }
-    }
-  }
+  // .#{$c4d-prefix}--leadspace--super {
+  //   .#{$c4d-prefix}--leadspace__section {
+  //     @include breakpoint(lg) {
+  //       min-height: 40rem;
+  //     }
+  //   }
+  // }
 
   :host(#{$c4d-prefix}-leadspace) ::slotted([slot='navigation']) {
     z-index: 1;
@@ -520,7 +505,7 @@ $btn-min-width: 26;
   }
 
   :host(#{$c4d-prefix}-leadspace-heading),
-  .#{$prefix}--leadspace__title {
+  .#{$c4d-prefix}--leadspace__title {
     padding-top: 0;
     margin-bottom: $spacing-09;
     padding-left: $spacing-05;
@@ -547,30 +532,22 @@ $btn-min-width: 26;
 
   :host(#{$c4d-prefix}-leadspace)[size='super'] {
     @include breakpoint(lg) {
-      .#{$prefix}--leadspace__overlay {
-        height: to-rem(608px);
+      .#{$c4d-prefix}--leadspace__overlay {
+        height: 40rem;
       }
     }
 
-    .#{$prefix}--leadspace__section {
+    .#{$c4d-prefix}--leadspace__section {
       @include breakpoint(lg) {
-        min-height: carbon--mini-units(80);
-      }
-    }
-  }
-
-  :host(#{$c4d-prefix}-leadspace)[size='tall'] {
-    @include breakpoint(lg) {
-      .#{$prefix}--leadspace__overlay {
-        height: to-rem(528px);
+        min-height: 40rem;
       }
     }
   }
 
   :host(#{$c4d-prefix}-leadspace)[size='medium'] {
     @include breakpoint(lg) {
-      .#{$prefix}--leadspace__overlay {
-        height: to-rem(448px);
+      .#{$c4d-prefix}--leadspace__overlay {
+        height: 30rem;
       }
     }
 
@@ -580,17 +557,17 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--leadspace__section {
+    .#{$c4d-prefix}--leadspace__section {
       @include breakpoint(lg) {
-        min-height: carbon--mini-units(60);
+        min-height: 30rem;
       }
     }
   }
 
   :host(#{$c4d-prefix}-leadspace)[size='short'] {
     @include breakpoint(lg) {
-      .#{$prefix}--leadspace__overlay {
-        height: to-rem(288px);
+      .#{$c4d-prefix}--leadspace__overlay {
+        height: 20rem;
       }
     }
 
@@ -602,9 +579,9 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--leadspace__section {
+    .#{$c4d-prefix}--leadspace__section {
       @include breakpoint(lg) {
-        min-height: carbon--mini-units(40);
+        min-height: 20rem;
       }
     }
   }
@@ -618,14 +595,16 @@ $btn-min-width: 26;
     }
   }
 
-  :host(#{$c4d-prefix}-leadspace)[size='tall'],
-  :host(#{$c4d-prefix}-leadspace)[size] {
-    .#{$prefix}--leadspace__section {
-      height: auto;
-
-      @include breakpoint(lg) {
-        min-height: carbon--mini-units(70);
+  :host(#{$c4d-prefix}-leadspace)[size='tall'] {
+    @include breakpoint(lg) {
+      .#{$c4d-prefix}--leadspace__overlay {
+        height: 35rem;
       }
+    }
+
+    .#{$c4d-prefix}--leadspace__section {
+      height: auto;
+      min-height: 35rem;
     }
   }
 
@@ -638,7 +617,7 @@ $btn-min-width: 26;
   }
 
   :host(#{$c4d-prefix}-leadspace-image),
-  .#{$prefix}--leadspace .#{$prefix}--image {
+  .#{$c4d-prefix}--leadspace .#{$prefix}--image {
     @include ratio-base(4, 3, false);
 
     @include breakpoint(md) {

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -138,7 +138,7 @@ $btn-min-width: 26;
 
       picture {
         width: 100%;
-        max-width: rem(1584px);
+        max-width: to-rem(1584px);
       }
     }
 
@@ -314,7 +314,7 @@ $btn-min-width: 26;
       }
 
       &.#{$prefix}--leadspace__section {
-        min-height: rem(560px);
+        min-height: to-rem(560px);
         padding-top: 0;
       }
 
@@ -548,7 +548,7 @@ $btn-min-width: 26;
   :host(#{$c4d-prefix}-leadspace)[size='super'] {
     @include breakpoint(lg) {
       .#{$prefix}--leadspace__overlay {
-        height: rem(608px);
+        height: to-rem(608px);
       }
     }
 
@@ -562,7 +562,7 @@ $btn-min-width: 26;
   :host(#{$c4d-prefix}-leadspace)[size='tall'] {
     @include breakpoint(lg) {
       .#{$prefix}--leadspace__overlay {
-        height: rem(528px);
+        height: to-rem(528px);
       }
     }
   }
@@ -570,7 +570,7 @@ $btn-min-width: 26;
   :host(#{$c4d-prefix}-leadspace)[size='medium'] {
     @include breakpoint(lg) {
       .#{$prefix}--leadspace__overlay {
-        height: rem(448px);
+        height: to-rem(448px);
       }
     }
 
@@ -590,7 +590,7 @@ $btn-min-width: 26;
   :host(#{$c4d-prefix}-leadspace)[size='short'] {
     @include breakpoint(lg) {
       .#{$prefix}--leadspace__overlay {
-        height: rem(288px);
+        height: to-rem(288px);
       }
     }
 

--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -19,7 +19,7 @@
 
 @use '../card' as *;
 @use '@carbon/styles/scss/components/search' as *;
-@use '../../../../carbon-web-components/src/components/modal/modal' as *;
+@use '@carbon/web-components/scss/components/modal/modal' as *;
 
 /// Locale modal
 /// @access private
@@ -51,7 +51,7 @@
         grid-template-rows: auto 1fr auto;
       }
 
-      @media (max-height: rem(450px)) {
+      @media (max-height: to-rem(450px)) {
         .#{$c4d-prefix}--locale-modal__filtering {
           .#{$c4d-prefix}--locale-modal__filter {
             overflow-y: initial;
@@ -134,8 +134,8 @@
       align-items: center;
 
       .#{$c4d-prefix}--locale-modal__label-globe {
-        width: rem(20px);
-        height: rem(20px);
+        width: to-rem(20px);
+        height: to-rem(20px);
         margin-left: $spacing-02;
       }
 

--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -19,7 +19,7 @@
 
 @use '../card' as *;
 @use '@carbon/styles/scss/components/search' as *;
-@use '@carbon/web-components/scss/components/modal/modal' as *;
+@use '@carbon/styles/scss/components/modal' as *;
 
 /// Locale modal
 /// @access private
@@ -164,11 +164,20 @@
   }
 
   :host(#{$c4d-prefix}-locale-modal[open]) {
-    @extend :host(#{$prefix}-modal[open]);
+    @extend .#{$prefix}--modal;
+
+    opacity: 1;
+    transition: opacity $duration-moderate-02 motion(entrance, expressive),
+      visibility 0ms linear;
+    visibility: inherit;
 
     .#{$prefix}--modal-container {
       transform: translate3d(0, 0, 0);
       transition: transform $duration-moderate-02 motion(entrance, expressive);
+    }
+
+    @media screen and (prefers-reduced-motion: reduce) {
+      transition: none;
     }
   }
 

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -715,7 +715,7 @@ $search-transition-timing: 95ms;
         svg {
           vertical-align: middle;
           position: relative;
-          bottom: rem(2px);
+          bottom: to-rem(2px);
           margin-inline-start: $spacing-03;
         }
       }

--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -22,7 +22,7 @@
 
 @mixin masthead-megamenu {
   $l0-nav-height: $spacing-09;
-  $l1-nav-height: rem(98px);
+  $l1-nav-height: to-rem(98px);
 
   @keyframes expand {
     0% {
@@ -199,7 +199,7 @@
             max-width: initial;
             margin-inline: initial;
             padding-inline: $spacing-07;
-            border-bottom: rem(1px) solid $layer-accent-01;
+            border-bottom: to-rem(1px) solid $layer-accent-01;
             overflow: initial;
             max-height: initial;
 
@@ -239,7 +239,7 @@
           z-index: 1;
           inset-block-end: 0;
           background-color: $background;
-          border-top: rem(1px) solid $layer-accent-01;
+          border-top: to-rem(1px) solid $layer-accent-01;
 
           @include breakpoint-up(lg) {
             display: none;
@@ -294,7 +294,7 @@
         .#{$prefix}--masthead__megamenu__view-all__border {
           position: absolute;
           top: 0;
-          height: rem(1px);
+          height: to-rem(1px);
           background: $layer-accent-01;
         }
       }
@@ -410,8 +410,8 @@
 
     display: block;
     color: $text-secondary;
-    margin: rem(6px) $spacing-05 rem(10px);
-    max-width: rem(272px);
+    margin: to-rem(6px) $spacing-05 to-rem(10px);
+    max-width: to-rem(272px);
   }
 
   :host(#{$c4d-prefix}-megamenu-category-group),
@@ -453,7 +453,7 @@
       @include type-style('body-short-01');
 
       color: $text-secondary;
-      margin: rem(-6px) $spacing-05 $spacing-06;
+      margin: to-rem(-6px) $spacing-05 $spacing-06;
     }
   }
 
@@ -480,7 +480,7 @@
     a,
     .#{$prefix}--link-with-icon {
       width: 100%;
-      padding: rem(6px) $spacing-05;
+      padding: to-rem(6px) $spacing-05;
       margin-block-end: $spacing-06;
     }
 
@@ -518,7 +518,7 @@
 
     color: $text-secondary;
     text-decoration: none;
-    padding: rem(6px) $spacing-05;
+    padding: to-rem(6px) $spacing-05;
     display: block;
 
     &:visited {
@@ -542,7 +542,7 @@
 
     a {
       width: 100%;
-      padding: rem(7px) $spacing-05;
+      padding: to-rem(7px) $spacing-05;
     }
 
     span {

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -83,11 +83,11 @@
         content: '';
         display: block;
         position: absolute;
-        right: rem(-3px);
+        right: to-rem(-3px);
         top: 50%;
         transform: translateY(-50%);
         height: $spacing-06;
-        width: rem(1px);
+        width: to-rem(1px);
         background-color: $layer-accent-01;
       }
     }
@@ -162,7 +162,7 @@
   @include type-style(body-compact-02, true);
 
   border: none;
-  padding: rem(13px) $spacing-05;
+  padding: to-rem(13px) $spacing-05;
   color: $text-secondary;
   white-space: nowrap;
 
@@ -307,7 +307,7 @@
     transition-timing-function: $search-transition;
     background: $background;
     border: none;
-    max-width: rem(1584px);
+    max-width: to-rem(1584px);
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 1px;
@@ -341,7 +341,7 @@
   }
 
   .#{$prefix}--skip-to-content:focus {
-    height: rem(49px);
+    height: to-rem(49px);
   }
 
   .#{$prefix}--header__logo {
@@ -421,7 +421,7 @@
       bottom: 0;
       left: 0;
       right: 0;
-      height: rem(3px);
+      height: to-rem(3px);
       background-color: var(--c4d-active-l0-border-color, $link-primary);
     }
   }
@@ -430,7 +430,7 @@
   :host(#{$c4d-prefix}-megamenu-top-nav-menu) {
     a.#{$prefix}--header__menu-item {
       border-bottom: $spacing-01 solid transparent;
-      padding: rem(13px) $spacing-05 rem(11px);
+      padding: to-rem(13px) $spacing-05 to-rem(11px);
     }
   }
 
@@ -443,7 +443,7 @@
         background-color: $layer-02;
         box-shadow: 0 $spacing-01 6px 0 rgba(0, 0, 0, 0.3);
         bottom: -1px;
-        width: rem(256px);
+        width: to-rem(256px);
 
         li {
           @include masthead-top-nav-menu-item;
@@ -609,7 +609,7 @@
       top: 50%;
       transform: translateY(-50%);
       height: $spacing-06;
-      width: rem(1px);
+      width: to-rem(1px);
       background-color: #dcdcdc;
     }
   }
@@ -636,7 +636,7 @@
       top: 50%;
       transform: translateY(-50%);
       height: $spacing-06;
-      width: rem(1px);
+      width: to-rem(1px);
       background-color: #dcdcdc;
     }
   }

--- a/packages/styles/scss/components/search-with-typeahead/_search-with-typeahead.scss
+++ b/packages/styles/scss/components/search-with-typeahead/_search-with-typeahead.scss
@@ -347,7 +347,7 @@
         top: calc($spacing-09 + 2px);
 
         @include breakpoint(md) {
-          top: rem(66px);
+          top: to-rem(66px);
         }
       }
 
@@ -387,10 +387,10 @@
         }
 
         .react-autosuggest__suggestions-container {
-          top: rem(50px);
+          top: to-rem(50px);
 
           @include breakpoint(md) {
-            top: rem(50px);
+            top: to-rem(50px);
           }
         }
       }

--- a/packages/styles/scss/components/tableofcontents/_table-of-contents.scss
+++ b/packages/styles/scss/components/tableofcontents/_table-of-contents.scss
@@ -57,11 +57,11 @@ $hover-transition-timing: 95ms;
         content: '';
         position: absolute;
         bottom: 0;
-        height: rem(20px);
+        height: to-rem(20px);
         width: $spacing-01;
-        top: rem(14px);
+        top: to-rem(14px);
         background-color: $border-interactive;
-        margin-left: rem(-6px);
+        margin-left: to-rem(-6px);
       }
     }
   }

--- a/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
+++ b/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
@@ -107,7 +107,7 @@
 
       &:focus,
       &:active {
-        border-bottom-width: rem(3px);
+        border-bottom-width: to-rem(3px);
       }
     }
   }
@@ -131,13 +131,13 @@
     a.#{$prefix}--tabs__nav-link {
       border-bottom: none;
       // Draws the border without affecting the inner-content
-      box-shadow: rem(-1px) 0 0 0 $border-strong;
+      box-shadow: to-rem(-1px) 0 0 0 $border-strong;
     }
   }
 
   :host(#{$c4d-prefix}-tab[type='contained'][hide-divider])
     a.#{$prefix}--tabs__nav-link {
-    box-shadow: rem(-1px) 0 0 0 transparent;
+    box-shadow: to-rem(-1px) 0 0 0 transparent;
   }
 
   :host(#{$c4d-prefix}-tab[type='contained'][disabled][role])

--- a/packages/styles/scss/components/tag-link/_tag-link.scss
+++ b/packages/styles/scss/components/tag-link/_tag-link.scss
@@ -15,8 +15,8 @@
   :host(#{$c4d-prefix}-tag-link) a {
     @include type-style(body-01, true);
 
-    padding: rem(6px) $spacing-05;
-    border-radius: rem(15px);
+    padding: to-rem(6px) $spacing-05;
+    border-radius: to-rem(15px);
     background-color: $layer-01;
     color: $text-secondary;
     text-decoration: none;

--- a/packages/styles/scss/patterns/blocks/leadspace-block/_leadspace-block.scss
+++ b/packages/styles/scss/patterns/blocks/leadspace-block/_leadspace-block.scss
@@ -69,18 +69,6 @@
           margin-top: 0;
         }
       }
-
-      .#{$prefix}--buttongroup {
-        padding-top: 0;
-
-        .#{$prefix}--buttongroup-item {
-          margin-top: 0;
-        }
-      }
-      .#{$prefix}--buttongroup-item {
-        margin-top: 0;
-        padding-top: 0;
-      }
     }
     .#{$prefix}--hr {
       border-color: $toggle-off;

--- a/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
+++ b/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
@@ -13,12 +13,12 @@
 $btn-min-width: 26;
 
 @mixin gradient($color) {
-  .#{$prefix}--leadspace--gradient {
+  .#{$c4d-prefix}--leadspace--gradient {
     background-color: rgba($color, 0.75);
   }
 
   @include breakpoint(md) {
-    .#{$prefix}--leadspace--gradient {
+    .#{$c4d-prefix}--leadspace--gradient {
       @include breakpoint(md) {
         background-color: transparent;
         background-image: linear-gradient(
@@ -29,7 +29,7 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--leadspace--centered {
+    .#{$c4d-prefix}--leadspace--centered {
       &__gradient {
         background: linear-gradient(
           to bottom,
@@ -53,25 +53,21 @@ $btn-min-width: 26;
 
   background-color: $background;
 
-  .#{$prefix}--leadspace--centered__overlay {
+  .#{$c4d-prefix}--leadspace--centered__overlay {
     background-color: $background;
   }
 
-  .#{$prefix}--leadspace__title,
-  .#{$prefix}--leadspace__desc,
-  .#{$prefix}--leadspace--centered__title,
-  .#{$prefix}--leadspace--centered__desc {
+  .#{$c4d-prefix}--leadspace__title,
+  .#{$c4d-prefix}--leadspace__desc,
+  .#{$c4d-prefix}--leadspace--centered__title,
+  .#{$c4d-prefix}--leadspace--centered__desc {
     color: $text-primary;
   }
-  .#{$prefix}--leadspace--centered__desc {
+  .#{$c4d-prefix}--leadspace--centered__desc {
     width: 100%;
-  }
-  .#{$prefix}--buttongroup {
-    padding-left: 0;
-  }
 
   @include breakpoint(md) {
-    .#{$prefix}--leadspace--centered {
+    .#{$c4d-prefix}--leadspace--centered {
       &__overlay {
         background-color: transparent;
       }
@@ -86,10 +82,7 @@ $btn-min-width: 26;
 }
 
 @mixin leadspace {
-  .#{$prefix}--buttongroup {
-    padding-top: $spacing-05;
-  }
-  .#{$prefix}--leadspace {
+  .#{$c4d-prefix}--leadspace {
     &--content__container {
       height: 100%;
       display: flex;
@@ -97,7 +90,7 @@ $btn-min-width: 26;
       justify-content: space-between;
     }
 
-    .#{$prefix}--image {
+    .#{$c4d-prefix}--image {
       position: absolute;
       top: 0;
       width: 100%;
@@ -128,7 +121,7 @@ $btn-min-width: 26;
       max-width: none;
     }
 
-    .#{$prefix}--leadspace__title {
+    .#{$c4d-prefix}--leadspace__title {
       padding-top: 0;
       margin-bottom: $spacing-09;
       @include type-style(display-01, true);
@@ -150,7 +143,7 @@ $btn-min-width: 26;
       min-width: carbon--mini-units($btn-min-width);
     }
 
-    .#{$prefix}--leadspace__desc {
+    .#{$c4d-prefix}--leadspace__desc {
       @include type-style(fluid-heading-03, true);
       @include make-col(4, 4);
     }
@@ -158,8 +151,8 @@ $btn-min-width: 26;
     @include themed-items;
   }
 
-  .#{$prefix}--leadspace--g100,
-  .#{$prefix}--leadspace--g90 {
+  .#{$c4d-prefix}--leadspace--g100,
+  .#{$c4d-prefix}--leadspace--g90 {
     @include theme(
       $g100,
       feature-flag-enabled('enable-css-custom-properties')
@@ -168,12 +161,12 @@ $btn-min-width: 26;
     }
   }
 
-  .#{$prefix}--leadspace--productive .#{$prefix}--leadspace__title {
+  .#{$c4d-prefix}--leadspace--productive .#{$c4d-prefix}--leadspace__title {
     @include type-style(fluid-heading-06, true);
   }
 
   @include breakpoint(md) {
-    .#{$prefix}--leadspace {
+    .#{$c4d-prefix}--leadspace {
       margin-right: auto;
       margin-left: auto;
       position: relative;
@@ -196,63 +189,59 @@ $btn-min-width: 26;
         height: 100%;
       }
 
-      .#{$prefix}--image {
+      .#{$c4d-prefix}--image {
         height: auto;
       }
 
-      .#{$prefix}--leadspace__title {
+      .#{$c4d-prefix}--leadspace__title {
         @include make-col(7, 8);
 
         flex-shrink: 1;
       }
 
-      .#{$prefix}--leadspace__desc {
+      .#{$c4d-prefix}--leadspace__desc {
         @include make-col(4, 8);
       }
     }
   }
 
   @include breakpoint(lg) {
-    .#{$prefix}--leadspace {
+    .#{$c4d-prefix}--leadspace {
       padding-top: aspect-ratio(1056px, 480px);
 
-      .#{$prefix}--leadspace__title {
+      .#{$c4d-prefix}--leadspace__title {
         @include make-col(8, 16);
       }
 
-      .#{$prefix}--leadspace__desc {
+      .#{$c4d-prefix}--leadspace__desc {
         @include make-col-ready;
         @include make-col(4, 16);
       }
     }
 
-    .#{$prefix}--leadspace--productive .#{$prefix}--leadspace__title {
+    .#{$c4d-prefix}--leadspace--productive .#{$c4d-prefix}--leadspace__title {
       @include make-col(7, 16);
     }
   }
 
   @include breakpoint(xlg) {
-    .#{$prefix}--leadspace {
+    .#{$c4d-prefix}--leadspace {
       padding-top: aspect-ratio(1312px, 560px);
     }
   }
 
   @include breakpoint(max) {
-    .#{$prefix}--leadspace {
+    .#{$c4d-prefix}--leadspace {
       padding-top: aspect-ratio(1584px, 640px);
     }
   }
 }
 
 @mixin leadspace-centered {
-  .#{$prefix}--leadspace--centered {
+  .#{$c4d-prefix}--leadspace--centered {
     margin-right: auto;
     margin-left: auto;
     max-width: 99rem;
-    .#{$prefix}--buttongroup {
-      padding-bottom: $spacing-05;
-      padding-top: 0;
-    }
 
     &--content__container {
       display: flex;
@@ -294,11 +283,7 @@ $btn-min-width: 26;
   }
 
   @include breakpoint(md) {
-    .#{$prefix}--leadspace--centered {
-      .#{$prefix}--buttongroup {
-        padding-bottom: 0;
-      }
-
+    .#{$c4d-prefix}--leadspace--centered {
       &__overlay {
         padding-bottom: carbon--mini-units(20);
       }
@@ -327,14 +312,14 @@ $btn-min-width: 26;
       }
     }
 
-    .#{$prefix}--leadspace--centered__image
-      .#{$prefix}--leadspace--centered__overlay {
+    .#{$c4d-prefix}--leadspace--centered__image
+      .#{$c4d-prefix}--leadspace--centered__overlay {
       padding-bottom: carbon--mini-units(32);
     }
   }
 
   @include breakpoint(lg) {
-    .#{$prefix}--leadspace--centered {
+    .#{$c4d-prefix}--leadspace--centered {
       &__title {
         padding-top: $spacing-10;
       }
@@ -345,8 +330,8 @@ $btn-min-width: 26;
       }
     }
   }
-  .#{$prefix}--leadspace--centered--g100,
-  .#{$prefix}--leadspace--centered--g90 {
+  .#{$c4d-prefix}--leadspace--centered--g100,
+  .#{$c4d-prefix}--leadspace--centered--g90 {
     @include theme(
       $g100,
       feature-flag-enabled('enable-css-custom-properties')

--- a/packages/utilities/src/utilities/focuswrap/focuswrap.js
+++ b/packages/utilities/src/utilities/focuswrap/focuswrap.js
@@ -1,11 +1,11 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../on.js';
 
 /**
  * Fires the given event if focus goes out of the given element.

--- a/packages/utilities/src/utilities/focuswrap/focuswrap.js
+++ b/packages/utilities/src/utilities/focuswrap/focuswrap.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import on from '../on.js';
+import { on } from '../on';
 
 /**
  * Fires the given event if focus goes out of the given element.

--- a/packages/utilities/src/utilities/index.js
+++ b/packages/utilities/src/utilities/index.js
@@ -15,6 +15,7 @@ export * from './formatVideoCaption';
 export * from './ipcinfoCookie';
 export * from './loadNonLatinPlex';
 export * from './markdownToHtml';
+export * from './on';
 export * from './removeHtmlTagEntities';
 export * from './sameHeight';
 export * from './serialize';

--- a/packages/utilities/src/utilities/on/index.js
+++ b/packages/utilities/src/utilities/on/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2018, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { default as on } from './on';

--- a/packages/utilities/src/utilities/on/on.js
+++ b/packages/utilities/src/utilities/on/on.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright IBM Corp. 2018, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ *
+ * @param {*} element
+ * @param  {...any} args
+ * @returns {Event} The event
+ */
+
+function on(element, ...args) {
+  element.addEventListener(...args);
+  return {
+    release() {
+      element.removeEventListener(...args);
+      return null;
+    },
+  };
+}
+
+export default on;

--- a/packages/web-components/gulp-tasks/build/modules/css.js
+++ b/packages/web-components/gulp-tasks/build/modules/css.js
@@ -82,7 +82,7 @@ const _cssStream = ({ banner, dir }) =>
     .pipe(
       through2.obj((file, enc, done) => {
         file.contents = Buffer.from(`
-        import { css } from 'lit-element';
+        import { css } from 'lit';
         export default css([${JSON.stringify(String(file.contents))}]);
       `);
         file.path = replaceExtension(file.path, dir === 'rtl' ? '.rtl.css.js' : '.css.js');

--- a/packages/web-components/src/components/button/button-expressive.ts
+++ b/packages/web-components/src/components/button/button-expressive.ts
@@ -10,19 +10,17 @@
 import { classMap } from 'lit/directives/class-map.js';
 import { LitElement, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import settings from 'carbon-components/es/globals/js/settings.js';
+import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import { BUTTON_ICON_LAYOUT, BUTTON_KIND, BUTTON_SIZE } from './defs';
-import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './button.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 export { BUTTON_KIND, BUTTON_SIZE };
 
-const { prefix } = settings;
-const { stablePrefix: c4dPrefix } = ddsSettings;
+const { prefix, stablePrefix: c4dPrefix } = settings;
 
 /**
  * Expressive button.

--- a/packages/web-components/src/components/card/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/card/__stories__/README.stories.react.mdx
@@ -77,7 +77,7 @@ import C4DCard from '@carbon/ibmdotcom-web-components/es/components-react/card/c
 import C4DCardHeading from '@carbon/ibmdotcom-web-components/es/components-react/card/card-heading';
 import C4DCardEyebrow from '@carbon/ibmdotcom-web-components/es/components-react/card/card-eyebrow';
 import C4DCardFooter from '@carbon/ibmdotcom-web-components/es/components-react/card/card-footer';
-import { Tag } from 'carbon-components-react';
+import { Tag } from '@carbon/react';
 
 function App() {
   return (
@@ -125,7 +125,7 @@ import C4DCard from '@carbon/ibmdotcom-web-components/es/components-react/card/c
 import C4DCardHeading from '@carbon/ibmdotcom-web-components/es/components-react/card/card-heading';
 import C4DCardEyebrow from '@carbon/ibmdotcom-web-components/es/components-react/card/card-eyebrow';
 import C4DCardFooter from '@carbon/ibmdotcom-web-components/es/components-react/card/card-footer';
-import { Tag } from 'carbon-components-react';
+import { Tag } from '@carbon/react';
 
 function App() {
   return (
@@ -182,7 +182,7 @@ import C4DCard from '@carbon/ibmdotcom-web-components/es/components-react/card/c
 import C4DCardHeading from '@carbon/ibmdotcom-web-components/es/components-react/card/card-heading';
 import C4DCardEyebrow from '@carbon/ibmdotcom-web-components/es/components-react/card/card-eyebrow';
 import C4DCardFooter from '@carbon/ibmdotcom-web-components/es/components-react/card/card-footer';
-import { Tag } from 'carbon-components-react';
+import { Tag } from '@carbon/react';
 
 function App() {
   return (

--- a/packages/web-components/src/components/cta/cta.ts
+++ b/packages/web-components/src/components/cta/cta.ts
@@ -7,7 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { property, html, LitElement } from 'lit-element';
+import { LitElement, html } from 'lit';
+import { property } from 'lit/decorators.js';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';

--- a/packages/web-components/src/components/cta/video-cta-composite.ts
+++ b/packages/web-components/src/components/cta/video-cta-composite.ts
@@ -9,7 +9,7 @@
 
 import { LitElement, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../../internal/vendor/@carbon/web-components/globals/mixins/on.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.react.tsx
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.react.tsx
@@ -8,7 +8,7 @@
  */
 
 import { text, select, boolean, object } from '@storybook/addon-knobs';
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../../../internal/vendor/@carbon/web-components/globals/mixins/on.js';
 import React from 'react';
 
 // Below path will be there when an application installs `@carbon/ibmdotcom-web-components` package.

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -9,7 +9,7 @@
 
 import { html } from 'lit';
 import { boolean, select, object } from '@storybook/addon-knobs';
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../../../internal/vendor/@carbon/web-components/globals/mixins/on.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import inPercy from '@percy-io/in-percy';
 import textNullable from '../../../../.storybook/knob-text-nullable';

--- a/packages/web-components/src/components/expressive-modal/expressive-modal.ts
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal.ts
@@ -16,7 +16,7 @@ import C4DExpressiveModalCloseButton from './expressive-modal-close-button';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../../internal/vendor/@carbon/web-components/globals/mixins/on.js';
 import { selectorTabbable } from '../../internal/vendor/@carbon/web-components/globals/settings.js';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './expressive-modal.scss';

--- a/packages/web-components/src/components/image/image.ts
+++ b/packages/web-components/src/components/image/image.ts
@@ -10,7 +10,7 @@
 import { LitElement, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../../internal/vendor/@carbon/web-components/globals/mixins/on.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import '../expressive-modal/expressive-modal';

--- a/packages/web-components/src/components/leadspace-block/leadspace-block-media.ts
+++ b/packages/web-components/src/components/leadspace-block/leadspace-block-media.ts
@@ -8,7 +8,7 @@
  */
 
 import { LitElement, html } from 'lit';
-import { property } from 'lit/decorators';
+import { property } from 'lit/decorators.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './leadspace-block.scss';

--- a/packages/web-components/src/components/leadspace-block/leadspace-block.ts
+++ b/packages/web-components/src/components/leadspace-block/leadspace-block.ts
@@ -8,8 +8,7 @@
  */
 
 import { LitElement, html } from 'lit';
-import { property } from 'lit/decorators.js';
-import { state } from 'lit/decorators.js';
+import { state, property } from 'lit/decorators.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import '../horizontal-rule/horizontal-rule';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -55,8 +55,8 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
    */
   protected _getGradientClass() {
     return classMap({
-      [`${prefix}--leadspace--gradient`]: this.defaultSrc,
-      [`${prefix}--leadspace__overlay`]: true,
+      [`${c4dPrefix}--leadspace--gradient`]: this.defaultSrc,
+      [`${c4dPrefix}--leadspace__overlay`]: true,
     });
   }
 
@@ -65,11 +65,13 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
    */
   protected _getTypeClass() {
     return classMap({
-      [`${prefix}--leadspace--centered`]: this.type === LEADSPACE_TYPE.CENTERED,
-      [`${prefix}--leadspace--centered__image`]:
+      [`${c4dPrefix}--leadspace--centered`]:
+        this.type === LEADSPACE_TYPE.CENTERED,
+      [`${c4dPrefix}--leadspace--centered__image`]:
         this.type === LEADSPACE_TYPE.CENTERED && this.defaultSrc,
-      [`${prefix}--leadspace--productive`]: this.type === LEADSPACE_TYPE.SMALL,
-      [`${prefix}--leadspace__section`]: true,
+      [`${c4dPrefix}--leadspace--productive`]:
+        this.type === LEADSPACE_TYPE.SMALL,
+      [`${c4dPrefix}--leadspace__section`]: true,
     });
   }
 
@@ -79,10 +81,10 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
   protected _renderCopy() {
     const { copy } = this;
     return html`
-      <div class="${prefix}--leadspace__row">
+      <div class="${c4dPrefix}--leadspace__row">
         <p
           data-autoid="${c4dPrefix}--leadspace__desc"
-          class="${prefix}--leadspace__desc">
+          class="${c4dPrefix}--leadspace__desc">
           <slot>${copy}</slot>
         </p>
       </div>
@@ -162,20 +164,20 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
     const { gradientStyleScheme, type, size } = this;
     return html`
       <section class="${this._getTypeClass()}" part="section">
-        <div class="${prefix}--leadspace__container">
+        <div class="${c4dPrefix}--leadspace__container">
           <div class="${this._getGradientClass()}">
             ${gradientStyleScheme === LEADSPACE_GRADIENT_STYLE_SCHEME.NONE
               ? undefined
               : svg`
                 <svg
-                  class="${prefix}--leadspace__gradient"
+                  class="${c4dPrefix}--leadspace__gradient"
                   viewBox="0 0 100 100"
                   preserveAspectRatio="none"
                   xmlns="http://www.w3.org/2000/svg"
                   xmlns:xlink="http://www.w3.org/1999/xlink"
                 >
                   <defs>
-                    <linearGradient id="stops" class="${prefix}--leadspace__gradient__stops" gradientTransform="${
+                    <linearGradient id="stops" class="${c4dPrefix}--leadspace__gradient__stops" gradientTransform="${
                   type === LEADSPACE_TYPE.CENTERED ? 'rotate(90)' : ''
                 }">
                       ${
@@ -195,11 +197,11 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
                       }
                     </linearGradient>
                   </defs>
-                  <rect class="${prefix}--leadspace__gradient__rect" width="100" height="100" />
+                  <rect class="${c4dPrefix}--leadspace__gradient__rect" width="100" height="100" />
                 </svg>
               `}
-            <div class="${prefix}--leadspace--content__container">
-              <div class="${prefix}--leadspace__row">
+            <div class="${c4dPrefix}--leadspace--content__container">
+              <div class="${c4dPrefix}--leadspace__row">
                 <slot
                   name="navigation"
                   @slotchange="${this._handleSlotChange}"></slot>
@@ -207,9 +209,9 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
               </div>
               ${size !== LEADSPACE_SIZE.SHORT
                 ? html`
-                    <div class="${prefix}--leadspace__content">
+                    <div class="${c4dPrefix}--leadspace__content">
                       ${this._renderCopy()}
-                      <div class="${prefix}--leadspace__action">
+                      <div class="${c4dPrefix}--leadspace__action">
                         <slot name="action"></slot>
                       </div>
                     </div>

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
@@ -9,7 +9,7 @@
 
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../../internal/vendor/@carbon/web-components/globals/mixins/on.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';

--- a/packages/web-components/src/components/masthead/__stories__/cloud-masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/cloud-masthead.stories.ts
@@ -9,7 +9,7 @@
 
 import { html } from 'lit';
 import { select } from '@storybook/addon-knobs';
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../../../internal/vendor/@carbon/web-components/globals/mixins/on.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import inPercy from '@percy-io/in-percy';
 import c4dLeftNav from '../left-nav';

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -9,7 +9,7 @@
 
 import { html } from 'lit';
 import { select, boolean } from '@storybook/addon-knobs';
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../../../internal/vendor/@carbon/web-components/globals/mixins/on.js';
 import ifNonEmpty from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-empty.js';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 import c4dLeftNav from '../left-nav';

--- a/packages/web-components/src/components/masthead/__stories__/scoped-search-masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/scoped-search-masthead.stories.ts
@@ -9,7 +9,7 @@
 
 import { html } from 'lit';
 import { boolean, select } from '@storybook/addon-knobs';
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../../../internal/vendor/@carbon/web-components/globals/mixins/on.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import inPercy from '@percy-io/in-percy';
 import textNullable from '../../../../.storybook/knob-text-nullable';

--- a/packages/web-components/src/components/masthead/left-nav-cta-item.ts
+++ b/packages/web-components/src/components/masthead/left-nav-cta-item.ts
@@ -7,11 +7,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, customElement } from 'lit-element';
+import { html } from 'lit';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import ArrowRight16 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/16.js';
 import BXSideNavMenuItem from '../../internal/vendor/@carbon/web-components/components/ui-shell/side-nav-menu-item.js';
 import styles from './masthead.scss';
+import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element';
 
 const { prefix, stablePrefix: c4dPrefix } = settings;
 

--- a/packages/web-components/src/components/masthead/left-nav-menu-category-heading.ts
+++ b/packages/web-components/src/components/masthead/left-nav-menu-category-heading.ts
@@ -7,8 +7,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, LitElement, property, state } from 'lit-element';
-import { classMap } from 'lit-html/directives/class-map';
+import { LitElement, html } from 'lit';
+import { state, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import ArrowRight20 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element';

--- a/packages/web-components/src/components/masthead/left-nav-menu-item.ts
+++ b/packages/web-components/src/components/masthead/left-nav-menu-item.ts
@@ -7,8 +7,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { classMap } from 'lit-html/directives/class-map.js';
-import { html, property } from 'lit-element';
+import { classMap } from 'lit/directives/class-map.js';
+import { html } from 'lit';
+import { property } from 'lit/decorators.js';
 import ArrowRight16 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/16.js';
 import CDSSideNavMenuItem from '../../internal/vendor/@carbon/web-components/components/ui-shell/side-nav-menu-item.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';

--- a/packages/web-components/src/components/masthead/left-nav-menu.ts
+++ b/packages/web-components/src/components/masthead/left-nav-menu.ts
@@ -7,8 +7,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { classMap } from 'lit-html/directives/class-map.js';
-import { html, property, LitElement } from 'lit-element';
+import { LitElement, html } from 'lit';
+import { property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import ChevronDown16 from '../../internal/vendor/@carbon/web-components/icons/chevron--down/16.js';
 import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';

--- a/packages/web-components/src/components/masthead/masthead-button-cta.ts
+++ b/packages/web-components/src/components/masthead/masthead-button-cta.ts
@@ -7,11 +7,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { customElement } from 'lit-element';
 import BXButton from '../../internal/vendor/@carbon/web-components/components/button/button';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import { CTA_TYPE } from '../cta/defs';
 import styles from './masthead.scss';
+import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element';
 
 export { CTA_TYPE };
 

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -7,19 +7,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  html,
-  property,
-  state,
-  customElement,
-  LitElement,
-  TemplateResult,
-} from 'lit-element';
-import { nothing } from 'lit-html';
-import { ifDefined } from 'lit-html/directives/if-defined';
+import { LitElement, html, TemplateResult } from 'lit';
+import { state, property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import ArrowRight16 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/16.js';
 import ifNonEmpty from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-empty.js';
-import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
+import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import root from 'window-or-global';
 import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
@@ -73,6 +66,7 @@ import '../search-with-typeahead/search-with-typeahead-item';
 import styles from './masthead.scss';
 import { MEGAMENU_LAYOUT_SCHEME } from './defs';
 import layoutBreakpoint from './masthead-breakpoint';
+import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element';
 
 const { stablePrefix: c4dPrefix } = settings;
 
@@ -156,7 +150,7 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
         ?hasTooltip="${tooltip}"
         aria-label="${ifDefined(tooltip)}"
         href="${href || C4DMastheadLogo.hrefDefault}"
-        >${useAlternateLogo ? unsafeSVG(svg) : nothing}</c4d-masthead-logo
+        >${useAlternateLogo ? unsafeSVG(svg) : ''}</c4d-masthead-logo
       >
     `;
   }

--- a/packages/web-components/src/components/masthead/masthead-contact.ts
+++ b/packages/web-components/src/components/masthead/masthead-contact.ts
@@ -7,14 +7,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ifDefined } from 'lit-html/directives/if-defined.js';
-import { html, customElement, property } from 'lit-element';
+import { html } from 'lit';
+import { property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import Chat20 from '../../internal/vendor/@carbon/web-components/icons/chat/20.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 import C4DMastheadProfile from './masthead-profile';
 import C4DMastheadContainer from './masthead-container';
 import { CMApp } from './masthead-composite';
+import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 const { prefix, stablePrefix: c4dPrefix } = settings;
 

--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -7,16 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  html,
-  customElement,
-  LitElement,
-  property,
-  TemplateResult as _TemplateResult,
-  state,
-  query,
-  queryAll,
-} from 'lit-element';
+import { TemplateResult as _TemplateResult, html, LitElement } from 'lit';
+import { property, query, queryAll, state } from 'lit/decorators.js';
 import root from 'window-or-global';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
@@ -27,15 +19,16 @@ import {
   L1SubmenuSectionHeading,
   MastheadL1,
 } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
-import { ifDefined } from 'lit-html/directives/if-defined';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import ChevronDown16 from '../../internal/vendor/@carbon/web-components/icons/chevron--down/16.js';
 import ArrowRight16 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/16';
 import ArrowRight20 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
 import CaretLeft20 from '../../internal/vendor/@carbon/web-components/icons/caret--left/20.js';
 import CaretRight20 from '../../internal/vendor/@carbon/web-components/icons/caret--right/20.js';
-import { classMap } from 'lit-html/directives/class-map';
+import { classMap } from 'lit/directives/class-map.js';
 import layoutBreakpoint from './masthead-breakpoint';
+import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 const { prefix, stablePrefix: c4dPrefix } = settings;
 

--- a/packages/web-components/src/components/masthead/megamenu-category-group.ts
+++ b/packages/web-components/src/components/masthead/megamenu-category-group.ts
@@ -7,7 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, LitElement, property } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 import './megamenu-link-with-icon';

--- a/packages/web-components/src/components/masthead/megamenu-category-heading.ts
+++ b/packages/web-components/src/components/masthead/megamenu-category-heading.ts
@@ -7,11 +7,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { customElement, property } from 'lit-element';
+import { property } from 'lit/decorators.js';
 import ArrowRight20 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import C4DMegaMenuHeading from './megamenu-heading';
 import styles from './masthead.scss';
+import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 const { stablePrefix: c4dPrefix } = settings;
 

--- a/packages/web-components/src/components/masthead/megamenu-category-link-group.ts
+++ b/packages/web-components/src/components/masthead/megamenu-category-link-group.ts
@@ -7,9 +7,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, customElement, LitElement } from 'lit-element';
+import { LitElement, html } from 'lit';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
+import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 const { stablePrefix: c4dPrefix } = settings;
 

--- a/packages/web-components/src/components/masthead/megamenu-category-link.ts
+++ b/packages/web-components/src/components/masthead/megamenu-category-link.ts
@@ -7,7 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property } from 'lit-element';
+import { html } from 'lit';
+import { property } from 'lit/decorators.js';
 import ifNonEmpty from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-empty.js';
 import CDSLink from '../../internal/vendor/@carbon/web-components/components/link/link.js';
 import Launch16 from '../../internal/vendor/@carbon/web-components/icons/launch/16.js';

--- a/packages/web-components/src/components/masthead/megamenu-heading.ts
+++ b/packages/web-components/src/components/masthead/megamenu-heading.ts
@@ -7,11 +7,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, customElement, LitElement, property } from 'lit-element';
+import { LitElement, html } from 'lit';
+import { property } from 'lit/decorators.js';
 import ArrowRight24 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/24.js';
 import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
+import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 const { stablePrefix: c4dPrefix } = settings;
 

--- a/packages/web-components/src/components/masthead/megamenu-right-navigation.ts
+++ b/packages/web-components/src/components/masthead/megamenu-right-navigation.ts
@@ -7,8 +7,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property, LitElement } from 'lit-element';
-import { classMap } from 'lit-html/directives/class-map.js';
+import { LitElement, html } from 'lit';
+import { property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import { MEGAMENU_RIGHT_NAVIGATION_STYLE_SCHEME } from './defs';

--- a/packages/web-components/src/components/masthead/megamenu-tab.ts
+++ b/packages/web-components/src/components/masthead/megamenu-tab.ts
@@ -7,11 +7,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { customElement, html } from 'lit-element';
+import { html } from 'lit';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import CDSTab from '../../internal/vendor/@carbon/web-components/components/tabs/tab';
 import c4dSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
+import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 const { prefix } = settings;
 const { stablePrefix: c4dPrefix } = c4dSettings;

--- a/packages/web-components/src/components/masthead/megamenu-tabs.ts
+++ b/packages/web-components/src/components/masthead/megamenu-tabs.ts
@@ -7,10 +7,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { customElement } from 'lit-element';
 import CDSTabs from '../../internal/vendor/@carbon/web-components/components/tabs/tabs';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
+import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 const { stablePrefix: c4dPrefix } = settings;
 

--- a/packages/web-components/src/components/masthead/megamenu.ts
+++ b/packages/web-components/src/components/masthead/megamenu.ts
@@ -7,7 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, LitElement, property } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './masthead.scss';

--- a/packages/web-components/src/components/notice-choice/__stories__/notice-choice.stories.ts
+++ b/packages/web-components/src/components/notice-choice/__stories__/notice-choice.stories.ts
@@ -10,9 +10,8 @@
 import '../index';
 
 import { select, text } from '@storybook/addon-knobs';
-
 import { action } from '@storybook/addon-actions';
-import { html } from 'lit-element';
+import { html } from 'lit';
 import readme from './README.stories.mdx';
 
 const questionChoices = {

--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -8,7 +8,8 @@
  */
 
 import { checkPreferencesv3, loadContent } from './services';
-import { html, LitElement, property, TemplateResult } from 'lit-element';
+import { TemplateResult, html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
 import {
   emailRegExp,
   pwsValueMap,
@@ -20,7 +21,7 @@ import countrySettings from './country-settings';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './notice-choice.scss';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { worldWideContent } from './world-wide-content';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element';
 

--- a/packages/web-components/src/components/pricing-table/pricing-table-head.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-head.ts
@@ -7,7 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {} from 'lit-element';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import C4DStructuredListHead from '../structured-list/structured-list-head';

--- a/packages/web-components/src/components/search-with-typeahead/scoped-search-dropdown.ts
+++ b/packages/web-components/src/components/search-with-typeahead/scoped-search-dropdown.ts
@@ -7,7 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {} from 'lit-element';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import C4DDropdown from '../footer/dropdown';
 import styles from './search-with-typeahead.scss';

--- a/packages/web-components/src/globals/mixins/throttled-input.ts
+++ b/packages/web-components/src/globals/mixins/throttled-input.ts
@@ -8,7 +8,7 @@
  */
 
 import throttle from 'lodash-es/throttle';
-import on from 'carbon-components/es/globals/js/misc/on.js';
+import on from '../../internal/vendor/@carbon/web-components/globals/mixins/on.js';
 import Handle from '../internal/handle';
 
 import { Constructor } from '../defs';

--- a/packages/web-components/tools/babel-plugin-create-react-custom-element-type.js
+++ b/packages/web-components/tools/babel-plugin-create-react-custom-element-type.js
@@ -545,10 +545,9 @@ module.exports = function generateCreateReactCustomElementType(
             buildCreateReactCustomElementTypeImport(declaredProps),
             ...template.ast`
               import PropTypes from "prop-types";
-              import settings from "carbon-components/es/globals/js/settings.js";
-              import ddsSettings from "@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js";
+              import settings from "@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js";
               var prefix = settings.prefix;
-              var c4dPrefix = ddsSettings.stablePrefix;
+              var c4dPrefix = settings.stablePrefix;
               export var descriptor = ${descriptorsWithParent};
               export var propTypes = ${propTypesWithParent};
               const Component = createReactCustomElementType(${context.customElementName}, descriptor);

--- a/packages/web-components/tools/get-rollup-config.js
+++ b/packages/web-components/tools/get-rollup-config.js
@@ -153,7 +153,6 @@ function getRollupConfig({
           '@carbon/ibmdotcom-services',
           '@carbon/ibmdotcom-styles',
           '@carbon/web-components',
-          'carbon-components',
         ],
         extensions: ['.js', '.ts'],
       }),

--- a/packages/web-components/tools/rollup-plugin-lit-scss.js
+++ b/packages/web-components/tools/rollup-plugin-lit-scss.js
@@ -22,7 +22,7 @@ const noop = (s) => s;
  * @returns {string} A `lit-html` template of the given CSS.
  */
 function transformToTemplate(css) {
-  return `import { css } from 'lit-element';export default css([${JSON.stringify(
+  return `import { css } from 'lit';export default css([${JSON.stringify(
     css
   )}])`;
 }


### PR DESCRIPTION
### Description

Fixes various issues for Dotcom v2 release candidate.

### Changelog

**New**

- add local `on` method, replacing version from `carbon-components`

**Changed**

- update `to-rem` mixin from `@carbon/styles`
- update Lit imports to v2

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
