### PR TITLE
fix(stackblitz): versions pointing to v2

### DIFF
--- a/packages/web-components/examples/stackblitz/components-react/cta-card/index.html
+++ b/packages/web-components/examples/stackblitz/components-react/cta-card/index.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/grid.css"/>
     <title>carbon-web-components example with React</title>
   </head>
   <body>

--- a/packages/web-components/examples/stackblitz/components-react/cta-feature/index.html
+++ b/packages/web-components/examples/stackblitz/components-react/cta-feature/index.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/grid.css"/>
     <title>carbon-web-components example with React</title>
   </head>
   <body>

--- a/packages/web-components/examples/stackblitz/components/back-to-top/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/back-to-top/cdn.html
@@ -18,7 +18,7 @@ LICENSE file in the root directory of this source tree.
       height: 6000px;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/back-to-top.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/back-to-top.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/background-media/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/background-media/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/background-media.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/background-media.min.js"></script>
 </head>
 <body>
   <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/button-group/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/button-group/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button-group.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/button-group.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/button-group/index.html
+++ b/packages/web-components/examples/stackblitz/components/button-group/index.html
@@ -14,7 +14,7 @@ LICENSE file in the root directory of this source tree.
     <link rel="stylesheet"
           href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
     <link rel="stylesheet"
