### PR TITLE
feat(radio-button): slug

### DIFF
--- a/packages/carbon-web-components/src/components/radio-button/radio-button-group.ts
+++ b/packages/carbon-web-components/src/components/radio-button/radio-button-group.ts
@@ -214,7 +214,7 @@ class CDSRadioButtonGroup extends FormMixin(HostListenerMixin(LitElement)) {
       legendText,
       helperText,
       _hasSlug: hasSlug,
-      _handleSlotChange: handleSlotChange
+      _handleSlotChange: handleSlotChange,
     } = this;
 
     const showWarning = !readOnly && !invalid && warn;
@@ -245,7 +245,10 @@ class CDSRadioButtonGroup extends FormMixin(HostListenerMixin(LitElement)) {
         ?disabled="${disabled}"
         aria-readonly="${readOnly}">
         ${legendText
-          ? html` <legend class="${prefix}--label">${legendText} <slot name="slug" @slotchange="${handleSlotChange}"></slot></legend>`
+          ? html` <legend class="${prefix}--label">
+              ${legendText}
+              <slot name="slug" @slotchange="${handleSlotChange}"></slot>
+            </legend>`
           : ``}
         <slot></slot>
       </fieldset>

--- a/packages/carbon-web-components/src/components/radio-button/radio-button-group.ts
+++ b/packages/carbon-web-components/src/components/radio-button/radio-button-group.ts
@@ -73,6 +73,30 @@ class CDSRadioButtonGroup extends FormMixin(HostListenerMixin(LitElement)) {
   }
 
   /**
+   * Handles `slotchange` event.
+   */
+  protected _handleSlotChange({ target }: Event) {
+    const hasContent = (target as HTMLSlotElement)
+      .assignedNodes()
+      .filter((elem) =>
+        (elem as HTMLElement).matches !== undefined
+          ? (elem as HTMLElement).matches(
+              (this.constructor as typeof CDSRadioButtonGroup).slugItem
+            )
+          : false
+      );
+
+    this._hasSlug = Boolean(hasContent);
+    (hasContent[0] as HTMLElement).setAttribute('size', 'mini');
+    this.requestUpdate();
+  }
+
+  /**
+   * `true` if there is a slug.
+   */
+  protected _hasSlug = false;
+
+  /**
    * The `value` attribute for the `<input>` for selection.
    */
   @property()
@@ -189,6 +213,8 @@ class CDSRadioButtonGroup extends FormMixin(HostListenerMixin(LitElement)) {
       orientation,
       legendText,
       helperText,
+      _hasSlug: hasSlug,
+      _handleSlotChange: handleSlotChange
     } = this;
 
     const showWarning = !readOnly && !invalid && warn;
@@ -211,6 +237,7 @@ class CDSRadioButtonGroup extends FormMixin(HostListenerMixin(LitElement)) {
       [`${prefix}--radio-button-group--readonly`]: readOnly,
       [`${prefix}--radio-button-group--${orientation}`]:
         orientation === 'vertical',
+      [`${prefix}--radio-button-group--slug`]: hasSlug,
     });
 
     return html` <fieldset
@@ -218,7 +245,7 @@ class CDSRadioButtonGroup extends FormMixin(HostListenerMixin(LitElement)) {
         ?disabled="${disabled}"
         aria-readonly="${readOnly}">
         ${legendText
-          ? html` <legend class="${prefix}--label">${legendText}</legend>`
+          ? html` <legend class="${prefix}--label">${legendText} <slot name="slug" @slotchange="${handleSlotChange}"></slot></legend>`
           : ``}
         <slot></slot>
       </fieldset>
@@ -242,6 +269,13 @@ class CDSRadioButtonGroup extends FormMixin(HostListenerMixin(LitElement)) {
    */
   static get selectorRadioButton() {
     return `${prefix}-radio-button`;
+  }
+
+  /**
+   * A selector that will return the slug item.
+   */
+  static get slugItem() {
+    return `${prefix}-slug`;
   }
 
   /**

--- a/packages/carbon-web-components/src/components/radio-button/radio-button.scss
+++ b/packages/carbon-web-components/src/components/radio-button/radio-button.scss
@@ -62,10 +62,10 @@ $css--plex: true !default;
 :host(#{$prefix}-radio-button[orientation='vertical']) {
   margin-block-end: to-rem(6px);
   margin-inline-end: 0;
-} 
+}
 
 :host(#{$prefix}-radio-button[invalid]) .#{$prefix}--radio-button__appearance {
-  border-color: $support-error;
+  border-color: $support-error !important; /* stylelint-disable-line declaration-no-important */
 }
 
 :host(#{$prefix}-radio-button[data-table]) {
@@ -109,21 +109,21 @@ $css--plex: true !default;
   }
 }
 
-:host(#{$prefix}-radio-button[slug]){
+:host(#{$prefix}-radio-button[slug]) {
   .#{$prefix}--radio-button__label-text {
     display: flex;
   }
 }
 
 :host(#{$prefix}-radio-button-group) .#{$prefix}--radio-button-group--slug,
-:host(#{$prefix}-radio-button[slug]){
-  ::slotted(#{$prefix}-slug){
+:host(#{$prefix}-radio-button[slug]) {
+  ::slotted(#{$prefix}-slug) {
     margin-inline-start: $spacing-03;
   }
 }
 
-:host(#{$prefix}-radio-button[slug]){
-  ::slotted(#{$prefix}-slug[inline]){
+:host(#{$prefix}-radio-button[slug]) {
+  ::slotted(#{$prefix}-slug[inline]) {
     line-height: inherit;
     margin-block-start: to-rem(-1px);
   }

--- a/packages/carbon-web-components/src/components/radio-button/radio-button.scss
+++ b/packages/carbon-web-components/src/components/radio-button/radio-button.scss
@@ -11,6 +11,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/utilities' as *;
+@use '@carbon/styles/scss/utilities/convert' as *;
 @use '@carbon/styles/scss/components/form';
 @use '@carbon/styles/scss/components/radio-button/radio-button' as *;
 
@@ -58,6 +59,11 @@ $css--plex: true !default;
   }
 }
 
+:host(#{$prefix}-radio-button[orientation='vertical']) {
+  margin-block-end: to-rem(6px);
+  margin-inline-end: 0;
+} 
+
 :host(#{$prefix}-radio-button[invalid]) .#{$prefix}--radio-button__appearance {
   border-color: $support-error;
 }
@@ -100,5 +106,25 @@ $css--plex: true !default;
   .#{$prefix}--radio-button__appearance {
     margin-right: 0;
     margin-left: $spacing-03;
+  }
+}
+
+:host(#{$prefix}-radio-button[slug]){
+  .#{$prefix}--radio-button__label-text {
+    display: flex;
+  }
+}
+
+:host(#{$prefix}-radio-button-group) .#{$prefix}--radio-button-group--slug,
+:host(#{$prefix}-radio-button[slug]){
+  ::slotted(#{$prefix}-slug){
+    margin-inline-start: $spacing-03;
+  }
+}
+
+:host(#{$prefix}-radio-button[slug]){
+  ::slotted(#{$prefix}-slug[inline]){
+    line-height: inherit;
+    margin-block-start: to-rem(-1px);
   }
 }

--- a/packages/carbon-web-components/src/components/radio-button/radio-button.ts
+++ b/packages/carbon-web-components/src/components/radio-button/radio-button.ts
@@ -120,7 +120,7 @@ class CDSRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
   /**
    * The hidden radio button.
    */
-  @query('#input')
+  @query('input')
   private _inputNode!: HTMLInputElement;
 
   /**
@@ -128,25 +128,31 @@ class CDSRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
    */
   @HostListener('click')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
-  private _handleClick = () => {
-    const { disabled, _radioButtonDelegate: radioButtonDelegate } = this;
-    if (radioButtonDelegate && !disabled && !this.disabledItem) {
-      this.checked = true;
-      if (this._manager) {
-        this._manager.select(radioButtonDelegate, this.readOnly);
+  private _handleClick = (event) => {
+    if (
+      !(event.target as HTMLElement).matches(
+        (this.constructor as typeof CDSRadioButton)?.slugItem
+      )
+    ) {
+      const { disabled, _radioButtonDelegate: radioButtonDelegate } = this;
+      if (radioButtonDelegate && !disabled && !this.disabledItem) {
+        this.checked = true;
+        if (this._manager) {
+          this._manager.select(radioButtonDelegate, this.readOnly);
+        }
+        this.dispatchEvent(
+          new CustomEvent(
+            (this.constructor as typeof CDSRadioButton).eventChange,
+            {
+              bubbles: true,
+              composed: true,
+              detail: {
+                checked: this.checked,
+              },
+            }
+          )
+        );
       }
-      this.dispatchEvent(
-        new CustomEvent(
-          (this.constructor as typeof CDSRadioButton).eventChange,
-          {
-            bubbles: true,
-            composed: true,
-            detail: {
-              checked: this.checked,
-            },
-          }
-        )
-      );
     }
   };
 
@@ -156,22 +162,28 @@ class CDSRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
   @HostListener('keydown')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleKeydown = (event: KeyboardEvent) => {
-    const { orientation, _radioButtonDelegate: radioButtonDelegate } = this;
-    const manager = this._manager;
-    if (radioButtonDelegate && manager) {
-      const navigationDirectionForKey =
-        orientation === RADIO_BUTTON_ORIENTATION.HORIZONTAL
-          ? navigationDirectionForKeyHorizontal
-          : navigationDirectionForKeyVertical;
-      const navigationDirection = navigationDirectionForKey[event.key];
-      if (navigationDirection) {
-        manager.select(
-          manager.navigate(radioButtonDelegate, navigationDirection),
-          this.readOnly
-        );
-      }
-      if (event.key === ' ' || event.key === 'Enter') {
-        manager.select(radioButtonDelegate, this.readOnly);
+    if (
+      !(event.target as HTMLElement).matches(
+        (this.constructor as typeof CDSRadioButton)?.slugItem
+      )
+    ) {
+      const { orientation, _radioButtonDelegate: radioButtonDelegate } = this;
+      const manager = this._manager;
+      if (radioButtonDelegate && manager) {
+        const navigationDirectionForKey =
+          orientation === RADIO_BUTTON_ORIENTATION.HORIZONTAL
+            ? navigationDirectionForKeyHorizontal
+            : navigationDirectionForKeyVertical;
+        const navigationDirection = navigationDirectionForKey[event.key];
+        if (navigationDirection) {
+          manager.select(
+            manager.navigate(radioButtonDelegate, navigationDirection),
+            this.readOnly
+          );
+        }
+        if (event.key === ' ' || event.key === 'Enter') {
+          manager.select(radioButtonDelegate, this.readOnly);
+        }
       }
     }
   };
@@ -192,7 +204,10 @@ class CDSRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
 
     this._hasSlug = Boolean(hasContent);
     const type = (hasContent[0] as HTMLElement).getAttribute('kind');
-    (hasContent[0] as HTMLElement).setAttribute('size',  type === 'inline' ? 'md' : 'mini');
+    (hasContent[0] as HTMLElement).setAttribute(
+      'size',
+      type === 'inline' ? 'md' : 'mini'
+    );
     this.requestUpdate();
   }
 
@@ -291,7 +306,7 @@ class CDSRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
       _radioButtonDelegate: radioButtonDelegate,
       name,
     } = this;
-    
+
     if (changedProperties.has('checked') || changedProperties.has('name')) {
       if (this.readOnly) {
         this.checked = false;
@@ -334,7 +349,7 @@ class CDSRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
     });
     return html`
       <input
