### PR TITLE
fix(cdn): emit the CSS grid classes in a new artifact cssgrid.css

### DIFF
--- a/packages/carbon-web-components/gulp-tasks/build/sass-cdn.js
+++ b/packages/carbon-web-components/gulp-tasks/build/sass-cdn.js
@@ -14,13 +14,30 @@ const sass = require('gulp-sass')(require('sass'));
 const config = require('../config');
 
 /**
- * Builds the sass file for the carbon grid
+ * Builds the sass file for the carbon (flex) grid
  *
  * @returns {*} gulp stream
  */
 function _buildGrid() {
   return gulp
     .src([`${config.srcDir}/globals/scss/grid.scss`])
+    .pipe(
+      sass({
+        includePaths: ['node_modules'],
+        outputStyle: 'compressed',
+      }).on('error', sass.logError)
+    )
+    .pipe(gulp.dest(config.bundleDestDir));
+}
+
+/**
+ * Builds the sass file for the carbon (css) grid
+ *
+ * @returns {*} gulp stream
+ */
+function _buildCSSGrid() {
+  return gulp
+    .src([`${config.srcDir}/globals/scss/cssgrid.scss`])
     .pipe(
       sass({
         includePaths: ['node_modules'],
@@ -49,11 +66,13 @@ function _buildThemes() {
 
 
 gulp.task('build:sass:cdn:grid', _buildGrid);
+gulp.task('build:sass:cdn:cssgrid', _buildCSSGrid);
 gulp.task('build:sass:cdn:themes', _buildThemes);
 gulp.task(
   'build:sass:cdn',
   gulp.parallel(
     'build:sass:cdn:grid',
+    'build:sass:cdn:cssgrid',
     'build:sass:cdn:themes',
   )
 );

--- a/packages/carbon-web-components/src/globals/scss/cssgrid.scss
+++ b/packages/carbon-web-components/src/globals/scss/cssgrid.scss
@@ -1,0 +1,16 @@
+//
+// Copyright IBM Corp. 2024
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+$feature-flags: (
+  enable-css-custom-properties: true,
+  grid-columns-16: true,
+);
+
+@use '@carbon/grid';
+
+// Emit the css-grid styles
+@include grid.css-grid();

--- a/packages/web-components/gulp-tasks/build/sass-cdn.js
+++ b/packages/web-components/gulp-tasks/build/sass-cdn.js
@@ -33,13 +33,30 @@ function _buildPlex() {
 }
 
 /**
- * Builds the sass file for the carbon grid
+ * Builds the sass file for the carbon (flex) grid
  *
  * @returns {*} gulp stream
  */
 function _buildGrid() {
   return gulp
     .src([`${config.srcDir}/globals/scss/grid.scss`])
+    .pipe(
+      sass({
+        includePaths: ['node_modules', '../../node_modules'],
+        outputStyle: 'compressed',
+      }).on('error', sass.logError)
+    )
+    .pipe(gulp.dest(config.bundleDestDir));
+}
+
+/**
+ * Builds the sass file for the carbon (css) grid
+ *
+ * @returns {*} gulp stream
+ */
+function _buildCSSGrid() {
+  return gulp
+    .src([`${config.srcDir}/globals/scss/cssgrid.scss`])
     .pipe(
       sass({
         includePaths: ['node_modules', '../../node_modules'],
@@ -104,6 +121,7 @@ function _buildTOC() {
 
 gulp.task('build:sass:cdn:plex', _buildPlex);
 gulp.task('build:sass:cdn:grid', _buildGrid);
+gulp.task('build:sass:cdn:cssgrid', _buildCSSGrid);
 gulp.task('build:sass:cdn:themes', _buildThemes);
 gulp.task('build:sass:cdn:scroll', _buildScroll);
 gulp.task('build:sass:cdn:toc', _buildTOC);
@@ -112,6 +130,7 @@ gulp.task(
   gulp.parallel(
     'build:sass:cdn:plex',
     'build:sass:cdn:grid',
+    'build:sass:cdn:cssgrid',
     'build:sass:cdn:themes',
     'build:sass:cdn:scroll',
     'build:sass:cdn:toc'

--- a/packages/web-components/src/globals/scss/cssgrid.scss
+++ b/packages/web-components/src/globals/scss/cssgrid.scss
@@ -1,0 +1,16 @@
+//
+// Copyright IBM Corp. 2024
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+$feature-flags: (
+  enable-css-custom-properties: true,
+  grid-columns-16: true,
+);
+
+@use '@carbon/grid';
+
+// Emit the css-grid styles
+@include grid.css-grid();


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This includes a new `cssgrid.css` output available via CDN, as the current `grid.css` emits the flex grid.

### Changelog

**New**

- `cssgrid.css` output (CDN)

**Changed**

- Updated build configuration output for CDN