-          href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+          href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/grid.css"/>
     <style>
       /* Suppress custom element until styles are loaded */
       cds-button-group:not(:defined) {

--- a/packages/web-components/examples/stackblitz/components/button/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/button/cdn.html
@@ -14,7 +14,7 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   <link rel="stylesheet"
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/grid.css"/>
   <style>
     /* Suppress custom element until styles are loaded */
     dds-button:not(:defined) {
@@ -22,13 +22,13 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/button.min.js"></script>
 </head>
 <body>
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-sm-4 bx--col-lg-12">
-      <dds-button href="https://www.example.com" cta-type="local">Button text</dds-button>
+<div class="cds--grid">
+  <div class="cds--row">
+    <div class="cds--col-sm-4 cds--col-lg-12">
+      <c4d-button href="https://www.example.com" cta-type="local">Button text</c4d-button>
     </div>
   </div>
 </div>

--- a/packages/web-components/examples/stackblitz/components/button/index.html
+++ b/packages/web-components/examples/stackblitz/components/button/index.html
@@ -14,7 +14,7 @@ LICENSE file in the root directory of this source tree.
     <link rel="stylesheet"
           href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
     <link rel="stylesheet"
-          href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+          href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/grid.css"/>
     <style>
       /* Suppress custom element until styles are loaded */
       dds-button:not(:defined) {
@@ -24,10 +24,10 @@ LICENSE file in the root directory of this source tree.
     <script src="src/index.js"></script>
   </head>
   <body>
-  <div class="bx--grid">
-    <div class="bx--row">
-      <div class="bx--col-sm-4 bx--col-lg-12">
-        <dds-button href="https://www.example.com" cta-type="local">Button text</dds-button>
+  <div class="cds--grid">
+    <div class="cds--row">
+      <div class="cds--col-sm-4 cds--col-lg-12">
+        <c4d-button href="https://www.example.com" cta-type="local">Button text</c4d-button>
       </div>
     </div>
   </div>

--- a/packages/web-components/examples/stackblitz/components/callout-quote/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/callout-quote/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/callout-quote.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/callout-quote.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/callout-with-media/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/callout-with-media/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/callout-with-media.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/callout-with-media.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/card-group/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/card-group/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-group.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card-group.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/card-in-card/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/card-in-card/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-in-card.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card-in-card.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/card-link/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/card-link/cdn.html
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-link.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card-link.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/card-link/index.html
+++ b/packages/web-components/examples/stackblitz/components/card-link/index.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8"/>
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/grid.css"/>
   <style>
     /* Suppress custom element until styles are loaded */
     c4d-card-link:not(:defined) {

--- a/packages/web-components/examples/stackblitz/components/card-section-carousel/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/card-section-carousel/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-section-carousel.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card-section-carousel.min.js"></script>
 </head>
 <body>
   <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/card-section-offset/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/card-section-offset/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-section-offset.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card-section-offset.min.js"></script>
 </head>
 <body>
   <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/card-section-offset/index.html
+++ b/packages/web-components/examples/stackblitz/components/card-section-offset/index.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <link rel="stylesheet"
-          href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/grid.css"/>
+          href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/grid.css"/>
     <style>
       /* Suppress custom element until styles are loaded */
       cds-card-section-offset:not(:defined) {

--- a/packages/web-components/examples/stackblitz/components/card-section-simple/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/card-section-simple/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-section-simple.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card-section-simple.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/card/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/card/cdn.html
@@ -18,7 +18,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/carousel/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/carousel/cdn.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/carousel.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/carousel.min.js"></script>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-block-card-static/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-block-card-static/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-card-static.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-block-card-static.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-block-cards/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-block-cards/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-cards.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-block-cards.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-block-headlines/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-block-headlines/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-headlines.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-block-headlines.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-block-media/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-block-media/cdn.html
@@ -19,8 +19,8 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-media.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/image-with-caption.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-block-media.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/image-with-caption.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-block-mixed/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-block-mixed/cdn.html
@@ -19,10 +19,10 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-mixed.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-cards.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-pictograms.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-simple.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-block-mixed.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-group-cards.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-group-pictograms.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-group-simple.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-block-segmented/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-block-segmented/cdn.html
@@ -19,9 +19,9 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-segmented.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-list.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/video-player.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-block-segmented.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/link-list.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/video-player.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-block-simple/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-block-simple/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block-simple.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-block-simple.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-block/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-block/cdn.html
@@ -17,8 +17,8 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-block.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-link-cta.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-block.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card-link-cta.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-group-cards/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-group-cards/cdn.html
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-cards.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-group-cards.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-group-pictograms/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-group-pictograms/cdn.html
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-pictograms.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-group-pictograms.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-group-simple/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-group-simple/cdn.html
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group-simple.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-group-simple.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-group/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-group/cdn.html
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-group.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-group.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/content-item-row/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-item-row/cdn.html
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-item-row.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-item-row.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/stackblitz/components/content-item/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-item/cdn.html
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-item.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-item.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/stackblitz/components/content-section/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/content-section/cdn.html
@@ -17,8 +17,8 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/content-section.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/text-cta.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/content-section.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/text-cta.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/stackblitz/components/cta-block/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/cta-block/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/cta-block.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/cta-block.min.js"></script>
 </head>
 
 <body>

--- a/packages/web-components/examples/stackblitz/components/cta-button/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/cta-button/cdn.html
@@ -24,7 +24,7 @@ LICENSE file in the root directory of this source tree.
     </style>
     <script
       type="module"
-      src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button-cta.min.js"
+      src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/button-cta.min.js"
     ></script>
   </head>
   <body>

--- a/packages/web-components/examples/stackblitz/components/cta-card-link/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/cta-card-link/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-link-cta.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card-link-cta.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/cta-card/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/cta-card/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card-cta.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card-cta.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/cta-feature/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/cta-feature/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/feature-cta.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/feature-cta.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/cta-section/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/cta-section/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/cta-section.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/cta-section.min.js"></script>
 </head>
 
 <body>

--- a/packages/web-components/examples/stackblitz/components/cta-text/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/cta-text/cdn.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/text-cta.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/text-cta.min.js"></script>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/video-cta-container.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/video-cta-container.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/dotcom-shell/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/dotcom-shell/cdn.html
@@ -153,7 +153,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/dotcom-shell.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/dotcom-shell.min.js"></script>
   <script src="src/index-cdn.js"></script>
 </head>
 <body>

--- a/packages/web-components/examples/stackblitz/components/expressive-modal/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/expressive-modal/cdn.html
@@ -21,9 +21,9 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/button.min.js"></script>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/expressive-modal.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/expressive-modal.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/feature-card/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/feature-card/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/feature-card.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/feature-card.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/feature-section/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/feature-section/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/feature-section.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/feature-section.min.js"></script>
 </head>
 <body>
   <c4d-feature-section media-alignment="right">

--- a/packages/web-components/examples/stackblitz/components/filter-panel/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/filter-panel/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/filter-panel.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/filter-panel.min.js"></script>
 </head>
 
 <body>

--- a/packages/web-components/examples/stackblitz/components/footer-language-only/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/footer-language-only/cdn.html
@@ -18,7 +18,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/footer.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/footer.min.js"></script>
 </head>
 <body>
 <div style="padding-top: 200px;"></div>

--- a/packages/web-components/examples/stackblitz/components/footer/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/footer/cdn.html
@@ -152,7 +152,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/footer.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/footer.min.js"></script>
 </head>
 <body>
 <c4d-footer-container></c4d-footer-container>

--- a/packages/web-components/examples/stackblitz/components/global-banner/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/global-banner/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/global-banner.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/global-banner.min.js"></script>
 </head>
 <body>
 	<c4d-global-banner image-width="4-col">

--- a/packages/web-components/examples/stackblitz/components/horizontal-rule/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/horizontal-rule/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/horizontal-rule.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/horizontal-rule.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/image/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/image/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/image.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/image.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/in-page-banner/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/in-page-banner/cdn.html
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/in-page-banner.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/in-page-banner.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/leadspace-block/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/leadspace-block/cdn.html
@@ -19,8 +19,8 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/leadspace-block.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-list.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/leadspace-block.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/link-list.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/leadspace-with-search/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/leadspace-with-search/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/leadspace-with-search.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/leadspace-with-search.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/leadspace/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/leadspace/cdn.html
@@ -24,11 +24,11 @@ LICENSE file in the root directory of this source tree.
     </style>
     <script
       type="module"
-      src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/leadspace.min.js"
+      src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/leadspace.min.js"
     ></script>
     <script
       type="module"
-      src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/background-media.min.js"
+      src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/background-media.min.js"
     ></script>
   </head>
   <body>

--- a/packages/web-components/examples/stackblitz/components/leaving-ibm/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/leaving-ibm/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/leaving-ibm.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/leaving-ibm.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/lightbox-media-viewer/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/lightbox-media-viewer/cdn.html
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/lightbox-video-player.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/button.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/lightbox-video-player.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/stackblitz/components/link-list-section/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/link-list-section/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-list-section.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/link-list-section.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/link-list/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/link-list/cdn.html
@@ -19,8 +19,8 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-list.min.js"></script>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/card.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/link-list.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/card.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/link-with-icon/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/link-with-icon/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/link-with-icon.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/link-with-icon.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/locale-modal/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/locale-modal/cdn.html
@@ -155,9 +155,9 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/locale-modal.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/locale-modal.min.js"></script>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/button.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/button.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/logo-grid/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/logo-grid/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/logo-grid.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/logo-grid.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/masthead-l1/cdn-rtl.html
+++ b/packages/web-components/examples/stackblitz/components/masthead-l1/cdn-rtl.html
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/rtl/masthead.rtl.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/rtl/masthead.rtl.min.js"></script>
   <script type="module" src="src/index-cdn.js"></script>
 </head>
   <body>

--- a/packages/web-components/examples/stackblitz/components/masthead-l1/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/masthead-l1/cdn.html
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/masthead.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/masthead.min.js"></script>
   <script type="module" src="src/index-cdn.js"></script>
 </head>
   <body>

--- a/packages/web-components/examples/stackblitz/components/pricing-table/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/pricing-table/cdn.html
@@ -23,7 +23,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/pricing-table.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/pricing-table.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/quote/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/quote/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/quote.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/quote.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/scroll-animations/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/scroll-animations/cdn.html
@@ -12,14 +12,14 @@ LICENSE file in the root directory of this source tree.
   <title>@carbon/ibmdotcom-web-components example</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
-  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/scroll-animations.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/scroll-animations.css" />
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     c4d-scroll-animations:not(:defined) {
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/scroll-animations.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/scroll-animations.min.js"></script>
 </head>
 <body>
 <c4d-scroll-animations animation="fade" selector-targets="h1" keep-animation="true">

--- a/packages/web-components/examples/stackblitz/components/search-with-typeahead/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/search-with-typeahead/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/search-with-typeahead.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/search-with-typeahead.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/structured-list/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/structured-list/cdn.html
@@ -23,7 +23,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/structured-list.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/structured-list.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/table-of-contents/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/table-of-contents/cdn.html
@@ -14,7 +14,7 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet"
         href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
   <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
-        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/table-of-contents.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/table-of-contents.css"/>
   <style type="text/css">
     /* Suppress custom element until styles are loaded */
     c4d-table-of-contents:not(:defined) {
@@ -27,7 +27,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/table-of-contents.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/table-of-contents.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/tabs-extended-media/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/tabs-extended-media/cdn.html
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/tabs-extended-media.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/tabs-extended-media.min.js"></script>
 </head>
 <body>
 <div id="app">

--- a/packages/web-components/examples/stackblitz/components/tabs-extended/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/tabs-extended/cdn.html
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     }
   </style>
   <script type="module"
-          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/tabs-extended.min.js"></script>
+          src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/tabs-extended.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/components/video-player/cdn.html
+++ b/packages/web-components/examples/stackblitz/components/video-player/cdn.html
@@ -19,7 +19,7 @@ LICENSE file in the root directory of this source tree.
       display: none;
     }
   </style>
-  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/video-player.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/video-player.min.js"></script>
 </head>
 <body>
 <div class="cds--grid">

--- a/packages/web-components/examples/stackblitz/usage/dotcom-shell-cdn-with-rtl/index.hbs
+++ b/packages/web-components/examples/stackblitz/usage/dotcom-shell-cdn-with-rtl/index.hbs
@@ -27,7 +27,7 @@ LICENSE file in the root directory of this source tree.
     <meta charset="UTF-8" />
     <script type="module">
       // Loads the LTR or RTL version of the bundle
-      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/dotcom-shell{{dirSuffix}}.min.js';
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/dotcom-shell{{dirSuffix}}.min.js';
     </script>
     <style type="text/css">
       html, body {

--- a/packages/web-components/examples/stackblitz/usage/dotcom-shell-cdn/index.html
+++ b/packages/web-components/examples/stackblitz/usage/dotcom-shell-cdn/index.html
@@ -12,7 +12,7 @@ LICENSE file in the root directory of this source tree.
     <title>@carbon/ibmdotcom-web-components example</title>
     <meta charset="UTF-8" />
     <script type="module">
-      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/dotcom-shell.min.js';
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v2/latest/dotcom-shell.min.js';
     </script>
     <style type="text/css">
       html,

--- a/packages/web-components/src/components/back-to-top/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/back-to-top/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/back-to-top)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/back-to-top)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/back-to-top)
 
 ## Getting started
 

--- a/packages/web-components/src/components/back-to-top/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/back-to-top/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/back-to-top)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/back-to-top)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/back-to-top)
 
 ## Getting started
 

