### PR TITLE
fix(masthead-v2): do not fail if object data does not exist

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-container.ts
+++ b/packages/web-components/src/components/masthead/masthead-container.ts
@@ -100,16 +100,17 @@ export function mapStateToProps(
         : translations?.[language]?.mastheadNav?.links,
       authenticatedProfileItems: !language
         ? undefined
-        : translations?.[language]?.profileMenu.signedin,
+        : translations?.[language]?.profileMenu?.signedin,
       unauthenticatedProfileItems: !language
         ? undefined
-        : translations?.[language]?.profileMenu.signedout,
+        : translations?.[language]?.profileMenu?.signedout,
       authenticatedCtaButtons: !language
         ? undefined
-        : translations?.[language]?.masthead?.profileMenu.signedin.ctaButtons,
+        : translations?.[language]?.masthead?.profileMenu?.signedin?.ctaButtons,
       unauthenticatedCtaButtons: !language
         ? undefined
-        : translations?.[language]?.masthead?.profileMenu.signedout.ctaButtons,
+        : translations?.[language]?.masthead?.profileMenu?.signedout
+            ?.ctaButtons,
       contactUsButton: !language
         ? undefined
         : translations?.[language]?.masthead?.contact,


### PR DESCRIPTION
### Related Ticket(s)

Closes https://github.ibm.com/webstandards/ibm-dotcom-translations/issues/973

### Description

We weren't conditionally accessing all the data that is sourced from the translations CDN endpoint before mapping it to props. In cases where data is not where expected, it throws an undefined error and prevents the whole L0 from appearing. 

### Changelog

**Changed**

- Prevents L0 from failing to appear if certain nav data is not present where expected.

### To test:

See the L0 doesn't show up in the latest alpha version's Storybook example: https://carbon-design-system.github.io/carbon-for-ibm-dotcom/masthead-v2/web-components/iframe.html?args=&id=components-masthead--with-l-1&viewMode=story&cc=ie&lc=en. You'll see an error in the console, too: `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'signedin')`.

Visit the deploy preview's masthead with L1 Story with `&cc=ie&lc=en` appended to the URL parameters (https://ibmdotcom-webcomponents.s3.us-east.cloud-object-storage.appdomain.cloud/deploy-previews/11205/iframe.html?args=&id=components-masthead--with-l-1&viewMode=story&cc=ie&lc=en). Verify the L0 shows up.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
