### PR TITLE
fix(tabs-extended): confusing behavior when in mobile the accordion c…

### DIFF
--- a/packages/web-components/src/components/tabs-extended/tab.ts
+++ b/packages/web-components/src/components/tabs-extended/tab.ts
@@ -108,6 +108,7 @@ class DDSTab extends MediaQueryMixin(StableSelectorMixin(LitElement), {
       [`${prefix}--accordion__item--disabled`]: disabled,
     });
 
+    //Toggle 'selected' value, enabling the ability to open and close the accordion item.
     const toggleSelected = () => {
       this.selected = !selected;
     };

--- a/packages/web-components/src/components/tabs-extended/tab.ts
+++ b/packages/web-components/src/components/tabs-extended/tab.ts
@@ -108,11 +108,6 @@ class DDSTab extends MediaQueryMixin(StableSelectorMixin(LitElement), {
       [`${prefix}--accordion__item--disabled`]: disabled,
     });
 
-    //Toggle 'selected' value, enabling the ability to open and close the accordion item.
-    const toggleSelected = () => {
-      this.selected = !selected;
-    };
-
     return html`
       <li class="${classes}">
         <button
@@ -120,8 +115,7 @@ class DDSTab extends MediaQueryMixin(StableSelectorMixin(LitElement), {
           aria-expanded="${selected}"
           aria-controls="pane-${index}"
           tabindex="${index + 1}"
-          ?disabled="${disabled}"
-          @click="${toggleSelected}">
+          ?disabled="${disabled}">
           ${ChevronRight20({
             part: 'expando-icon',
             class: `${prefix}--accordion__arrow`,

--- a/packages/web-components/src/components/tabs-extended/tab.ts
+++ b/packages/web-components/src/components/tabs-extended/tab.ts
@@ -107,6 +107,11 @@ class DDSTab extends MediaQueryMixin(StableSelectorMixin(LitElement), {
       [`${prefix}--accordion__item--active`]: selected,
       [`${prefix}--accordion__item--disabled`]: disabled,
     });
+
+    const toggleSelected = () => {
+      this.selected = !selected;
+    };
+
     return html`
       <li class="${classes}">
         <button
