### PR TITLE
fix(masthead-v2): provide accessible nav label

### DIFF
--- a/packages/web-components/src/components/masthead/top-nav.ts
+++ b/packages/web-components/src/components/masthead/top-nav.ts
@@ -122,6 +122,12 @@ class DDSTopNav extends StableSelectorMixin(HostListenerMixin(BXHeaderNav)) {
   importedMegamenu = false;
 
   /**
+   * The `aria-label` attribute for the nav element.
+   */
+  @property({ attribute: 'nav-label' })
+  navLabel: string = 'Primary navigation';
+
+  /**
    * The English title of the selected nav item.
    */
   @property({ attribute: 'selected-menu-item' })
@@ -557,7 +563,10 @@ class DDSTopNav extends StableSelectorMixin(HostListenerMixin(BXHeaderNav)) {
                 </div>
                 <div class="${ddsPrefix}-ce--header__nav-content-container">
                   <div class="${prefix}--header__nav-content">
-                    <nav part="nav" class="${prefix}--header__nav">
+                    <nav
+                      part="nav"
+                      class="${prefix}--header__nav"
+                      aria-label="${ifNonNull(this.navLabel)}">
                       <div class="${prefix}--sub-content-right"></div>
                       <div
                         part="menubar"
@@ -597,7 +606,10 @@ class DDSTopNav extends StableSelectorMixin(HostListenerMixin(BXHeaderNav)) {
                 </div>
                 <div class="${ddsPrefix}-ce--header__nav-content-container">
                   <div class="${prefix}--header__nav-content">
-                    <nav part="nav" class="${prefix}--header__nav">
+                    <nav
+                      part="nav"
+                      class="${prefix}--header__nav"
+                      aria-label="${ifNonNull(this.navLabel)}">
                       <div class="${prefix}--sub-content-left"></div>
                       <div
                         part="menubar"


### PR DESCRIPTION
### Related Ticket(s)

Resolves https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/11267

### Description

Provides an overridable `aria-label` for the top nav.

### To test

Visit the [deploy preview masthead story](https://ibmdotcom-webcomponents.s3.us-east.cloud-object-storage.appdomain.cloud/deploy-previews/11269/index.html?path=/story/components-masthead--default) and verify the `<nav>` element within the `<dds-top-nav>` component has an `aria-label`.

### Changelog

**New**

- Adds a `navLabel` property to `DDSTopNav` that sets an `aria-label` on the `<nav>` element in the shadow root.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
