### PR TITLE
fix(toc): adjust mobile selector to condition on layout

### DIFF
--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -90,7 +90,9 @@ class StickyHeader {
       }
     } else {
       this._tableOfContentsInnerBar = tocRoot.querySelector(
-        `.${prefix}--tableofcontents__sidebar`
+        toc.layout === 'horizontal'
+          ? `.${prefix}--tableofcontents__navbar`
+          : `.${prefix}--tableofcontents__sidebar`
       );
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

Closes #11588
[Jira ticket](https://jsw.ibm.com/browse/ADCMS-4307)

### Description

Fixes sticky behavior issue with TOC horizontal plus Dotcom shell at less than lg breakpoint.

### Testing instructions

1. Open the Dotcom shell > Default
2. Scroll the page
3. The Masthead should be sticky until it reaches the TOC, then the masthead should scroll away, while the TOC becomes sticky to the top.
4. Repeat at both `lg` and less than `lg` breakpoints
5. Repeat 1-4 with the Dotcom shell > With ToC horizontal  story

### Changelog

**Changed**

- TOC dotcom shell sticky behavior fixed at less than lg breakpoint.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
