### PR TITLE
fix(data-table): radio button all selection option disabled

### DIFF
--- a/packages/carbon-web-components/src/components/data-table/stories/data-table-selection-story.ts
+++ b/packages/carbon-web-components/src/components/data-table/stories/data-table-selection-story.ts
@@ -107,7 +107,7 @@ export const WithRadioSelection = () => {
       >
 
       <cds-table-head>
-        <cds-table-header-row selection-name="header" hide-checkbox>
+        <cds-table-header-row>
           <cds-table-header-cell>Name</cds-table-header-cell>
           <cds-table-header-cell>Protocol</cds-table-header-cell>
           <cds-table-header-cell>Port</cds-table-header-cell>
@@ -117,7 +117,7 @@ export const WithRadioSelection = () => {
         </cds-table-header-row>
       </cds-table-head>
       <cds-table-body>
-        <cds-table-row selection-name="0">
+        <cds-table-row>
           <cds-table-cell>Load Balancer 3</cds-table-cell>
           <cds-table-cell>HTTP</cds-table-cell>
           <cds-table-cell>3000</cds-table-cell>
@@ -127,7 +127,7 @@ export const WithRadioSelection = () => {
             ><cds-link disabled>Disabled</cds-link></cds-table-cell
           >
         </cds-table-row>
-        <cds-table-row selection-name="1">
+        <cds-table-row>
           <cds-table-cell>Load Balancer 1</cds-table-cell>
           <cds-table-cell>HTTP</cds-table-cell>
           <cds-table-cell>443</cds-table-cell>
@@ -135,7 +135,7 @@ export const WithRadioSelection = () => {
           <cds-table-cell>Maureen's VM Groups</cds-table-cell>
           <cds-table-cell><cds-link>Starting</cds-link></cds-table-cell>
         </cds-table-row>
-        <cds-table-row selection-name="2">
+        <cds-table-row>
           <cds-table-cell>Load Balancer 2</cds-table-cell>
           <cds-table-cell>HTTP</cds-table-cell>
           <cds-table-cell>80</cds-table-cell>
@@ -143,7 +143,7 @@ export const WithRadioSelection = () => {
           <cds-table-cell>Andrew's VM Groups</cds-table-cell>
           <cds-table-cell><cds-link>Active</cds-link></cds-table-cell>
         </cds-table-row>
-        <cds-table-row selection-name="3">
+        <cds-table-row>
           <cds-table-cell>Load Balancer 6</cds-table-cell>
           <cds-table-cell>HTTP</cds-table-cell>
           <cds-table-cell>3000</cds-table-cell>
@@ -153,7 +153,7 @@ export const WithRadioSelection = () => {
             ><cds-link disabled>Disabled</cds-link></cds-table-cell
           >
         </cds-table-row>
-        <cds-table-row selection-name="4">
+        <cds-table-row>
           <cds-table-cell>Load Balancer 4</cds-table-cell>
           <cds-table-cell>HTTP</cds-table-cell>
           <cds-table-cell>443</cds-table-cell>
@@ -161,7 +161,7 @@ export const WithRadioSelection = () => {
           <cds-table-cell>Mel's VM Groups</cds-table-cell>
           <cds-table-cell><cds-link>Starting</cds-link></cds-table-cell>
         </cds-table-row>
-        <cds-table-row selection-name="5">
+        <cds-table-row>
           <cds-table-cell>Load Balancer 5</cds-table-cell>
           <cds-table-cell>HTTP</cds-table-cell>
           <cds-table-cell>80</cds-table-cell>

--- a/packages/carbon-web-components/src/components/data-table/table.ts
+++ b/packages/carbon-web-components/src/components/data-table/table.ts
@@ -668,7 +668,10 @@ class CDSTable extends HostListenerMixin(LitElement) {
     }
 
     if (changedProperties.has('isSelectable')) {
-      if (this.isSelectable) {
+      if (this.isSelectable || this.hasAttribute('radio')) {
+        if (this.hasAttribute('radio')) {
+          this._tableHeaderRow.setAttribute('hide-checkbox', '');
+        }
         this._tableHeaderRow.setAttribute('selection-name', 'header');
         this._tableRows.forEach((e, index) => {
           if (!e.hasAttribute('selection-name')) {


### PR DESCRIPTION
### Related Ticket(s)

Closes #11667
### Description

In Data Table, Radio buttons should not include check all option and selecting individual rows does not trigger toolbar.

### Changelog

**New**

- Added functionality to check if the Data table has `radio` attribute and if so, add `hide-checkbox` attribute to the table header row.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
