### PR TITLE
fix(filter-tag): v1 open not showing

### DIFF
--- a/packages/carbon-web-components/src/components/tag/tag.scss
+++ b/packages/carbon-web-components/src/components/tag/tag.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2022
+// Copyright IBM Corp. 2019, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -74,10 +74,10 @@ $css--plex: true !default;
   @extend .#{$prefix}--tag--filter;
 
   display: none;
+}
 
-  &[open] {
-    display: inline-flex;
-  }
+:host(#{$prefix}-filter-tag[open]) {
+  display: inline-flex;
 }
 
 :host(#{$prefix}-filter-tag[disabled]) .#{$prefix}--tag__close-icon {


### PR DESCRIPTION
### Related Ticket(s)

Closes [#10874](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/10874)

### Description

filter tag `open` styles aren't coming through
### Changelog



**Changed**

- seperate the styles out


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
