### PR TITLE
feat(checkbox): slug

### DIFF
--- a/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
@@ -209,6 +209,13 @@ class CDSCheckboxGroup extends FormMixin(LitElement) {
     return `${prefix}-checkbox`;
   }
 
+  /**
+   * A selector that will return the slug item.
+   */
+  static get slugItem() {
+    return `${prefix}-slug`;
+  }
+
   static shadowRootOptions = {
     ...LitElement.shadowRootOptions,
     delegatesFocus: true,

--- a/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { LitElement, html } from 'lit';
+import { property } from 'lit/decorators.js';
+import { prefix } from '../../globals/settings';
+import WarningFilled16 from '@carbon/icons/lib/warning--filled/16';
+import WarningAltFilled16 from '@carbon/icons/lib/warning--alt--filled/16';
+import styles from './checkbox.scss';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
+
+/**
+ * Check box.
+ *
+ * @element cds-checkbox
+ * @fires cds-checkbox-changed - The custom event fired after this changebox changes its checked state.
+ * @csspart input The checkbox.
+ * @csspart label The label.
+ */
+@customElement(`${prefix}-checkbox-group`)
+class CDSCheckboxGroup extends LitElement {
+  /**
+   * fieldset `aria-labelledby`
+   */
+  @property({ type: String, reflect: true, attribute: 'aria-labelledby' })
+  ariaLabelledBy;
+
+  /**
+   * Specify whether the form group is currently disabled
+   */
+  @property({ type: Boolean })
+  disabled;
+
+  /**
+   * Provide text for the form group for additional help
+   */
+  @property({ type: String, reflect: true, attribute: 'helper-text' })
+  helperText;
+
+  /**
+   * Specify whether the form group is currently invalid
+   */
+  @property({ type: Boolean, attribute: 'invalid' })
+  invalid;
+
+  /**
+   * Provide the text that is displayed when the form group is in an invalid state
+   */
+  @property({ type: String, reflect: true, attribute: 'invalid-text' })
+  invalidText;
+
+  /**
+   * Provide id for the fieldset <legend> which corresponds to the fieldset
+   * `aria-labelledby`
+   */
+  @property({ type: String, reflect: true, attribute: 'legend-id' })
+  legendId;
+
+  /**
+   * Provide the text to be rendered inside of the fieldset <legend>
+   */
+  @property({ type: String, reflect: true, attribute: 'legend-text' })
+  legendText;
+
+  /**
+   * Whether the CheckboxGroup should be read-only
+   */
+  @property({ type: Boolean, reflect: true })
+  readonly = false;
+
+  /**
+   * Specify whether the form group is currently in warning state
+   */
+  @property({ type: Boolean, reflect: true })
+  warn = false;
+
+  /**
+   * Provide the text that is displayed when the form group is in warning state
+   */
+  @property({ type: String, reflect: true, attribute: 'warn-text' })
+  warnText = '';
+
+  render() {
+    const {
+      ariaLabelledBy,
+      disabled,
+      helperText,
+      invalid,
+      invalidText,
+      legendId,
+      legendText,
+      readonly,
+      warn,
+      warnText,
+    } = this;
+
+    const showWarning = !readonly && !invalid && warn;
+    const showHelper = !invalid && !warn;
+
+    const checkboxGroupInstanceId = Math.random().toString(16).slice(2);
+
+    const helperId = !helperText
+      ? undefined
+      : `checkbox-group-helper-text-${checkboxGroupInstanceId}`;
+
+    const helper = helperText
+      ? html` <div id="${helperId}" class="${prefix}--form__helper-text">
+          ${helperText}
+        </div>`
+      : null;
+
+    const fieldsetClasses = classMap({
+      [`${prefix}--checkbox-group`]: true,
+      [`${prefix}--checkbox-group--readonly`]: readonly,
+      [`${prefix}--checkbox-group--invalid`]: !readonly && invalid,
+      [`${prefix}--checkbox-group--warning`]: showWarning,
+    });
+
+    return html`
+      <fieldset
+        class="${fieldsetClasses}"
+        ?data-invalid=${invalid}
+        ?disabled=${disabled}
+        aria-readonly=${readonly}
+        ?aria-labelledby=${ariaLabelledBy || legendId}
+        ?aria-describedby=${!invalid && !warn && helper ? helperId : undefined}>
+        <legend class="${prefix}--label" id=${legendId || ariaLabelledBy}>
+          ${legendText}
+        </legend>
+        <slot></slot>
+        <div class="${prefix}--checkbox-group__validation-msg">
+          ${!readonly && invalid
+            ? html`
+                ${WarningFilled16({
+                  class: `${prefix}--checkbox__invalid-icon`,
+                })}
+                <div class="${prefix}--form-requirement">${invalidText}</div>
+              `
+            : undefined}
+          ${showWarning
+            ? html`
+                ${WarningAltFilled16({
+                  class: `${prefix}--checkbox__invalid-icon ${prefix}--checkbox__invalid-icon--warning`,
+                })}
+                <div class="${prefix}--form-requirement">${warnText}</div>
+              `
+            : undefined}
+        </div>
+        ${showHelper ? helper : undefined}
+      </fieldset>
+    `;
+  }
+
+  static shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+  static styles = styles; // `styles` here is a `CSSResult` generated by custom WebPack loader
+}
+
+export default CDSCheckboxGroup;

--- a/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
@@ -11,7 +11,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
-import FormMixin from '../../globals/mixins/form';
 import WarningFilled16 from '@carbon/icons/lib/warning--filled/16';
 import WarningAltFilled16 from '@carbon/icons/lib/warning--alt--filled/16';
 import CDSCheckbox from './checkbox';
@@ -27,7 +26,7 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * @csspart label The label.
  */
 @customElement(`${prefix}-checkbox-group`)
-class CDSCheckboxGroup extends FormMixin(LitElement) {
+class CDSCheckboxGroup extends LitElement {
   /**
    * fieldset `aria-labelledby`
    */

--- a/packages/carbon-web-components/src/components/checkbox/checkbox-story.mdx
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-story.mdx
@@ -31,6 +31,15 @@ import '@carbon/web-components/es/components/checkbox/index.js';
 <cds-checkbox label-text="Lorem Ipsum"></cds-checkbox>
 ```
 
+Use `cds-checkbox-group` when handling multiple checkboxes
+
+```html
+<cds-checkbox-group legend-text="Group label">
+  <cds-checkbox label-text="Lorem Ipsum 0"></cds-checkbox>
+  <cds-checkbox label-text="Lorem Ipsum 1"></cds-checkbox>
+</cds-checkbox-group>
+```
+
 ## `<cds-checkbox>` attributes, properties and events
 
 Unlike regular checkbox, `<cds-checkbox>` does _not_ fire `change` event. Please

--- a/packages/carbon-web-components/src/components/checkbox/checkbox-story.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-story.ts
@@ -20,11 +20,10 @@ const checkboxLabel = 'Checkbox label';
 
 export const Default = () => {
   return html`
-    <fieldset class="${prefix}--fieldset">
-      <legend class="${prefix}--label">Group label</legend>
+    <cds-checkbox-group legend-text="Group label">
       <cds-checkbox label-text="${checkboxLabel}"></cds-checkbox>
       <cds-checkbox label-text="${checkboxLabel}"></cds-checkbox>
-    </fieldset>
+    </cds-checkbox-group>
   `;
 };
 
@@ -39,52 +38,81 @@ export const Skeleton = () => {
   `;
 };
 
+export const Single = () => {
+  return html`
+    <cds-checkbox
+      label-text="${checkboxLabel}"
+      helper-text="Helper text goes here"></cds-checkbox>
+    <br /><br />
+    <cds-checkbox
+      label-text="${checkboxLabel}"
+      invalid
+      invalid-text="Invalid test goes here"></cds-checkbox>
+    <br /><br />
+    <cds-checkbox
+      label-text="${checkboxLabel}"
+      warn
+      warn-text="Warning test goes here"></cds-checkbox>
+    <br /><br />
+    <cds-checkbox label-text="${checkboxLabel}" readonly></cds-checkbox>
+  `;
+};
+
 export const Playground = (args) => {
   const {
-    checked,
     disabled,
-    hideLabel,
-    indeterminate,
-    labelText = checkboxLabel,
     readonly,
-    title,
     onChange,
+    helperText,
+    invalid,
+    invalidText,
+    legendText,
+    warn,
+    warnText,
   } = args?.[`${prefix}-checkbox`] ?? {};
   return html`
-    <fieldset class="${prefix}--fieldset">
-      <legend class="${prefix}--label">Group label</legend>
+    <cds-checkbox-group
+      helper-text="${helperText}"
+      ?disabled="${disabled}"
+      ?invalid="${invalid}"
+      invalid-text="${invalidText}"
+      legend-text="${legendText}"
+      ?readonly="${readonly}"
+      ?warn="${warn}"
+      warn-text="${warnText}">
       <cds-checkbox
-        ?checked="${checked}"
-        ?disabled="${disabled}"
-        ?hide-label="${hideLabel}"
-        ?indeterminate="${indeterminate}"
-        label-text="${ifDefined(labelText)}"
-        ?readonly="${readonly}"
-        title="${ifDefined(title)}"
+        checked
+        label-text="Checkbox label"
         @cds-checkbox-changed="${onChange}"></cds-checkbox>
       <cds-checkbox
-        ?checked="${checked}"
-        ?disabled="${disabled}"
-        ?hide-label="${hideLabel}"
-        ?indeterminate="${indeterminate}"
-        label-text="${ifDefined(labelText)}"
-        ?readonly="${readonly}"
-        title="${ifDefined(title)}"
+        label-text="Checkbox label"
         @cds-checkbox-changed="${onChange}"></cds-checkbox>
-    </fieldset>
+      <cds-checkbox
+        disabled
+        label-text="Checkbox label"
+        @cds-checkbox-changed="${onChange}"></cds-checkbox>
+    </cds-checkbox-group>
   `;
 };
 
 Playground.parameters = {
   knobs: {
     [`${prefix}-checkbox`]: () => ({
-      checked: boolean('Checked (checked)', false),
-      disabled: boolean('Disabled (disabled)', false),
-      hideLabel: boolean('Hide label (hide-label)', false),
-      indeterminate: boolean('Indeterminate (indeterminate)', false),
-      readonly: boolean('Read only (readonly)', false),
-      title: textNullable('Title (title)', ''),
       onChange: action(`${prefix}-checkbox-changed`),
+      disabled: boolean('Disabled (disabled)', false),
+      helperText: textNullable(
+        'Helper text (helper-text)',
+        'Helper text goes here'
+      ),
+      invalid: boolean('Invalid (invalid)', false),
+      invalidText: textNullable(
+        'Invalid text (invalid-text)',
+        'Invalid message goes here'
+      ),
+      legendText: textNullable('Legend text (legend-text)', 'Group label'),
+      readonly: boolean('Read only (readonly)', false),
+      warn: boolean('Warn (warn)', false),
+      warnText: textNullable('Warn text (warn-text)', 'Warn message goes here'),
     }),
   },
 };

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.scss
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.scss
@@ -27,6 +27,10 @@ $css--plex: true !default;
   @extend .#{$prefix}--checkbox-wrapper--invalid;
 }
 
+:host(#{$prefix}-checkbox[invalid-group]) {
+  @extend .#{$prefix}--checkbox-wrapper--invalid;
+}
+
 :host(#{$prefix}-checkbox:not([readonly]):not([invalid])[warn]) {
   @extend .#{$prefix}--checkbox-wrapper--warning;
 }
@@ -49,7 +53,4 @@ $css--plex: true !default;
   .#{$prefix}--checkbox-label {
     cursor: default;
   }
