### PR TITLE
fix(carousel): update mobile styles

### DIFF
--- a/packages/styles/scss/components/carousel/_carousel.scss
+++ b/packages/styles/scss/components/carousel/_carousel.scss
@@ -1,7 +1,7 @@
 //
 // @license
 //
-// Copyright IBM Corp. 2020, 2023
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -36,19 +36,21 @@
 
     overflow: hidden;
     flex-direction: column;
-    inline-size: calc(
-      100% + var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
-    );
+    inline-size: 100%;
     margin-inline-end: calc(
       -1 * var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
     );
-    padding-inline: $spacing-05
-      calc(
-        #{$spacing-05} + var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
-      );
+    padding-inline: $spacing-05;
 
     @include breakpoint(md) {
-      padding-inline-start: 0;
+      inline-size: calc(
+        100% +
+          var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+      );
+      padding-inline: 0
+        calc(
+          #{$spacing-05} + var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+        );
     }
 
     ::slotted(:not([name])) {


### PR DESCRIPTION
### Related Ticket(s)

Closes #11343 

### Description

Updates the padding for `carousel` in mobile breakpoints. The width of the canvas exceeded that of the viewport, allowing users to scroll horizontally. The scrolling, in addition to swiping within the carousel, caused a jerky and inconsistent experience.

### Changelog

**Changed**

- update spacing and width for mobile breakpoints


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
