### PR TITLE
fix(tabs): container size wrong

### DIFF
--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -28,7 +28,7 @@ $inset-transition: inset 110ms motion(standard, productive);
     overflow: scroll;
     flex: 1 1 0%;
     // for some reason, overflow: hidden shrinks the content
-    block-size: $spacing-09;
+    block-size: $spacing-08;
     scrollbar-width: none;
 
     &::-webkit-scrollbar {

--- a/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
+++ b/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -58,4 +58,9 @@
       }
     }
   }
+}
+
+:host(#{$c4d-prefix}-tabs-extended-media[type='contained'])
+  .#{$prefix}--tabs-nav-content-container {
+  block-size: $spacing-09;
 }


### PR DESCRIPTION
### Related Ticket(s)

Closes #11540 

### Description

The tab size had the incorrect height
<img width="631" alt="Screenshot 2024-02-19 at 10 28 18 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/20210594/759b4afb-0098-4c3f-a636-499ab6508081">

### Changelog


**Changed**

- styles to use $spacing-08 instead of 09


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