--- a/packages/web-components/src/components/background-media/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/background-media/__stories__/README.stories.mdx
@@ -15,7 +15,7 @@ import contributing from '../../../../../../docs/contributing-license.md';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/background-media)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/background-media)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/background-media)
 
 ## Getting started
 

--- a/packages/web-components/src/components/background-media/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/background-media/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/background-media)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/background-media)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/background-media)
 
 ## Getting started
 

--- a/packages/web-components/src/components/button-group/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/button-group/__stories__/README.stories.mdx
@@ -15,7 +15,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/button-group)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/button-group)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/button-group)
 
 ## Getting started
 

--- a/packages/web-components/src/components/button-group/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/button-group/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/button-group)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/button-group)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/button-group)
 
 ## Getting started
 

--- a/packages/web-components/src/components/button/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/button/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/button)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/button)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/button)
 
 ## Getting started
 

--- a/packages/web-components/src/components/button/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/button/__stories__/README.stories.react.mdx
@@ -8,7 +8,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/button)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/button)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/button)
 
 ## Getting started
 

--- a/packages/web-components/src/components/callout-quote/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/callout-quote/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/callout-quote)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/callout-quote)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/callout-quote)
 
 ## Getting started
 

--- a/packages/web-components/src/components/callout-quote/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/callout-quote/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/callout-quote)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/callout-quote)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/callout-quote)
 
 ## Getting started
 

