### PR TITLE
feat(video-player): fade in video on load

### DIFF
--- a/packages/web-components/src/components/video-player/video-player-container.ts
+++ b/packages/web-components/src/components/video-player/video-player-container.ts
@@ -252,13 +252,20 @@ export const DDSVideoPlayerContainerMixin = <
         `${width} / ${height}`
       );
       doc!.getElementById(playerId)!.dataset.videoId = videoId;
-      const videoEmbed = (doc!.getElementById(playerId)?.firstElementChild as HTMLIFrameElement | null | undefined);
+      const videoEmbed = doc!.getElementById(playerId)?.firstElementChild as
+        | HTMLIFrameElement
+        | null
+        | undefined;
       if (videoEmbed) {
         // Hide iFrame until it's fully loaded
         videoEmbed.style.opacity = '0';
-        videoEmbed.addEventListener('load', () => {
-          videoEmbed.style.opacity = '';
-        }, {once: true});
+        videoEmbed.addEventListener(
+          'load',
+          () => {
+            videoEmbed.style.opacity = '';
+          },
+          { once: true }
+        );
         setTimeout(() => {
           // Fade in (@carbon/motion moderate02)
           videoEmbed.style.transition = 'opacity 240ms ease-in-out';


### PR DESCRIPTION
### Related Ticket(s)
[ADCMS-4477](https://jsw.ibm.com/browse/ADCMS-4477)

### Description
Updates the video-player-container component to make the inserted iFrame elements invisible until their `load` event is fired. This prevents a harsh black box from appearing before videos are ready to display.

![ugly-load](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/25532785/72acbf5b-08e8-42d8-bc05-4453075767b9)

### Changelog

**Changed**

- video-player-container videos will be invisible until the iframe is loaded