### PR TITLE
fix(tooltip): tooltip persists issue

### DIFF
--- a/packages/carbon-web-components/src/components/tooltip/tooltip.ts
+++ b/packages/carbon-web-components/src/components/tooltip/tooltip.ts
@@ -53,13 +53,13 @@ class CDSTooltip extends HostListenerMixin(CDSPopover) {
    * Specify the duration in milliseconds to delay before displaying the tooltip
    */
   @property({ attribute: 'enter-delay-ms', type: Number })
-  enterDelayMs = 100;
+  enterDelayMs = 500;
 
   /**
    * Specify the duration in milliseconds to delay before hiding the tooltip
    */
   @property({ attribute: 'leave-delay-ms', type: Number })
-  leaveDelayMs = 300;
+  leaveDelayMs = 100;
 
   /**
    * Specify the size of the tooltip
@@ -93,6 +93,7 @@ class CDSTooltip extends HostListenerMixin(CDSPopover) {
    * Handles `mouseleave` event on this element.
    */
   private _handleHoverOut = async () => {
+    this.leaveDelayMs = this.enterDelayMs > this.leaveDelayMs ? this.leaveDelayMs + this.enterDelayMs : this.leaveDelayMs; 
     setTimeout(async () => {
       const { open } = this;
       if (open) {

--- a/packages/carbon-web-components/src/components/tooltip/tooltip.ts
+++ b/packages/carbon-web-components/src/components/tooltip/tooltip.ts
@@ -53,13 +53,13 @@ class CDSTooltip extends HostListenerMixin(CDSPopover) {
    * Specify the duration in milliseconds to delay before displaying the tooltip
    */
   @property({ attribute: 'enter-delay-ms', type: Number })
-  enterDelayMs = 500;
+  enterDelayMs = 100;
 
   /**
    * Specify the duration in milliseconds to delay before hiding the tooltip
    */
   @property({ attribute: 'leave-delay-ms', type: Number })
-  leaveDelayMs = 100;
+  leaveDelayMs = 300;
 
   /**
    * Specify the size of the tooltip


### PR DESCRIPTION
### Related Ticket(s)

Closes #10471

### Description

Carbon Web Components tooltip persists with certain delay durations. If the `enter-delay-ms` is higher than the `leave-delay-ms` tooltip doesn't work as expected.

### Changelog

**Changed**

- Added a condition to check if `enter-delay-ms` is higher than `leave-delay-ms`. And if so, the value of `leave-delay-ms` will be increased by the value of `enter-delay-ms`.


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
