### PR TITLE
fix(datatable): is-sortable not working with table column cell

### DIFF
--- a/packages/carbon-web-components/src/components/data-table/table-header-cell.ts
+++ b/packages/carbon-web-components/src/components/data-table/table-header-cell.ts
@@ -130,13 +130,13 @@ class CDSTableHeaderCell extends FocusMixin(LitElement) {
   /**
    * `true` if the table has expandable rows
    */
-  @property({ type: Boolean, reflect: true, attribute: 'is-sortable' })
+  @property({ type: Boolean, reflect: true, attribute: 'expandable' })
   isExpandable = false;
 
   /**
    * `true` if this table has selectable rows
    */
-  @property({ type: Boolean, reflect: true, attribute: 'is-sortable' })
+  @property({ type: Boolean, reflect: true, attribute: 'is-selectable' })
   isSelectable = false;
   /**
    * `true` if this table header column should be sortable

--- a/packages/carbon-web-components/src/components/data-table/table.ts
+++ b/packages/carbon-web-components/src/components/data-table/table.ts
@@ -404,9 +404,13 @@ class CDSTable extends HostListenerMixin(LitElement) {
     const columns = [...this._tableHeaderRow.children];
     const columnIndex = columns.indexOf(target);
 
-    columns.forEach(
-      (e) => e !== target && e.setAttribute('sort-direction', 'none')
-    );
+    columns.forEach((e) => {
+      if (e !== target && this.isSortable) {
+        e.setAttribute('sort-direction', 'none');
+      } else if (e.hasAttribute('is-sortable')) {
+        e.setAttribute('sort-direction', 'none');
+      }
+    });
 
     this._handleSortAction(columnIndex, sortDirection);
 
@@ -821,10 +825,13 @@ class CDSTable extends HostListenerMixin(LitElement) {
       }
     });
 
-    columns.forEach(
-      (e, index) =>
-        index !== columnIndex && e.setAttribute('sort-direction', 'none')
-    );
+    columns.forEach((e, index) => {
+      if (index !== columnIndex && this.isSortable) {
+        e.setAttribute('sort-direction', 'none');
+      } else if (e.hasAttribute('is-sortable')) {
+        e.setAttribute('sort-direction', 'none');
+      }
+    });
     this._handleSortAction(columnIndex, sortDirection);
   }
 


### PR DESCRIPTION
### Related Ticket(s)

Closes https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/11474

### Description

Passing `is-sortable` to `<cds-table-header-cell>` makes the column unsortable.
Column being unsortble is already fixed with [PR](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/11468)
But clicking on the sort icon makes all the columns sortable, this is fixed.

### Changelog

**Changed**

- `expandable` and `is-selectable` attributes mapped to proper variables. This was affecting the sorting action on individual columns.
- Updated the sort action to check if only specific columns are made sortable with `is-sortable` attribute and if so prevent other columns from showing sort icon.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