--- a/packages/web-components/src/components/callout-with-media/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/callout-with-media/__stories__/README.stories.mdx
@@ -14,7 +14,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/callout-with-media)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/callout-with-media)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/callout-with-media)
 
 **Note:** as of release v1.18.0 the copy in `C4DCalloutWithMedia` has been
 updated to use `C4DCalloutWithMediaCopy` and no longer using

--- a/packages/web-components/src/components/callout-with-media/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/callout-with-media/__stories__/README.stories.react.mdx
@@ -14,7 +14,7 @@ import { PropTypesRef as imageProps } from '@carbon/ibmdotcom-web-components/es/
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/callout-with-media)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/callout-with-media)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/callout-with-media)
 
 ## Getting started
 

--- a/packages/web-components/src/components/card-group/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-group/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/card-group)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/card-group)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/card-group)
 
 ## Getting started
 

--- a/packages/web-components/src/components/card-group/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/card-group/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/card-group)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/card-group)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/card-group)
 
 ## Getting started
 

--- a/packages/web-components/src/components/card-in-card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-in-card/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/card-in-card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/card-in-card)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/card-in-card)
 
 ## Getting started
 

--- a/packages/web-components/src/components/card-in-card/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/card-in-card/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/card-in-card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/card-in-card)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/card-in-card)
 
 ## Getting started
 

--- a/packages/web-components/src/components/card-section-offset/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-section-offset/__stories__/README.stories.mdx
@@ -7,10 +7,10 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 
 > The Card Section - Offset pattern is an L shaped card group with a heading and
 > an optional CTA. 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/card-section-offset)
+> [stackblitz](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/card-section-offset)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/card-section-offset)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/card-section-offset)
 
 ## Getting started
 

--- a/packages/web-components/src/components/card-section-offset/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/card-section-offset/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/card-section-offset)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/card-section-offset)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/card-section-offset)
 
 ## Getting started
 

--- a/packages/web-components/src/components/card-section-simple/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-section-simple/__stories__/README.stories.mdx
@@ -7,9 +7,9 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 
 > The Card Section - Simple pattern is a collection of cards presented in a
 > section with a left-column header. 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/card-section-simple)
+> [stackblitz](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/card-section-simple)
 > example implementation.
-> [![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/card-section-simple)
+> [![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/card-section-simple)
 
 ## Getting started
 

--- a/packages/web-components/src/components/card-section-simple/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/card-section-simple/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/card-section-simple)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/card-section-simple)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/card-section-simple)
 
 ## Getting started
 

