### PR TITLE
fix: a11y - ensure side panel closes properly with reduced motion

### DIFF
--- a/packages/carbon-web-components/src/components/side-panel/side-panel.ts
+++ b/packages/carbon-web-components/src/components/side-panel/side-panel.ts
@@ -354,10 +354,14 @@ class CDSSidePanel extends HostListenerMixin(LitElement) {
   private _checkSetOpen = () => {
     const { _sidePanel: sidePanel } = this;
     if (sidePanel && this._isOpen) {
-      // wait until the side panel has transitioned off the screen to remove
-      sidePanel.addEventListener('transitionend', () => {
+      if (this._reducedMotion) {
         this._isOpen = false;
-      });
+      } else {
+        // wait until the side panel has transitioned off the screen to remove
+        sidePanel.addEventListener('transitionend', () => {
+          this._isOpen = false;
+        });
+      }
     } else {
       // allow the html to render before animating in the side panel
       this._isOpen = this.open;


### PR DESCRIPTION
### Related Ticket(s)

## Description

With reduce motion enabled the side panel was left in a state where it was waiting for a transition to end before completing the close. There is not transition with reduced motion, and as a result a transparent pane was left over the rest of the page.

This PR corrects that to ensure the side panel is correctly closed when reduced motion is enabled.

### Changelog

**Changed**

- packages/carbon-web-components/src/components/side-panel/side-panel.ts
