### PR TITLE
feat(ibmdotcom-styles) remove react classes from component styles

### DIFF
--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -5,677 +5,636 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@use '@carbon/styles/scss/breakpoint' as *;
-@use '@carbon/styles/scss/colors' as *;
-@use '@carbon/styles/scss/config' as *;
-@use '@carbon/styles/scss/motion' as *;
-@use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/type' as *;
-@use '@carbon/styles/scss/components/tag/index' as *;
-@use '@carbon/styles/scss/components/tile/index' as *;
-@use '@carbon/styles/scss/theme' as *;
-@use '../../globals/vars' as *;
-@use '../../globals/utils/content-width' as *;
-@use '../../globals/utils/ratio-base' as *;
-@use '../lightbox-media-viewer/lightbox-media-viewer';
-@use '../link-with-icon/link-with-icon';
-
-@mixin card {
-  .#{$prefix}--card,
-  :host(#{$c4d-prefix}-card),
-  :host(#{$c4d-prefix}-region-item) .#{$prefix}--link,
-  :host(#{$c4d-prefix}-card-cta),
-  :host(#{$c4d-prefix}-card-in-card),
-  :host(#{$c4d-prefix}-card-group-item),
-  :host(#{$c4d-prefix}-card-group-item) .#{$prefix}--card,
-  :host(#{$c4d-prefix}-content-group-cards-item),
-  :host(#{$c4d-prefix}-content-group-cards-item) .#{$prefix}--card {
-    @include tile($enable-experimental-tile-contrast: true);
-
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    height: 100%;
-    background-color: $layer-01;
-    text-decoration: none;
-    padding: 0;
-    transition: $duration-moderate-01 motion(standard, productive);
-
-    &:focus-within {
-      .#{$prefix}--tile--clickable {
-        outline: $spacing-01 solid $focus;
-        outline-offset: -#{$spacing-01};
-        position: relative;
-        z-index: 2;
-      }
-
-      ::slotted(#{$c4d-prefix}-image),
-      ::slotted(#{$c4d-prefix}-card-cta-image),
-      .#{$prefix}--card__img,
-      .#{$prefix}--image {
-        z-index: -1;
-      }
-    }
-
-    &:focus,
-    &:visited,
-    &:active {
-      position: relative;
-      z-index: 2;
-      text-decoration: none;
-
-      ::slotted(#{$c4d-prefix}-image),
-      .#{$prefix}--image {
-        z-index: -1;
-      }
-    }
-
-    ::slotted(#{$c4d-prefix}-image),
-    ::slotted(#{$c4d-prefix}-card-cta-image) {
-      position: relative;
-
-      &::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        background-color: $border-inverse;
-        opacity: 0;
-        transition: $duration-moderate-01 motion(standard, productive);
-      }
-    }
-
-    &:not([disabled]) .#{$prefix}--card.#{$prefix}--tile {
-      padding: 0;
-      transition: $duration-moderate-01 motion(standard, productive);
-
-      &:hover {
-        #{$c4d-prefix}-image,
-        ::slotted(#{$c4d-prefix}-image),
-        ::slotted(#{$c4d-prefix}-card-cta-image) {
-          &::after {
-            content: '';
-            position: absolute;
-            top: 0;
-            width: 100%;
-            height: 100%;
-            background: $overlay;
-            opacity: 16%;
-          }
-        }
-      }
-    }
-
-    .#{$prefix}--card__wrapper {
-      display: flex;
-      flex: 1;
-      min-height: carbon--mini-units(20);
-      justify-content: space-between;
-      transition: $duration-moderate-01 motion(standard, productive);
-
-      @include ratio-base(2, 1, false);
-    }
-
-    .#{$prefix}--card__content {
-      display: flex;
-      flex-direction: column;
-      padding: $spacing-05;
-      width: 100%;
-    }
-
-    .#{$prefix}--card__heading {
-      @include type-style('fluid-heading-03', true);
-
-      margin-bottom: $spacing-10;
-    }
-
-    .#{$prefix}--card__heading,
-    .#{$prefix}--card__copy {
-      @include content-width;
-
-      color: $text-primary;
-    }
-
-    .#{$prefix}--card__copy:not([hidden]) {
-      @include type-style('body-02');
-
-      margin-bottom: $spacing-07;
-    }
-
-    .#{$prefix}--card__img {
-      transition: $duration-moderate-01 motion(standard, productive);
-    }
-  }
-
-  // Card with pictogram placement style
-  :host(#{$c4d-prefix}-card-group-item),
-  :host(#{$c4d-prefix}-card-in-card),
-  :host(#{$c4d-prefix}-card-cta),
-  :host(#{$c4d-prefix}-card) {
-    outline: none;
-
-    .#{$prefix}--card__pictogram {
-      display: flex;
-
-      ::slotted(#{$c4d-prefix}-card-heading) {
-        padding-top: $spacing-07;
-        margin-bottom: 0;
-
-        @include breakpoint(md) {
-          padding-left: 0;
-          flex: 1;
-          display: flex;
-        }
-      }
-    }
-
-    &[pictogram] .#{$prefix}--card {
-      ::slotted(#{$c4d-prefix}-card-heading) {
-        padding-top: 0;
-      }
-
-      ::slotted(svg[slot='pictogram']) {
-        margin-left: 0;
-      }
-
-      .#{$prefix}--card__content {
-        position: relative;
-      }
-
-      .#{$prefix}--card__copy {
-        margin-top: $spacing-07;
-        margin-bottom: 0;
-
-        &[hidden] {
-          margin: 0;
-        }
-      }
-
-      svg {
-        position: absolute;
-        right: $spacing-05;
-        bottom: $spacing-05;
-        color: $link-primary;
-      }
-    }
-
-    &[pictogram] {
-      &[pictogram-placement='top'] .#{$prefix}--card {
-        ::slotted(#{$c4d-prefix}-card-heading) {
-          align-items: flex-end;
-          margin-bottom: 0;
-          margin-top: auto;
-        }
-
-        .#{$prefix}--card__copy {
-          margin-top: $spacing-07;
-        }
-
-        ::slotted(svg[slot='pictogram']) {
-          margin-bottom: $spacing-07;
-        }
-      }
-
-      &[pictogram-placement='bottom'] .#{$prefix}--card {
-        ::slotted(#{$c4d-prefix}-card-heading) {
-          align-items: flex-start;
-        }
-
-        .#{$prefix}--card__copy {
-          margin-bottom: $spacing-07;
-        }
-
-        ::slotted(svg[slot='pictogram']) {
-          margin-top: auto;
-          align-items: flex-end;
-        }
-      }
-    }
-
-    ::slotted(svg[slot='pictogram']) {
-      fill: currentColor;
-      @include breakpoint(md) {
-        margin-left: 0;
-      }
-      @include breakpoint(sm) {
-        margin-left: $spacing-05;
-      }
-    }
-
-    &[color-scheme='inverse'] {
-      .#{$prefix}--card svg,
-      ::slotted(svg[slot='pictogram']) {
-        color: $link-inverse;
-      }
-    }
-
-    .#{$prefix}--card__copy {
-      display: flex;
-      flex-direction: column;
-      gap: $spacing-05;
-    }
-
-    ::slotted(div) {
-      /* stylelint-disable declaration-no-important */
-      // need the !important to prevent CSS reset styles from overwritting margin for tags
-      margin-left: -$spacing-02 !important;
-    }
-  }
-
-  :host(#{$c4d-prefix}-card[aspect-ratio='1:1']) .#{$prefix}--card__wrapper {
-    @include ratio-base(1, 1, false);
-  }
-
-  :host(#{$c4d-prefix}-card[aspect-ratio='3:2']) .#{$prefix}--card__wrapper {
-    @include ratio-base(3, 2, false);
-  }
-
-  :host(#{$c4d-prefix}-card[aspect-ratio='4:3']) .#{$prefix}--card__wrapper {
-    @include ratio-base(4, 3, false);
-  }
-
-  :host(#{$c4d-prefix}-card[aspect-ratio='16:9']) .#{$prefix}--card__wrapper {
-    @include ratio-base(16, 9, false);
-  }
-  .#{$prefix}--card.#{$prefix}--card--light {
-    background-color: $layer-02;
-  }
-
-  .#{$prefix}--card--border {
-    border: 1px solid $layer-accent-01;
-  }
-
-  // FIXME: CardLink is being used as Card in React, need to separate this
-  .#{$prefix}--card__CTA.#{$prefix}--card__CardCTA .#{$prefix}--card__heading {
-    @include type-style('fluid-heading-03', true);
-  }
-
-  // static card
-
-  :host(#{$c4d-prefix}-card),
-  :host(#{$c4d-prefix}-card-group-item) {
-    &:not([href]) {
-      .#{$prefix}--card .#{$prefix}--card__copy {
-        margin-bottom: $spacing-01;
-      }
-
-      .#{$prefix}--card.#{$prefix}--tile ::slotted(#{$c4d-prefix}-image) {
-        &::after {
-          display: none;
-        }
-      }
-
-      &:focus-within ::slotted(#{$c4d-prefix}-image) {
-        z-index: 0;
-      }
-
-      ::slotted(#{$c4d-prefix}-card-heading) {
-        padding-bottom: $spacing-10;
-        margin-bottom: auto;
-      }
-
-      ::slotted(#{$c4d-prefix}-card-footer) {
-        margin-top: $spacing-07;
-        display: inline-flex;
-        &::after {
-          position: relative;
-        }
-      }
-    }
-
-    &[color-scheme='light'] {
-      &,
-      &:hover {
-        .#{$prefix}--card__wrapper {
-          background-color: $layer-02;
-          transition: $duration-moderate-01 motion(standard, productive);
-        }
-      }
-
-      &[href] {
-        :hover {
-          .#{$prefix}--card__wrapper {
-            background-color: $background-hover;
-          }
-        }
-        &:active,
-        a:active {
-          outline: none;
-        }
-      }
-    }
-
-    // Logo card
-    &[logo] {
-      .#{$prefix}--card {
-        background-color: $layer-02;
-      }
-
-      .#{$prefix}--card__copy {
-        margin-bottom: $spacing-05;
-      }
-
-      &:hover {
-        border-color: $toggle-off;
-
-        .#{$prefix}--card__wrapper {
-          background-color: $layer-02;
-        }
-      }
-
-      &:active {
-        border-color: $border-inverse;
-      }
-
-      ::slotted(#{$c4d-prefix}-card-footer) {
-        height: 0;
-      }
-    }
-
-    &[href][logo] {
-      &:hover {
-        .#{$prefix}--card__wrapper {
-          background-color: $layer-02;
-        }
-      }
-    }
-  }
-
-  :host(#{$c4d-prefix}-card[link]) {
-    ::slotted(#{$c4d-prefix}-card-heading) {
-      @include type-style('heading-02');
-
-      margin-bottom: 0;
-    }
-
-    .#{$prefix}--card .#{$prefix}--card__copy {
-      margin-top: 0;
-    }
-  }
-
-  :host(#{$c4d-prefix}-card-cta),
-  :host(#{$c4d-prefix}-card-link-cta),
-  :host(#{$c4d-prefix}-card-link) {
-    outline: none;
-  }
-
-  :host(#{$c4d-prefix}-card-eyebrow),
-  .#{$prefix}--card__eyebrow {
-    @include content-width;
-    @include type-style('label-02');
-
-    margin-bottom: $spacing-03;
-    color: $text-secondary;
-  }
-
-  :host(#{$c4d-prefix}-card-footer),
-  :host(#{$c4d-prefix}-card-cta-footer),
-  :host(#{$c4d-prefix}-card-in-card-footer),
-  :host(#{$c4d-prefix}-feature-card-footer),
-  :host(#{$c4d-prefix}-feature-cta-footer) {
-    margin-top: auto;
-    display: flex;
-    align-items: flex-end;
-
-    &:focus-visible {
-      outline: none;
-    }
-  }
-
-  :host(#{$c4d-prefix}-card-footer) {
-    .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon {
-      display: flex;
-
-      svg,
-      ::slotted(svg[slot='icon']) {
-        display: block;
-      }
-    }
-  }
-
-  .#{$prefix}--card .#{$prefix}--card__footer,
-  :host(#{$c4d-prefix}-card-footer) a,
-  :host(#{$c4d-prefix}-card-cta-footer) a,
-  :host(#{$c4d-prefix}-card-in-card-footer) a,
-  :host(#{$c4d-prefix}-feature-card-footer) a,
-  :host(#{$c4d-prefix}-feature-cta-footer) a {
-    /* Moves the footer down to the bottom in the card */
-    margin-top: auto;
-    text-decoration: none;
-
-    &:focus {
-      outline: none;
-    }
-
-    &:hover {
-      text-decoration: none;
-    }
-
-    span {
-      flex: none;
-    }
-
-    &::after {
-      content: '';
-      position: absolute;
-      z-index: 1;
-      top: 0;
-      left: 0;
-      bottom: 0;
-      right: 0;
-    }
-
-    .#{$prefix}--card__cta__copy {
-      max-width: calc(100% - 20px - #{$spacing-03});
-      margin-right: $spacing-03;
-      @include type-style('body-02');
-    }
-
-    .#{$prefix}--card__footer__copy {
-      max-width: calc(100% - 20px);
-      margin-bottom: -$spacing-01;
-    }
-
-    svg,
-    ::slotted(svg[slot='icon']) {
-      display: block;
-      min-width: 20px;
-      margin-left: 0;
-    }
-  }
-
-  :host(#{$c4d-prefix}-card-footer),
-  :host(#{$c4d-prefix}-card-cta-footer) {
-    .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon {
-      display: flex;
-      width: 100%;
-      justify-content: flex-end;
-      align-items: center;
-
-      &:active {
-        color: $link-primary-hover;
-      }
-    }
-
-    &[color-scheme='inverse']
-      .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon:not(
-        .#{$prefix}--link--disabled
-      ) {
-      color: $link-inverse;
-    }
-  }
-
-  // static card footer
-  :host(#{$c4d-prefix}-card-footer):not([parent-href]) {
-    .#{$prefix}--card__footer {
-      width: auto;
-      justify-content: flex-start;
-
-      &:hover {
-        color: $link-primary-hover;
-      }
-
-      &:active,
-      &:hover {
-        text-decoration: none;
-      }
-
-      &::after {
-        content: none;
-      }
-      &:focus {
-        outline: $spacing-01 solid $focus;
-      }
-    }
-
-    .#{$prefix}--card__cta__copy {
-      margin-right: $spacing-03;
-    }
-  }
-
-  :host(#{$c4d-prefix}-card)[color-scheme='inverse']:not([disabled]),
-  :host(#{$c4d-prefix}-card-group-item)[color-scheme='inverse']:not([disabled])
-    .#{$prefix}--card {
-    .#{$prefix}--tile {
-      background-color: $background-inverse;
-      border-color: $background-inverse;
-
-      &:hover {
-        #{$c4d-prefix}-image,
-        ::slotted(#{$c4d-prefix}-image),
-        ::slotted(#{$c4d-prefix}-card-cta-image) {
-          filter: brightness(108%);
-
-          &::after {
-            display: none;
-          }
-        }
-      }
-    }
-
-    .#{$prefix}--card__wrapper:hover {
-      background-color: $background-inverse-hover;
-    }
-
-    .#{$prefix}--card__heading,
-    .#{$prefix}--card__copy {
-      color: $icon-inverse;
-    }
-
-    .#{$prefix}--card__eyebrow {
-      color: $text-placeholder;
-    }
-
-    &:focus-within {
-      &::after {
-        content: '';
-        position: absolute;
-        z-index: 2;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        right: 0;
-        border: $spacing-01 solid $focus;
-        outline: 1px solid $focus-inset;
-        outline-offset: -3px;
-        pointer-events: none;
-      }
-    }
-  }
-
-  :host(#{$c4d-prefix}-card-heading),
-  :host(#{$c4d-prefix}-card-link-heading) {
-    @include content-width;
-
-    color: $text-primary;
-    margin-bottom: $spacing-10;
-  }
-
-  :host(#{$c4d-prefix}-card-heading) {
-    @include type-style('heading-03', true);
-  }
-
-  :host(#{$c4d-prefix}-card-link-heading) {
-    @include type-style('heading-02', true);
-
-    margin-bottom: 0;
-  }
-
-  :host(#{$c4d-prefix}-card)[color-scheme='inverse'],
-  :host(#{$c4d-prefix}-card-group-item)[color-scheme='inverse'],
-  :host(#{$c4d-prefix}-feature-section-card-link)[color-scheme='inverse'],
-  .#{$prefix}--card-group__card {
-    ::slotted(#{$c4d-prefix}-card-eyebrow),
-    ::slotted(#{$c4d-prefix}-card-heading),
-    ::slotted(#{$c4d-prefix}-card-link-heading) {
-      color: $text-inverse;
-    }
-
-    &:hover {
-      ::slotted(#{$c4d-prefix}-image),
-      ::slotted(#{$c4d-prefix}-card-cta-image) {
-        filter: brightness(108%);
-      }
-    }
-  }
-
-  @media print {
-    :host(#{$c4d-prefix}-card),
-    :host(#{$c4d-prefix}-card-group-item),
-    :host(#{$c4d-prefix}-card-cta),
-    :host(#{$c4d-prefix}-card-in-card),
-    :host(#{$c4d-prefix}-content-group-cards-item) {
-      border: 1px solid $layer-accent-01;
-
-      .#{$prefix}--card {
-        background-color: $layer-02;
-        border: none;
-      }
-
-      ::slotted(#{$c4d-prefix}-image),
-      ::slotted(#{$c4d-prefix}-card-cta-image),
-      .#{$prefix}--image {
-        display: none;
-      }
-    }
-
-    .#{$prefix}--card {
-      background-color: $layer-02;
-      border: 1px solid $layer-accent-01;
-
-      .#{$prefix}--card__img,
-      .#{$prefix}--card__image_img,
-      .#{$prefix}--image,
-      .#{$prefix}--card__video-thumbnail {
-        display: none;
-      }
-    }
-  }
-
-  :host(#{$c4d-prefix}-card[disabled]),
-  :host(#{$c4d-prefix}-region-item[disabled]) {
-    .#{$prefix}--card {
-      cursor: not-allowed;
-    }
-
-    .#{$prefix}--card__copy,
-    ::slotted(#{$c4d-prefix}-card-eyebrow),
-    ::slotted(#{$c4d-prefix}-card-heading) {
-      color: $text-disabled;
-    }
-  }
-
-  :host(#{$c4d-prefix}-card-cta-footer[cta-type='video']),
-  :host(#{$c4d-prefix}-card-footer[cta-type='video']) {
-    .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon {
-      justify-content: space-between;
-    }
-  }
-
-  :host(#{$c4d-prefix}-card-footer[href])::after {
-    position: relative;
-  }
-}
+ @use '@carbon/styles/scss/breakpoint' as *;
+ @use '@carbon/styles/scss/colors' as *;
+ @use '@carbon/styles/scss/config' as *;
+ @use '@carbon/styles/scss/motion' as *;
+ @use '@carbon/styles/scss/spacing' as *;
+ @use '@carbon/styles/scss/type' as *;
+ @use '@carbon/styles/scss/components/tag/index' as *;
+ @use '@carbon/styles/scss/components/tile/index' as *;
+ @use '@carbon/styles/scss/theme' as *;
+ @use '../../globals/vars' as *;
+ @use '../../globals/utils/content-width' as *;
+ @use '../../globals/utils/ratio-base' as *;
+ @use '../lightbox-media-viewer/lightbox-media-viewer';
+ @use '../link-with-icon/link-with-icon';
+ 
+ @mixin card {
+   .#{$prefix}--card,
+   :host(#{$c4d-prefix}-card),
+   :host(#{$c4d-prefix}-region-item) .#{$prefix}--link,
+   :host(#{$c4d-prefix}-card-cta),
+   :host(#{$c4d-prefix}-card-in-card),
+   :host(#{$c4d-prefix}-card-group-item),
+   :host(#{$c4d-prefix}-card-group-item) .#{$prefix}--card,
+   :host(#{$c4d-prefix}-content-group-cards-item),
+   :host(#{$c4d-prefix}-content-group-cards-item) .#{$prefix}--card {
+     @include tile($enable-experimental-tile-contrast: true);
+ 
+     position: relative;
+     display: flex;
+     flex-direction: column;
+     width: 100%;
+     height: 100%;
+     background-color: $layer-01;
+     text-decoration: none;
+     padding: 0;
+     transition: $duration-moderate-01 motion(standard, productive);
+ 
+     &:focus-within {
+       .#{$prefix}--tile--clickable {
+         outline: $spacing-01 solid $focus;
+         outline-offset: -#{$spacing-01};
+         position: relative;
+         z-index: 2;
+       }
+ 
+       ::slotted(#{$c4d-prefix}-image),
+       ::slotted(#{$c4d-prefix}-card-cta-image) {
+         z-index: -1;
+       }
+     }
+ 
+     &:focus,
+     &:visited,
+     &:active {
+       position: relative;
+       z-index: 2;
+       text-decoration: none;
+ 
+       ::slotted(#{$c4d-prefix}-image) {
+         z-index: -1;
+       }
+     }
+ 
+     ::slotted(#{$c4d-prefix}-image),
+     ::slotted(#{$c4d-prefix}-card-cta-image) {
+       position: relative;
+ 
+       &::before {
+         content: '';
+         position: absolute;
+         top: 0;
+         right: 0;
+         bottom: 0;
+         left: 0;
+         background-color: $border-inverse;
+         opacity: 0;
+         transition: $duration-moderate-01 motion(standard, productive);
+       }
+     }
+ 
+     &:not([disabled]) .#{$prefix}--card.#{$prefix}--tile {
+       padding: 0;
+       transition: $duration-moderate-01 motion(standard, productive);
+ 
+       &:hover {
+         #{$c4d-prefix}-image,
+         ::slotted(#{$c4d-prefix}-image),
+         ::slotted(#{$c4d-prefix}-card-cta-image) {
+           &::after {
+             content: '';
+             position: absolute;
+             top: 0;
+             width: 100%;
+             height: 100%;
+             background: $overlay;
+             opacity: 16%;
+           }
+         }
+       }
+     }
+ 
+     .#{$prefix}--card__wrapper {
+       display: flex;
+       flex: 1;
+       min-height: carbon--mini-units(20);
+       justify-content: space-between;
+       transition: $duration-moderate-01 motion(standard, productive);
+ 
+       @include ratio-base(2, 1, false);
+     }
+ 
+     .#{$prefix}--card__content {
+       display: flex;
+       flex-direction: column;
+       padding: $spacing-05;
+       width: 100%;
+     }
+ 
+     .#{$prefix}--card__copy {
+       @include content-width;
+ 
+       color: $text-primary;
+     }
+ 
+     .#{$prefix}--card__copy:not([hidden]) {
+       @include type-style('body-02');
+ 
+       margin-bottom: $spacing-07;
+     }
+   }
+ 
+   // Card with pictogram placement style
+   :host(#{$c4d-prefix}-card-group-item),
+   :host(#{$c4d-prefix}-card-in-card),
+   :host(#{$c4d-prefix}-card-cta),
+   :host(#{$c4d-prefix}-card) {
+     outline: none;
+ 
+     .#{$prefix}--card__pictogram {
+       display: flex;
+ 
+       ::slotted(#{$c4d-prefix}-card-heading) {
+         padding-top: $spacing-07;
+         margin-bottom: 0;
+ 
+         @include breakpoint(md) {
+           padding-left: 0;
+           flex: 1;
+           display: flex;
+         }
+       }
+     }
+ 
+     &[pictogram] .#{$prefix}--card {
+       ::slotted(#{$c4d-prefix}-card-heading) {
+         padding-top: 0;
+       }
+ 
+       ::slotted(svg[slot='pictogram']) {
+         margin-left: 0;
+       }
+ 
+       .#{$prefix}--card__content {
+         position: relative;
+       }
+ 
+       .#{$prefix}--card__copy {
+         margin-top: $spacing-07;
+         margin-bottom: 0;
+ 
+         &[hidden] {
+           margin: 0;
+         }
+       }
+ 
+       svg {
+         position: absolute;
+         right: $spacing-05;
+         bottom: $spacing-05;
+         color: $link-primary;
+       }
+     }
+ 
+     &[pictogram] {
+       &[pictogram-placement='top'] .#{$prefix}--card {
+         ::slotted(#{$c4d-prefix}-card-heading) {
+           align-items: flex-end;
+           margin-bottom: 0;
+           margin-top: auto;
+         }
+ 
+         .#{$prefix}--card__copy {
+           margin-top: $spacing-07;
+         }
+ 
+         ::slotted(svg[slot='pictogram']) {
+           margin-bottom: $spacing-07;
+         }
+       }
+ 
+       &[pictogram-placement='bottom'] .#{$prefix}--card {
+         ::slotted(#{$c4d-prefix}-card-heading) {
+           align-items: flex-start;
+         }
+ 
+         .#{$prefix}--card__copy {
+           margin-bottom: $spacing-07;
+         }
+ 
+         ::slotted(svg[slot='pictogram']) {
+           margin-top: auto;
+           align-items: flex-end;
+         }
+       }
+     }
+ 
+     ::slotted(svg[slot='pictogram']) {
+       fill: currentColor;
+       @include breakpoint(md) {
+         margin-left: 0;
+       }
+       @include breakpoint(sm) {
+         margin-left: $spacing-05;
+       }
+     }
+ 
+     &[color-scheme='inverse'] {
+       .#{$prefix}--card svg,
+       ::slotted(svg[slot='pictogram']) {
+         color: $link-inverse;
+       }
+     }
+ 
+     .#{$prefix}--card__copy {
+       display: flex;
+       flex-direction: column;
+       gap: $spacing-05;
+     }
+ 
+     ::slotted(div) {
+       /* stylelint-disable declaration-no-important */
+       // need the !important to prevent CSS reset styles from overwritting margin for tags
+       margin-left: -$spacing-02 !important;
+     }
+   }
+ 
+   :host(#{$c4d-prefix}-card[aspect-ratio='1:1']) .#{$prefix}--card__wrapper {
+     @include ratio-base(1, 1, false);
+   }
+ 
+   :host(#{$c4d-prefix}-card[aspect-ratio='3:2']) .#{$prefix}--card__wrapper {
+     @include ratio-base(3, 2, false);
+   }
+ 
+   :host(#{$c4d-prefix}-card[aspect-ratio='4:3']) .#{$prefix}--card__wrapper {
+     @include ratio-base(4, 3, false);
+   }
+ 
+   :host(#{$c4d-prefix}-card[aspect-ratio='16:9']) .#{$prefix}--card__wrapper {
+     @include ratio-base(16, 9, false);
+   }
+   // static card
+ 
+   :host(#{$c4d-prefix}-card),
+   :host(#{$c4d-prefix}-card-group-item) {
+     &:not([href]) {
+       .#{$prefix}--card .#{$prefix}--card__copy {
+         margin-bottom: $spacing-01;
+       }
+ 
+       .#{$prefix}--card.#{$prefix}--tile ::slotted(#{$c4d-prefix}-image) {
+         &::after {
+           display: none;
+         }
+       }
+ 
+       &:focus-within ::slotted(#{$c4d-prefix}-image) {
+         z-index: 0;
+       }
+ 
+       ::slotted(#{$c4d-prefix}-card-heading) {
+         padding-bottom: $spacing-10;
+         margin-bottom: auto;
+       }
+ 
+       ::slotted(#{$c4d-prefix}-card-footer) {
+         margin-top: $spacing-07;
+         display: inline-flex;
+         &::after {
+           position: relative;
+         }
+       }
+     }
+ 
+     &[color-scheme='light'] {
+       &,
+       &:hover {
+         .#{$prefix}--card__wrapper {
+           background-color: $layer-02;
+           transition: $duration-moderate-01 motion(standard, productive);
+         }
+       }
+ 
+       &[href] {
+         :hover {
+           .#{$prefix}--card__wrapper {
+             background-color: $background-hover;
+           }
+         }
+         &:active,
+         a:active {
+           outline: none;
+         }
+       }
+     }
+ 
+     // Logo card
+     &[logo] {
+       .#{$prefix}--card {
+         background-color: $layer-02;
+       }
+ 
+       .#{$prefix}--card__copy {
+         margin-bottom: $spacing-05;
+       }
+ 
+       &:hover {
+         border-color: $toggle-off;
+ 
+         .#{$prefix}--card__wrapper {
+           background-color: $layer-02;
+         }
+       }
+ 
+       &:active {
+         border-color: $border-inverse;
+       }
+ 
+       ::slotted(#{$c4d-prefix}-card-footer) {
+         height: 0;
+       }
+     }
+ 
+     &[href][logo] {
+       &:hover {
+         .#{$prefix}--card__wrapper {
+           background-color: $layer-02;
+         }
+       }
+     }
+   }
+ 
+   :host(#{$c4d-prefix}-card[link]) {
+     ::slotted(#{$c4d-prefix}-card-heading) {
+       @include type-style('heading-02');
+ 
+       margin-bottom: 0;
+     }
+ 
+     .#{$prefix}--card .#{$prefix}--card__copy {
+       margin-top: 0;
+     }
+   }
+ 
+   :host(#{$c4d-prefix}-card-cta),
+   :host(#{$c4d-prefix}-card-link-cta),
+   :host(#{$c4d-prefix}-card-link) {
+     outline: none;
+   }
+ 
+   :host(#{$c4d-prefix}-card-eyebrow) {
+     @include content-width;
+     @include type-style('label-02');
+ 
+     margin-bottom: $spacing-03;
+     color: $text-secondary;
+   }
+ 
+   :host(#{$c4d-prefix}-card-footer),
+   :host(#{$c4d-prefix}-card-cta-footer),
+   :host(#{$c4d-prefix}-card-in-card-footer),
+   :host(#{$c4d-prefix}-feature-card-footer),
+   :host(#{$c4d-prefix}-feature-cta-footer) {
+     margin-top: auto;
+     display: flex;
+     align-items: flex-end;
+ 
+     &:focus-visible {
+       outline: none;
+     }
+   }
+ 
+   :host(#{$c4d-prefix}-card-footer) {
+     .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon {
+       display: flex;
+ 
+       svg,
+       ::slotted(svg[slot='icon']) {
+         display: block;
+       }
+     }
+   }
+ 
+   .#{$prefix}--card .#{$prefix}--card__footer,
+   :host(#{$c4d-prefix}-card-footer) a,
+   :host(#{$c4d-prefix}-card-cta-footer) a,
+   :host(#{$c4d-prefix}-card-in-card-footer) a,
+   :host(#{$c4d-prefix}-feature-card-footer) a,
+   :host(#{$c4d-prefix}-feature-cta-footer) a {
+     /* Moves the footer down to the bottom in the card */
+     margin-top: auto;
+     text-decoration: none;
+ 
+     &:focus {
+       outline: none;
+     }
+ 
+     &:hover {
+       text-decoration: none;
+     }
+ 
+     span {
+       flex: none;
+     }
+ 
+     &::after {
+       content: '';
+       position: absolute;
+       z-index: 1;
+       top: 0;
+       left: 0;
+       bottom: 0;
+       right: 0;
+     }
+ 
+     .#{$prefix}--card__cta__copy {
+       max-width: calc(100% - 20px - #{$spacing-03});
+       margin-right: $spacing-03;
+       @include type-style('body-02');
+     }
+ 
+ 
+     svg,
+     ::slotted(svg[slot='icon']) {
+       display: block;
+       min-width: 20px;
+       margin-left: 0;
+     }
+   }
+ 
+   :host(#{$c4d-prefix}-card-footer),
+   :host(#{$c4d-prefix}-card-cta-footer) {
+     .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon {
+       display: flex;
+       width: 100%;
+       justify-content: flex-end;
+       align-items: center;
+ 
+       &:active {
+         color: $link-primary-hover;
+       }
+     }
+ 
+     &[color-scheme='inverse']
+       .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon:not(
+         .#{$prefix}--link--disabled
+       ) {
+       color: $link-inverse;
+     }
+   }
+ 
+   // static card footer
+   :host(#{$c4d-prefix}-card-footer):not([parent-href]) {
+     .#{$prefix}--card__footer {
+       width: auto;
+       justify-content: flex-start;
+ 
+       &:hover {
+         color: $link-primary-hover;
+       }
+ 
+       &:active,
+       &:hover {
+         text-decoration: none;
+       }
+ 
+       &::after {
+         content: none;
+       }
+       &:focus {
+         outline: $spacing-01 solid $focus;
+       }
+     }
+ 
+     .#{$prefix}--card__cta__copy {
+       margin-right: $spacing-03;
+     }
+   }
+ 
+   :host(#{$c4d-prefix}-card)[color-scheme='inverse']:not([disabled]),
+   :host(#{$c4d-prefix}-card-group-item)[color-scheme='inverse']:not([disabled])
+     .#{$prefix}--card {
+     .#{$prefix}--tile {
+       background-color: $background-inverse;
+       border-color: $background-inverse;
+ 
+       &:hover {
+         #{$c4d-prefix}-image,
+         ::slotted(#{$c4d-prefix}-image),
+         ::slotted(#{$c4d-prefix}-card-cta-image) {
+           filter: brightness(108%);
+ 
+           &::after {
+             display: none;
+           }
+         }
+       }
+     }
+ 
+     .#{$prefix}--card__wrapper:hover {
+       background-color: $background-inverse-hover;
+     }
+ 
+     .#{$prefix}--card__copy {
+       color: $icon-inverse;
+     }
+ 
+ 
+     &:focus-within {
+       &::after {
+         content: '';
+         position: absolute;
+         z-index: 2;
+         top: 0;
+         left: 0;
+         bottom: 0;
+         right: 0;
+         border: $spacing-01 solid $focus;
+         outline: 1px solid $focus-inset;
+         outline-offset: -3px;
+         pointer-events: none;
+       }
+     }
+   }
+ 
+   :host(#{$c4d-prefix}-card-heading),
+   :host(#{$c4d-prefix}-card-link-heading) {
+     @include content-width;
+ 
+     color: $text-primary;
+     margin-bottom: $spacing-10;
+   }
+ 
+   :host(#{$c4d-prefix}-card-heading) {
+     @include type-style('heading-03', true);
+   }
+ 
+   :host(#{$c4d-prefix}-card-link-heading) {
+     @include type-style('heading-02', true);
+ 
+     margin-bottom: 0;
+   }
+ 
+   :host(#{$c4d-prefix}-card)[color-scheme='inverse'],
+   :host(#{$c4d-prefix}-card-group-item)[color-scheme='inverse'],
+   :host(#{$c4d-prefix}-feature-section-card-link)[color-scheme='inverse'],
+   .#{$prefix}--card-group__card {
+     ::slotted(#{$c4d-prefix}-card-eyebrow),
+     ::slotted(#{$c4d-prefix}-card-heading),
+     ::slotted(#{$c4d-prefix}-card-link-heading) {
+       color: $text-inverse;
+     }
+ 
+     &:hover {
+       ::slotted(#{$c4d-prefix}-image),
+       ::slotted(#{$c4d-prefix}-card-cta-image) {
+         filter: brightness(108%);
+       }
+     }
+   }
+ 
+   @media print {
+     :host(#{$c4d-prefix}-card),
+     :host(#{$c4d-prefix}-card-group-item),
+     :host(#{$c4d-prefix}-card-cta),
+     :host(#{$c4d-prefix}-card-in-card),
+     :host(#{$c4d-prefix}-content-group-cards-item) {
+       border: 1px solid $layer-accent-01;
+ 
+       .#{$prefix}--card {
+         background-color: $layer-02;
+         border: none;
+       }
+ 
+       ::slotted(#{$c4d-prefix}-image),
+       ::slotted(#{$c4d-prefix}-card-cta-image),
+       .#{$prefix}--image {
+         display: none;
+       }
+     }
+ 
+     .#{$prefix}--card {
+       background-color: $layer-02;
+       border: 1px solid $layer-accent-01;
+ 
+     }
+   }
+ 
+   :host(#{$c4d-prefix}-card[disabled]),
+   :host(#{$c4d-prefix}-region-item[disabled]) {
+     .#{$prefix}--card {
+       cursor: not-allowed;
+     }
+ 
+     .#{$prefix}--card__copy,
+     ::slotted(#{$c4d-prefix}-card-eyebrow),
+     ::slotted(#{$c4d-prefix}-card-heading) {
+       color: $text-disabled;
+     }
+   }
+ 
+   :host(#{$c4d-prefix}-card-cta-footer[cta-type='video']),
+   :host(#{$c4d-prefix}-card-footer[cta-type='video']) {
+     .#{$prefix}--link-with-icon.#{$prefix}--link-with-icon--inline-icon {
+       justify-content: space-between;
+     }
+   }
+ 
+   :host(#{$c4d-prefix}-card-footer[href])::after {
+     position: relative;
+   }
+ }
+ 

--- a/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
+++ b/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
@@ -27,18 +27,6 @@
     }
   }
 
-  .#{$prefix}--content-block-horizontal {
-    .#{$prefix}--content-block {
-      padding-top: $spacing-07;
-      padding-bottom: $spacing-05;
-
-      @include breakpoint(lg) {
-        padding-top: $spacing-10;
-        padding-bottom: $spacing-09;
-      }
-    }
-  }
-
   :host(#{$c4d-prefix}-content-block-horizontal) ::slotted([slot='heading']),
   .#{$prefix}--content-block-horizontal .#{$prefix}--content-block__heading {
     margin-bottom: $spacing-07;

--- a/packages/styles/scss/components/content-block-media/_content-block-media.scss
+++ b/packages/styles/scss/components/content-block-media/_content-block-media.scss
@@ -20,30 +20,11 @@
 @mixin themed-items {
   color: $text-primary;
   background: $background;
-
-  &.#{$prefix}--content-block-media--with-border
-    .#{$prefix}--content-block-media__divider {
-    border-bottom-color: $toggle-off;
-  }
 }
 
 @mixin content-block-media {
   .#{$prefix}--content-block-media,
   :host(#{$c4d-prefix}-content-block-media) {
-    @include themed-items;
-
-    .#{$prefix}--content-group:last-child {
-      margin-bottom: 0;
-    }
-
-    .#{$prefix}--feature-card {
-      max-width: to-rem(640px);
-    }
-  }
-
-  .#{$prefix}--content-block-media--g100 {
-    @include theme($g100, true);
-
     @include themed-items;
   }
 }

--- a/packages/styles/scss/components/content-block-mixed/_content-block-mixed.scss
+++ b/packages/styles/scss/components/content-block-mixed/_content-block-mixed.scss
@@ -26,20 +26,5 @@
         max-width: calc(100% + $spacing-05);
       }
     }
-
-    .#{$prefix}--layout-1-3 {
-      @include breakpoint-down(md) {
-        .#{$prefix}--link-list__list.#{$prefix}--link-list__list--card {
-          margin-right: -$spacing-05;
-        }
-      }
-      @include breakpoint(lg) {
-        @include make-col-offset(1, 12);
-      }
-    }
-
-    .#{$prefix}--content-block__cta-col {
-      max-width: carbon--mini-units(40);
-    }
   }
 }

--- a/packages/styles/scss/components/content-block-segmented/_content-block-segmented.scss
+++ b/packages/styles/scss/components/content-block-segmented/_content-block-segmented.scss
@@ -22,65 +22,8 @@
         @include breakpoint(lg) {
           padding-bottom: $spacing-13;
         }
-
-        .#{$prefix}--content-block__cta-row {
-          margin-bottom: 0;
-        }
-
-        .#{$prefix}--layout-2-3 {
-          padding-left: 0;
-        }
       }
     }
-
-    .#{$prefix}--content-group__cta-row {
-      @include breakpoint-down(md) {
-        margin-left: 0;
-      }
-    }
-
-    .#{$prefix}--content-block__cta-row {
-      margin-bottom: $spacing-07;
-      @include breakpoint(lg) {
-        margin-bottom: $spacing-13;
-      }
-    }
-  }
-
-  // React specific classes to manage bottom spacing
-  .#{$prefix}--content-block-segmented {
-    &-border {
-      .#{$prefix}--content-block {
-        padding-bottom: 0;
-      }
-    }
-
-    .#{$prefix}--content-block__cta-row {
-      margin-bottom: 0;
-
-      &-border {
-        margin-bottom: $spacing-07;
-        @include breakpoint(lg) {
-          margin-bottom: $spacing-13;
-        }
-      }
-    }
-  }
-
-  :host(#{$c4d-prefix}-content-block-segmented)
-    .#{$prefix}--content-block__children
-    .#{$prefix}--content-block-segmented__media
-    ::slotted(:not([slot])) {
-    display: block;
-    margin-top: $spacing-10;
-    margin-bottom: $spacing-10;
-  }
-
-  :host(#{$c4d-prefix}-content-block-segmented)
-    .#{$prefix}--content-block__children
-    .#{$prefix}--content-block-segmented__media
-    ::slotted(:not([slot]):last-of-type) {
-    margin-bottom: 0;
   }
 
   .#{$prefix}--content-block-segmented .#{$prefix}--content-group {

--- a/packages/styles/scss/components/content-block-simple/_content-block-simple.scss
+++ b/packages/styles/scss/components/content-block-simple/_content-block-simple.scss
@@ -12,15 +12,4 @@
 @use '../image';
 
 @mixin content-block-simple {
-  .#{$prefix}--content-block-simple__media-video {
-    max-width: to-rem(640px);
-  }
-
-  .#{$prefix}--content-block-simple__content {
-    .#{$prefix}--content-item {
-      &:first-of-type {
-        margin-top: 0;
-      }
-    }
-  }
 }