-        id="input"
+        id="radio"
         type="radio"
         class="${prefix}--radio-button"
         .checked=${checked}
@@ -343,9 +358,10 @@ class CDSRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
         value=${ifDefined(value)} />
       <label for="input" class="${prefix}--radio-button__label">
         <span class="${prefix}--radio-button__appearance"></span>
-        <span class="${innerLabelClasses}">${labelText}
-        <slot name="slug" @slotchange="${this._handleSlotChange}"></slot></span>
-
+        <span class="${innerLabelClasses}"
+          >${labelText}
+          <slot name="slug" @slotchange="${this._handleSlotChange}"></slot
+        ></span>
       </label>
     `;
   }

--- a/packages/carbon-web-components/src/components/slug/slug-example-story.ts
+++ b/packages/carbon-web-components/src/components/slug/slug-example-story.ts
@@ -191,6 +191,72 @@ export const _NumberItem = () => {
   `;
 };
 
+export const _RadioButton = () => {
+  return html`
+  <div class="slug-check-radio-container">
+  <cds-radio-button-group
+    legend-text="Group label"
+    name="radio-group"
+    value="radio-1"
+    orientation="vertical">
+    <cds-slug alignment="bottom-left"> ${content}${actions} </cds-slug>
+    <cds-radio-button
+      label-text="Radio button label"
+      value="radio-1"></cds-radio-button>
+    <cds-radio-button
+      label-text="Radio button label"
+      value="radio-2"></cds-radio-button>
+    <cds-radio-button
+      label-text="Radio button label"
+      value="radio-3"></cds-radio-button>
+  </cds-radio-button-group>
+
+  <cds-radio-button-group
+    legend-text="Group label"
+    name="radio-group-2"
+    value="radio-4"
+    orientation="vertical">
+    <cds-radio-button
+      label-text="Radio button label"
+      value="radio-4">
+      <cds-slug alignment="bottom-left"> ${content}${actions} </cds-slug>
+
+      </cds-radio-button>
+    <cds-radio-button
+      label-text="Radio button label"
+      value="radio-5">
+      <cds-slug alignment="bottom-left"> ${content}${actions} </cds-slug>
+
+      </cds-radio-button>
+    <cds-radio-button
+      label-text="Radio button label"
+      value="radio-6"></cds-radio-button>
+  </cds-radio-button-group>
+
+  <cds-radio-button-group
+    legend-text="Group label"
+    name="radio-group-2"
+    value="radio-4"
+    orientation="vertical">
+    <cds-radio-button
+      label-text="Radio button label"
+      value="radio-4">
+      <cds-slug alignment="bottom-left" kind="inline"> ${content}${actions} </cds-slug>
+
+      </cds-radio-button>
+    <cds-radio-button
+      label-text="Radio button label"
+      value="radio-5">
+      <cds-slug alignment="bottom-left" kind="inline"> ${content}${actions} </cds-slug>
+
+      </cds-radio-button>
+    <cds-radio-button
+      label-text="Radio button label"
+      value="radio-6"></cds-radio-button>
+  </cds-radio-button-group>
+  </div>
+  `;
+};
 export const _Select = () => {
   return html`
     <div style="width: 400px">

--- a/packages/carbon-web-components/src/components/slug/slug-example-story.ts
+++ b/packages/carbon-web-components/src/components/slug/slug-example-story.ts
@@ -12,6 +12,7 @@ import { boolean } from '@storybook/addon-knobs';
 import View16 from '@carbon/icons/lib/view/16';
 import FolderOpen16 from '@carbon/icons/lib/folder--open/16';
 import Folders16 from '@carbon/icons/lib/folders/16';
+import textNullable from '../../../.storybook/knob-text-nullable';
 import { prefix } from '../../globals/settings';
 import './index';
 import '../icon-button/index';
@@ -210,72 +211,102 @@ export const _NumberItem = () => {
     </div> `;
 };
 
