### PR TITLE
chore(deps): remove duplicate build storybook from percy command

### DIFF
--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -37,7 +37,7 @@ jobs:
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_WEBCOMPONENTS }}
       - name: Run percy storybook
-        run: yarn visual-snapshot
+        run: yarn build-storybook && visual-snapshot
         working-directory: packages/web-components
   carbon-web-components:
     if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
@@ -67,5 +67,5 @@ jobs:
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_CARBONWEBCOMPONENTS }}
       - name: Run percy storybook
-        run: yarn visual-snapshot
+        run: yarn build-storybook && visual-snapshot
         working-directory: packages/carbon-web-components

--- a/packages/carbon-web-components/package.json
+++ b/packages/carbon-web-components/package.json
@@ -46,7 +46,7 @@
     "test:unit": "gulp test:unit",
     "test:unit:updateSnapshot": "gulp test:unit --update-snapshot",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "visual-snapshot": "yarn build-storybook && percy storybook:start ./storybook-static",
+    "visual-snapshot": "yarn percy storybook:start ./storybook-static",
     "wca": "web-component-analyzer analyze src --outFile custom-elements.json"
   },
   "files": [

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -86,7 +86,7 @@
     "test:unit:updateSnapshot": "gulp test:unit --update-snapshot",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "upgrade-carbon": "yarn upgrade-interactive @carbon/web-components @carbon/icon-helpers @carbon/icons --latest --exact",
-    "visual-snapshot": "yarn build-storybook && percy storybook:start ./storybook-static",
+    "visual-snapshot": "yarn percy storybook:start ./storybook-static",
     "wca": "web-component-analyzer analyze src --outFile custom-elements.json"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

The `build-storybook` is running twice since it is included in the `visual-snapshot` command. This removes the extra build command.

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- remove `build-storybook` from `visual-snapshot`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
