### PR TITLE
fix(datatable): selection option shows by default with out is selectable being added

### DIFF
--- a/packages/carbon-web-components/src/components/data-table/table.ts
+++ b/packages/carbon-web-components/src/components/data-table/table.ts
@@ -664,12 +664,14 @@ class CDSTable extends HostListenerMixin(LitElement) {
     }
 
     if (changedProperties.has('isSelectable')) {
-      this._tableHeaderRow.setAttribute('selection-name', 'header');
-      this._tableRows.forEach((e, index) => {
-        if (!e.hasAttribute('selection-name')) {
-          e.setAttribute('selection-name', index);
-        }
-      });
+      if(this.isSelectable){
+        this._tableHeaderRow.setAttribute('selection-name', 'header');
+        this._tableRows.forEach((e, index) => {
+          if (!e.hasAttribute('selection-name')) {
+            e.setAttribute('selection-name', index);
+          }
+        });
+      }
       this.headerCount++;
     }
 


### PR DESCRIPTION
### Related Ticket(s)

Closes #11481

### Description

Selection option is enabled for Data table by default without adding the `is-selectable` attribute to the table element,

### Changelog

**Changed**

- Added a condition to check if `is-selectable` attribute is added to the Data table component

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
