### PR TITLE
Fix(checkbox): a11y issue v1

### DIFF
--- a/packages/carbon-web-components/src/components/checkbox/checkbox.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.ts
@@ -130,7 +130,6 @@ class BXCheckbox extends FocusMixin(FormMixin(LitElement)) {
         type="checkbox"
         part="input"
         class="${`${prefix}--checkbox`}"
-        aria-checked="${indeterminate ? 'mixed' : String(Boolean(checked))}"
         .checked="${checked}"
         ?disabled="${disabled}"
         .indeterminate="${indeterminate}"


### PR DESCRIPTION
### Related Ticket(s)

Closes #11345

### Description

Accessibility issue on checkbox:
The ARIA attributes `aria-checked` are not valid for the element <input> with implicit ARIA role "checkbox"


### Changelog

**Removed**

- Removed `aria-checked` attribute from the input field.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
