### PR TITLE
chore(icons): use js icons instead of svg

### DIFF
--- a/packages/styles/scss/components/footer/_footer-logo.scss
+++ b/packages/styles/scss/components/footer/_footer-logo.scss
@@ -64,12 +64,19 @@
   }
 
   :host(#{$c4d-prefix}-footer-logo[size='micro']) {
+    position: relative;
+
+    .#{$c4d-prefix}--footer-logo__link {
+      position: absolute;
+      top: -37px;
+
+      @include breakpoint(lg) {
+        position: relative;
+        top: 0;
+      }
+    }
+
     align-self: center;
     margin: 0;
-
-    @include breakpoint-between(md, lg) {
-      position: absolute;
-      bottom: to-rem(58.5px);
-    }
   }
 }

--- a/packages/web-components/src/components/footer/footer-logo.ts
+++ b/packages/web-components/src/components/footer/footer-logo.ts
@@ -8,12 +8,11 @@
  */
 
 import { html, LitElement } from 'lit';
-import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import { property } from 'lit/decorators.js';
 import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import IBM8BarLogoH65White from '@carbon/ibmdotcom-styles/icons/svg/IBM-8bar-logo--h65-white.svg';
-import IBM8BarLogoH23White from '@carbon/ibmdotcom-styles/icons/svg/IBM-8bar-logo--h23-white.svg';
+import IBM8BarLogoH65White from '../../../es/icons/IBM-8bar-logo--h65-white.js';
+import IBM8BarLogoH23White from '../../../es/icons/IBM-8bar-logo--h23-white.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import { FOOTER_SIZE } from './footer';
@@ -55,8 +54,8 @@ class C4DFooterLogo extends StableSelectorMixin(FocusMixin(LitElement)) {
         aria-label="IBM logo"
         href="${ifDefined(href)}">
         ${size !== FOOTER_SIZE.MICRO
-          ? unsafeSVG(IBM8BarLogoH65White)
-          : unsafeSVG(IBM8BarLogoH23White)}
+          ? IBM8BarLogoH65White()
+          : IBM8BarLogoH23White()}
         <slot></slot>
       </a>
     `;

--- a/packages/web-components/src/components/masthead/masthead-logo.ts
+++ b/packages/web-components/src/components/masthead/masthead-logo.ts
@@ -9,12 +9,11 @@
 
 import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import CDSLink from '../../internal/vendor/@carbon/web-components/components/link/link.js';
 import HostListener from '../../internal/vendor/@carbon/web-components/globals/decorators/host-listener.js';
 import HostListenerMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/host-listener.js';
 import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
-import IBM8BarLogoH23 from '@carbon/ibmdotcom-styles/icons/svg/IBM-8bar-logo--h23.svg';
+import IBM8BarLogoH23 from '../../../es/icons/IBM-8bar-logo--h23.js';
 import settings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import styles from './masthead.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
@@ -70,7 +69,7 @@ class C4DMastheadLogo extends FocusMixin(
 
   // eslint-disable-next-line class-methods-use-this
   protected _renderInner() {
-    return html` <slot>${unsafeSVG(IBM8BarLogoH23)}</slot> `;
+    return html` <slot>${IBM8BarLogoH23()}</slot> `;
   }
 
   updated(changedProperties) {

--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -11,9 +11,8 @@ import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import FocusMixin from '../../internal/vendor/@carbon/web-components/globals/mixins/focus.js';
-import PlayVideo from '@carbon/ibmdotcom-styles/icons/svg/play-video.svg';
+import PlayVideo from '../../../es/icons/play-video.js';
 import {
   formatVideoCaption,
   formatVideoDuration,
@@ -86,7 +85,7 @@ class C4DVideoPlayer extends FocusMixin(
               class="${c4dPrefix}--video-player__image-overlay"
               @click="${this._handleClickOverlay}">
               <c4d-image default-src="${thumbnailUrl}" alt="${ifDefined(name)}">
-                ${unsafeSVG(PlayVideo)}
+                ${PlayVideo()}
               </c4d-image>
             </button>
           </div>

--- a/packages/web-components/tools/svg-result-from-icon-descriptor.js
+++ b/packages/web-components/tools/svg-result-from-icon-descriptor.js
@@ -13,9 +13,9 @@ const { getAttributes, formatAttributes } = require('@carbon/icon-helpers');
 
 // For `@carbon/ibmdotcom-web-components`, we let our consumers set those attributes
 const omitAttrs = {
-  class: true,
-  role: true,
-  'aria-labelledby': true,
+  class: false,
+  role: false,
+  'aria-labelledby': false,
 };
 
 /**


### PR DESCRIPTION
### Description

This updates web component templates to use JS versions of IBM logo icons instead of the direct SVG. Some frameworks, such as NextJS, can throw errors when using `unsafeSVG()`.

### Changelog

**New**

- {{new thing}}

**Changed**

- change IBM logos to use es modules instead of SVG
- update logo styles in `footer - micro`

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
