### PR TITLE
fix(rtl): add wc storybook rtl cmd back in for testing

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -53,6 +53,7 @@
     "build-storybook": "build-storybook",
     "build-storybook:experimental": "cross-env C4D_FLAGS_ALL=true build-storybook -o storybook-static-experimental",
     "build-storybook:react": "gulp build:modules:react && node --max-old-space-size=8192 node_modules/@storybook/react/bin/build.js -c .storybook/react -o storybook-static-react",
+    "build-storybook:rtl": "cross-env STORYBOOK_USE_RTL=true build-storybook -o storybook-static-rtl",
     "ci-check": "yarn wca && yarn typecheck && yarn build && yarn test:unit",
     "clean": "gulp clean",
     "clean:dist": "rimraf dist",


### PR DESCRIPTION
### Related Ticket(s)

Closes # {{Provide issue number link(s) to the related ticket(s) that this pull request addresses}}

### Description

Current the deploy next/staging environment workflow is failing as it tries to generate the rtl storybook build but we no longer have the build command for it. Adding it back in for testing purposes.

### Changelog

**New**

- {{new thing}}

**Changed**

- add back the `rtl` storybook build command for web-components

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