--- a/packages/web-components/src/components/card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/card)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/card)
 
 ## Getting started
 

--- a/packages/web-components/src/components/card/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/card/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/card)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/card)
 
 ## Getting started
 

--- a/packages/web-components/src/components/carousel/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/carousel/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/carousel)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/carousel)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/carousel)
 
 ## Getting started
 

--- a/packages/web-components/src/components/carousel/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/carousel/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/carousel)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/carousel)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/carousel)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-card-static/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-card-static/__stories__/README.stories.mdx
@@ -12,7 +12,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-card-static)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-block-card-static)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-card-static)
 
 ## Feature Flag
 

--- a/packages/web-components/src/components/content-block-cards/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-cards/__stories__/README.stories.mdx
@@ -12,7 +12,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-cards)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-block-cards)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-cards)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-cards/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-block-cards/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block-cards)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-block-cards)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block-cards)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-headlines/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-headlines/__stories__/README.stories.mdx
@@ -9,7 +9,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-headlines)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-block-headlines)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-headlines)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-horizontal/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-horizontal/__stories__/README.stories.mdx
@@ -12,7 +12,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-horizontal)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-block-horizontal)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-horizontal)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-horizontal/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-block-horizontal/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block-horizontal)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-block-horizontal)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block-horizontal)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-media/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-media/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-media)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-block-media)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-media)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-media/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-block-media/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block-media)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-block-media)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block-media)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-mixed/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-mixed/__stories__/README.stories.mdx
@@ -9,7 +9,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-mixed)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-block-mixed)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-mixed)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-mixed/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-block-mixed/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block-mixed)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-block-mixed)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block-mixed)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-segmented/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-segmented/__stories__/README.stories.mdx
@@ -12,7 +12,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-segmented)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-block-segmented)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-segmented)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-segmented/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-block-segmented/__stories__/README.stories.react.mdx
@@ -11,7 +11,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block-segmented)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-block-segmented)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block-segmented)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-simple/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-simple/__stories__/README.stories.mdx
@@ -12,7 +12,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-simple)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-block-simple)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-simple)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block-simple/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-block-simple/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-simple)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-block-simple)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block-simple)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block/__stories__/README.stories.mdx
@@ -9,7 +9,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-block)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-block)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-block/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-block/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-block)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-block)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-group-cards/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-group-cards/__stories__/README.stories.mdx
@@ -11,7 +11,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-group-cards)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-group-cards)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-group-cards)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-group-cards/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-group-cards/__stories__/README.stories.react.mdx
@@ -11,7 +11,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-group-cards)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-group-cards)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-group-cards)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-group-pictograms/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-group-pictograms/__stories__/README.stories.react.mdx
@@ -11,7 +11,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-group-pictograms)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-group-pictograms)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-group-pictograms)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-group-simple/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-group-simple/__stories__/README.stories.mdx
@@ -8,10 +8,10 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > The Content Group – Simple pattern is a variant of `<c4d-content-group>`, and
 > includes a heading, content items, optional media (image or video), and ends
 > with a CTA. 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-group-simple)
+> [stackblitz](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-group-simple)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-group-simple)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-group-simple)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-group-simple/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-group-simple/__stories__/README.stories.react.mdx
@@ -12,7 +12,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-group-simple)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-group-simple)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-group-simple)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-group/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-group/__stories__/README.stories.mdx
@@ -9,7 +9,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-group)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-group)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-group)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-group/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-group/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-group)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-group)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-group)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-item-row/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-item-row/__stories__/README.stories.mdx
@@ -9,7 +9,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-item-row)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-item-row)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-item-row)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-item-row/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-item-row/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-item-row)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-item-row)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-item-row)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-item/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-item/__stories__/README.stories.mdx
@@ -9,7 +9,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-item)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-item)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-item)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-item/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-item/__stories__/README.stories.react.mdx
@@ -14,7 +14,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-item)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-item)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-item)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-section/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-section/__stories__/README.stories.mdx
@@ -9,7 +9,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-section)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/content-section)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/content-section)
 
 ## Getting started
 

--- a/packages/web-components/src/components/content-section/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/content-section/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-section)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/content-section)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/content-section)
 
 ## Getting started
 

--- a/packages/web-components/src/components/cta-block/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/cta-block/__stories__/README.stories.mdx
@@ -8,7 +8,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > 💡 Check our
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-block)
 > example implementation.
-> [![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-block)
+> [![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-block)
 
 ## Getting started
 

--- a/packages/web-components/src/components/cta-block/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/cta-block/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-block)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/cta-block)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-block)
 
 ## Getting started
 

--- a/packages/web-components/src/components/cta-section/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/cta-section/__stories__/README.stories.mdx
@@ -8,7 +8,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > 💡 Check our
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-section)
 > example implementation.