-}
-
-:host(#{$prefix}-checkbox-group[data-invalid]) {
 }

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.scss
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.scss
@@ -54,3 +54,20 @@ $css--plex: true !default;
     cursor: default;
   }
 }
+
+:host(#{$prefix}-checkbox-group) {
+  display: flex;
+}
+
+:host(#{$prefix}-checkbox-group) .#{$prefix}--checkbox-group--slug,
+:host(#{$prefix}-checkbox[slug]) {
+  ::slotted(#{$prefix}-slug) {
+    margin-inline-start: $spacing-03;
+  }
+}
+
+:host(#{$prefix}-checkbox[slug]) {
+  .#{$prefix}--checkbox-label-text {
+    display: flex;
+  }
+}

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.scss
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.scss
@@ -67,6 +67,14 @@ $css--plex: true !default;
 }
 
 :host(#{$prefix}-checkbox[slug]) {
+  flex-direction: row;
+}
+
+:host(#{$prefix}-checkbox[slug]) ::slotted(#{$prefix}-slug) {
+  align-self: center;
+}
+
+:host(#{$prefix}-checkbox[slug]) {
   .#{$prefix}--checkbox-label-text {
     display: flex;
   }

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.scss
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.scss
@@ -23,6 +23,14 @@ $css--plex: true !default;
   @extend .#{$prefix}--checkbox-wrapper--readonly;
 }
 
