### PR TITLE
chore(masthead-tests): updating/fixing masthead cypress tests

### DIFF
--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-authenticated.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-authenticated.e2e.js
@@ -21,7 +21,7 @@ const _selectors = {
 const _pathDefault =
   '/iframe.html?id=components-masthead--default&knob-use%20mock%20nav%20data%20(use-mock)=true&knob-The%20user%20authenticated%20status%20(user-status)=test.user@ibm.com';
 
-describe('dds-masthead | authenticated (desktop)', () => {
+describe('c4d-masthead | authenticated (desktop)', () => {
   beforeEach(() => {
     cy.viewport(1280, 780).visit(`/${_pathDefault}`);
   });
@@ -42,7 +42,7 @@ describe('dds-masthead | authenticated (desktop)', () => {
   });
 });
 
-describe('dds-masthead | default (mobile)', () => {
+describe('c4d-masthead | default (mobile)', () => {
   beforeEach(() => {
     cy.viewport(320, 780).visit(`/${_pathDefault}`);
   });

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-authenticated.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-authenticated.e2e.js
@@ -11,6 +11,13 @@
  * @type {string}
  * @private
  */
+
+const _selectors = {
+  mastheadContainer: 'c4d-masthead-container',
+  mastheadProfile: 'c4d-masthead-profile',
+  mastheadProfileItem: 'c4d-masthead-profile-item',
+}
+
 const _pathDefault =
   '/iframe.html?id=components-masthead--default&knob-use%20mock%20nav%20data%20(use-mock)=true&knob-The%20user%20authenticated%20status%20(user-status)=test.user@ibm.com';
 
@@ -20,17 +27,17 @@ describe('dds-masthead | authenticated (desktop)', () => {
   });
 
   it('should open the login menu with 4 items', () => {
-    cy.get('dds-masthead-profile')
+    cy.get(_selectors.mastheadProfile)
       .shadow()
       .find('a')
       .click();
-    cy.get('dds-masthead-profile-item').should('have.length', 4);
+    cy.get(_selectors.mastheadProfileItem).should('have.length', 4);
     cy.takeSnapshots();
   });
 
   it('should not render profile menu when disabled', () => {
-    cy.get('dds-masthead-composite').invoke('attr', 'has-profile', 'false');
-    cy.get('dds-masthead-profile').should('not.exist');
+    cy.get(_selectors.mastheadContainer).invoke('attr', 'has-profile', 'false');
+    cy.get(_selectors.mastheadProfile).should('not.exist');
     cy.takeSnapshots();
   });
 });
@@ -41,11 +48,11 @@ describe('dds-masthead | default (mobile)', () => {
   });
 
   it('should open the login menu with 4 items', () => {
-    cy.get('dds-masthead-profile')
+    cy.get(_selectors.mastheadProfile)
       .shadow()
       .find('a')
       .click();
-    cy.get('dds-masthead-profile-item').should('have.length', 4);
+    cy.get(_selectors.mastheadProfileItem).should('have.length', 4);
     cy.takeSnapshots('mobile');
   });
 });

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-custom-search.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-custom-search.e2e.js
@@ -48,7 +48,7 @@ describe('cds-masthead | custom search (desktop)', () => {
     // string. Every keypress will trigger an API request, so here we mock each
     // successive cumulative search query.
     ['c', 'cl', 'clo', 'clou', 'cloud'].forEach(query => {
-      cy.intercept(`https://ibmdocs-dev.dcs.ibm.com/docs/api/v1/suggest?query=${query}&lang=undefined&categories=&limit=6`, {
+      cy.intercept(`https://ibm.com/docs/api/v1/suggest?query=${query}&lang=undefined&categories=&limit=6`, {
         fixture: `grouped-typeahead-${query}.json`,
       }).as(`grouped-typeahead-${query}`);
     });

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-custom-search.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-custom-search.e2e.js
@@ -11,6 +11,13 @@
  * @type {string}
  * @private
  */
+
+const _selectors = {
+  masthead: 'c4d-masthead',
+  mastheadSearch: 'c4d-search-with-typeahead',
+  mastheadSearchButton: '.cds--header__search--search',
+}
+
 const _pathCustomSearch =
   '/iframe.html?id=components-masthead--with-custom-typeahead&knob-use%20mock%20nav%20data%20(use-mock)=true';
 
@@ -28,30 +35,30 @@ describe('cds-masthead | custom search (desktop)', () => {
   });
 
   it('should open the search bar on click', () => {
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearch}`)
       .shadow()
-      .find('.bx--header__search--search')
+      .find(_selectors.mastheadSearchButton)
       .click();
 
     cy.takeSnapshots();
   });
 
-  xit('should display grouped results with hrefs', () => {
+  it('should display grouped results with hrefs', () => {
     // Mock grouped search typeahead API. Below we user the "cloud" search
     // string. Every keypress will trigger an API request, so here we mock each
     // successive cumulative search query.
-    [('c', 'cl', 'clo', 'clou', 'cloud')].forEach(query => {
+    ['c', 'cl', 'clo', 'clou', 'cloud'].forEach(query => {
       cy.intercept(`https://ibmdocs-dev.dcs.ibm.com/docs/api/v1/suggest?query=${query}&lang=undefined&categories=&limit=6`, {
         fixture: `grouped-typeahead-${query}.json`,
       }).as(`grouped-typeahead-${query}`);
     });
 
-    cy.get('c4d-masthead > c4d-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearch}`)
       .shadow()
-      .find('.bx--header__search--search')
+      .find(_selectors.mastheadSearchButton)
       .click();
 
-    cy.get('c4d-masthead > c4d-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearch}`)
       .shadow()
       .find('.react-autosuggest__container > input')
       .type('cloud', { force: true });

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-custom-search.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-custom-search.e2e.js
@@ -21,7 +21,7 @@ const _selectors = {
 const _pathCustomSearch =
   '/iframe.html?id=components-masthead--with-custom-typeahead&knob-use%20mock%20nav%20data%20(use-mock)=true';
 
-describe('cds-masthead | custom search (desktop)', () => {
+describe('c4d-masthead | custom search (desktop)', () => {
   beforeEach(() => {
     cy.visit(`/${_pathCustomSearch}`);
     cy.injectAxe();

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-default.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-default.e2e.js
@@ -423,7 +423,6 @@ describe('c4d-masthead | performance optimizations', () => {
     // Left nav not opened yet, assert that none of the lazy loaded elements
     // are registered.
     [
-      'c4d-left-nav-cta-item',
       'c4d-left-nav-name',
       'c4d-left-nav-menu',
       'c4d-left-nav-menu-section',
@@ -444,7 +443,6 @@ describe('c4d-masthead | performance optimizations', () => {
     // Left nav opened! Assert that all the lazy loaded elements have been
     // loaded and registered.
     [
-      'c4d-left-nav-cta-item',
       'c4d-left-nav-name',
       'c4d-left-nav-menu',
       'c4d-left-nav-menu-section',

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-l1.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-l1.e2e.js
@@ -18,17 +18,39 @@ const _pathl1 = '/iframe.html?id=components-masthead--with-l-1&knob-use%20mock%2
  */
 const _selectors = {
   l1: 'c4d-masthead-l1',
+  l1CtaContainer: 'c4d-masthead-l1-cta',
   l1Name: '.cds--masthead__l1-title',
   l1Login: '.cds--masthead__l1-login',
-  l1Cta: '.cds--masthead__l1-login',
+  l1Cta: '.cds--masthead__l1-cta',
   l1Menu: '.cds--masthead__l1-menu',
   l1Item: '.cds--masthead__l1-item',
+  l1ScrollNextArrow: '#scroll-next',
   l1Dropdown: '.cds--masthead__l1-dropdown',
   l1DropdownAnnouncement: '.cds--masthead__l1-dropdown-announcement',
   l1DropdownLinks: '.cds--masthead__l1-dropdown-links',
   l1DropdownSection: '.cds--masthead__l1-dropdown-section',
   l1DropdownViewAll: '.cds--masthead__l1-dropdown-viewall',
 };
+
+describe('dds-masthead L1 | default (mobile)', () => {
+  const mastheadButton = () => cy.get(_selectors.l1).shadow().find('.cds--masthead__l1-inner-container > button');
+
+  beforeEach(() => {
+    cy.viewport(320, 780).visit(`/${_pathl1}`);
+  });
+
+  it('should open L1 menu with all items', () => {
+    mastheadButton().click();
+    cy.get(`${_selectors.l1Dropdown} > li`).should('have.length', 9);
+  });
+
+  it('should open L1 sub menus', () => {
+    mastheadButton().click();
+    cy.get('.cds--masthead__l1-dropdown > li:nth-child(2)').click();
+    cy.get('.cds--masthead__l1-dropdown-subsection > ul:first-child > li > a').should('have.length', 4);
+  });
+});
+
 
 describe('cds-masthead | with L1 (desktop)', () => {
   beforeEach(() => {
@@ -108,8 +130,7 @@ describe('cds-masthead | with L1 (desktop)', () => {
       });
   });
 
-  // @TODO: re-enable once :has selector use is replaced
-  it.skip('should support two column dropdowns', () => {
+  it('should support two column dropdowns', () => {
     cy.get(_selectors.l1)
       .shadow()
       .find(_selectors.l1Item)
@@ -125,8 +146,7 @@ describe('cds-masthead | with L1 (desktop)', () => {
       });
   });
 
-  // @TODO: re-enable once :has selector use is replaced
-  it.skip('should support asymmetrical two column dropdowns', () => {
+  it('should support asymmetrical two column dropdowns', () => {
     cy.get(_selectors.l1)
       .shadow()
       .find(_selectors.l1Item)
@@ -142,8 +162,7 @@ describe('cds-masthead | with L1 (desktop)', () => {
       });
   });
 
-  // @TODO: re-enable once :has selector use is replaced
-  it.skip('should support three column dropdowns', () => {
+  it('should support three column dropdowns', () => {
     cy.get(_selectors.l1)
       .shadow()
       .find(_selectors.l1Item)
@@ -173,7 +192,7 @@ describe('cds-masthead | with L1 (desktop)', () => {
   });
 
   it('should render a single CTA link', () => {
-    cy.get(_selectors.l1)
+    cy.get(_selectors.l1CtaContainer)
       .shadow()
       .find(_selectors.l1Cta)
       .should('have.length', 1)
@@ -183,4 +202,19 @@ describe('cds-masthead | with L1 (desktop)', () => {
       })
   });
 
+  it('should have horizontal scroll for L1 items working', () => {
+    cy.viewport(1100, 780);
+    
+    cy.get(_selectors.l1)
+      .shadow()
+      .find(_selectors.l1ScrollNextArrow)
+      .click()
+      .get(_selectors.l1)
+      .shadow()
+      .find(_selectors.l1Item)
+      .eq(5)
+      .should('be.visible');
+  });
+  
 });
+

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-l1.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-l1.e2e.js
@@ -26,31 +26,13 @@ const _selectors = {
   l1Item: '.cds--masthead__l1-item',
   l1ScrollNextArrow: '#scroll-next',
   l1Dropdown: '.cds--masthead__l1-dropdown',
+  l1DropdownSubSection: '.cds--masthead__l1-dropdown-subsection',
+  l1DropdownContainer: '.cds--masthead__l1-inner-container',
   l1DropdownAnnouncement: '.cds--masthead__l1-dropdown-announcement',
   l1DropdownLinks: '.cds--masthead__l1-dropdown-links',
   l1DropdownSection: '.cds--masthead__l1-dropdown-section',
   l1DropdownViewAll: '.cds--masthead__l1-dropdown-viewall',
 };
-
-describe('dds-masthead L1 | default (mobile)', () => {
-  const mastheadButton = () => cy.get(_selectors.l1).shadow().find('.cds--masthead__l1-inner-container > button');
-
-  beforeEach(() => {
-    cy.viewport(320, 780).visit(`/${_pathl1}`);
-  });
-
-  it('should open L1 menu with all items', () => {
-    mastheadButton().click();
-    cy.get(`${_selectors.l1Dropdown} > li`).should('have.length', 9);
-  });
-
-  it('should open L1 sub menus', () => {
-    mastheadButton().click();
-    cy.get('.cds--masthead__l1-dropdown > li:nth-child(2)').click();
-    cy.get('.cds--masthead__l1-dropdown-subsection > ul:first-child > li > a').should('have.length', 4);
-  });
-});
-
 
 describe('cds-masthead | with L1 (desktop)', () => {
   beforeEach(() => {
@@ -216,5 +198,24 @@ describe('cds-masthead | with L1 (desktop)', () => {
       .should('be.visible');
   });
   
+});
+
+describe('dds-masthead L1 | default (mobile)', () => {
+  const mastheadButton = () => cy.get(_selectors.l1).shadow().find(`${_selectors.l1DropdownContainer} > button`);
+
+  beforeEach(() => {
+    cy.viewport(320, 780).visit(`/${_pathl1}`);
+  });
+
+  it('should open L1 menu with all items', () => {
+    mastheadButton().click();
+    cy.get(`${_selectors.l1Dropdown} > li`).should('be.visible');
+  });
+
+  it('should open L1 sub menus', () => {
+    mastheadButton().click();
+    cy.get(`${_selectors.l1Dropdown} > li:nth-child(2)`).click();
+    cy.get(`${_selectors.l1DropdownSubSection} > ul:first-child > li > a`).should('be.visible');
+  });
 });
 

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-l1.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-l1.e2e.js
@@ -34,7 +34,7 @@ const _selectors = {
   l1DropdownViewAll: '.cds--masthead__l1-dropdown-viewall',
 };
 
-describe('cds-masthead | with L1 (desktop)', () => {
+describe('c4d-masthead | with L1 (desktop)', () => {
   beforeEach(() => {
     cy.visit(`/${_pathl1}`);
     cy.injectAxe();
@@ -190,8 +190,9 @@ describe('cds-masthead | with L1 (desktop)', () => {
     cy.get(_selectors.l1)
       .shadow()
       .find(_selectors.l1ScrollNextArrow)
-      .click()
-      .get(_selectors.l1)
+      .click();
+
+      cy.get(_selectors.l1)
       .shadow()
       .find(_selectors.l1Item)
       .eq(5)
@@ -200,7 +201,7 @@ describe('cds-masthead | with L1 (desktop)', () => {
   
 });
 
-describe('dds-masthead L1 | default (mobile)', () => {
+describe('c4d-masthead L1 | default (mobile)', () => {
   const mastheadButton = () => cy.get(_selectors.l1).shadow().find(`${_selectors.l1DropdownContainer} > button`);
 
   beforeEach(() => {

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-platform.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-platform.e2e.js
@@ -11,6 +11,13 @@
  * @type {string}
  * @private
  */
+
+const _selectors = {
+  masthead: 'c4d-masthead',
+  mastheadNavName: 'c4d-top-nav-name',
+  mastheadSearchBar: 'c4d-search-with-typeahead',
+}
+
 const _pathPlatform = '/iframe.html?id=components-masthead--with-platform&knob-use%20mock%20nav%20data%20(use-mock)=true';
 
 describe('cds-masthead | with platform (desktop)', () => {
@@ -25,7 +32,7 @@ describe('cds-masthead | with platform (desktop)', () => {
   });
 
   it('should load platform containing a link', () => {
-    cy.get('cds-masthead > cds-top-nav-name')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadNavName}`)
       .shadow()
       .find('a')
       .then($link => {
@@ -35,15 +42,15 @@ describe('cds-masthead | with platform (desktop)', () => {
   });
 
   it('should render platform next to IBM logo', () => {
-    cy.get('cds-masthead > cds-top-nav-name').then($platform => {
-      cy.get('cds-masthead > cds-masthead-logo').then($logo => {
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadNavName}`).then($platform => {
+      cy.get(`${_selectors.masthead} > ${_selectors.masthead}-logo`).then($logo => {
         expect($logo[0].getBoundingClientRect().right).to.equal($platform[0].getBoundingClientRect().left);
       });
     });
   });
 
   it('should open the search bar with platform', () => {
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
       .find('[part="open-button"]')
       .click();

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-platform.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-platform.e2e.js
@@ -20,7 +20,7 @@ const _selectors = {
 
 const _pathPlatform = '/iframe.html?id=components-masthead--with-platform&knob-use%20mock%20nav%20data%20(use-mock)=true';
 
-describe('cds-masthead | with platform (desktop)', () => {
+describe('c4d-masthead | with platform (desktop)', () => {
   beforeEach(() => {
     cy.visit(`/${_pathPlatform}`);
     cy.injectAxe();

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-scoped-search.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-scoped-search.e2e.js
@@ -11,6 +11,20 @@
  * @type {string}
  * @private
  */
+
+const _selectors = {
+  masthead: 'c4d-masthead',
+  mastheadNavName: 'c4d-top-nav-name',
+  mastheadSearchBar: 'c4d-search-with-typeahead',
+  mastheadSearchButton: '.cds--header__search--search',
+  mastheadScopedSearchDropDown: 'c4d-scoped-search-dropdown',
+  mastheadScopedSearchDropDownMobile: 'c4d-scoped-search-dropdown-mobile',
+  mastheadSearchItem: 'c4d-search-with-typeahead-item',
+  mastheadDropDownButton: '.cds--dropdown',
+  mastheadDropDownButtonMobile: '.cds--select-input',
+  mastheadDropDownItem: 'cds-dropdown-item',
+}
+
 const _pathScopedSearch = '/iframe.html?id=components-masthead--with-scoped-search';
 
 describe('cds-masthead | scoped search (desktop)', () => {
@@ -27,28 +41,28 @@ describe('cds-masthead | scoped search (desktop)', () => {
   });
 
   it('should open the search bar on click', () => {
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
-      .find('.bx--header__search--search')
+      .find(_selectors.mastheadSearchButton)
       .click();
 
     cy.takeSnapshots();
   });
 
   it('should retrieve regular results with "all" scope', () => {
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
-      .find('.bx--header__search--search')
+      .find(_selectors.mastheadSearchButton)
       .click();
 
-    cy.get('cds-scoped-search-dropdown').should('have.value', 'all');
+    cy.get(_selectors.mastheadScopedSearchDropDown).should('have.value', 'all');
 
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
       .find('input[type="text"]')
       .type('cloud', { force: true });
 
-    cy.get('cds-search-with-typeahead-item').should('have.length', 10);
+    cy.get(_selectors.mastheadSearchItem).should('have.length', 10);
 
     cy.takeSnapshots();
   });
@@ -59,28 +73,28 @@ describe('cds-masthead | scoped search (desktop)', () => {
       fixture: 'scoped-typeahead.json',
     });
 
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
-      .find('.bx--header__search--search')
+      .find(_selectors.mastheadSearchButton)
       .click();
 
-    cy.get('cds-scoped-search-dropdown')
+    cy.get(_selectors.mastheadScopedSearchDropDown)
       .shadow()
-      .find('.bx--dropdown')
+      .find(_selectors.mastheadDropDownButton)
       .click();
 
-    cy.get('cds-scoped-search-dropdown')
-      .find(`bx-dropdown-item[value="pw"]`)
+    cy.get(_selectors.mastheadScopedSearchDropDown)
+      .find(`${_selectors.mastheadDropDownItem}[value="pw"]`)
       .click();
 
-    cy.get('cds-scoped-search-dropdown').should('have.value', 'pw');
+    cy.get(_selectors.mastheadScopedSearchDropDown).should('have.value', 'pw');
 
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
       .find('input[type="text"]')
       .type('cloud', { force: true });
 
-    cy.get('cds-search-with-typeahead-item').should('have.length', 5);
+    cy.get(_selectors.mastheadSearchItem).should('have.length', 5);
     cy.takeSnapshots();
   });
 });
@@ -94,28 +108,28 @@ describe('cds-masthead | scoped search (mobile)', () => {
   });
 
   it('should open the search bar on click', () => {
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
-      .find('.bx--header__search--search')
+      .find(_selectors.mastheadSearchButton)
       .click();
 
     cy.takeSnapshots();
   });
 
   it('should retrieve regular results with "all" scope', () => {
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
-      .find('.bx--header__search--search')
+      .find(_selectors.mastheadSearchButton)
       .click();
 
-    cy.get('cds-scoped-search-dropdown-mobile').should('have.value', 'all');
+    cy.get(_selectors.mastheadScopedSearchDropDownMobile).should('have.value', 'all');
 
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
       .find('input[type="text"]')
       .type('cloud', { force: true });
 
-    cy.get('cds-search-with-typeahead-item').should('have.length', 10);
+    cy.get(_selectors.mastheadSearchItem).should('have.length', 10);
 
     cy.takeSnapshots();
   });
@@ -126,23 +140,23 @@ describe('cds-masthead | scoped search (mobile)', () => {
       fixture: 'scoped-typeahead.json',
     });
 
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
-      .find('.bx--header__search--search')
+      .find(_selectors.mastheadSearchButton)
       .click();
 
-    cy.get('cds-scoped-search-dropdown-mobile')
+    cy.get(_selectors.mastheadScopedSearchDropDownMobile)
       .shadow()
-      .find('.bx--select-input')
+      .find(_selectors.mastheadDropDownButtonMobile)
       .select('pw');
-    cy.get('cds-scoped-search-dropdown-mobile').should('have.value', 'pw');
+    cy.get(_selectors.mastheadScopedSearchDropDownMobile).should('have.value', 'pw');
 
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchBar}`)
       .shadow()
       .find('input[type="text"]')
       .type('cloud', { force: true });
 
-    cy.get('cds-search-with-typeahead-item').should('have.length', 5);
+    cy.get(_selectors.mastheadSearchItem).should('have.length', 5);
     cy.takeSnapshots();
   });
 });

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-scoped-search.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-scoped-search.e2e.js
@@ -27,7 +27,7 @@ const _selectors = {
 
 const _pathScopedSearch = '/iframe.html?id=components-masthead--with-scoped-search';
 
-describe('cds-masthead | scoped search (desktop)', () => {
+describe('c4d-masthead | scoped search (desktop)', () => {
   beforeEach(() => {
     cy.visit(`/${_pathScopedSearch}`);
     cy.injectAxe();
@@ -99,7 +99,7 @@ describe('cds-masthead | scoped search (desktop)', () => {
   });
 });
 
-describe('cds-masthead | scoped search (mobile)', () => {
+describe('c4d-masthead | scoped search (mobile)', () => {
   beforeEach(() => {
     cy.visit(`/${_pathScopedSearch}`);
     cy.viewport(320, 780);

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-search-onload.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-search-onload.e2e.js
@@ -11,6 +11,13 @@
  * @type {string}
  * @private
  */
+
+const _selectors = {
+  mastheadSearch: 'c4d-search-with-typeahead',
+  mastheadSearchItem: 'c4d-search-with-typeahead-item',
+  mastheadTopNav: 'c4d-top-nav',
+}
+
 const _pathSearchOpenOnload =
   '/iframe.html?id=components-masthead--search-open-onload&knob-use%20mock%20nav%20data%20(use-mock)=true';
 
@@ -35,7 +42,7 @@ describe('cds-masthead | search open onload (desktop)', () => {
   });
 
   it('should load search field open by default', () => {
-    cy.get('cds-search-with-typeahead')
+    cy.get(_selectors.mastheadSearch)
       .shadow()
       .find('input[type="text"]')
       .should('be.visible');
@@ -44,7 +51,7 @@ describe('cds-masthead | search open onload (desktop)', () => {
   });
 
   it('should have typable search field', () => {
-    cy.get('cds-search-with-typeahead')
+    cy.get(_selectors.mastheadSearch)
       .shadow()
       .find('input[type="text"]')
       .type('test')
@@ -52,17 +59,17 @@ describe('cds-masthead | search open onload (desktop)', () => {
   });
 
   it('should display 10 auto suggest results', () => {
-    cy.get('cds-search-with-typeahead')
+    cy.get(_selectors.mastheadSearch)
       .shadow()
       .find('input[type="text"]')
       .type('test');
 
-    cy.get('c4d-search-with-typeahead-item').should('have.length', 10);
+    cy.get(_selectors.mastheadSearchItem).should('have.length', 10);
 
     cy.takeSnapshots();
   });
 
   it('should not display menu options while search field is open', () => {
-    cy.get('cds-top-nav').should('have.attr', 'hidenav');
+    cy.get(_selectors.mastheadTopNav).should('have.attr', 'hidenav');
   });
 });

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-search-onload.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-search-onload.e2e.js
@@ -21,7 +21,7 @@ const _selectors = {
 const _pathSearchOpenOnload =
   '/iframe.html?id=components-masthead--search-open-onload&knob-use%20mock%20nav%20data%20(use-mock)=true';
 
-describe('cds-masthead | search open onload (desktop)', () => {
+describe('c4d-masthead | search open onload (desktop)', () => {
   beforeEach(() => {
     // TODO: fix the uncaught exception in Firefox only
     cy.on('uncaught:exception', (err, runnable) => {

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead.e2e.js
@@ -11,6 +11,20 @@
  * @type {string}
  * @private
  */
+
+const _selectors = {
+  masthead: 'c4d-masthead',
+  mastheadLogo: 'c4d-masthead-logo',
+  mastheadSearchTypeBar: 'c4d-search-with-typeahead',
+  mastheadSearchResultItem: 'c4d-search-with-typeahead-item',
+  mastheadSearchBtn: '.cds--header__search--search',
+  mastheadMenuItem: 'c4d-top-nav-item',
+  mastheadDropDownMenuItem: 'c4d-megamenu-top-nav-menu',
+  mastheadProfileBtn: 'c4d-masthead-profile',
+  mastheadProfileItems: 'c4d-masthead-profile-item',
+  mastheadMenuBtnMobile: 'c4d-masthead-menu-button',
+}
+
 const _pathDefault = '/iframe.html?id=components-masthead--default';
 
 describe('cds-masthead | default (desktop)', () => {
@@ -27,7 +41,7 @@ describe('cds-masthead | default (desktop)', () => {
   });
 
   it('should have url for IBM logo', () => {
-    cy.get('cds-masthead-logo')
+    cy.get(_selectors.mastheadLogo)
       .shadow()
       .find('a')
       .then($link => {
@@ -38,11 +52,12 @@ describe('cds-masthead | default (desktop)', () => {
 
   it('should load menu item with selected state', () => {
     let selectedState = false;
-    cy.get('cds-megamenu-top-nav-menu')
+    cy.get(_selectors.mastheadMenuItem)
       .each($menuItem => {
         if ($menuItem.attr('active') !== undefined) {
           selectedState = true;
         }
+        console.log($menuItem,'TB');
       })
       .then(() => {
         expect(selectedState).to.be.true;
@@ -52,7 +67,7 @@ describe('cds-masthead | default (desktop)', () => {
   });
 
   it('should load a megamenu with links', () => {
-    cy.get('cds-megamenu-top-nav-menu:nth-child(2)')
+    cy.get(`${_selectors.mastheadDropDownMenuItem}:nth-child(2)`)
       .shadow()
       .find('a')
       .click();
@@ -63,13 +78,13 @@ describe('cds-masthead | default (desktop)', () => {
   it('should have urls for the submenu items within the megamenu', () => {
     // Click to open the megamenu that we're interested in inspecting, since
     // due to lazy loading, it's not in the DOM by default.
-    cy.get('cds-megamenu-top-nav-menu:nth-child(2)')
+    cy.get(`${_selectors.mastheadDropDownMenuItem}:nth-child(2)`)
       .shadow()
       .find('[part=trigger]')
       .click();
 
     cy.get(
-      'cds-megamenu-top-nav-menu:nth-child(2) > cds-megamenu >  cds-megamenu-right-navigation >  cds-megamenu-category-group > cds-megamenu-category-link:nth-child(1)'
+      'c4d-megamenu-right-navigation >  c4d-megamenu-category-group > c4d-megamenu-category-link:nth-child(1)'
     )
       .shadow()
       .find('a')
@@ -80,7 +95,7 @@ describe('cds-masthead | default (desktop)', () => {
   });
 
   it('should open the login menu', () => {
-    cy.get('cds-masthead-profile')
+    cy.get(_selectors.mastheadProfileBtn)
       .shadow()
       .find('a')
       .click();
@@ -89,30 +104,30 @@ describe('cds-masthead | default (desktop)', () => {
   });
 
   it('should have 2 menu items under the login menu', () => {
-    cy.get('cds-masthead-profile-item').should('have.length', 2);
+    cy.get(_selectors.mastheadProfileItems).should('have.length', 2);
   });
 
   it('should open the search bar on click', () => {
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchTypeBar}`)
       .shadow()
-      .find('.bx--header__search--search')
+      .find(_selectors.mastheadSearchBtn)
       .click();
 
     cy.takeSnapshots();
   });
 
   it('should allow keywords in the search bar and display 10 suggested results', () => {
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchTypeBar}`)
       .shadow()
-      .find('.bx--header__search--search')
+      .find(_selectors.mastheadSearchBtn)
       .click();
 
-    cy.get('cds-masthead > cds-search-with-typeahead')
+    cy.get(`${_selectors.masthead} > ${_selectors.mastheadSearchTypeBar}`)
       .shadow()
       .find('.react-autosuggest__container > input')
       .type('redhat', { force: true });
 
-    cy.get('cds-search-with-typeahead-item').should('have.length', 10);
+    cy.get(_selectors.mastheadSearchResultItem).should('have.length', 10);
 
     cy.takeSnapshots();
   });
@@ -132,7 +147,7 @@ describe('cds-masthead | default (mobile)', () => {
   });
 
   it('should load the mobile menu', () => {
-    cy.get('cds-masthead-menu-button')
+    cy.get(_selectors.mastheadMenuBtnMobile)
       .shadow()
       .find('button')
       .click();
@@ -141,12 +156,12 @@ describe('cds-masthead | default (mobile)', () => {
   });
 
   it('should load the mobile menu | level 2', () => {
-    cy.get('cds-masthead-menu-button')
+    cy.get(_selectors.mastheadMenuBtnMobile)
       .shadow()
       .find('button')
       .click();
 
-    cy.get('cds-left-nav-menu-section:nth-child(1) > cds-left-nav-menu:nth-child(2)')
+    cy.get('c4d-left-nav-menu-section:nth-child(1) > c4d-left-nav-menu:nth-child(2)')
       .shadow()
       .find('button')
       .click();

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead.e2e.js
@@ -23,11 +23,17 @@ const _selectors = {
   mastheadProfileBtn: 'c4d-masthead-profile',
   mastheadProfileItems: 'c4d-masthead-profile-item',
   mastheadMenuBtnMobile: 'c4d-masthead-menu-button',
+  mastheadRightNav: 'c4d-megamenu-right-navigation',
+  mastheadLeftNav: 'c4d-left-nav-menu',
+  mastheadCategoryGroup: 'c4d-megamenu-category-group',
+  mastheadCategoryLink: 'c4d-megamenu-category-link',
+  mastheadNavMenuSection: 'c4d-left-nav-menu-section',
+
 }
 
 const _pathDefault = '/iframe.html?id=components-masthead--default';
 
-describe('cds-masthead | default (desktop)', () => {
+describe('c4d-masthead | default (desktop)', () => {
   beforeEach(() => {
     cy.visit(`/${_pathDefault}`);
     cy.injectAxe();
@@ -57,7 +63,6 @@ describe('cds-masthead | default (desktop)', () => {
         if ($menuItem.attr('active') !== undefined) {
           selectedState = true;
         }
-        console.log($menuItem,'TB');
       })
       .then(() => {
         expect(selectedState).to.be.true;
@@ -84,7 +89,7 @@ describe('cds-masthead | default (desktop)', () => {
       .click();
 
     cy.get(
-      'c4d-megamenu-right-navigation >  c4d-megamenu-category-group > c4d-megamenu-category-link:nth-child(1)'
+      `${_selectors.mastheadRightNav} >  ${_selectors.mastheadCategoryGroup} > ${_selectors.mastheadCategoryLink}:nth-child(1)`
     )
       .shadow()
       .find('a')
@@ -133,7 +138,7 @@ describe('cds-masthead | default (desktop)', () => {
   });
 });
 
-describe('cds-masthead | default (mobile)', () => {
+describe('c4d-masthead | default (mobile)', () => {
   beforeEach(() => {
     cy.visit(`/${_pathDefault}`);
     cy.injectAxe();
@@ -161,7 +166,7 @@ describe('cds-masthead | default (mobile)', () => {
       .find('button')
       .click();
 
-    cy.get('c4d-left-nav-menu-section:nth-child(1) > c4d-left-nav-menu:nth-child(2)')
+    cy.get(`${_selectors.mastheadNavMenuSection}:nth-child(1) > ${_selectors.mastheadLeftNav}:nth-child(2)`)
       .shadow()
       .find('button')
       .click();


### PR DESCRIPTION
### Related Ticket(s)

Closes # 
ADCMS-4576 | https://jsw.ibm.com/browse/ADCMS-4576

### Description

There were some gaps in our tests for the masthead and they're now fixed:

- tests were using the wrong prefix, trying to access elements that had their semantics changed
- all prefixes are now grouped in an object for better maintenance
- fixed lots of tests that were not working
- added mobile test cases for the L1