-> [![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-section)
+> [![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-section)
 
 ## Breaking Changes
 

--- a/packages/web-components/src/components/cta-section/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/cta-section/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-section)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/cta-section)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-section)
 
 ## Getting started
 

--- a/packages/web-components/src/components/cta/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/cta/__stories__/README.stories.mdx
@@ -49,7 +49,7 @@ CTA Text is the most basic version of CTA, presented as a simple link.
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-text)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-text)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-text)
 
 ### HTML
 
@@ -71,7 +71,7 @@ CTA Button is a version of CTA presented as a button.
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-button)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-button)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-button)
 
 ### HTML
 
@@ -97,7 +97,7 @@ CTA Card is a version of CTA presented as a card.
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-card)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-card)
 
 ### HTML
 
@@ -134,7 +134,7 @@ Card link CTA is a version of CTA presented as a card.
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-card)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-card)
 
 ### HTML
 
@@ -171,7 +171,7 @@ Feature card CTA is a version of CTA presented as a feature card.
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-feature)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta-feature)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta-feature)
 
 ### HTML
 
@@ -268,7 +268,7 @@ import '@carbon/ibmdotcom-web-components/es/components/cta/video-cta-container.j
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta/text)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/cta/text)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/cta/text)
 
 ### `cds-cta-run-action` customization
 

--- a/packages/web-components/src/components/cta/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/cta/__stories__/README.stories.react.mdx
@@ -27,7 +27,7 @@ import { PropTypesRef as FeatureCTAProps } from '@carbon/ibmdotcom-web-component
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-text)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/cta-text)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-text)
 
 ### JS
 
@@ -55,7 +55,7 @@ function App() {
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-button)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/cta-button)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-button)
 
 ### JS
 
@@ -86,7 +86,7 @@ function App() {
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/cta-card)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-card)
 
 ### JS
 
@@ -119,7 +119,7 @@ function App() {
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-card-link)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/cta-card-link)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-card-link)
 
 ### JS
 
@@ -153,7 +153,7 @@ function App() {
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-feature)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/cta-feature)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/cta-feature)
 
 ### JS
 

--- a/packages/web-components/src/components/dotcom-shell/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/dotcom-shell)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/dotcom-shell)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/dotcom-shell)
 
 ## Getting started
 

--- a/packages/web-components/src/components/dotcom-shell/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/dotcom-shell)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/dotcom-shell)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/dotcom-shell)
 
 ## Getting started
 

--- a/packages/web-components/src/components/expressive-modal/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/expressive-modal/__stories__/README.stories.mdx
@@ -17,7 +17,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/expressive-modal)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/expressive-modal)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/expressive-modal)
 
 ## Getting started
 

--- a/packages/web-components/src/components/expressive-modal/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/expressive-modal/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/expressive-modal)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/expressive-modal)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/expressive-modal)
 
 ## Getting started
 

--- a/packages/web-components/src/components/feature-card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/feature-card/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/feature-card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/feature-card)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/feature-card)
 
 ## Getting started
 

--- a/packages/web-components/src/components/feature-card/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/feature-card/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/feature-card)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/feature-card)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/feature-card)
 
 ## Getting started
 

--- a/packages/web-components/src/components/feature-section/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/feature-section/__stories__/README.stories.mdx
@@ -12,7 +12,7 @@ import contributing from '../../../../../../docs/contributing-license.md';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/feature-section)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/feature-section)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/feature-section)
 
 ## Getting started
 

--- a/packages/web-components/src/components/feature-section/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/feature-section/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/feature-section)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/feature-section)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/feature-section)
 
 ## Getting started
 

--- a/packages/web-components/src/components/filter-panel/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/filter-panel/__stories__/README.stories.mdx
@@ -14,7 +14,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/filter-panel)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/filter-panel)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/filter-panel)
 
 ## Getting started
 

--- a/packages/web-components/src/components/filter-panel/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/filter-panel/__stories__/README.stories.react.mdx
@@ -16,7 +16,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/filter-panel)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/filter-panel)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/filter-panel)
 
 ## Getting started
 

--- a/packages/web-components/src/components/footer/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/footer/__stories__/README.stories.mdx
@@ -18,11 +18,11 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 
 ### Footer (locale selector):
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/footer)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/footer)
 
 ### Footer (language selector):
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/footer-language-only)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/footer-language-only)
 
 ## Getting started
 

--- a/packages/web-components/src/components/footer/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/footer/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/footer)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/footer)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/footer)
 
 ## Getting started
 

--- a/packages/web-components/src/components/global-banner/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/global-banner/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ global event, COVID 19 messages etc).
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/global-banner)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/global-banner)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/global-banner)
 
 ## Getting started
 

