### PR TITLE
fix(input): display default value properly

### DIFF
--- a/packages/carbon-web-components/src/components/input/input.ts
+++ b/packages/carbon-web-components/src/components/input/input.ts
@@ -45,11 +45,6 @@ export default class BXInput extends ValidityMixin(FormMixin(LitElement)) {
   protected _input!: HTMLInputElement;
 
   /**
-   * The internal value.
-   */
-  protected _value = '';
-
-  /**
    * Set initial value of input
    */
   @property({ reflect: true })
@@ -301,7 +296,7 @@ export default class BXInput extends ValidityMixin(FormMixin(LitElement)) {
           ?readonly="${this.readonly}"
           ?required="${this.required}"
           type="${ifNonEmpty(this.type)}"
-          .value="${this._value}"
+          .value="${this.value}"
           @input="${handleInput}" />
         ${this.showPasswordVisibilityToggle &&
         (this.type === INPUT_TYPE.PASSWORD || this.type === INPUT_TYPE.TEXT)

--- a/packages/carbon-web-components/src/components/number-input/number-input.ts
+++ b/packages/carbon-web-components/src/components/number-input/number-input.ts
@@ -316,7 +316,7 @@ export default class BXNumberInput extends BXInput {
         ?readonly="${this.readonly}"
         ?required="${this.required}"
         type="number"
-        .value="${this._value}"
+        .value="${this.value}"
         @input="${handleInput}"
         min="${ifNonEmpty(this.min)}"
         max="${ifNonEmpty(this.max)}"


### PR DESCRIPTION
### Related Ticket(s)

Closes #11391

### Description
Ensures `bx-input` value property works as intended

### Changelog

**Changed**

- now uses `this.value` instead of `this._value` as the latter isn't used anywhere

**Removed**

- `_value` internal property

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
