### PR TITLE
Fix/a11y on pagination issue

### DIFF
--- a/packages/carbon-web-components/src/components/pagination/pages-select.ts
+++ b/packages/carbon-web-components/src/components/pagination/pages-select.ts
@@ -89,7 +89,9 @@ class BXPagesSelect extends FocusMixin(LitElement) {
     // https://github.com/Polymer/lit-html/issues/1052
     return html`
       <div class="${prefix}--select__page-number">
-        <label for="select-page" class="${prefix}--label ${prefix}--visually-hidden">
+        <label
+          for="select-page"
+          class="${prefix}--label ${prefix}--visually-hidden">
           ${formatLabelText({ count: total })}
         </label>
         <select

--- a/packages/carbon-web-components/src/components/pagination/pages-select.ts
+++ b/packages/carbon-web-components/src/components/pagination/pages-select.ts
@@ -89,12 +89,13 @@ class BXPagesSelect extends FocusMixin(LitElement) {
     // https://github.com/Polymer/lit-html/issues/1052
     return html`
       <div class="${prefix}--select__page-number">
-        <label for="select" class="${prefix}--label ${prefix}--visually-hidden">
+        <label for="select-page" class="${prefix}--label ${prefix}--visually-hidden">
           ${formatLabelText({ count: total })}
         </label>
         <select
           class="${prefix}--select-input"
           .value="${value}"
+          id="select-page"
           @change="${handleChange}">
           ${Array.from(new Array(total)).map(
             (_item, index) =>


### PR DESCRIPTION
### Related Ticket(s)

Closes #11319

### Description

Accessibility on pagination component. 
`id` missing for select element. 

Note: Not all the A11y violations mentioned the issue were active.


### Changelog

**New**

- Added `id` attribute for `select`

**Changed**

- Updated the `for` attribute for `label` with the newly added `id` to `select`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
