### PR TITLE
feat(cwc): bump package to 2.0.2-rc.1

### DIFF
--- a/packages/carbon-web-components/package.json
+++ b/packages/carbon-web-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/web-components",
   "private": true,
-  "version": "2.0.2-rc.0",
+  "version": "2.0.2-rc.1",
   "publishConfig": {
     "access": "public"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,7 +3630,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/styles@npm:^1.44.0":
+"@carbon/styles@npm:1.44.0, @carbon/styles@npm:^1.44.0":
   version: 1.44.0
   resolution: "@carbon/styles@npm:1.44.0"
   dependencies:
@@ -3682,7 +3682,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/web-components@npm:2.0.2-rc.0, @carbon/web-components@workspace:packages/carbon-web-components":
+"@carbon/web-components@npm:2.0.2-rc.0":
+  version: 2.0.2-rc.0
+  resolution: "@carbon/web-components@npm:2.0.2-rc.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.16.3"
+    "@carbon/styles": "npm:1.44.0"
+    flatpickr: "npm:4.6.1"
+    lit: "npm:^2.7.6"
+    lodash-es: "npm:^4.17.21"
+  checksum: a02ded4b303bfdeb0e80203bfe069bc0de72d247be7f25671a8ff4d3cd6447916b2982ff898b3bd16336d51ed443e92aed5ab9cf021d1bde6696f954fbf1cab0
+  languageName: node
+  linkType: hard
+
+"@carbon/web-components@workspace:packages/carbon-web-components":
   version: 0.0.0-use.local
   resolution: "@carbon/web-components@workspace:packages/carbon-web-components"
   dependencies:


### PR DESCRIPTION
### Related Ticket(s)

none
### Description

CWC bump package to rc.1


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