--- a/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
+++ b/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
@@ -22,10 +22,8 @@
 }
 
 @mixin content-group-cards {
-  :host(#{$c4d-prefix}-content-group-cards),
-  .#{$prefix}--content-group-cards {
-    ::slotted([slot='copy']),
-    .#{$prefix}--content-group__copy {
+  :host(#{$c4d-prefix}-content-group-cards) {
+    ::slotted([slot='copy']) {
       margin-bottom: $spacing-09;
 
       @include breakpoint(md) {
@@ -48,8 +46,7 @@
     }
   }
 
-  :host(#{$c4d-prefix}-content-group-cards-item),
-  .#{$prefix}--content-group-cards-item__col {
+  :host(#{$c4d-prefix}-content-group-cards-item) {
     margin-top: list.slash($grid-gutter, 2);
     margin-bottom: list.slash($grid-gutter, 2);
     padding-left: list.slash($grid-gutter, 2);

--- a/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
+++ b/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
@@ -27,16 +27,5 @@
   div.#{$prefix}--content-group-pictograms {
     padding-left: 0;
     padding-right: 0;
-
-    .#{$prefix}--content-group__title {
-      padding-left: $spacing-05;
-      padding-right: $spacing-05;
-    }
-  }
-
-  .#{$prefix}--content-group-pictograms__item:last-child {
-    .#{$prefix}--content-item {
-      margin-bottom: 0;
-    }
   }
 }

