### PR TITLE
fix(autoalign): fix autoalign CSB example

### DIFF
--- a/packages/carbon-web-components/examples/codesandbox/autoalign/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/autoalign/cdn.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 
 <html>
   <head>
-    <title>@carbon/ibmdotcom-web-components example</title>
+    <title>@carbon/web-components autoalign example</title>
     <meta charset="UTF-8" />
     <link
       rel="stylesheet"
@@ -144,16 +144,18 @@ LICENSE file in the root directory of this source tree.
     </div>
 
     <script>
-      _handleClick = () => {
-        const popover = document.querySelector("cds-popover");
-        const open = popover?.hasAttribute("open");
-        open
-          ? popover?.removeAttribute("open")
-          : popover?.setAttribute("open", "");
+     _handleClick = () => {
+        const popover = document.querySelector('cds-popover');
+        if (popover) {
+          const open = popover.hasAttribute('open');
+          open
+            ? popover.removeAttribute('open')
+            : popover.setAttribute('open', '');
+        }
       };
 
-      const trigger = document.querySelector(".playground-trigger");
-      trigger.addEventListener("click", _handleClick);
+      const trigger = document.querySelector('.playground-trigger');
+      trigger.addEventListener('click', _handleClick);
     </script>
   </body>
 </html>

--- a/packages/carbon-web-components/examples/codesandbox/autoalign/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/autoalign/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 
 <html>
   <head>
-    <title>carbon-web-components example</title>
+    <title>@carbon/web-components autoalign example</title>
     <meta charset="UTF-8" />
     <link
       rel="stylesheet"
@@ -129,15 +129,17 @@ LICENSE file in the root directory of this source tree.
 
     <script>
       _handleClick = () => {
-        const popover = document.querySelector("cds-popover");
-        const open = popover?.hasAttribute("open");
-        open
-          ? popover?.removeAttribute("open")
-          : popover?.setAttribute("open", "");
+        const popover = document.querySelector('cds-popover');
+        if (popover) {
+          const open = popover.hasAttribute('open');
+          open
+            ? popover.removeAttribute('open')
+            : popover.setAttribute('open', '');
+        }
       };
 
-      const trigger = document.querySelector(".playground-trigger");
-      trigger.addEventListener("click", _handleClick);
+      const trigger = document.querySelector('.playground-trigger');
+      trigger.addEventListener('click', _handleClick);
     </script>
   </body>
 </html>

--- a/packages/carbon-web-components/examples/codesandbox/autoalign/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/autoalign/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-web-components-accordion-example",
+  "name": "carbon-web-components-autoalign-example",
   "version": "0.1.0",
   "private": true,
   "description": "Sample project for getting started with the Web Components from Carbon.",


### PR DESCRIPTION
### Related Ticket(s)

Closes # N/A

### Description

Codesandbox example was displaying errors - this PR adds the `.sassrc` file necessary for the styles to be imported correctly and adjustments to the click function for the popover as optional chaining isn't supported in the codesandbox example

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
