### PR TITLE
fix(footer): locale modal button now working

### DIFF
--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -348,7 +348,7 @@ class C4DFooterComposite extends MediaQueryMixin(
         buttonLabel="${ifDefined(buttonLabel)}"
         size="${size}"
         slot="${slot}"
-        @click="${handleClickLocaleButton}"
+        @click="${handleClickLocaleButton.bind(this)}"
         >${langDisplay}</c4d-locale-button
       >
     `;


### PR DESCRIPTION
### Related Ticket(s)

Closes #11494

### Description
The locale modal button used to be working right until the v2 merge -- seems like Lit v2 decided to change the way it binds `this` to `@click` events, it now has to be explicit. So no matter how many times you were pressing the button to change the `openLocaleModal` boolean to true, it never changed the actual Footer's prop, it changed the **Button's** (nonexistent) prop instead 🤦 , so the modal rendering functions never ran.

### Changelog

**Changed**

- the locale modal button in the footer now binds `this` to its `@click` function to trigger the modal render functions properly

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