--- a/packages/styles/scss/components/content-group-simple/_content-group-simple.scss
+++ b/packages/styles/scss/components/content-group-simple/_content-group-simple.scss
@@ -13,13 +13,7 @@
 
 @mixin content-group-simple {
   :host(#{$c4d-prefix}-content-group-simple)
-    ::slotted(#{$c4d-prefix}-content-group-copy),
-  .#{$prefix}--content-group-simple .#{$prefix}--content-group__copy {
+    ::slotted(#{$c4d-prefix}-content-group-copy) {
     margin-bottom: $spacing-07;
-  }
-
-  .bx--content-group__cta {
-    max-width: calc(320px + $spacing-05);
-    padding-right: 0;
   }
 }

--- a/packages/styles/scss/components/content-item-row/_content-item-row.scss
+++ b/packages/styles/scss/components/content-item-row/_content-item-row.scss
@@ -143,15 +143,6 @@
     }
   }
 
-  .#{$prefix}--content-item-row__content-wrapper_with-media {
-    width: 100%;
-    @include breakpoint(lg) {
-      @include make-col(8, 12);
-
-      padding-left: $spacing-04;
-    }
-  }
-
   :host(#{$c4d-prefix}-content-item-row) ::slotted([slot='media']) {
     display: block;
     padding-top: $spacing-07;
@@ -242,20 +233,6 @@
       @include breakpoint(lg) {
         grid-column: 9 / span 4;
       }
-    }
-  }
-
-  :host(#{$c4d-prefix}-content-item-row) .#{$prefix}--content-item__cta {
-    .#{$prefix}--link-list {
-      padding: 0;
-
-      &:first-of-type {
-        padding: 0;
-      }
-    }
-
-    .#{$prefix}--link-list li:last-of-type {
-      margin-bottom: 0;
     }
   }
 

