### PR TITLE
fix(webpack-rtl): pin dependencies to v1 for webpack-rtl example

### DIFF
--- a/packages/web-components/docs/enable-rtl.md
+++ b/packages/web-components/docs/enable-rtl.md
@@ -37,10 +37,10 @@ module.exports = {
 ```
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/usage/webpack-rtl)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/v1/packages/web-components/examples/codesandbox/usage/webpack-rtl)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/usage/webpack-rtl)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/v1/packages/web-components/examples/codesandbox/usage/webpack-rtl)
 
 While we recommend using a module bundler for creating a fully optimized RTL version 
 for your application (as shown in the example above), 
@@ -48,7 +48,7 @@ you can use our pre-built CDN version for evaluation purposes (which comes with 
 version can be found at `https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/rtl/ibmdotcom-web-components-dotcom-shell.rtl.min.js`.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/v1/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/carbon-for-ibm-dotcom/tree/v1/packages/web-components/examples/codesandbox/usage/dotcom-shell-cdn-with-rtl)

--- a/packages/web-components/examples/codesandbox/usage/webpack-rtl/package.json
+++ b/packages/web-components/examples/codesandbox/usage/webpack-rtl/package.json
@@ -12,8 +12,8 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "@carbon/web-components": "latest",
-    "@carbon/ibmdotcom-web-components": "canary",
+    "@carbon/web-components": "v1-latest",
+    "@carbon/ibmdotcom-web-components": "v1-latest",
     "accept-language-parser": "^1.5.0",
     "lit-element": "^2.4.0",
     "lit-html": "^1.3.0",


### PR DESCRIPTION
### Related Ticket(s)

None.

### Description

This fixes the webpack-rtl example for v1, which is currently broken on account of `main` branch and `latest` and `canary` tags all pointing to v2.

### Changelog

**Changed**

- Update webpack-rtl example links and dependencies to v1

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
