### PR TITLE
fix(sticky-header): prevent negative overscroll from hiding stuck elements

### DIFF
--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -225,7 +225,7 @@ class StickyHeader {
     if (localeModal && localeModal.hasAttribute('open')) return;
 
     const newY = window.scrollY;
-    this._lastScrollPosition = newY;
+    this._lastScrollPosition = Math.max(0, newY);
 
     /**
      * maxScrollaway is a calculated value matching the height of all components


### PR DESCRIPTION
### Description

Safari treats the bounce back from an "overscrolled" position as a scroll event. This can cause elements to be scrolled out of view when a user, for example, rapidly swipes to scroll to the top of the document.

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/12532727/097c055e-d039-4a9b-b23d-b8e5a2100da4

This PR fixes this interaction by limiting how far up the scroll is considered to be. This effectively ignores overscroll.

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/12532727/344ffe1b-1354-4c3d-b485-e83039eb782c

### To test 

Visit the Web Components deploy preview's [Dotcom Shell With L1 story](https://ibmdotcom-webcomponents.s3.us-east.cloud-object-storage.appdomain.cloud/deploy-previews/11266/index.html?path=/story/components-dotcom-shell--with-l-1) in Safari, and resize the window down to the mobile breakpoint. Scroll down the page until the L0 and L1 have disappeared above the viewport, then rapidly scroll to the top of the page. When the document "bounces" back into position, both the L0 and L1 should be visible.

### Changelog

**Changed**

- Prevents the bounce back when scrolling beyond the top of the document from hiding stuck elements above the viewport. 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