--- a/packages/styles/scss/components/cta-block/_cta-block.scss
+++ b/packages/styles/scss/components/cta-block/_cta-block.scss
@@ -21,178 +21,23 @@
   color: $text-primary;
   background: $background;
 
-  .#{$prefix}--content-item__heading {
-    color: $text-primary;
-  }
-
-  .#{$prefix}--content-item__copy {
-    p {
-      color: $text-primary;
-    }
-  }
-
   .#{$prefix}--content-item__cta {
     color: $link-primary;
   }
 }
 
 @mixin cta-block {
-  :host(#{$c4d-prefix}-cta-block),
-  .#{$prefix}--cta-block {
+  :host(#{$c4d-prefix}-cta-block) {
     padding-top: $spacing-07;
     padding-bottom: $spacing-10;
     @include breakpoint(lg) {
       padding-top: $spacing-10;
     }
 
-    .#{$prefix}--cta-block__cta {
-      padding-bottom: $spacing-10;
-      @include breakpoint(md) {
-        padding-bottom: $spacing-12;
-      }
-      @include breakpoint(lg) {
-        padding-bottom: $spacing-13;
-      }
-
-      .#{$prefix}--buttongroup {
-        @include breakpoint(md) {
-          flex-direction: row;
-        }
-      }
-
-      .#{$prefix}--buttongroup-item {
-        @include breakpoint(md) {
-          padding-right: $spacing-07;
-        }
-      }
-    }
-
-    .#{$prefix}--content-block {
-      padding-top: $spacing-07;
-      padding-bottom: 0;
-
-      @include breakpoint(lg) {
-        padding-top: $spacing-10;
-      }
-    }
-
-    .#{$prefix}--content-block__heading,
-    .#{$prefix}--content-block__copy {
-      width: 90%;
-      max-width: to-rem(640px);
-
-      @include breakpoint(sm) {
-        width: 100%;
-      }
-    }
-
-    .#{$prefix}--content-block__heading {
-      @include type-style('fluid-heading-05', true);
-    }
-
-    .#{$prefix}--content-block__copy {
-      p {
-        margin-bottom: 0;
-        @include type-style('fluid-heading-03', true);
-      }
-    }
-
-    .#{$prefix}--content-block__cta-col {
-      margin-top: 0;
-    }
-
     .#{$prefix}--helper-wrapper {
       .#{$prefix}--content-item-wrapper {
         @include make-row;