@@ -114,13 +119,12 @@ class DDSTab extends MediaQueryMixin(StableSelectorMixin(LitElement), {
           aria-expanded="${selected}"
           aria-controls="pane-${index}"
           tabindex="${index + 1}"
-          ?disabled="${disabled}">
-          ${selected
-            ? ''
-            : ChevronRight20({
-                part: 'expando-icon',
-                class: `${prefix}--accordion__arrow`,
-              })}
+          ?disabled="${disabled}"
+          @click="${toggleSelected}">
+          ${ChevronRight20({
+            part: 'expando-icon',
+            class: `${prefix}--accordion__arrow`,
+          })}
           <div class="${prefix}--accordion__title">${label}</div>
         </button>
         <div id="pane-${index}" class="${prefix}--accordion__content">

--- a/packages/web-components/src/components/tabs-extended/tab.ts
+++ b/packages/web-components/src/components/tabs-extended/tab.ts
@@ -115,10 +115,12 @@ class DDSTab extends MediaQueryMixin(StableSelectorMixin(LitElement), {
           aria-controls="pane-${index}"
           tabindex="${index + 1}"
           ?disabled="${disabled}">
-          ${ChevronRight20({
-            part: 'expando-icon',
-            class: `${prefix}--accordion__arrow`,
-          })}
+          ${selected
+            ? ''
+            : ChevronRight20({
+                part: 'expando-icon',
+                class: `${prefix}--accordion__arrow`,
+              })}
           <div class="${prefix}--accordion__title">${label}</div>
         </button>
         <div id="pane-${index}" class="${prefix}--accordion__content">

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -88,6 +88,8 @@ class DDSTabsExtended extends MediaQueryMixin(
 
   private _handleAccordionClick(e) {
     const tab = e.target.closest(`${ddsPrefix}-tab`);
+    // const allClosed = this._tabItems.every((tab) => !tab.selected);
+
     this._handleClick(tab.getIndex(), e);
   }
 
@@ -208,13 +210,10 @@ class DDSTabsExtended extends MediaQueryMixin(
           `${ddsPrefix}-tab:nth-of-type(${_activeTabIndex + 1})`
         )?.shadowRoot?.querySelector(`.${prefix}--accordion__heading`);
 
-    if (activeItemControl instanceof HTMLElement) {
-      if (!isLargeOrGreater) {
-        // Unset focus so that when element is focused programmatically, the
-        // browser scrolls element into view.
-        activeItemControl.blur();
-      }
-      activeItemControl.focus();
+    if (activeItemControl instanceof HTMLElement && isLargeOrGreater) {
+      // Unset focus so that when element is focused programmatically, the
+      // browser scrolls element into view.
+      activeItemControl.blur();
     }
   };
 

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -236,9 +236,9 @@ class DDSTabsExtended extends MediaQueryMixin(
         (tab as DDSTab).setIndex(index);
 
         //Checking for the presence of 'dds-processed' attr. Since the logic will only succeed once, attaching only one version of the 'click' event at a time when switching views.
-        if (!tab.hasAttribute('dds-processed') && !_isLargeOrGreater) {
+        if (!tab.hasAttribute(`${ddsPrefix}-processed`) && !_isLargeOrGreater) {
           tab.addEventListener('click', this._handleAccordionClick.bind(this));
-          tab.setAttribute('dds-processed', 'true');
+          tab.setAttribute(`${ddsPrefix}-processed`, '');
         }
       });
     }

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -93,7 +93,7 @@ class DDSTabsExtended extends MediaQueryMixin(
     // Adding the ability to close the accordion. If the tab that's clicked is already active, we pass a bogus number through _setActiveItem() method, so that all tabs are closed.
     if (tab.getIndex() === currentIndex && !this._isLargeOrGreater) {
       this._setActiveItem(-1);
-      // return;
+      return;
     }
 
     this._handleClick(tab.getIndex(), e);
@@ -232,21 +232,21 @@ class DDSTabsExtended extends MediaQueryMixin(
     this._activeTabIndex = parseInt(this._activeTab, 10);
 
     // Reset state and event listeners when switching views
-    // if (changedProperties.has('_isLargeOrGreater')) {
-    //   // Removing event listener if in mobile view, else adding the event listener to any other view that's not mobile.
-    //   if (!_isLargeOrGreater) {
-    //     _tabItems.forEach((tab) => {
-    //       tab.removeEventListener(
-    //         'click',
-    //         this._handleAccordionClick.bind(this)
-    //       );
-    //     });
-    //   } else {
-    //     _tabItems.forEach((tab) => {
-    //       tab.addEventListener('click', this._handleAccordionClick.bind(this));
-    //     });
-    //   }
-    // }
+    if (changedProperties.has('_isLargeOrGreater')) {
+      // Removing event listener if in mobile view, else adding the event listener to any other view that's not mobile.
+      if (!_isLargeOrGreater) {
+        _tabItems.forEach((tab) => {
+          tab.removeEventListener(
+            'click',
+            this._handleAccordionClick.bind(this)
+          );
+        });
+      } else {
+        _tabItems.forEach((tab) => {
+          tab.addEventListener('click', this._handleAccordionClick.bind(this));
+        });
+      }
+    }
 
     if (changedProperties.has('_tabItems')) {
       _tabItems.forEach((tab, index) => {

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -90,6 +90,11 @@ class DDSTabsExtended extends MediaQueryMixin(
     const tab = e.target.closest(`${ddsPrefix}-tab`);
     const currentIndex = this._activeTabIndex;
 
+    // Adding the ability to close the accordion. If the tab that's clicked is already active, we pass a bogus number through _setActiveItem() method, so that all tabs are closed.
+    if (tab.getIndex() === currentIndex && !this._isLargeOrGreater) {
+      this._setActiveItem(-1);
+    }
+
     // If the tab is already active and selected when clicked, just return
     if (
       tab &&
@@ -243,6 +248,23 @@ class DDSTabsExtended extends MediaQueryMixin(
     const { _isLargeOrGreater, _tabItems } = this;
     this._isLTR = window.getComputedStyle(this).direction === 'ltr';
     this._activeTabIndex = parseInt(this._activeTab, 10);
+
+    // Reset state and event listeners when switching views
+    if (changedProperties.has('_isLargeOrGreater')) {
+      // Removing event listener if in mobile view, else adding the event listener to any other view that's not mobile.
+      if (!_isLargeOrGreater) {
+        _tabItems.forEach((tab) => {
+          tab.removeEventListener(
+            'click',
+            this._handleAccordionClick.bind(this)
+          );
+        });
+      } else {
+        _tabItems.forEach((tab) => {
+          tab.addEventListener('click', this._handleAccordionClick.bind(this));
+        });
+      }
+    }
 
     if (changedProperties.has('_tabItems')) {
       _tabItems.forEach((tab, index) => {

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -231,29 +231,14 @@ class DDSTabsExtended extends MediaQueryMixin(
     this._isLTR = window.getComputedStyle(this).direction === 'ltr';
     this._activeTabIndex = parseInt(this._activeTab, 10);
 
-    // Reset state and event listeners when switching views
-    if (changedProperties.has('_isLargeOrGreater')) {
-      // Removing event listener if in mobile view, else adding the event listener to any other view that's not mobile.
-      if (!_isLargeOrGreater) {
-        _tabItems.forEach((tab) => {
-          tab.removeEventListener(
-            'click',
-            this._handleAccordionClick.bind(this)
-          );
-        });
-      } else {
-        _tabItems.forEach((tab) => {
-          tab.addEventListener('click', this._handleAccordionClick.bind(this));
-        });
-      }
-    }
-
     if (changedProperties.has('_tabItems')) {
       _tabItems.forEach((tab, index) => {
         (tab as DDSTab).setIndex(index);
 
-        if (!_isLargeOrGreater) {
+        //Checking for the presence of 'dds-processed' attr. Since the logic will only succeed once, attaching only one version of the 'click' event at a time when switching views.
+        if (!tab.hasAttribute('dds-processed') && !_isLargeOrGreater) {
           tab.addEventListener('click', this._handleAccordionClick.bind(this));
+          tab.setAttribute('dds-processed', 'true');
         }
       });
     }

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -93,28 +93,10 @@ class DDSTabsExtended extends MediaQueryMixin(
     // Adding the ability to close the accordion. If the tab that's clicked is already active, we pass a bogus number through _setActiveItem() method, so that all tabs are closed.
     if (tab.getIndex() === currentIndex && !this._isLargeOrGreater) {
       this._setActiveItem(-1);
-    }
-
-    // If the tab is already active and selected when clicked, just return
-    if (
-      tab &&
-      tab.getIndex() === currentIndex &&
-      this._tabItems[currentIndex].selected
-    ) {
-      return;
+      // return;
     }
 
     this._handleClick(tab.getIndex(), e);
-
-    // Checking if the clicked tab is different from the previously active tab, if they're different, it just sets the focus to the new clicked tab
-    if (currentIndex !== tab.getIndex()) {
-      const tabButton = tab.shadowRoot?.querySelector(
-        `.${prefix}--accordion__heading`
-      );
-      if (tabButton instanceof HTMLElement) {
-        tabButton.focus();
-      }
-    }
   }
 
   private _setActiveItem(index: number) {
@@ -250,21 +232,21 @@ class DDSTabsExtended extends MediaQueryMixin(
     this._activeTabIndex = parseInt(this._activeTab, 10);
 
     // Reset state and event listeners when switching views
-    if (changedProperties.has('_isLargeOrGreater')) {
-      // Removing event listener if in mobile view, else adding the event listener to any other view that's not mobile.
-      if (!_isLargeOrGreater) {
-        _tabItems.forEach((tab) => {
-          tab.removeEventListener(
-            'click',
-            this._handleAccordionClick.bind(this)
-          );
-        });
-      } else {
-        _tabItems.forEach((tab) => {
-          tab.addEventListener('click', this._handleAccordionClick.bind(this));
-        });
-      }
-    }
+    // if (changedProperties.has('_isLargeOrGreater')) {
+    //   // Removing event listener if in mobile view, else adding the event listener to any other view that's not mobile.
+    //   if (!_isLargeOrGreater) {
+    //     _tabItems.forEach((tab) => {
+    //       tab.removeEventListener(
+    //         'click',
+    //         this._handleAccordionClick.bind(this)
+    //       );
+    //     });
+    //   } else {
+    //     _tabItems.forEach((tab) => {
+    //       tab.addEventListener('click', this._handleAccordionClick.bind(this));
+    //     });
+    //   }
+    // }
 
     if (changedProperties.has('_tabItems')) {
       _tabItems.forEach((tab, index) => {
@@ -306,8 +288,6 @@ class DDSTabsExtended extends MediaQueryMixin(
     }
 
     if (changedProperties.has('_isLargeOrGreater')) {
-      const { _isLargeOrGreater, _tabItems } = this;
-
       // If the user switches to desktop view and all tabs are closed, then the first tab will be the default selected one.
       if (_isLargeOrGreater && _tabItems.every((tab) => !tab.selected)) {
         this._setActiveItem(0);

--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -88,9 +88,28 @@ class DDSTabsExtended extends MediaQueryMixin(
 
   private _handleAccordionClick(e) {
     const tab = e.target.closest(`${ddsPrefix}-tab`);
-    // const allClosed = this._tabItems.every((tab) => !tab.selected);
+    const currentIndex = this._activeTabIndex;
+
+    // If the tab is already active and selected when clicked, just return
+    if (
+      tab &&
+      tab.getIndex() === currentIndex &&
+      this._tabItems[currentIndex].selected
+    ) {
+      return;
+    }
 
     this._handleClick(tab.getIndex(), e);
+
+    // Checking if the clicked tab is different from the previously active tab, if they're different, it just sets the focus to the new clicked tab
+    if (currentIndex !== tab.getIndex()) {
+      const tabButton = tab.shadowRoot?.querySelector(
+        `.${prefix}--accordion__heading`
+      );
+      if (tabButton instanceof HTMLElement) {
+        tabButton.focus();
+      }
+    }
   }
 
   private _setActiveItem(index: number) {
@@ -210,10 +229,13 @@ class DDSTabsExtended extends MediaQueryMixin(
           `${ddsPrefix}-tab:nth-of-type(${_activeTabIndex + 1})`
         )?.shadowRoot?.querySelector(`.${prefix}--accordion__heading`);
 
-    if (activeItemControl instanceof HTMLElement && isLargeOrGreater) {
-      // Unset focus so that when element is focused programmatically, the
-      // browser scrolls element into view.
-      activeItemControl.blur();
+    if (activeItemControl instanceof HTMLElement) {
+      if (!isLargeOrGreater) {
+        // Unset focus so that when element is focused programmatically, the
+        // browser scrolls element into view.
+        activeItemControl.blur();
+      }
+      activeItemControl.focus();
     }
   };
 
@@ -259,6 +281,15 @@ class DDSTabsExtended extends MediaQueryMixin(
           }
         }
       });
+    }
+
+    if (changedProperties.has('_isLargeOrGreater')) {
+      const { _isLargeOrGreater, _tabItems } = this;
+
+      // If the user switches to desktop view and all tabs are closed, then the first tab will be the default selected one.
+      if (_isLargeOrGreater && _tabItems.every((tab) => !tab.selected)) {
+        this._setActiveItem(0);
+      }
     }
   }
 


### PR DESCRIPTION
…annot be closed

### Related Ticket(s)

[ADCMS-4434](https://jsw.ibm.com/browse/ADCMS-4434)

### Description

The design for the Tabs Extended when in mobile is confusing. It turns into an accordion and there's always one item opened and showing. However, that opened item has an arrow on the right hand side, that deceives the user into thinking it's possible to close that item, when in fact, the accordion mimics the desktop behavior for tabs where we always have one item being shown at a time.

**I'm opening this PR initially as draft with the solution of removing the arrow for opened items so the whole team can discuss the best approach here.**

As per discussion with the team, the suggested changes were:


1.     Added the ability to open and close the accordion items;
2.     When all accordion items are closed, in desktop view the first tab is selected as default.




