### PR TITLE
fix(package.json): remove node exports field

### DIFF
--- a/packages/carbon-web-components/package.json
+++ b/packages/carbon-web-components/package.json
@@ -13,15 +13,12 @@
   "module": "es/index.js",
   "exports": {
     "./es/components-react/*": {
-      "node": "./lib/components-react-node/*",
       "default": "./es/components-react/*"
     },
     "./es/components/*": {
-      "node": "./lib/components/*",
       "default": "./es/components/*"
     },
     "./es/globals/": {
-      "node": "./lib/globals/",
       "default": "./es/globals/"
     },
     "./es": "./es/index.js",


### PR DESCRIPTION
### Related Ticket(s)

Closes #11274 

### Description

Remove the `node` exports field that was pointing to the `lib` folder containing only the source map files.

### Changelog

**Removed**

- `node` exports field

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