-
-        .#{$prefix}--content-item {
-          width: 100%;
-          margin-bottom: 0;
-          padding-bottom: $spacing-05;
-          position: relative;
-
-          @include make-col-ready;
-
-          @include breakpoint(md) {
-            @include make-col(4, 8);
-          }
-
-          &:last-of-type {
-            margin-top: $spacing-05;
-
-            @include breakpoint(md) {
-              margin-top: $spacing-07;
-            }
-          }
-        }
-
-        .#{$prefix}--content-item__heading {
-          width: 100%;
-
-          @include type-style('heading-02', true);
-
-          @include breakpoint(md) {
-            width: 90%;
-          }
-        }
-
-        .#{$prefix}--content-item__copy {
-          width: 100%;
-
-          @include breakpoint(md) {
-            width: 90%;
-          }
-
-          p {
-            width: 100%;
-            margin-bottom: $spacing-05;
-
-            @include type-style('body-02', true);
-          }
-        }
       }
     }
-
-    &.#{$prefix}--cta-block__has-items {
-      padding-bottom: $spacing-09;
-
-      @include breakpoint(lg) {
-        padding-bottom: carbon--mini-units(10);
-      }
-
-      .#{$prefix}--cta-block__cta {
-        padding-bottom: $spacing-07;
-
-        @include breakpoint(md) {
-          padding-bottom: $spacing-10;
-        }
-
-        @include breakpoint(lg) {
-          padding-bottom: $spacing-12;
-        }
-      }
-
-      .#{$prefix}--content-block {
-        padding-bottom: 0;
-      }
-    }
-  }
-
-  .#{$prefix}--cta-block--g10 {
-    @include theme($g10, feature-flag-enabled('enable-css-custom-properties'));
-
-    @include themed-items;
-  }
-
-  .#{$prefix}--cta-block--g90 {
-    @include theme($g90, feature-flag-enabled('enable-css-custom-properties'));
-
-    @include themed-items;
-  }
-
-  .#{$prefix}--cta-block--g100 {
-    @include theme($g100, feature-flag-enabled('enable-css-custom-properties'));
-
-    @include themed-items;
   }
 }

