### PR TITLE
fix(card-group):change tagGroupHeight target Element

### DIFF
--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -218,7 +218,7 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
           (this.constructor as typeof DDSCardGroup).selectorItemTagGroup
         )
       ) {
-        e.style.marginBottom = `${tagGroupHeight + headingBottomMargin}px`;
+        e.style.marginBottom = `${tagGroupHeight}px`;
       } else {
         let childTagGroup = e.nextElementSibling;
         childTagGroup.style.marginTop = `${

--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -219,6 +219,11 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
         )
       ) {
         e.style.marginBottom = `${tagGroupHeight + headingBottomMargin}px`;
+      } else {
+        let childTagGroup = e.nextElementSibling;
+        childTagGroup.style.marginTop = `${
+          tagGroupHeight - childTagGroup.offsetHeight
+        }px`;
       }
     });
   };

--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -26,6 +26,9 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 const gridLgBreakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
 const gridMdBreakpoint = parseFloat(breakpoints.md.width) * baseFontSize;
 
+// tag constants used for same height calculations
+const headingBottomMargin = 16; 
+
 /**
  * Card Group.
  *
@@ -215,7 +218,7 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
           (this.constructor as typeof DDSCardGroup).selectorItemTagGroup
         )
       ) {
-        e.style.marginBottom = `${tagGroupHeight}px`;
+        e.style.marginBottom = `${tagGroupHeight + headingBottomMargin}px`;
       } else {
         let childTagGroup = e.nextElementSibling;
         childTagGroup.style.marginTop = `${

--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -27,7 +27,7 @@ const gridLgBreakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
 const gridMdBreakpoint = parseFloat(breakpoints.md.width) * baseFontSize;
 
 // tag constants used for same height calculations
-const headingBottomMargin = 16; 
+const headingBottomMargin = 16;
 
 /**
  * Card Group.

--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -220,7 +220,11 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
         tagGroupHeight > 0
       ) {
         e.style.marginBottom = `${tagGroupHeight + paragraphBottomMargin}px`;
-      } else {
+      } else if (
+        e.nextElementSibling?.matches(
+          (this.constructor as typeof DDSCardGroup).selectorItemTagGroup
+        )
+      ) {
         let siblingTagGroup = e.nextElementSibling;
         siblingTagGroup.style.marginTop = `${
           tagGroupHeight - siblingTagGroup.offsetHeight

--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -26,9 +26,6 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 const gridLgBreakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
 const gridMdBreakpoint = parseFloat(breakpoints.md.width) * baseFontSize;
 
-// tag constants used for same height calculations
-const headingBottomMargin = 64;
-
 /**
  * Card Group.
  *

--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -210,7 +210,7 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
       }
     });
 
-    this._childItemHeadings.forEach((e) => {
+    this._childItemParagraphs.forEach((e) => {
       // add tag group height to heading to the cards lacking tag group
       if (
         e &&

--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -27,7 +27,7 @@ const gridLgBreakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
 const gridMdBreakpoint = parseFloat(breakpoints.md.width) * baseFontSize;
 
 // tag constants used for same height calculations
-const headingBottomMargin = 16;
+const paragraphBottomMargin = 16;
 
 /**
  * Card Group.
@@ -216,13 +216,14 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
         e &&
         !e.nextElementSibling?.matches(
           (this.constructor as typeof DDSCardGroup).selectorItemTagGroup
-        )
+        ) &&
+        tagGroupHeight > 0
       ) {
-        e.style.marginBottom = `${tagGroupHeight + headingBottomMargin}px`;
+        e.style.marginBottom = `${tagGroupHeight + paragraphBottomMargin}px`;
       } else {
-        let childTagGroup = e.nextElementSibling;
-        childTagGroup.style.marginTop = `${
-          tagGroupHeight - childTagGroup.offsetHeight
+        let siblingTagGroup = e.nextElementSibling;
+        siblingTagGroup.style.marginTop = `${
+          tagGroupHeight - siblingTagGroup.offsetHeight
         }px`;
       }
     });


### PR DESCRIPTION
### Related Ticket(s)

Closes https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/11605
JIRA  [ADCMS-4691](https://jsw.ibm.com/browse/ADCMS-4691) 

### Description

Fix for the  big extra unexpected space on cards between heading and paragraph.


### Changelog


**Changed**

Changing the card group script so it adds `tagGroupHeight`  as margin-botton to paragraphs instead of  headings