+:host(#{$prefix}-checkbox:not([readonly])[invalid]) {
+  @extend .#{$prefix}--checkbox-wrapper--invalid;
+}
+
+:host(#{$prefix}-checkbox:not([readonly]):not([invalid])[warn]) {
+  @extend .#{$prefix}--checkbox-wrapper--warning;
+}
+
 :host(#{$prefix}-checkbox[data-table]) {
   margin: 0;
 }
@@ -41,4 +49,7 @@ $css--plex: true !default;
   .#{$prefix}--checkbox-label {
     cursor: default;
   }
+}
+
+:host(#{$prefix}-checkbox-group[data-invalid]) {
 }

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.ts
@@ -254,11 +254,9 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
         part="label"
         class="${labelClasses}"
         title="${ifDefined(title)}">
-        <span class="${labelTextClasses}"
-          >${labelText}
-          <slot name="slug" @slotchange="${this._handleSlotChange}"></slot
-        ></span>
+        <span class="${labelTextClasses}">${labelText}</span>
       </label>
+      <slot name="slug" @slotchange="${this._handleSlotChange}"></slot>
       <div class="${prefix}--checkbox__validation-msg">
         ${!readonly && invalid
           ? html`

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.ts
@@ -14,6 +14,8 @@ import { property, query } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import FocusMixin from '../../globals/mixins/focus';
 import FormMixin from '../../globals/mixins/form';
+import WarningFilled16 from '@carbon/icons/lib/warning--filled/16';
+import WarningAltFilled16 from '@carbon/icons/lib/warning--alt--filled/16';
 import styles from './checkbox.scss';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 
@@ -86,6 +88,12 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
   disabled = false;
 
   /**
+   * Provide text for the form group for additional help
+   */
+  @property({ type: String, reflect: true, attribute: 'helper-text' })
+  helperText;
+
+  /**
    * Specify whether the checkbox should be present in the DOM,
    * but invisible and uninteractable. Used for data-table purposes.
    */
@@ -124,6 +132,18 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
   readonly = false;
 
   /**
+   * Specify whether the Checkbox is currently invalid
+   */
+  @property({ type: Boolean })
+  invalid = false;
+
+  /**
+   * Provide the text that is displayed when the Checkbox is in an invalid state
+   */
+  @property({ type: String, attribute: 'invalid-text' })
+  invalidText;
+
+  /**
    * Specify a title for the node for the Checkbox
    */
   @property({ attribute: 'title' })
@@ -135,20 +155,53 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
   @property()
   value!: string;
 
+  /**
+   * Specify whether the Checkbox is in a warn state
+   */
+  @property({ type: Boolean })
+  warn = false;
+
+  /**
+   * Provide the text that is displayed when the Checkbox is in a warn state
+   */
+  @property({ type: String, attribute: 'warn-text' })
+  warnText = false;
+
   render() {
     const {
       checked,
       disabled,
+      helperText,
       hideLabel,
       indeterminate,
+      invalid,
+      invalidText,
       labelText,
       name,
       readonly,
       title,
       value,
+      warn,
+      warnText,
       _handleChange: handleChange,
       _handleClick: handleClick,
     } = this;
+
+    const showWarning = !readonly && !invalid && warn;
+    const showHelper = !invalid && !warn;
+
+    const checkboxGroupInstanceId = Math.random().toString(16).slice(2);
+
+    const helperId = !helperText
+      ? undefined
+      : `checkbox-group-helper-text-${checkboxGroupInstanceId}`;
+
+    const helper = helperText
+      ? html` <div id="${helperId}" class="${prefix}--form__helper-text">
+          ${helperText}
+        </div>`
+      : null;
+
     const labelClasses = classMap({
       [`${prefix}--checkbox-label`]: true,
     });
@@ -178,6 +231,25 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
         title="${ifDefined(title)}">
         <span class="${labelTextClasses}"><slot>${labelText}</slot></span>
       </label>
+      <div class="${prefix}--checkbox__validation-msg">
+        ${!readonly && invalid
+          ? html`
+              ${WarningFilled16({
+                class: `${prefix}--checkbox__invalid-icon`,
+              })}
+              <div class="${prefix}--form-requirement">${invalidText}</div>
+            `
+          : undefined}
+        ${showWarning
+          ? html`
+              ${WarningAltFilled16({
+                class: `${prefix}--checkbox__invalid-icon ${prefix}--checkbox__invalid-icon--warning`,
+              })}
+              <div class="${prefix}--form-requirement">${warnText}</div>
+            `
+          : undefined}
+      </div>
+      ${showHelper ? helper : undefined}
     `;
   }
 

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.ts
@@ -190,16 +190,8 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
     const showWarning = !readonly && !invalid && warn;
     const showHelper = !invalid && !warn;
 