--- a/packages/styles/scss/components/cta-section/_cta-section.scss
+++ b/packages/styles/scss/components/cta-section/_cta-section.scss
@@ -20,158 +20,16 @@
 @mixin themed-items {
   color: $text-primary;
   background: $background;
-
-  .#{$prefix}--content-item__heading {
-    color: $text-primary;
-  }
-
-  .#{$prefix}--content-item__copy {
-    p {
-      color: $text-primary;
-    }
-  }
-
-  .#{$prefix}--content-item__cta {
-    color: $link-primary;
-  }
 }
 
 @mixin cta-section {
-  :host(#{$c4d-prefix}-cta-section),
-  .#{$prefix}--cta-section {
-    .#{$prefix}--cta-section__cta {
-      padding-bottom: $spacing-10;
-
-      @include breakpoint(md) {
-        padding-bottom: $spacing-12;
-      }
-
-      @include breakpoint(lg) {
-        padding-bottom: $spacing-13;
-      }
-
-      .#{$prefix}--buttongroup {
-        @include breakpoint(md) {
-          flex-direction: row;
-        }
-      }
-
-      .#{$prefix}--buttongroup-item {
-        @include breakpoint(md) {
-          padding-right: $spacing-05;
-        }
-      }
-    }
-
-    .#{$prefix}--content-block {
-      padding-top: $spacing-07;
-      padding-bottom: 0;
-
-      @include breakpoint(lg) {
-        padding-top: $spacing-10;
-      }
-    }
-
-    .#{$prefix}--content-block__heading,
-    .#{$prefix}--content-block__copy {
-      width: 90%;
-      max-width: 640px;
-
-      @include breakpoint(sm) {
-        width: 100%;
-      }
-    }
-
-    .#{$prefix}--content-block__heading {
-      @include type-style('fluid-heading-05', true);
-    }
-
-    .#{$prefix}--content-block__copy {
-      p {
-        margin-bottom: 0;
-        @include type-style('fluid-heading-03', true);
-      }
-    }
-
-    .#{$prefix}--content-block__cta-col {
-      margin-top: 0;
-    }
+  :host(#{$c4d-prefix}-cta-section) {
 
     .#{$prefix}--helper-wrapper {
       .#{$prefix}--content-item-wrapper {
         border-top: 1px solid $layer-accent-01;
-
         @include make-row;
 
-        .#{$prefix}--content-item {
-          width: 100%;
-          margin-bottom: 0;
-          padding-bottom: $spacing-05;
-          position: relative;
-
-          @include make-col-ready;
-
-          @include breakpoint(md) {
-            @include make-col(4, 8);
-          }
-
-          &:last-of-type {
-            margin-top: $spacing-05;
-
-            @include breakpoint(md) {
-              margin-top: $spacing-07;
-            }
-          }
-        }
-
-        .#{$prefix}--content-item__heading {
-          width: 100%;
-
-          @include type-style('heading-02', true);
-
-          @include breakpoint(md) {
-            width: 90%;
-          }
-        }
-
-        .#{$prefix}--content-item__copy {
-          width: 100%;
-
-          @include breakpoint(md) {
-            width: 90%;
-          }
-
-          p {
-            width: 100%;
-            margin-bottom: $spacing-05;
-
-            @include type-style('body-02', true);
-          }
-        }
-      }
-    }
-
-    &.#{$prefix}--cta-section__has-items {
-      padding-bottom: $spacing-09;
-
-      @include breakpoint(lg) {
-        padding-bottom: carbon--mini-units(10);
-      }
-
-      .#{$prefix}--cta-section__cta {
-        padding-bottom: $spacing-07;
-
-        @include breakpoint(md) {
-          padding-bottom: $spacing-10;
-        }
-
-        @include breakpoint(lg) {
-          padding-bottom: $spacing-12;
-        }
-      }
-
-      .#{$prefix}--content-block {
-        padding-bottom: 0;
       }
     }
 
@@ -180,18 +38,4 @@
     }
   }
 
-  .#{$prefix}--cta-section--g10 {
-    @include theme($g10, true);
-    @include themed-items;
-  }
-
-  .#{$prefix}--cta-section--g90 {
-    @include theme($g90, true);
-    @include themed-items;
-  }
-
-  .#{$prefix}--cta-section--g100 {
-    @include theme($g100, true);
-    @include themed-items;
-  }
 }


### PR DESCRIPTION
### Related Ticket(s)

Closes #11194

### Description

Remove React classes from component styles

### Changelog

**Removed**

- Removed react classes from components in styles package

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
