### PR TITLE
fix(datatable): search not working with uppercase characters in query

### DIFF
--- a/packages/carbon-web-components/src/components/data-table/table.ts
+++ b/packages/carbon-web-components/src/components/data-table/table.ts
@@ -168,7 +168,7 @@ class CDSTable extends HostListenerMixin(LitElement) {
    */
   @property()
   filterRows = (rowText: string, searchString: string) =>
-    rowText.toLowerCase().indexOf(searchString) < 0;
+    rowText.toLowerCase().indexOf(searchString.toLowerCase()) < 0;
 
   /**
    * The total headers


### PR DESCRIPTION
### Related Ticket(s)

Closes #11483

### Description

Search is not working as expected with uppercase characters in query string.

### Changelog

**Changed**

- Updated the search logic to convert the query string as well as the main string to lowercase and then compare.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