-    const checkboxGroupInstanceId = Math.random().toString(16).slice(2);
-
-    const helperId = !helperText
-      ? undefined
-      : `checkbox-group-helper-text-${checkboxGroupInstanceId}`;
-
     const helper = helperText
-      ? html` <div id="${helperId}" class="${prefix}--form__helper-text">
-          ${helperText}
-        </div>`
+      ? html` <div class="${prefix}--form__helper-text">${helperText}</div>`
       : null;
 
     const labelClasses = classMap({
@@ -239,7 +231,7 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
               })}
               <div class="${prefix}--form-requirement">${invalidText}</div>
             `
-          : undefined}
+          : null}
         ${showWarning
           ? html`
               ${WarningAltFilled16({
@@ -247,9 +239,9 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
               })}
               <div class="${prefix}--form-requirement">${warnText}</div>
             `
-          : undefined}
+          : null}
       </div>
-      ${showHelper ? helper : undefined}
+      ${showHelper ? helper : null}
     `;
   }
 

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.ts
@@ -167,6 +167,39 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
   @property({ type: String, attribute: 'warn-text' })
   warnText = false;
 
+  /**
+   * Handles `slotchange` event.
+   */
+  protected _handleSlotChange({ target }: Event) {
+    const hasContent = (target as HTMLSlotElement)
+      .assignedNodes()
+      .filter((elem) =>
+        (elem as HTMLElement).matches !== undefined
+          ? (elem as HTMLElement).matches(
+              (this.constructor as typeof CDSCheckbox).slugItem
+            )
+          : false
+      );
+
+    this._hasSlug = Boolean(hasContent);
+    const type = (hasContent[0] as HTMLElement).getAttribute('kind');
+    (hasContent[0] as HTMLElement).setAttribute(
+      'size',
+      type === 'inline' ? 'md' : 'mini'
+    );
+    this.requestUpdate();
+  }
+
+  /**
+   * `true` if there is a slug.
+   */
+  protected _hasSlug = false;
+
+  updated() {
+    const { _hasSlug: hasSlug } = this;
+    hasSlug ? this.setAttribute('slug', '') : this.removeAttribute('slug');
+  }
+
   render() {
     const {
       checked,
@@ -221,7 +254,10 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
         part="label"
         class="${labelClasses}"
         title="${ifDefined(title)}">
-        <span class="${labelTextClasses}"><slot>${labelText}</slot></span>
+        <span class="${labelTextClasses}"
+          >${labelText}
+          <slot name="slug" @slotchange="${this._handleSlotChange}"></slot
+        ></span>
       </label>
       <div class="${prefix}--checkbox__validation-msg">
         ${!readonly && invalid
@@ -250,6 +286,13 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
    */
   static get eventChange() {
     return `${prefix}-checkbox-changed`;
+  }
+
+  /**
+   * A selector that will return the slug item.
+   */
+  static get slugItem() {
+    return `${prefix}-slug`;
   }
 
   static shadowRootOptions = {

--- a/packages/carbon-web-components/src/components/checkbox/index.ts
+++ b/packages/carbon-web-components/src/components/checkbox/index.ts
@@ -8,4 +8,5 @@
  */
 
 import './checkbox';
+import './checkbox-group';
 import './checkbox-skeleton';

--- a/packages/carbon-web-components/src/components/slug/slug-example-story.ts
+++ b/packages/carbon-web-components/src/components/slug/slug-example-story.ts
@@ -81,6 +81,85 @@ export default {
   title: 'Experimental/Slug/Examples',
 };
 
+export const _Checkbox = (args) => {
+  const { disabled, invalid, invalidText, warn, warnText } =
+    args?.['cds-checkbox'] ?? {};
+
+  return html`
+    <style>
+      ${styles}
+    </style>
+    <div style="width: 400px">
+      <cds-checkbox-group
+        legend-text="Group label"
+        ?disabled="${disabled}"
+        ?invalid="${invalid}"
+        invalid-text="${invalidText}"
+        ?warn="${warn}"
+        warn-text="${warnText}">
+        <cds-slug alignment="bottom-left"> ${content}${actions}</cds-slug>
+        <cds-checkbox label-text="Checkbox label"></cds-checkbox>
+        <cds-checkbox label-text="Checkbox label"></cds-checkbox>
+        <cds-checkbox label-text="Checkbox label"></cds-checkbox>
+      </cds-checkbox-group>
+
+      <cds-checkbox-group
+        legend-text="Group label"
+        ?disabled="${disabled}"
+        ?invalid="${invalid}"
+        invalid-text="${invalidText}"
+        ?warn="${warn}"
+        warn-text="${warnText}">
+        <cds-checkbox label-text="Checkbox label">
+          <cds-slug alignment="bottom-left"> ${content}${actions}</cds-slug>
+        </cds-checkbox>
+        <cds-checkbox label-text="Checkbox label">
+          <cds-slug alignment="bottom-left"> ${content}${actions}</cds-slug>
+        </cds-checkbox>
+        <cds-checkbox label-text="Checkbox label"></cds-checkbox>
+      </cds-checkbox-group>
+
+      <cds-checkbox-group
+        legend-text="Group label"
+        ?disabled="${disabled}"
+        ?invalid="${invalid}"
+        invalid-text="${invalidText}"
+        ?warn="${warn}"
+        warn-text="${warnText}">
+        <cds-checkbox label-text="Checkbox label">
+          <cds-slug alignment="bottom-left" kind="inline">
+            ${content}${actions}
+          </cds-slug>
+        </cds-checkbox>
+        <cds-checkbox label-text="Checkbox label">
+          <cds-slug alignment="bottom-left" kind="inline">
+            ${content}${actions}
+          </cds-slug>
+        </cds-checkbox>
+        <cds-checkbox label-text="Checkbox label"></cds-checkbox>
+      </cds-checkbox-group>
+    </div>
+  `;
+};
+
+_Checkbox.parameters = {
+  knobs: {
+    [`${prefix}-checkbox`]: () => ({
+      disabled: boolean('Disabled (disabled)', false),
+      invalid: boolean('Invalid (invalid)', false),
+      invalidText: textNullable(
+        'Invalid text (invalid-text)',
+        'Error message goes here'
+      ),
+      warn: boolean('Warn (warn)', false),
+      warnText: textNullable(
+        'Warn text (warn-text)',
+        'Warning message that is really long can wrap to more lines but should not be excessively long.'
+      ),
+    }),
+  },
+};
+
 export const _Combobox = () => {
   return html` <style>
       ${styles}

--- a/packages/carbon-web-components/src/components/slug/slug-story.scss
+++ b/packages/carbon-web-components/src/components/slug/slug-story.scss
@@ -110,3 +110,7 @@ div #{$prefix}-selectable-tile::-moz-list-bullet {
 #{$prefix}-radio-button-group:not(:first-of-type) {
   margin-top: $spacing-07;
 }
+
+#{$prefix}-checkbox-group:not(:first-of-type) {
+  margin-top: $spacing-07;
+}


### PR DESCRIPTION
### Related Ticket(s)

Closes #11140 

### Description

Adds slug slot to checkbox and new component - checkbox-group

### Changelog

**New**

- `cds-checkbox-group` component
- new states for `cds-checkbox` component - `warn` and `invalid` to sync with core Carbon
- new story for checkbox (`Single`) to display the `warn` and `invalid` states of checkbox
- slug option to checkbox and checkbox-group

**Testing**

Experimental -> Slug -> Examples -> Checkbox