-export const _RadioButton = () => {
+export const _RadioButton = (args) => {
+  const { disabled, invalid, invalidText, warn, warnText } =
+    args?.['cds-radio-button'] ?? {};
+
   return html`
-  <div class="slug-check-radio-container">
-  <cds-radio-button-group
-    legend-text="Group label"
-    name="radio-group"
-    value="radio-1"
-    orientation="vertical">
-    <cds-slug alignment="bottom-left"> ${content}${actions} </cds-slug>
-    <cds-radio-button
-      label-text="Radio button label"
-      value="radio-1"></cds-radio-button>
-    <cds-radio-button
-      label-text="Radio button label"
-      value="radio-2"></cds-radio-button>
-    <cds-radio-button
-      label-text="Radio button label"
-      value="radio-3"></cds-radio-button>
-  </cds-radio-button-group>
-
-  <cds-radio-button-group
-    legend-text="Group label"
-    name="radio-group-2"
-    value="radio-4"
-    orientation="vertical">
-    <cds-radio-button
-      label-text="Radio button label"
-      value="radio-4">
+    <style>
+      ${styles}
+    </style>
+    <cds-radio-button-group
+      legend-text="Group label"
+      name="radio-group"
+      value="radio-1"
+      orientation="vertical"
+      ?disabled="${disabled}"
+      ?invalid="${invalid}"
+      invalid-text="${invalidText}"
+      ?warn="${warn}"
+      warn-text="${warnText}">
       <cds-slug alignment="bottom-left"> ${content}${actions} </cds-slug>
+      <cds-radio-button
+        label-text="Radio button label"
+        value="radio-1"></cds-radio-button>
+      <cds-radio-button
+        label-text="Radio button label"
+        value="radio-2"></cds-radio-button>
+      <cds-radio-button
+        label-text="Radio button label"
+        value="radio-3"></cds-radio-button>
+    </cds-radio-button-group>
 
+    <cds-radio-button-group
+      legend-text="Group label"
+      name="radio-group-2"
+      value="radio-4"
+      orientation="vertical"
+      ?disabled="${disabled}"
+      ?invalid="${invalid}"
+      invalid-text="${invalidText}"
+      ?warn="${warn}"
+      warn-text="${warnText}">
+      <cds-radio-button label-text="Radio button label" value="radio-4">
+        <cds-slug alignment="bottom-left"> ${content}${actions} </cds-slug>
       </cds-radio-button>
-    <cds-radio-button
-      label-text="Radio button label"
-      value="radio-5">
-      <cds-slug alignment="bottom-left"> ${content}${actions} </cds-slug>
-
+      <cds-radio-button label-text="Radio button label" value="radio-5">
+        <cds-slug alignment="bottom-left"> ${content}${actions} </cds-slug>
       </cds-radio-button>
-    <cds-radio-button
-      label-text="Radio button label"
-      value="radio-6"></cds-radio-button>
-  </cds-radio-button-group>
+      <cds-radio-button
+        label-text="Radio button label"
+        value="radio-6"></cds-radio-button>
+    </cds-radio-button-group>
 
-  <cds-radio-button-group
-    legend-text="Group label"
-    name="radio-group-2"
-    value="radio-4"
-    orientation="vertical">
-    <cds-radio-button
-      label-text="Radio button label"
-      value="radio-4">
-      <cds-slug alignment="bottom-left" kind="inline"> ${content}${actions} </cds-slug>
-
+    <cds-radio-button-group
+      legend-text="Group label"
+      name="radio-group-3"
+      value="radio-7"
+      orientation="vertical"
+      ?disabled="${disabled}"
+      ?invalid="${invalid}"
+      invalid-text="${invalidText}"
+      ?warn="${warn}"
+      warn-text="${warnText}">
+      <cds-radio-button label-text="Radio button label" value="radio-7">
+        <cds-slug alignment="bottom-left" kind="inline">
+          ${content}${actions}
+        </cds-slug>
       </cds-radio-button>
-    <cds-radio-button
-      label-text="Radio button label"
-      value="radio-5">
-      <cds-slug alignment="bottom-left" kind="inline"> ${content}${actions} </cds-slug>
-
+      <cds-radio-button label-text="Radio button label" value="radio-8">
+        <cds-slug alignment="bottom-left" kind="inline">
+          ${content}${actions}
+        </cds-slug>
       </cds-radio-button>
-    <cds-radio-button
-      label-text="Radio button label"
-      value="radio-6"></cds-radio-button>
-  </cds-radio-button-group>
-  </div>
+      <cds-radio-button
+        label-text="Radio button label"
+        value="radio-9"></cds-radio-button>
+    </cds-radio-button-group>
   `;
 };
+
+_RadioButton.parameters = {
+  knobs: {
+    [`${prefix}-radio-button`]: () => ({
+      disabled: boolean('Disabled (disabled)', false),
+      invalid: boolean('Invalid (invalid)', false),
+      invalidText: textNullable(
+        'Invalid text (invalid-text)',
+        'Error message goes here'
+      ),
+      warn: boolean('Warn (warn)', false),
+      warnText: textNullable(
+        'Warn text (warn-text)',
+        'Warning message that is really long can wrap to more lines but should not be excessively long.'
+      ),
+    }),
+  },
+};
+
 export const _Select = () => {
   return html`<style>
       ${styles}

--- a/packages/carbon-web-components/src/components/slug/slug-story.scss
+++ b/packages/carbon-web-components/src/components/slug/slug-story.scss
@@ -47,7 +47,7 @@ hr {
 }
 
 div #{$prefix}-selectable-tile::-moz-list-bullet {
-  margin-block-end: 1rem;
+  margin-block-end: $spacing-05;
 }
 
 .slug-tile-container {
@@ -60,8 +60,8 @@ div #{$prefix}-selectable-tile::-moz-list-bullet {
   #{$prefix}-clickable-tile,
   #{$prefix}-tile {
     max-width: 320px;
-    margin-right: 3rem;
-    margin-bottom: 3rem;
+    margin-right: $spacing-09;
+    margin-bottom: $spacing-09;
   }
 
   #{$prefix}-expandable-tile,
@@ -73,12 +73,12 @@ div #{$prefix}-selectable-tile::-moz-list-bullet {
 }
 
 .slug-tile-container h4 {
-  margin-bottom: 1rem;
+  margin-bottom: $spacing-05;
 }
 
 .slug-tile-container .ai-data {
-  margin-top: 16px;
-  padding: 16px 0;
+  margin-top: $spacing-05;
+  padding: $spacing-05 0;
   display: flex;
 }
 
@@ -87,7 +87,7 @@ div #{$prefix}-selectable-tile::-moz-list-bullet {
 }
 
 .slug-tile-container .data-container:first-of-type {
-  margin-right: 16px;
+  margin-right: $spacing-05;
 }
 
 .slug-tile-container p {
@@ -98,17 +98,15 @@ div #{$prefix}-selectable-tile::-moz-list-bullet {
   @include type-style('label-02');
 }
 
-.slug-tile-container .arrow-right {
-  position: absolute;
-  bottom: 16px;
-  right: 16px;
-}
-
 .slug-tile-container #{$prefix}-tile-below-the-fold-content {
-  padding-top: 16px;
+  padding-top: $spacing-05;
 }
 
 .slug-tile-container #{$prefix}-tile-below-the-fold-content p {
   @include type-style('label-01');
-  margin: 8px 0 50px;
+  margin: $spacing-03 0 50px;
+}
+
+#{$prefix}-radio-button-group:not(:first-of-type) {
+  margin-top: $spacing-07;
 }

--- a/packages/carbon-web-components/src/components/tile/tile.scss
+++ b/packages/carbon-web-components/src/components/tile/tile.scss
@@ -251,6 +251,6 @@ $css--plex: true !default;
   @extend .#{$prefix}--tile--slug-rounded;
 
   .#{$prefix}--tile__chevron {
-    border-bottom-right-radius: 1rem;
+    border-bottom-right-radius: $spacing-05;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

Closes #11141 
### Description

Adds slug slot to radio-button and radio-button-group

### Changelog

**New**

- slug option to radio-button and radio-button-group
- radio-button slug changes size depending on slug kind

**Changed**

- changing the `id` and `query` logic allowed the modal to appear from the slug
- fix error in radio-button invalid where the `checked` radio-button border wasn't turning red
- cleaned up slug-story.scss to use tokens

**Testing**

Experimental -> Slug -> Examples -> Radio Button


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
