### PR TITLE
fix(datatable): selection function not working as expected

### DIFF
--- a/packages/carbon-web-components/src/components/data-table/table.ts
+++ b/packages/carbon-web-components/src/components/data-table/table.ts
@@ -632,6 +632,12 @@ class CDSTable extends HostListenerMixin(LitElement) {
     }
 
     if (changedProperties.has('isSelectable')) {
+      this._tableHeaderRow.setAttribute('selection-name', 'header');
+      this._tableRows.forEach((e, index) => {
+        if (!e.hasAttribute('selection-name')) {
+          e.setAttribute('selection-name', index);
+        }
+      });
       this.headerCount++;
     }
 


### PR DESCRIPTION
### Related Ticket(s)

Closes #11349

### Description

To use Selection on DataTable, the documentation states that just need to add the `is-selectable` property in the cds-table tag and setting the prop will automatically set a numerical `selection-name` attribute to every row. This does not happen.

### Changelog

**Changed**

- Updated the selection functionality to check if `is-selectable` property set to the DataTable, and if so to add `selection-name` property to the rows.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