--- a/packages/web-components/src/components/global-banner/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/global-banner/__stories__/README.stories.react.mdx
@@ -17,7 +17,7 @@ global event, COVID 19 messages etc).
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/global-banner)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/global-banner)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/global-banner)
 
 ## Getting started
 

--- a/packages/web-components/src/components/horizontal-rule/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/horizontal-rule/__stories__/README.stories.mdx
@@ -14,7 +14,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/horizontal-rule)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/horizontal-rule)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/horizontal-rule)
 
 ## Getting started
 

--- a/packages/web-components/src/components/horizontal-rule/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/horizontal-rule/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/horizontal-rule)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/horizontal-rule)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/horizontal-rule)
 
 ## Getting started
 

--- a/packages/web-components/src/components/image/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/image/__stories__/README.stories.mdx
@@ -21,7 +21,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > 💡 Check our
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/image)
 > example implementation.
-> [![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/image)
+> [![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/image)
 
 ## Getting started
 

--- a/packages/web-components/src/components/image/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/image/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef as ImageProps } from '@carbon/ibmdotcom-web-components/es/
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/image)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/image)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/image)
 
 ## Getting started
 

--- a/packages/web-components/src/components/in-page-banner/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/in-page-banner/__stories__/README.stories.mdx
@@ -12,7 +12,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/in-page-banner)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/in-page-banner)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/in-page-banner)
 
 ## Getting started
 

--- a/packages/web-components/src/components/in-page-banner/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/in-page-banner/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/in-page-banner)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/in-page-banner)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/in-page-banner)
 
 ## Getting started
 

--- a/packages/web-components/src/components/leadspace-block/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/leadspace-block/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/leadspace-block)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/leadspace-block)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/leadspace-block)
 
 ## Getting started
 

--- a/packages/web-components/src/components/leadspace-block/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/leadspace-block/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/leadspace-block)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/leadspace-block)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/leadspace-block)
 
 ## Getting started
 

--- a/packages/web-components/src/components/leadspace-with-search/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/leadspace-with-search/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/leadspace-with-search)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/leadspace-with-search)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/leadspace-with-search)
 
 ## Getting started
 

--- a/packages/web-components/src/components/leadspace-with-search/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/leadspace-with-search/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/leadspace-with-search)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/leadspace-with-search)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/leadspace-with-search)
 
 ## Getting started
 

--- a/packages/web-components/src/components/leadspace/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/leadspace/__stories__/README.stories.mdx
@@ -14,7 +14,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/leadspace)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/leadspace)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/leadspace)
 
 ## Getting started
 

--- a/packages/web-components/src/components/leadspace/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/leadspace/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/leadspace)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/leadspace)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/leadspace)
 
 ## Getting started
 

--- a/packages/web-components/src/components/leaving-ibm/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/leaving-ibm/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/leaving-ibm)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/leaving-ibm)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/leaving-ibm)
 
 ## Getting started
 

--- a/packages/web-components/src/components/leaving-ibm/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/leaving-ibm/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/leaving-ibm)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/leaving-ibm)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/leaving-ibm)
 
 ## Getting started
 

--- a/packages/web-components/src/components/lightbox-media-viewer/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/lightbox-media-viewer/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/lightbox-media-viewer)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/lightbox-media-viewer)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/lightbox-media-viewer)
 
 ## Getting started
 

--- a/packages/web-components/src/components/link-list-section/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/link-list-section/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/link-list-section)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/link-list-section)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/link-list-section)
 
 ## Getting started
 

--- a/packages/web-components/src/components/link-list-section/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/link-list-section/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/link-list-section)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/link-list-section)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/link-list-section)
 
 ## Getting started
 

--- a/packages/web-components/src/components/link-list/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/link-list/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/link-list)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/link-list)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/link-list)
 
 ## Getting started
 

--- a/packages/web-components/src/components/link-list/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/link-list/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/link-list)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/link-list)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/link-list)
 
 ## Getting started
 

--- a/packages/web-components/src/components/link-with-icon/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/link-with-icon/__stories__/README.stories.mdx
@@ -18,7 +18,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/link-with-icon)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/link-with-icon)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/link-with-icon)
 
 ## Getting started
 

--- a/packages/web-components/src/components/locale-modal/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/locale-modal/__stories__/README.stories.mdx
@@ -18,7 +18,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/locale-modal)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/locale-modal)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/locale-modal)
 
 ## Getting started
 

--- a/packages/web-components/src/components/locale-modal/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/locale-modal/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef as LocaleModalProps } from '@carbon/ibmdotcom-web-componen
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/locale-modal)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/locale-modal)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/locale-modal)
 
 ## Getting started
 

--- a/packages/web-components/src/components/logo-grid/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/logo-grid/__stories__/README.stories.mdx
@@ -14,7 +14,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/logo-grid)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/logo-grid)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/logo-grid)
 
 ## Getting started
 

