### PR TITLE
fix(datatable): is sortable console error

### DIFF
--- a/packages/carbon-web-components/src/components/data-table/table.ts
+++ b/packages/carbon-web-components/src/components/data-table/table.ts
@@ -842,7 +842,7 @@ class CDSTable extends HostListenerMixin(LitElement) {
     });
     const columns = [...this._tableHeaderRow.children];
     let sortDirection;
-    let columnIndex = -1;
+    let columnIndex = 0;
     columns.forEach((column, index) => {
       if (
         column.hasAttribute('sort-direction') &&


### PR DESCRIPTION
### Related Ticket(s)

Fix for an issue reported in the support channel

### Description

Using `is-sortable` attribute in Data table was causing console error in firefox browser.

### Changelog


**Changed**

- Updated the initial value of variable `columnIndex` which was causing the error.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
