### PR TITLE
fix(toc): adjust mobile selector, should always be navbar

### DIFF
--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -87,7 +87,7 @@ class StickyHeader {
       }
     } else {
       this._tableOfContentsInnerBar = tocRoot.querySelector(
-        `.${prefix}--tableofcontents__sidebar`
+        `.${prefix}--tableofcontents__navbar`
       );
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

Closes #11587

### Description

Fixes sticky behavior issue with TOC Dotcom shell at less than lg breakpoin.

### Changelog

**Changed**

- TOC dotcom shell sticky behavior fixed at less than lg breakpoint

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