--- a/packages/web-components/src/components/logo-grid/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/logo-grid/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/logo-grid)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/logo-grid)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/logo-grid)
 
 ## Getting started
 

--- a/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/masthead/__stories__/README.stories.mdx
@@ -19,11 +19,11 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 
 ### Masthead (L0):
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/masthead)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/masthead)
 
 ### Masthead (L1):
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/masthead-l1)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/masthead-l1)
 
 ## Getting Started
 

--- a/packages/web-components/src/components/masthead/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/masthead/__stories__/README.stories.react.mdx
@@ -19,11 +19,11 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 
 ### Masthead (L0):
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/masthead)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/masthead)
 
 ### Masthead (L1):
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/masthead-l1)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/masthead-l1)
 
 ## Getting Started
 

--- a/packages/web-components/src/components/notice-choice/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/notice-choice/__stories__/README.stories.mdx
@@ -13,7 +13,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/notice-choice)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/notice-choice)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/notice-choice)
 
 ## Getting started
 

--- a/packages/web-components/src/components/pricing-table/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/pricing-table/__stories__/README.stories.mdx
@@ -8,7 +8,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/pricing-table)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/pricing-table)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/pricing-table)
 
 ## Getting started
 

--- a/packages/web-components/src/components/quote/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/quote/__stories__/README.stories.mdx
@@ -14,7 +14,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/quote)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/quote)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/quote)
 
 ## Getting started
 

--- a/packages/web-components/src/components/quote/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/quote/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/quote)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/quote)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/quote)
 
 ## Getting started
 

--- a/packages/web-components/src/components/scroll-animations/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/scroll-animations/__stories__/README.stories.mdx
@@ -19,7 +19,7 @@ import {
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/scroll-animations)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/scroll-animations)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/scroll-animations)
 
 ## Getting started
 

--- a/packages/web-components/src/components/search-with-typeahead/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/search-with-typeahead/__stories__/README.stories.mdx
@@ -12,7 +12,7 @@ import '../index';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/search-with-typeahead)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/search-with-typeahead)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/search-with-typeahead)
 
 ## Getting started
 

--- a/packages/web-components/src/components/search-with-typeahead/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/search-with-typeahead/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/search-with-typeahead)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/search-with-typeahead)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/search-with-typeahead)
 
 ## Getting started
 

--- a/packages/web-components/src/components/structured-list/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/structured-list/__stories__/README.stories.mdx
@@ -9,7 +9,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/structured-list)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/structured-list)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/structured-list)
 
 ## Getting started
 

--- a/packages/web-components/src/components/structured-list/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/structured-list/__stories__/README.stories.react.mdx
@@ -8,7 +8,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/structured-list)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/structured-list)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/structured-list)
 
 ## Getting started
 

--- a/packages/web-components/src/components/table-of-contents/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/README.stories.mdx
@@ -16,7 +16,7 @@ import {
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/table-of-contents)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/table-of-contents)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/table-of-contents)
 
 ## Getting started
 

--- a/packages/web-components/src/components/table-of-contents/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/table-of-contents/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/table-of-contents)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/table-of-contents)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/table-of-contents)
 
 ## Getting started
 

--- a/packages/web-components/src/components/tabs-extended-media/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/tabs-extended-media/__stories__/README.stories.mdx
@@ -11,7 +11,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/tabs-extended-media)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/tabs-extended-media)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/tabs-extended-media)
 
 ## Getting started
 

--- a/packages/web-components/src/components/tabs-extended-media/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/tabs-extended-media/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/tabs-extended-media)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/tabs-extended-media)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/tabs-extended-media)
 
 ## Getting started
 

--- a/packages/web-components/src/components/tabs-extended/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/tabs-extended/__stories__/README.stories.mdx
@@ -11,7 +11,7 @@ import { cdnJs, cdnCss } from '../../../globals/internal/storybook-cdn';
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/tabs-extended)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components/tabs-extended)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components/tabs-extended)
 
 ## Getting started
 

--- a/packages/web-components/src/components/tabs-extended/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/tabs-extended/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/tabs-extended)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/tabs-extended)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/tabs-extended)
 
 ## Getting started
 

--- a/packages/web-components/src/components/video-player/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/video-player/__stories__/README.stories.react.mdx
@@ -13,7 +13,7 @@ import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-rea
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/video-player)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/components-react/video-player)
+[![Edit @carbon/ibmdotcom-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/stackblitz/components-react/video-player)
 
 ## Getting started
 


### PR DESCRIPTION
### Related Ticket(s)

Closes #none
### Description

fixes examples to point to v2 cdn's and stackblitz folder
### Changelog

**Changed**

- v1 -> v2
- codesandbox folder -> stackblitz folder

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
