### PR TITLE
chore(storybook): content-block-card storybook link fix

### DIFF
--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -588,7 +588,7 @@ $feature-flags: (
     }
 
     &[size='large'] {
-      .dds-ce--card__footer ::slotted(svg[slot='icon']) {
+      .#{$c4d-prefix}-ce--card__footer ::slotted(svg[slot='icon']) {
         @include breakpoint(max) {
           block-size: $spacing-10;
           inline-size: $spacing-10;

--- a/packages/web-components/src/components/back-to-top/__stories__/data/content.ts
+++ b/packages/web-components/src/components/back-to-top/__stories__/data/content.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -273,9 +273,9 @@ export const StoryContent = () =>
                   Linux on IBM mainframes lets you transform your application
                   and data portfolio with data privacy, security, and cyber
                   resiliency.
-                  <c4d-card-cta-footer slot="footer">
+                  <c4d-card-footer>
                     ${ArrowRight20({ slot: 'icon' })}
-                  </c4d-card-cta-footer>
+                  </c4d-card-footer>
                 </c4d-card-group-item>
                 <c4d-card-group-item href="https://example.com">
                   <c4d-card-heading>Linux OS on LinuxONE</c4d-card-heading>
@@ -284,9 +284,9 @@ export const StoryContent = () =>
                     innovative data privacy, security and cyber resiliency
                     capabilities, plus minimal downtime.
                   </p>
-                  <c4d-card-cta-footer slot="footer">
+                  <c4d-card-footer>
                     ${ArrowRight20({ slot: 'icon' })}
-                  </c4d-card-cta-footer>
+                  </c4d-card-footer>
                 </c4d-card-group-item>
                 <c4d-card-group-item href="https://example.com">
                   <c4d-card-heading>Linux OS on Power Systems</c4d-card-heading>
@@ -295,9 +295,9 @@ export const StoryContent = () =>
                     cost-effectively on an open, scalable infrastructure with
                     built-in acceleration.
                   </p>
-                  <c4d-card-cta-footer slot="footer">
+                  <c4d-card-footer>
                     ${ArrowRight20({ slot: 'icon' })}
-                  </c4d-card-cta-footer>
+                  </c4d-card-footer>
                 </c4d-card-group-item>
               </c4d-card-group>
             </c4d-card-section-simple>

--- a/packages/web-components/src/components/button/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/button/__stories__/README.stories.react.mdx
@@ -1,4 +1,9 @@
-import { Preview, Props, Description, Story } from '@storybook/addon-docs/blocks';
+import {
+  Preview,
+  Props,
+  Description,
+  Story,
+} from '@storybook/addon-docs/blocks';
 import contributing from '../../../../../../docs/contributing-license.md';
 import { PropTypesRef } from '@carbon/ibmdotcom-web-components/es/components-react/button/button';
 
@@ -20,37 +25,39 @@ Here's a quick example to get you started.
 import DDSButton from '@carbon/ibmdotcom-web-components/es/components-react/button/index.js';
 
 function App() {
-  return (
-    <DDSButton href="https://example.com">Example</DDSButton>
-  );
+  return <DDSButton href="https://example.com">Example</DDSButton>;
 }
 ```
 
 ### CTA features
 
-The `cta-type` attribute allows every type of CTA and icon available in the Carbon for IBM.com library. 
-The default CTA style is `local`, which provides a basic link and arrow icon.
+The `cta-type` attribute allows every type of CTA and icon available in the
+Carbon for IBM.com library. The default CTA style is `local`, which provides a
+basic link and arrow icon.
 
-In order to use the desired type, modify the `cta-type` attribute to one of the following:
+In order to use the desired type, modify the `cta-type` attribute to one of the
+following:
 
-* local
-* jump
-* external
-* new tab
-* download
-* video
-* pdf
-* blog
-* email
-* schedule
-* chat
-* call
+- local
+- jump
+- external
+- new tab
+- download
+- video
+- pdf
+- blog
+- email
+- schedule
+- chat
+- call
 
-Notes: 
-* When using `video`, you need to pass the video ID as the `href` attribute.
-* The Button component will need to be wrapped within a `DDSVideoCTAContainer` components for videos to play.
-* Custom icons can replace the built-in ones within `DDSCardFooter`, they only need to be assigned to the `icon` slot.
+Notes:
 
+- When using `video`, you need to pass the video ID as the `href` attribute.
+- The Button component will need to be wrapped within a `DDSVideoCTAContainer`
+  components for videos to play.
+- Custom icons can replace the built-in ones within `DDSCardFooter`, they only
+  need to be assigned to the `icon` slot.
 
 ## Props
 
@@ -58,10 +65,12 @@ Notes:
 
 ## Stable selectors
 
-See [our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components#stable-selectors-for-analytics-and-integratione2e-testing-in-web-components) to see how Web Components selector and `data-autoid` should be used.
+See
+[our README](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/web-components#stable-selectors-for-analytics-and-integratione2e-testing-in-web-components)
+to see how Web Components selector and `data-autoid` should be used.
 
-| Web Components selector   | Compatibility selector                 | Description |
-| ------------------------- | -------------------------------------- | ----------- |
-| `<dds-button>`      | `data-autoid="dds--button"`      | Component   |
+| Web Components selector | Compatibility selector      | Description |
+| ----------------------- | --------------------------- | ----------- |
+| `<c4d-button>`          | `data-autoid="c4d--button"` | Component   |
 
 <Description markdown={contributing} />

--- a/packages/web-components/src/components/button/__stories__/button.stories.react.tsx
+++ b/packages/web-components/src/components/button/__stories__/button.stories.react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -27,14 +27,14 @@ import {
   types,
 } from '../../cta/__stories__/ctaTypeConfig';
 
-export const Default = args => {
+export const Default = (args) => {
   const { copy, customVideoTitle, ctaType, disabled, download, href } =
     args?.Button ?? {};
 
   let videoCopy;
 
   if (ctaType === CTA_TYPE.VIDEO) {
-    const button = document.querySelector('dds-button') as any;
+    const button = document.querySelector('cds-button') as any;
     const duration = button?.videoTitle?.match(/\((.*)\)/)?.pop();
 
     if (!customVideoTitle) {
@@ -48,7 +48,11 @@ export const Default = args => {
 
   return (
     <DDSVideoCTAContainer>
-      <DDSButton disabled={disabled || undefined} href={href} download={download} cta-type={ctaType}>
+      <DDSButton
+        disabled={disabled || undefined}
+        href={href}
+        download={download}
+        cta-type={ctaType}>
         {videoCopy ?? copy}
       </DDSButton>
     </DDSVideoCTAContainer>
@@ -97,11 +101,13 @@ Default.story = {
 export default {
   title: 'Components/Button',
   decorators: [
-    story => {
+    (story) => {
       return (
         <div className="cds--grid">
           <div className="cds--row">
-            <div className="cds--col-sm-16 cds--col-md-6 cds--col-lg-16">{story()}</div>
+            <div className="cds--col-sm-16 cds--col-md-6 cds--col-lg-16">
+              {story()}
+            </div>
           </div>
         </div>
       );

--- a/packages/web-components/src/components/card-group/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-group/__stories__/README.stories.mdx
@@ -42,15 +42,11 @@ import '@carbon/ibmdotcom-web-components/es/components/card-in-card/index.js';
       ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit
       sollicitudin, sodales nulla quis, consequat libero.
     </p>
-    <c4d-card-footer slot="footer"> </c4d-card-footer>
+    <c4d-card-footer> </c4d-card-footer>
   </c4d-card-group-item>
-  <c4d-card-group-item
-    cta-type="local"
-    href="https://example.com"
-    >
+  <c4d-card-group-item cta-type="local" href="https://example.com">
     <c4d-card-heading>Top level card link</c4d-card-heading>
-    <c4d-card-footer slot="footer">
-    </c4d-card-footer>
+    <c4d-card-footer> </c4d-card-footer>
   </c4d-card-group-item>
 </c4d-card-group>
 ```
@@ -58,12 +54,8 @@ import '@carbon/ibmdotcom-web-components/es/components/card-in-card/index.js';
 ### HTML (with Card pictogram)
 
 ```html
-
 <c4d-card-group>
-  <c4d-card-group-item
-    href="https://example.com"
-    pictogram-placement="bottom"
-    >
+  <c4d-card-group-item href="https://example.com" pictogram-placement="bottom">
     <c4d-card-heading>Aerospace and defence</c4d-card-heading>
     <p>
       Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -90,10 +82,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-in-card/index.js';
   18.64h29.28V5c0-0.904-0.735-1.64-1.64-1.64H3C2.096,3.36,1.36,4.096,1.36,5V18.64z" />
     </svg>
   </c4d-card-group-item>
-  <c4d-card-group-item
-    href="https://example.com"
-    pictogram-placement="bottom"
-    >
+  <c4d-card-group-item href="https://example.com" pictogram-placement="bottom">
     <c4d-card-heading>Aerospace and defence</c4d-card-heading>
     <p>
       Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -120,10 +109,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-in-card/index.js';
   18.64h29.28V5c0-0.904-0.735-1.64-1.64-1.64H3C2.096,3.36,1.36,4.096,1.36,5V18.64z" />
     </svg>
   </c4d-card-group-item>
-  <c4d-card-group-item
-    href="https://example.com"
-    pictogram-placement="bottom"
-    >
+  <c4d-card-group-item href="https://example.com" pictogram-placement="bottom">
     <c4d-card-heading>Aerospace and defence</c4d-card-heading>
     <p>
       Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -149,9 +135,8 @@ import '@carbon/ibmdotcom-web-components/es/components/card-in-card/index.js';
   0.904,0.736,1.64,1.64,1.64h26c0.904,0,1.64-0.735,1.64-1.64v-2.64H1.36z M1.36,
   18.64h29.28V5c0-0.904-0.735-1.64-1.64-1.64H3C2.096,3.36,1.36,4.096,1.36,5V18.64z" />
     </svg>
-  </c4d-card-group-item>    
+  </c4d-card-group-item>
 </c4d-card-group>
-
 ```
 
 ### HTML (with Card static)
@@ -165,14 +150,11 @@ import '@carbon/ibmdotcom-web-components/es/components/card-in-card/index.js';
       ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit
       sollicitudin, sodales nulla quis, consequat libero.
     </p>
-    <c4d-card-footer slot="footer"> </c4d-card-footer>
+    <c4d-card-footer> </c4d-card-footer>
   </c4d-card-group-item>
-  <c4d-card-group-item
-    cta-type="local"
-    >
+  <c4d-card-group-item cta-type="local">
     <c4d-card-heading>Top level card link</c4d-card-heading>
-    <c4d-card-footer slot="footer">
-    </c4d-card-footer>
+    <c4d-card-footer> </c4d-card-footer>
   </c4d-card-group-item>
 </c4d-card-group>
 ```
@@ -188,7 +170,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-in-card/index.js';
     pattern-background>
     <c4d-card-heading>IBM Developer - Card 01</c4d-card-heading>
     <p>Learn, code and connect with your community</p>
-    <c4d-card-footer slot="footer"> </c4d-card-footer>
+    <c4d-card-footer> </c4d-card-footer>
   </c4d-card-group-card-link-item>
 
   <c4d-card-group-item
@@ -198,7 +180,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-in-card/index.js';
     pattern-background>
     <c4d-card-heading>IBM Developer - Card 02</c4d-card-heading>
     <p>Learn, code and connect with your community</p>
-    <c4d-card-footer slot="footer"> </c4d-card-footer>
+    <c4d-card-footer> </c4d-card-footer>
   </c4d-card-group-item>
 
   <c4d-card-group-item
@@ -208,7 +190,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-in-card/index.js';
     pattern-background>
     <c4d-card-heading>IBM Developer - Card 03</c4d-card-heading>
     <p>Learn, code and connect with your community</p>
-    <c4d-card-footer slot="footer"> </c4d-card-footer>
+    <c4d-card-footer> </c4d-card-footer>
   </c4d-card-group-item>
 </c4d-card-group>
 ```
@@ -288,7 +270,7 @@ import '@carbon/ibmdotcom-web-components/es/components/cta/video-cta-container.j
       ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit
       sollicitudin, sodales nulla quis, consequat libero.
     </p>
-    <c4d-card-footer slot="footer"> </c4d-card-footer>
+    <c4d-card-footer> </c4d-card-footer>
   </c4d-card-group-item>
 </c4d-card-group>
 ```
@@ -297,9 +279,9 @@ import '@carbon/ibmdotcom-web-components/es/components/cta/video-cta-container.j
 
 There are three different options for the `grid-mode` property:
 
-* Default (32px gap)
-* Condensed (16px gap)
-* Collapsed (no gap)
+- Default (32px gap)
+- Condensed (16px gap)
+- Collapsed (no gap)
 
 ## Props
 

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -85,7 +85,7 @@ const cardsDiffLengthPhrase = (index, tagGroup, media, cardType, addCta) => {
         ? addCta
           ? textCTAContent
           : ''
-        : html` <c4d-card-footer slot="footer"></c4d-card-footer> `}
+        : html` <c4d-card-footer></c4d-card-footer> `}
     </c4d-card-group-item>
   `;
 
@@ -128,7 +128,7 @@ const longHeadingCardGroupItem = (tagGroup, media, cardType, addCta) => {
         ? addCta
           ? textCTAContent
           : ''
-        : html` <c4d-card-footer slot="footer"></c4d-card-footer> `}
+        : html` <c4d-card-footer></c4d-card-footer> `}
     </c4d-card-group-item>
   `;
 };
@@ -171,7 +171,7 @@ const cardLink = html`
     pattern-background>
     <c4d-card-heading>IBM Developer</c4d-card-heading>
     <p>Learn, code and connect with your community</p>
-    <c4d-card-footer slot="footer"> </c4d-card-footer>
+    <c4d-card-footer> </c4d-card-footer>
   </c4d-card>
 `;
 
@@ -187,7 +187,7 @@ const cardInCardItems = (i, tagGroup, media) => {
               marine litter</c4d-card-heading
             >
             ${tagGroup ? tagGroupContent : ''}
-            <c4d-card-footer slot="footer"> </c4d-card-footer>
+            <c4d-card-footer> </c4d-card-footer>
           </c4d-card-group-item>
         `
       : html`
@@ -207,7 +207,7 @@ const cardInCardItems = (i, tagGroup, media) => {
         litter</c4d-card-heading
       >
       ${tagGroup ? tagGroupContent : ''}
-      <c4d-card-footer slot="footer"> </c4d-card-footer>
+      <c4d-card-footer> </c4d-card-footer>
     </c4d-card-group-item>
   `;
 };
@@ -230,7 +230,7 @@ export const Default = (args) => {
         html`
           <c4d-card-group-item cta-type="local" href="https://example.com">
             <c4d-card-heading>Top level card link</c4d-card-heading>
-            <c4d-card-footer slot="footer"> </c4d-card-footer>
+            <c4d-card-footer> </c4d-card-footer>
           </c4d-card-group-item>
         `
       );
@@ -255,7 +255,7 @@ export const Default = (args) => {
         html`
           <c4d-card-group-item cta-type="local" href="https://example.com">
             <c4d-card-heading>Top level card link</c4d-card-heading>
-            <c4d-card-footer slot="footer"> </c4d-card-footer>
+            <c4d-card-footer> </c4d-card-footer>
           </c4d-card-group-item>
         `
       );

--- a/packages/web-components/src/components/card-section-offset/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-section-offset/__stories__/README.stories.mdx
@@ -54,7 +54,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-offset/index
         Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis
         democritum ex. Illud ullum graecis
       </p>
-      <c4d-card-footer slot="footer">
+      <c4d-card-footer>
         <svg
           slot="icon"
           focusable="false"
@@ -78,7 +78,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-offset/index
         Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis
         democritum ex. Illud ullum graecis
       </p>
-      <c4d-card-footer slot="footer">
+      <c4d-card-footer>
         <svg
           slot="icon"
           focusable="false"
@@ -102,7 +102,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-offset/index
         Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis
         democritum ex. Illud ullum graecis
       </p>
-      <c4d-card-footer slot="footer">
+      <c4d-card-footer>
         <svg
           slot="icon"
           focusable="false"

--- a/packages/web-components/src/components/card-section-offset/__stories__/card-section-offset.stories.ts
+++ b/packages/web-components/src/components/card-section-offset/__stories__/card-section-offset.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -56,9 +56,7 @@ const defaultCardGroupItem = html`
       Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis
       democritum ex. Illud ullum graecis
     </p>
-    <c4d-card-cta-footer slot="footer">
-      ${ArrowRight20({ slot: 'icon' })}
-    </c4d-card-cta-footer>
+    <c4d-card-footer> ${ArrowRight20({ slot: 'icon' })} </c4d-card-footer>
   </c4d-card-group-item>
 `;
 

--- a/packages/web-components/src/components/card-section-offset/__tests__/card-section-offset.test.ts
+++ b/packages/web-components/src/components/card-section-offset/__tests__/card-section-offset.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -50,23 +50,23 @@ describe('c4d-card-section-offset', function () {
             <c4d-card-group-item href="https://example.com">
               <c4d-card-eyebrow>Topic</c4d-card-eyebrow>
               <c4d-card-heading>Natural Language Processing.</c4d-card-heading>
-              <c4d-card-cta-footer slot="footer">
-                ${ArrowRight20({ slot: 'icon' })}
-              </c4d-card-cta-footer>
-            </c4d-card-group-item>
-            <c4d-card-group-item href="https://example.com">
-              <c4d-card-eyebrow>Topic</c4d-card-eyebrow>
-              <c4d-card-heading>Natural Language Processing.</c4d-card-heading>
-              <c4d-card-footer slot="footer">
+              <c4d-card-footer>
                 ${ArrowRight20({ slot: 'icon' })}
               </c4d-card-footer>
             </c4d-card-group-item>
             <c4d-card-group-item href="https://example.com">
               <c4d-card-eyebrow>Topic</c4d-card-eyebrow>
               <c4d-card-heading>Natural Language Processing.</c4d-card-heading>
-              <c4d-card-cta-footer slot="footer">
+              <c4d-card-footer>
                 ${ArrowRight20({ slot: 'icon' })}
-              </c4d-card-cta-footer>
+              </c4d-card-footer>
+            </c4d-card-group-item>
+            <c4d-card-group-item href="https://example.com">
+              <c4d-card-eyebrow>Topic</c4d-card-eyebrow>
+              <c4d-card-heading>Natural Language Processing.</c4d-card-heading>
+              <c4d-card-footer>
+                ${ArrowRight20({ slot: 'icon' })}
+              </c4d-card-footer>
             </c4d-card-group-item>
           `,
         }),

--- a/packages/web-components/src/components/card-section-simple/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-section-simple/__stories__/README.stories.mdx
@@ -40,7 +40,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-simple/index
         ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at
         elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
-      <c4d-card-footer slot="footer"> </c4d-card-footer>
+      <c4d-card-footer> </c4d-card-footer>
     </c4d-card-group-item>
   </c4d-card-group>
 </c4d-card-section-simple>
@@ -59,7 +59,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card-section-simple/index
       </c4d-image>
       <c4d-card-eyebrow>Topic</c4d-card-eyebrow>
       <c4d-card-heading>Natural Language Processing.</c4d-card-heading>
-      <c4d-card-footer slot="footer"> </c4d-card-footer>
+      <c4d-card-footer> </c4d-card-footer>
     </c4d-card-group-item>
   </c4d-card-group>
 </c4d-card-section-simple>

--- a/packages/web-components/src/components/card-section-simple/__stories__/card-section-simple.stories.ts
+++ b/packages/web-components/src/components/card-section-simple/__stories__/card-section-simple.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -34,7 +34,7 @@ const cardGroupItems = (withImages) => {
         ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at
         elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
-      <c4d-card-cta-footer slot="footer"></c4d-card-cta-footer>
+      <c4d-card-footer></c4d-card-footer>
     </c4d-card-group-item>
   `;
 };
@@ -59,9 +59,9 @@ export const Default = (args) => {
                 color-scheme="inverse"
                 cta-type="local">
                 <c4d-card-heading>Top level card link</c4d-card-heading>
-                <c4d-card-cta-footer
+                <c4d-card-footer
                   slot="footer"
-                  color-scheme="inverse"></c4d-card-cta-footer>
+                  color-scheme="inverse"></c4d-card-footer>
               </c4d-card-group-item>
             `
           : ``}

--- a/packages/web-components/src/components/card-section-simple/__tests__/card-section-simple.test.ts
+++ b/packages/web-components/src/components/card-section-simple/__tests__/card-section-simple.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -45,9 +45,9 @@ describe('c4d-card-section-simple', function () {
                 Phasellus at elit sollicitudin, sodales nulla quis, consequat
                 libero.
               </p>
-              <c4d-card-cta-footer slot="footer">
+              <c4d-card-footer>
                 ${ArrowRight20({ slot: 'icon' })}
-              </c4d-card-cta-footer>
+              </c4d-card-footer>
             </c4d-card-group-item>
           `,
         }),

--- a/packages/web-components/src/components/card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card/__stories__/README.stories.mdx
@@ -167,7 +167,7 @@ An optional light theme is available under `color-scheme`.
 
 ## Tags
 
-If using tags within `dds-card` in tandem with the dark themes, make sure the
+If using tags within `c4d-card` in tandem with the dark themes, make sure the
 proper styles are imported from `@carbon/styles` in your application.
 
 ```

--- a/packages/web-components/src/components/card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card/__stories__/README.stories.mdx
@@ -34,7 +34,7 @@ import '@carbon/ibmdotcom-web-components/es/components/card/index.js';
 <c4d-card href="https://example.com">
   <c4d-card-eyebrow>Eyebrow text</c4d-card-eyebrow>
   <c4d-card-heading>Lorem ipsum dolor sit amet</c4d-card-heading>
-  <c4d-card-footer slot="footer">
+  <c4d-card-footer>
     <svg
       slot="icon"
       focusable="false"

--- a/packages/web-components/src/components/card/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/card/__stories__/README.stories.react.mdx
@@ -161,7 +161,7 @@ An optional light theme is available under `color-scheme`.
 
 ## Tags
 
-If using tags within `dds-card` in tandem with the dark themes, make sure the
+If using tags within `c4d-card` in tandem with the dark themes, make sure the
 proper styles are imported from `@carbon/styles` in your application.
 
 ```

--- a/packages/web-components/src/components/content-block-card-static/__tests__/content-block-card-static.test.ts
+++ b/packages/web-components/src/components/content-block-card-static/__tests__/content-block-card-static.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -54,9 +54,9 @@ describe('c4d-content-block-card-static', function () {
                 Phasellus at elit sollicitudin, sodales nulla quis, consequat
                 libero.
               </p>
-              <c4d-card-cta-footer slot="footer">
+              <c4d-card-footer>
                 ${ArrowRight20({ slot: 'icon' })}
-              </c4d-card-cta-footer>
+              </c4d-card-footer>
             </c4d-card-group-item>
           `,
           contentItemHeading: 'Lorem ipsum',

--- a/packages/web-components/src/components/content-block-cards/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-cards/__stories__/README.stories.mdx
@@ -43,7 +43,7 @@ import '@carbon/ibmdotcom-web-components/es/components/content-block-cards/index
         ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at
         elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
-      <c4d-card-footer slot="footer">
+      <c4d-card-footer>
         <svg
           slot="icon"
           focusable="false"
@@ -66,7 +66,7 @@ import '@carbon/ibmdotcom-web-components/es/components/content-block-cards/index
         ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at
         elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
-      <c4d-card-footer slot="footer">
+      <c4d-card-footer>
         <svg
           slot="icon"
           focusable="false"
@@ -89,7 +89,7 @@ import '@carbon/ibmdotcom-web-components/es/components/content-block-cards/index
         ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at
         elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
-      <c4d-card-footer slot="footer">
+      <c4d-card-footer>
         <svg
           slot="icon"
           focusable="false"

--- a/packages/web-components/src/components/content-block-cards/__stories__/content-block-cards.stories.ts
+++ b/packages/web-components/src/components/content-block-cards/__stories__/content-block-cards.stories.ts
@@ -31,7 +31,7 @@ const cardGroupItem = html`
       ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit
       sollicitudin, sodales nulla quis, consequat libero.
     </p>
-    <c4d-card-footer slot="footer"> </c4d-card-footer>
+    <c4d-card-footer> </c4d-card-footer>
   </c4d-card-group-item>
 `;
 
@@ -45,14 +45,14 @@ const cardGroupItemWithImages = html`
     </c4d-image>
     <c4d-card-eyebrow>Topic</c4d-card-eyebrow>
     <c4d-card-heading>Natural Language Processing.</c4d-card-heading>
-    <c4d-card-cta-footer><c4d-card-cta-footer>
+    <c4d-card-footer><c4d-card-footer>
   </c4d-card-group-item>
 `;
 
 const cardGroupItemWithVideos = html`
   <c4d-card-group-item cta-type="video" href="0_ibuqxqbe">
-    <c4d-card-cta-footer cta-type="video" slot="footer" href="0_ibuqxqbe">
-    </c4d-card-cta-footer>
+    <c4d-card-footer cta-type="video" slot="footer" href="0_ibuqxqbe">
+    </c4d-card-footer>
   </c4d-card-group-item>
 `;
 
@@ -70,7 +70,7 @@ export const Default = (args) => {
         cta-type="${ifDefined(ctaType)}"
         href="${ifDefined(href)}">
         <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-        <c4d-card-cta-footer></c4d-card-cta-footer>
+        <c4d-card-footer></c4d-card-footer>
       </c4d-card-link-cta>
     </c4d-content-block-cards>
   `;
@@ -91,7 +91,7 @@ export const withImages = (args) => {
         cta-type="${ifDefined(ctaType)}"
         href="${ifDefined(href)}">
         <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-        <c4d-card-cta-footer></c4d-card-cta-footer>
+        <c4d-card-footer></c4d-card-footer>
       </c4d-card-link-cta>
     </c4d-content-block-cards>
   `;
@@ -116,7 +116,7 @@ export const withVideos = (args) => {
         cta-type="${ifDefined(ctaType)}"
         href="${ifDefined(href)}">
         <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-        <c4d-card-cta-footer></c4d-card-cta-footer>
+        <c4d-card-footer></c4d-card-footer>
       </c4d-card-link-cta>
     </c4d-content-block-cards>
   `;

--- a/packages/web-components/src/components/content-block-cards/__stories__/content-block-cards.stories.ts
+++ b/packages/web-components/src/components/content-block-cards/__stories__/content-block-cards.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,7 +31,7 @@ const cardGroupItem = html`
       ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit
       sollicitudin, sodales nulla quis, consequat libero.
     </p>
-    <c4d-card-cta-footer></c4d-card-cta-footer>
+    <c4d-card-footer slot="footer"> </c4d-card-footer>
   </c4d-card-group-item>
 `;
 

--- a/packages/web-components/src/components/content-block-cards/__tests__/content-block-cards.test.ts
+++ b/packages/web-components/src/components/content-block-cards/__tests__/content-block-cards.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -53,9 +53,9 @@ describe('c4d-content-block-cards', function () {
                 Phasellus at elit sollicitudin, sodales nulla quis, consequat
                 libero.
               </p>
-              <c4d-card-cta-footer slot="footer">
+              <c4d-card-footer>
                 ${ArrowRight20({ slot: 'icon' })}
-              </c4d-card-cta-footer>
+              </c4d-card-footer>
             </c4d-card-group-item>
           `,
         }),

--- a/packages/web-components/src/components/content-block-media/__stories__/content-block-media.stories.ts
+++ b/packages/web-components/src/components/content-block-media/__stories__/content-block-media.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -128,7 +128,7 @@ export const Default = (args) => {
           <c4d-card-link-heading
             >Lorem ipsum dolor sit amet</c4d-card-link-heading
           >
-          <c4d-card-cta-footer></c4d-card-cta-footer>
+          <c4d-card-footer></c4d-card-footer>
         </c4d-card-link-cta>
       </c4d-content-block-media-content>
       <c4d-content-block-media-content>
@@ -164,7 +164,7 @@ export const Default = (args) => {
           <c4d-card-link-heading
             >Lorem ipsum dolor sit amet</c4d-card-link-heading
           >
-          <c4d-card-cta-footer></c4d-card-cta-footer>
+          <c4d-card-footer></c4d-card-footer>
         </c4d-card-link-cta>
       </c4d-content-block-media-content>
       <c4d-content-block-media-content>
@@ -239,7 +239,7 @@ export const withLinkList = (args) => {
           <c4d-card-link-heading
             >Lorem ipsum dolor sit amet</c4d-card-link-heading
           >
-          <c4d-card-cta-footer></c4d-card-cta-footer>
+          <c4d-card-footer></c4d-card-footer>
         </c4d-card-link-cta>
       </c4d-content-block-media-content>
       <c4d-content-block-media-content>
@@ -275,7 +275,7 @@ export const withLinkList = (args) => {
           <c4d-card-link-heading
             >Lorem ipsum dolor sit amet</c4d-card-link-heading
           >
-          <c4d-card-cta-footer></c4d-card-cta-footer>
+          <c4d-card-footer></c4d-card-footer>
         </c4d-card-link-cta>
       </c4d-content-block-media-content>
       <c4d-content-block-media-content>

--- a/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.ts
+++ b/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.ts
@@ -2,7 +2,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -235,7 +235,7 @@ export const Default = (args) => {
           <c4d-card-link-heading
             >Lorem ipsum dolor sit amet</c4d-card-link-heading
           >
-          <c4d-card-cta-footer></c4d-card-cta-footer>
+          <c4d-card-footer></c4d-card-footer>
         </c4d-card-link-cta>
       </c4d-content-group-simple>
     </c4d-content-block-mixed>
@@ -339,7 +339,7 @@ export const WithLinkList = (args) => {
           <c4d-card-link-heading
             >Lorem ipsum dolor sit amet</c4d-card-link-heading
           >
-          <c4d-card-cta-footer></c4d-card-cta-footer>
+          <c4d-card-footer></c4d-card-footer>
         </c4d-card-link-cta>
       </c4d-content-group-simple>
       <c4d-link-list type="default" slot="complementary">

--- a/packages/web-components/src/components/content-block-segmented/__stories__/content-block-segmented.stories.ts
+++ b/packages/web-components/src/components/content-block-segmented/__stories__/content-block-segmented.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -142,7 +142,7 @@ export const Default = (args) => {
               cta-type=${ctaType}
               href=${hrefsForType[ctaType]}>
               <c4d-card-link-heading>Lorem ipsum dolor</c4d-card-link-heading>
-              <c4d-card-cta-footer></c4d-card-cta-footer>
+              <c4d-card-footer></c4d-card-footer>
             </c4d-card-link-cta>
           `}
     </c4d-content-block-segmented>
@@ -227,7 +227,7 @@ export const withLinkList = (args) => {
               cta-type=${ctaType}
               href=${hrefsForType[ctaType]}>
               <c4d-card-link-heading>Lorem ipsum dolor</c4d-card-link-heading>
-              <c4d-card-cta-footer></c4d-card-cta-footer>
+              <c4d-card-footer></c4d-card-footer>
             </c4d-card-link-cta>
           `}
     </c4d-content-block-segmented>

--- a/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.ts
+++ b/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -93,11 +93,11 @@ export const Default = (args) => {
               cta-type="${ifDefined(ctaType)}"
               href="${ifDefined(href)}">
               <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-              <c4d-card-cta-footer>
+              <c4d-card-footer>
                 ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
                 ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
                 ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </c4d-card-cta-footer>
+              </c4d-card-footer>
             </c4d-card-link-cta>
           `
         : html`
@@ -134,11 +134,11 @@ export const WithImage = (args) => {
               cta-type="${ifDefined(ctaType)}"
               href="${ifDefined(href)}">
               <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-              <c4d-card-cta-footer>
+              <c4d-card-footer>
                 ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
                 ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
                 ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </c4d-card-cta-footer>
+              </c4d-card-footer>
             </c4d-card-link-cta>
           `
         : html`
@@ -181,11 +181,11 @@ export const WithVideo = (args) => {
               cta-type="${ifDefined(ctaType)}"
               href="${ifDefined(href)}">
               <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-              <c4d-card-cta-footer>
+              <c4d-card-footer>
                 ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
                 ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
                 ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </c4d-card-cta-footer>
+              </c4d-card-footer>
             </c4d-card-link-cta>
           `
         : html`
@@ -244,11 +244,11 @@ export const WithLinkList = (args) => {
               cta-type="${ifDefined(ctaType)}"
               href="${ifDefined(href)}">
               <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-              <c4d-card-cta-footer>
+              <c4d-card-footer>
                 ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
                 ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
                 ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </c4d-card-cta-footer>
+              </c4d-card-footer>
             </c4d-card-link-cta>
           `
         : html`

--- a/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.ts
+++ b/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.ts
@@ -13,9 +13,6 @@ import '../../link-list/index';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { select } from '@storybook/addon-knobs';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
-import ArrowDown20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--down/20.js';
-import Launch20 from '../../../internal/vendor/@carbon/web-components/icons/launch/20.js';
 import { CONTENT_BLOCK_COMPLEMENTARY_STYLE_SCHEME } from '../../content-block/content-block';
 import { CONTENT_BLOCK_COPY_SIZE } from '../../content-block/content-block-copy';
 import { CTA_STYLE, CTA_TYPE } from '../../cta/defs';
@@ -93,11 +90,7 @@ export const Default = (args) => {
               cta-type="${ifDefined(ctaType)}"
               href="${ifDefined(href)}">
               <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-              <c4d-card-footer>
-                ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
-                ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
-                ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </c4d-card-footer>
+              <c4d-card-footer> </c4d-card-footer>
             </c4d-card-link-cta>
           `
         : html`
@@ -134,11 +127,7 @@ export const WithImage = (args) => {
               cta-type="${ifDefined(ctaType)}"
               href="${ifDefined(href)}">
               <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-              <c4d-card-footer>
-                ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
-                ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
-                ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </c4d-card-footer>
+              <c4d-card-footer> </c4d-card-footer>
             </c4d-card-link-cta>
           `
         : html`
@@ -181,11 +170,7 @@ export const WithVideo = (args) => {
               cta-type="${ifDefined(ctaType)}"
               href="${ifDefined(href)}">
               <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-              <c4d-card-footer>
-                ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
-                ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
-                ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </c4d-card-footer>
+              <c4d-card-footer> </c4d-card-footer>
             </c4d-card-link-cta>
           `
         : html`
@@ -244,11 +229,7 @@ export const WithLinkList = (args) => {
               cta-type="${ifDefined(ctaType)}"
               href="${ifDefined(href)}">
               <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-              <c4d-card-footer>
-                ${ctaType === 'local' ? ArrowRight20({ slot: 'icon' }) : ''}
-                ${ctaType === 'jump' ? ArrowDown20({ slot: 'icon' }) : ''}
-                ${ctaType === 'external' ? Launch20({ slot: 'icon' }) : ''}
-              </c4d-card-footer>
+              <c4d-card-footer> </c4d-card-footer>
             </c4d-card-link-cta>
           `
         : html`

--- a/packages/web-components/src/components/content-group-simple/__stories__/content-group-simple.stories.ts
+++ b/packages/web-components/src/components/content-group-simple/__stories__/content-group-simple.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -143,7 +143,7 @@ export const Default = (args) => {
         cta-type="${ifDefined(ctaType)}"
         href="${ifDefined(href)}">
         <c4d-card-link-heading>${ctaCopy}</c4d-card-link-heading>
-        <c4d-card-cta-footer></c4d-card-cta-footer>
+        <c4d-card-footer></c4d-card-footer>
       </c4d-card-link-cta>
     </c4d-content-group-simple>
   `;

--- a/packages/web-components/src/components/content-section/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-section/__stories__/README.stories.mdx
@@ -89,7 +89,7 @@ component to render correctly within the grid.
         ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at
         elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
-      <c4d-card-footer slot="footer"> </c4d-card-footer>
+      <c4d-card-footer> </c4d-card-footer>
     </c4d-card-group-item>
   </c4d-card-group>
 </c4d-content-section>
@@ -276,47 +276,55 @@ component to render correctly within the grid.
 </c4d-content-section>
 ```
 
-As part of the ongoing upgrade to Carbon for IBM.com v2, we have consolidated some of the other `Content section` variants under a single one.
-Some of the components that are compatible with the `Content section` component are: `Card group`, `Carousel`, `Link list`.
+As part of the ongoing upgrade to Carbon for IBM.com v2, we have consolidated
+some of the other `Content section` variants under a single one. Some of the
+components that are compatible with the `Content section` component are:
+`Card group`, `Carousel`, `Link list`.
 
 ### Card group
 
 ```html
-
 <dds-content-section>
   <dds-content-section-heading>Heading</dds-content-section-heading>
   <dds-content-section-copy>Copy</dds-content-section-copy>
-  <dds-text-cta slot="footer" cta-type="local" href="https://www.example.com"> CTA text</dds-text-cta>
+  <dds-text-cta slot="footer" cta-type="local" href="https://www.example.com">
+    CTA text</dds-text-cta
+  >
   <dds-card-group>
     <dds-card-group-item href="https://example.com" cta-type="local">
       <dds-card-heading>Nunc convallis lobortis</dds-card-heading>
       <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.
-        Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
+        ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at
+        elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
-      <dds-card-cta-footer slot="footer">
-      </dds-card-cta-footer>
+      <dds-card-cta-footer slot="footer"> </dds-card-cta-footer>
     </dds-card-group-item>
-  </dds-card-group>  
+  </dds-card-group>
 </dds-content-section>
 ```
 
 ### Carousel
 
 ```html
-
 <dds-content-section>
   <dds-content-section-heading>Heading</dds-content-section-heading>
   <dds-content-section-copy>Copy</dds-content-section-copy>
-  <dds-text-cta slot="footer" cta-type="local" href="https://www.example.com"> CTA text</dds-text-cta>
-  <dds-content-section-heading>Lorem ipsum dolor sit amet</dds-content-section-heading>
+  <dds-text-cta slot="footer" cta-type="local" href="https://www.example.com">
+    CTA text</dds-text-cta
+  >
+  <dds-content-section-heading
+    >Lorem ipsum dolor sit amet</dds-content-section-heading
+  >
   <dds-content-section-copy>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies
+    est.
   </dds-content-section-copy>
   <dds-carousel>
     <dds-card href="https://example.com">
       <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
+      ultricies est.
       <dds-card-footer>
         <svg
           slot="footer"
@@ -327,15 +335,16 @@ Some of the components that are compatible with the `Content section` component 
           aria-hidden="true"
           width="20"
           height="20"
-          viewBox="0 0 20 20"
-        >
-          <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+          viewBox="0 0 20 20">
+          <path
+            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
       </dds-card-footer>
     </dds-card>
     <dds-card href="https://example.com">
       <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
+      ultricies est.
       <dds-card-footer>
         <svg
           slot="footer"
@@ -346,15 +355,16 @@ Some of the components that are compatible with the `Content section` component 
           aria-hidden="true"
           width="20"
           height="20"
-          viewBox="0 0 20 20"
-        >
-          <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+          viewBox="0 0 20 20">
+          <path
+            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
       </dds-card-footer>
     </dds-card>
     <dds-card href="https://example.com">
       <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
+      ultricies est.
       <dds-card-footer>
         <svg
           slot="footer"
@@ -365,15 +375,16 @@ Some of the components that are compatible with the `Content section` component 
           aria-hidden="true"
           width="20"
           height="20"
-          viewBox="0 0 20 20"
-        >
-          <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+          viewBox="0 0 20 20">
+          <path
+            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
       </dds-card-footer>
     </dds-card>
     <dds-card href="https://example.com">
       <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
+      ultricies est.
       <dds-card-footer>
         <svg
           slot="footer"
@@ -384,15 +395,16 @@ Some of the components that are compatible with the `Content section` component 
           aria-hidden="true"
           width="20"
           height="20"
-          viewBox="0 0 20 20"
-        >
-          <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+          viewBox="0 0 20 20">
+          <path
+            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
       </dds-card-footer>
     </dds-card>
     <dds-card href="https://example.com">
       <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
+      ultricies est.
       <dds-card-footer>
         <svg
           slot="footer"
@@ -403,15 +415,16 @@ Some of the components that are compatible with the `Content section` component 
           aria-hidden="true"
           width="20"
           height="20"
-          viewBox="0 0 20 20"
-        >
-          <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+          viewBox="0 0 20 20">
+          <path
+            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
       </dds-card-footer>
     </dds-card>
     <dds-card href="https://example.com">
       <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
+      ultricies est.
       <dds-card-footer>
         <svg
           slot="footer"
@@ -422,9 +435,9 @@ Some of the components that are compatible with the `Content section` component 
           aria-hidden="true"
           width="20"
           height="20"
-          viewBox="0 0 20 20"
-        >
-          <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+          viewBox="0 0 20 20">
+          <path
+            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
       </dds-card-footer>
     </dds-card>
@@ -438,14 +451,20 @@ Some of the components that are compatible with the `Content section` component 
 <dds-content-section>
   <dds-content-section-heading>Heading</dds-content-section-heading>
   <dds-content-section-copy>Copy</dds-content-section-copy>
-  <dds-text-cta slot="footer" cta-type="local" href="https://www.example.com"> CTA text</dds-text-cta>
-  <dds-content-section-heading>Lorem ipsum dolor sit amet</dds-content-section-heading>
+  <dds-text-cta slot="footer" cta-type="local" href="https://www.example.com">
+    CTA text</dds-text-cta
+  >
+  <dds-content-section-heading
+    >Lorem ipsum dolor sit amet</dds-content-section-heading
+  >
   <dds-content-section-copy>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies
+    est.
   </dds-content-section-copy>
   <dds-link-list>
     <dds-link-list-item href="https://example.com">
-      Learn more about Kubernetes and automating deployment ${ArrowRight20({ slot: 'icon' })}
+      Learn more about Kubernetes and automating deployment ${ArrowRight20({
+      slot: 'icon' })}
     </dds-link-list-item>
     <dds-link-list-item href="https://example.com">
       Containerization A Complete Guide ${ArrowRight20({ slot: 'icon' })}
@@ -462,7 +481,7 @@ Some of the components that are compatible with the `Content section` component 
     <dds-link-list-item href="https://example.com">
       Microservices and containers ${ArrowRight20({ slot: 'icon' })}
     </dds-link-list-item>
-  </dds-link-list>  
+  </dds-link-list>
 </dds-content-section>
 ```
 

--- a/packages/web-components/src/components/content-section/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-section/__stories__/README.stories.mdx
@@ -284,48 +284,48 @@ components that are compatible with the `Content section` component are:
 ### Card group
 
 ```html
-<dds-content-section>
-  <dds-content-section-heading>Heading</dds-content-section-heading>
-  <dds-content-section-copy>Copy</dds-content-section-copy>
-  <dds-text-cta slot="footer" cta-type="local" href="https://www.example.com">
-    CTA text</dds-text-cta
+<c4d-content-section>
+  <c4d-content-section-heading>Heading</c4d-content-section-heading>
+  <c4d-content-section-copy>Copy</c4d-content-section-copy>
+  <c4d-text-cta slot="footer" cta-type="local" href="https://www.example.com">
+    CTA text</c4d-text-cta
   >
-  <dds-card-group>
-    <dds-card-group-item href="https://example.com" cta-type="local">
-      <dds-card-heading>Nunc convallis lobortis</dds-card-heading>
+  <c4d-card-group>
+    <c4d-card-group-item href="https://example.com" cta-type="local">
+      <c4d-card-heading>Nunc convallis lobortis</c4d-card-heading>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
         ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at
         elit sollicitudin, sodales nulla quis, consequat libero.
       </p>
-      <dds-card-cta-footer slot="footer"> </dds-card-cta-footer>
-    </dds-card-group-item>
-  </dds-card-group>
-</dds-content-section>
+      <c4d-card-cta-footer slot="footer"> </c4d-card-cta-footer>
+    </c4d-card-group-item>
+  </c4d-card-group>
+</c4d-content-section>
 ```
 
 ### Carousel
 
 ```html
-<dds-content-section>
-  <dds-content-section-heading>Heading</dds-content-section-heading>
-  <dds-content-section-copy>Copy</dds-content-section-copy>
-  <dds-text-cta slot="footer" cta-type="local" href="https://www.example.com">
-    CTA text</dds-text-cta
+<c4d-content-section>
+  <c4d-content-section-heading>Heading</c4d-content-section-heading>
+  <c4d-content-section-copy>Copy</c4d-content-section-copy>
+  <c4d-text-cta slot="footer" cta-type="local" href="https://www.example.com">
+    CTA text</c4d-text-cta
   >
-  <dds-content-section-heading
-    >Lorem ipsum dolor sit amet</dds-content-section-heading
+  <c4d-content-section-heading
+    >Lorem ipsum dolor sit amet</c4d-content-section-heading
   >
-  <dds-content-section-copy>
+  <c4d-content-section-copy>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies
     est.
-  </dds-content-section-copy>
-  <dds-carousel>
-    <dds-card href="https://example.com">
-      <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
+  </c4d-content-section-copy>
+  <c4d-carousel>
+    <c4d-card href="https://example.com">
+      <c4d-card-heading>Lorem ipsum dolor sit amet</c4d-card-heading>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
       ultricies est.
-      <dds-card-footer>
+      <c4d-card-footer>
         <svg
           slot="footer"
           focusable="false"
@@ -339,13 +339,13 @@ components that are compatible with the `Content section` component are:
           <path
             d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
-      </dds-card-footer>
-    </dds-card>
-    <dds-card href="https://example.com">
-      <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
+      </c4d-card-footer>
+    </c4d-card>
+    <c4d-card href="https://example.com">
+      <c4d-card-heading>Lorem ipsum dolor sit amet</c4d-card-heading>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
       ultricies est.
-      <dds-card-footer>
+      <c4d-card-footer>
         <svg
           slot="footer"
           focusable="false"
@@ -359,13 +359,13 @@ components that are compatible with the `Content section` component are:
           <path
             d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
-      </dds-card-footer>
-    </dds-card>
-    <dds-card href="https://example.com">
-      <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
+      </c4d-card-footer>
+    </c4d-card>
+    <c4d-card href="https://example.com">
+      <c4d-card-heading>Lorem ipsum dolor sit amet</c4d-card-heading>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
       ultricies est.
-      <dds-card-footer>
+      <c4d-card-footer>
         <svg
           slot="footer"
           focusable="false"
@@ -379,13 +379,13 @@ components that are compatible with the `Content section` component are:
           <path
             d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
-      </dds-card-footer>
-    </dds-card>
-    <dds-card href="https://example.com">
-      <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
+      </c4d-card-footer>
+    </c4d-card>
+    <c4d-card href="https://example.com">
+      <c4d-card-heading>Lorem ipsum dolor sit amet</c4d-card-heading>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
       ultricies est.
-      <dds-card-footer>
+      <c4d-card-footer>
         <svg
           slot="footer"
           focusable="false"
@@ -399,13 +399,13 @@ components that are compatible with the `Content section` component are:
           <path
             d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
-      </dds-card-footer>
-    </dds-card>
-    <dds-card href="https://example.com">
-      <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
+      </c4d-card-footer>
+    </c4d-card>
+    <c4d-card href="https://example.com">
+      <c4d-card-heading>Lorem ipsum dolor sit amet</c4d-card-heading>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
       ultricies est.
-      <dds-card-footer>
+      <c4d-card-footer>
         <svg
           slot="footer"
           focusable="false"
@@ -419,13 +419,13 @@ components that are compatible with the `Content section` component are:
           <path
             d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
-      </dds-card-footer>
-    </dds-card>
-    <dds-card href="https://example.com">
-      <dds-card-heading>Lorem ipsum dolor sit amet</dds-card-heading>
+      </c4d-card-footer>
+    </c4d-card>
+    <c4d-card href="https://example.com">
+      <c4d-card-heading>Lorem ipsum dolor sit amet</c4d-card-heading>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
       ultricies est.
-      <dds-card-footer>
+      <c4d-card-footer>
         <svg
           slot="footer"
           focusable="false"
@@ -439,50 +439,50 @@ components that are compatible with the `Content section` component are:
           <path
             d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
         </svg>
-      </dds-card-footer>
-    </dds-card>
-  </dds-carousel>
-</dds-content-section>
+      </c4d-card-footer>
+    </c4d-card>
+  </c4d-carousel>
+</c4d-content-section>
 ```
 
 ### Link list
 
 ```html
-<dds-content-section>
-  <dds-content-section-heading>Heading</dds-content-section-heading>
-  <dds-content-section-copy>Copy</dds-content-section-copy>
-  <dds-text-cta slot="footer" cta-type="local" href="https://www.example.com">
-    CTA text</dds-text-cta
+<c4d-content-section>
+  <c4d-content-section-heading>Heading</c4d-content-section-heading>
+  <c4d-content-section-copy>Copy</c4d-content-section-copy>
+  <c4d-text-cta slot="footer" cta-type="local" href="https://www.example.com">
+    CTA text</c4d-text-cta
   >
-  <dds-content-section-heading
-    >Lorem ipsum dolor sit amet</dds-content-section-heading
+  <c4d-content-section-heading
+    >Lorem ipsum dolor sit amet</c4d-content-section-heading
   >
-  <dds-content-section-copy>
+  <c4d-content-section-copy>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies
     est.
-  </dds-content-section-copy>
-  <dds-link-list>
-    <dds-link-list-item href="https://example.com">
+  </c4d-content-section-copy>
+  <c4d-link-list>
+    <c4d-link-list-item href="https://example.com">
       Learn more about Kubernetes and automating deployment ${ArrowRight20({
       slot: 'icon' })}
-    </dds-link-list-item>
-    <dds-link-list-item href="https://example.com">
+    </c4d-link-list-item>
+    <c4d-link-list-item href="https://example.com">
       Containerization A Complete Guide ${ArrowRight20({ slot: 'icon' })}
-    </dds-link-list-item>
-    <dds-link-list-item href="https://example.com">
+    </c4d-link-list-item>
+    <c4d-link-list-item href="https://example.com">
       Microservices and containers ${ArrowRight20({ slot: 'icon' })}
-    </dds-link-list-item>
-    <dds-link-list-item href="https://example.com">
+    </c4d-link-list-item>
+    <c4d-link-list-item href="https://example.com">
       Learn more about Kubernetes ${ArrowRight20({ slot: 'icon' })}
-    </dds-link-list-item>
-    <dds-link-list-item href="https://example.com">
+    </c4d-link-list-item>
+    <c4d-link-list-item href="https://example.com">
       Containerization A Complete Guide ${ArrowRight20({ slot: 'icon' })}
-    </dds-link-list-item>
-    <dds-link-list-item href="https://example.com">
+    </c4d-link-list-item>
+    <c4d-link-list-item href="https://example.com">
       Microservices and containers ${ArrowRight20({ slot: 'icon' })}
-    </dds-link-list-item>
-  </dds-link-list>
-</dds-content-section>
+    </c4d-link-list-item>
+  </c4d-link-list>
+</c4d-content-section>
 ```
 
 ## Props

--- a/packages/web-components/src/components/cta/__stories__/cta.stories.ts
+++ b/packages/web-components/src/components/cta/__stories__/cta.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -158,14 +158,14 @@ export const Default = (args) => {
                     ? html` <c4d-card-heading>${heading}</c4d-card-heading> `
                     : ''}
                   ${ctaType !== 'video' ? copy : ''}
-                  <c4d-card-cta-footer
+                  <c4d-card-footer
                     cta-type="${ifDefined(ctaType)}"
                     download="${ifDefined(footerDownload)}"
                     video-name="${ifDefined(customVideoTitle)}"
                     video-description="${ifDefined(customVideoDescription)}"
                     href="${ifDefined(footerHref)}">
                     ${footerCopy || ctaIcons[ctaType]({ slot: 'icon' })}
-                  </c4d-card-cta-footer>
+                  </c4d-card-footer>
                 `
               : ''}
             ${ctaStyle === 'feature'
@@ -206,14 +206,14 @@ export const Default = (args) => {
               ? html`
                   <c4d-card-link-heading>${heading}</c4d-card-link-heading>
                   ${copy}
-                  <c4d-card-cta-footer
+                  <c4d-card-footer
                     cta-type="${ifDefined(ctaType)}"
                     download="${ifDefined(footerDownload)}"
                     video-name="${ifDefined(customVideoTitle)}"
                     video-description="${ifDefined(customVideoDescription)}"
                     href="${ifDefined(footerHref)}">
                     ${footerCopy || ctaIcons[ctaType]({ slot: 'icon' })}
-                  </c4d-card-cta-footer>
+                  </c4d-card-footer>
                 `
               : ''}
           </c4d-cta>

--- a/packages/web-components/src/components/cta/__stories__/cta.stories.ts
+++ b/packages/web-components/src/components/cta/__stories__/cta.stories.ts
@@ -158,14 +158,14 @@ export const Default = (args) => {
                     ? html` <c4d-card-heading>${heading}</c4d-card-heading> `
                     : ''}
                   ${ctaType !== 'video' ? copy : ''}
-                  <c4d-card-footer
+                  <c4d-card-cta-footer
                     cta-type="${ifDefined(ctaType)}"
                     download="${ifDefined(footerDownload)}"
                     video-name="${ifDefined(customVideoTitle)}"
                     video-description="${ifDefined(customVideoDescription)}"
                     href="${ifDefined(footerHref)}">
                     ${footerCopy || ctaIcons[ctaType]({ slot: 'icon' })}
-                  </c4d-card-footer>
+                  </c4d-card-cta-footer>
                 `
               : ''}
             ${ctaStyle === 'feature'
@@ -206,14 +206,14 @@ export const Default = (args) => {
               ? html`
                   <c4d-card-link-heading>${heading}</c4d-card-link-heading>
                   ${copy}
-                  <c4d-card-footer
+                  <c4d-card-cta-footer
                     cta-type="${ifDefined(ctaType)}"
                     download="${ifDefined(footerDownload)}"
                     video-name="${ifDefined(customVideoTitle)}"
                     video-description="${ifDefined(customVideoDescription)}"
                     href="${ifDefined(footerHref)}">
                     ${footerCopy || ctaIcons[ctaType]({ slot: 'icon' })}
-                  </c4d-card-footer>
+                  </c4d-card-cta-footer>
                 `
               : ''}
           </c4d-cta>

--- a/packages/web-components/src/components/cta/__tests__/card-cta-footer.test.ts
+++ b/packages/web-components/src/components/cta/__tests__/card-cta-footer.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,24 +21,24 @@ const template = (props?) => {
     children,
   } = props ?? {};
   return html`
-    <c4d-card-cta-footer
+    <c4d-card-footer
       cta-type="${ifDefined(ctaType)}"
       video-duration="${ifDefined(videoDuration)}"
       .formatVideoCaption="${ifDefined(formatVideoCaption)}"
       .formatVideoDuration="${ifDefined(formatVideoDuration)}">
       ${children}
-    </c4d-card-cta-footer>
+    </c4d-card-footer>
   `;
 };
 
-describe('c4d-card-cta-footer', function () {
+describe('c4d-card-footer', function () {
   describe('Misc attributes', function () {
     it('should render with minimum attributes', async function () {
       render(template(), document.body);
       await Promise.resolve();
-      expect(
-        document.body.querySelector('c4d-card-cta-footer')
-      ).toMatchSnapshot({ mode: 'shadow' });
+      expect(document.body.querySelector('c4d-card-footer')).toMatchSnapshot({
+        mode: 'shadow',
+      });
     });
 
     it('should render with various attributes', async function () {
@@ -54,9 +54,9 @@ describe('c4d-card-cta-footer', function () {
         document.body
       );
       await Promise.resolve();
-      expect(
-        document.body.querySelector('c4d-card-cta-footer')
-      ).toMatchSnapshot({ mode: 'shadow' });
+      expect(document.body.querySelector('c4d-card-footer')).toMatchSnapshot({
+        mode: 'shadow',
+      });
     });
   });
 
@@ -76,7 +76,7 @@ describe('c4d-card-cta-footer', function () {
       await Promise.resolve(); // Update cycle for rendering upon `slotchange` event
       expect(
         document.body
-          .querySelector('c4d-card-cta-footer')!
+          .querySelector('c4d-card-footer')!
           .shadowRoot!.querySelector('.cds--card__cta__copy')!
           .textContent!.trim()
       ).toBe('');

--- a/packages/web-components/src/components/cta/__tests__/card-cta.test.ts
+++ b/packages/web-components/src/components/cta/__tests__/card-cta.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -73,15 +73,15 @@ xdescribe('c4d-card-cta', function () {
           // Should yeild to `undefined` in `name` part given card footer doesn't render the video name
           formatVideoCaption: ({ name, duration }) => `${name}-${duration}`,
           formatVideoDuration: ({ duration }) => duration,
-          children: html` <c4d-card-cta-footer></c4d-card-cta-footer> `,
+          children: html` <c4d-card-footer></c4d-card-footer> `,
         }),
         document.body
       );
       await Promise.resolve(); // Update cycle for `<c4d-card-cta>`
-      await Promise.resolve(); // Update cycle for `<c4d-card-cta-footer>` upon property forwarding
-      expect(
-        document.body.querySelector('c4d-card-cta-footer')
-      ).toMatchSnapshot({ mode: 'shadow' });
+      await Promise.resolve(); // Update cycle for `<c4d-card-footer>` upon property forwarding
+      expect(document.body.querySelector('c4d-card-footer')).toMatchSnapshot({
+        mode: 'shadow',
+      });
     });
   });
 

--- a/packages/web-components/src/components/cta/card-cta-footer.ts
+++ b/packages/web-components/src/components/cta/card-cta-footer.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -27,7 +27,7 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
 /**
  * Card CTA footer.
  *
- * @element c4d-card-cta-footer
+ * @element c4d-card-footer
  */
 @customElement(`${c4dPrefix}-card-cta-footer`)
 class C4DCardCTAFooter extends VideoCTAMixin(CTAMixin(C4DCardFooter)) {

--- a/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -149,9 +149,7 @@ export const cardGroupItems = html`
     </c4d-image>
     <c4d-card-eyebrow>Topic</c4d-card-eyebrow>
     <c4d-card-heading>Natural Language Processing.</c4d-card-heading>
-    <c4d-card-cta-footer slot="footer">
-      ${ArrowRight20({ slot: 'icon' })}
-    </c4d-card-cta-footer>
+    <c4d-card-footer> ${ArrowRight20({ slot: 'icon' })} </c4d-card-footer>
   </c4d-card-group-item>
 `;
 
@@ -270,7 +268,7 @@ export const tocContent = html`
     ${Array.from([1, 2]).map(() => contentBlockSegmentedItemsWithImage)}
     <c4d-card-cta slot="footer" cta-type="local" href="https://example.com">
       Lorem ipsum dolor
-      <c4d-card-cta-footer></c4d-card-cta-footer>
+      <c4d-card-footer></c4d-card-footer>
     </c4d-card-cta>
   </c4d-content-block-segmented>
 
@@ -470,7 +468,7 @@ export const StoryContentNoToC = () =>
             cta-type="local"
             href="https://example.com">
             Lorem ipsum dolor
-            <c4d-card-cta-footer></c4d-card-cta-footer>
+            <c4d-card-footer></c4d-card-footer>
           </c4d-card-cta>
         </c4d-content-block-segmented>
 

--- a/packages/web-components/src/components/filter-panel/filter-panel-composite.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-composite.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -443,10 +443,10 @@ class C4DFilterPanelComposite extends MediaQueryMixin(
 
   render() {
     // Note that the <slot name="heading"> contents, intended to be
-    // <dds-filter-panel-heading> are never shown as is. The text contents
+    // <c4d-filter-panel-heading> are never shown as is. The text contents
     // are composed, using this._getComposedHeadingFilterCount(), together with
     // the current filter count, and passed as an attribute to
-    // <dds-filter-panel-modal> and <dds-filter-panel>.
+    // <c4d-filter-panel-modal> and <c4d-filter-panel>.
     return html`
       <slot
         name="heading"

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/locale-modal/locale-modal.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/locale-modal/locale-modal.e2e.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2023
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -90,9 +90,9 @@ describe('c4d-locale-modal | default', () => {
         );
       });
 
-    cy.get('dds-locale-modal')
+    cy.get('c4d-locale-modal')
       .shadow()
-      .find('dds-expressive-modal-close-button')
+      .find('c4d-expressive-modal-close-button')
       .shadow()
       .find('button')
       .click();

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-authenticated.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/masthead/masthead-authenticated.e2e.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2023
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,38 +14,38 @@
 const _pathDefault =
   '/iframe.html?id=components-masthead--default&knob-use%20mock%20nav%20data%20(use-mock)=true&knob-The%20user%20authenticated%20status%20(user-status)=test.user@ibm.com';
 
-describe('dds-masthead | authenticated (desktop)', () => {
+describe('c4d-masthead | authenticated (desktop)', () => {
   beforeEach(() => {
     cy.viewport(1280, 780).visit(`/${_pathDefault}`);
   });
 
   it('should open the login menu with 4 items', () => {
-    cy.get('dds-masthead-profile')
+    cy.get('c4d-masthead-profile')
       .shadow()
       .find('a')
       .click();
-    cy.get('dds-masthead-profile-item').should('have.length', 4);
+    cy.get('c4d-masthead-profile-item').should('have.length', 4);
     cy.takeSnapshots();
   });
 
   it('should not render profile menu when disabled', () => {
-    cy.get('dds-masthead-composite').invoke('attr', 'has-profile', 'false');
-    cy.get('dds-masthead-profile').should('not.exist');
+    cy.get('c4d-masthead-composite').invoke('attr', 'has-profile', 'false');
+    cy.get('c4d-masthead-profile').should('not.exist');
     cy.takeSnapshots();
   });
 });
 
-describe('dds-masthead | default (mobile)', () => {
+describe('c4d-masthead | default (mobile)', () => {
   beforeEach(() => {
     cy.viewport(320, 780).visit(`/${_pathDefault}`);
   });
 
   it('should open the login menu with 4 items', () => {
-    cy.get('dds-masthead-profile')
+    cy.get('c4d-masthead-profile')
       .shadow()
       .find('a')
       .click();
-    cy.get('dds-masthead-profile-item').should('have.length', 4);
+    cy.get('c4d-masthead-profile-item').should('have.length', 4);
     cy.takeSnapshots('mobile');
   });
 });

--- a/packages/web-components/tests/snapshots/c4d-card-footer.md
+++ b/packages/web-components/tests/snapshots/c4d-card-footer.md
@@ -31,17 +31,19 @@
 
 ```
 <a
-  aria-label=" - This link plays a video"
+  aria-label=""
   class="c4d-ce--card__footer cds--card__footer cds--link cds--link--lg cds--link-with-icon cds--link-with-icon--inline-icon cds--link-with-icon__icon-right"
   href="#"
   id="link"
   part="link"
   tabindex="0"
 >
-  <span class="cds--card__cta__copy">
+  <span
+    class="cds--card__cta__copy"
+    hidden=""
+  >
     <slot>
     </slot>
-    undefined-180000
   </span>
   <slot name="icon">
     <span class="cds--visually-hidden">

--- a/packages/web-components/tests/snapshots/c4d-content-block-card-static.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-card-static.md
@@ -103,14 +103,15 @@
                 Phasellus at elit sollicitudin, sodales nulla quis, consequat
                 libero.
       </p>
-      <c4d-card-cta-footer
+      <c4d-card-footer
         color-scheme=""
         cta-type=""
-        data-autoid="c4d--card-cta-footer"
+        data-autoid="c4d--card-footer"
         icon-placement="right"
+        parent-href="https://example.com"
         slot="footer"
       >
-      </c4d-card-cta-footer>
+      </c4d-card-footer>
     </c4d-card-group-item>
   </c4d-card-group>
   <c4d-content-item data-autoid="c4d--content-item">

--- a/packages/web-components/tests/snapshots/c4d-search-with-typeahead.md
+++ b/packages/web-components/tests/snapshots/c4d-search-with-typeahead.md
@@ -100,13 +100,6 @@
     </div>
   </div>
 </form>
-<div
-  aria-live="assertive"
-  aria-relevant="additions text"
-  class="cds--assistive-text"
-  role="status"
->
-</div>
 <div class="cds--header__search--actions">
   <button
     aria-label="perform-search-button-assistive-text-foo"

--- a/packages/web-components/tests/snapshots/dds-content-block-card-static.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-card-static.md
@@ -1,42 +1,42 @@
-# `dds-content-block-card-static`
+# `c4d-content-block-card-static`
 
 ## `Misc attributes`
 
 ####   `should render with minimum attributes`
 
 ```
-<dds-content-block-card-static>
-  <dds-card-group-item
+<c4d-content-block-card-static>
+  <c4d-card-group-item
     color-scheme=""
-    data-autoid="dds--card-group-item"
+    data-autoid="c4d--card-group-item"
     pictogram-placement=""
     size="md"
   >
-  </dds-card-group-item>
-  <dds-card-group
-    data-autoid="dds--card-group"
+  </c4d-card-group-item>
+  <c4d-card-group
+    data-autoid="c4d--card-group"
     grid-mode="collapsed"
   >
-  </dds-card-group>
-  <dds-content-item data-autoid="dds--content-item">
-    <dds-content-item-heading
+  </c4d-card-group>
+  <c4d-content-item data-autoid="c4d--content-item">
+    <c4d-content-item-heading
       aria-level="4"
-      data-autoid="dds--content-item__heading"
+      data-autoid="c4d--content-item__heading"
       role="heading"
       slot="heading"
     >
-    </dds-content-item-heading>
-    <dds-content-item-copy data-autoid="dds--content-item__copy">
-    </dds-content-item-copy>
-  </dds-content-item>
-  <dds-button-group
-    data-autoid="dds--button-group"
+    </c4d-content-item-heading>
+    <c4d-content-item-copy data-autoid="c4d--content-item__copy">
+    </c4d-content-item-copy>
+  </c4d-content-item>
+  <c4d-button-group
+    data-autoid="c4d--button-group"
     role="list"
-    style="--dds--button-group--item-count: 2;"
+    style="--c4d--button-group--item-count: 2;"
   >
-    <dds-button-group-item
+    <c4d-button-group-item
       cta-type=""
-      data-autoid="dds--button-group-item"
+      data-autoid="c4d--button-group-item"
       isexpressive=""
       kind="primary"
       role="listitem"
@@ -46,10 +46,10 @@
       type="button"
     >
       Button 1
-    </dds-button-group-item>
-    <dds-button-group-item
+    </c4d-button-group-item>
+    <c4d-button-group-item
       cta-type=""
-      data-autoid="dds--button-group-item"
+      data-autoid="c4d--button-group-item"
       isexpressive=""
       kind="tertiary"
       role="listitem"
@@ -59,83 +59,83 @@
       type="button"
     >
       Buuton 2
-    </dds-button-group-item>
-  </dds-button-group>
-</dds-content-block-card-static>
+    </c4d-button-group-item>
+  </c4d-button-group>
+</c4d-content-block-card-static>
 
 ```
 
 ####   `should render with various attributes`
 
 ```
-<dds-content-block-card-static>
-  <dds-card-group-item
+<c4d-content-block-card-static>
+  <c4d-card-group-item
     color-scheme=""
-    data-autoid="dds--card-group-item"
+    data-autoid="c4d--card-group-item"
     pictogram-placement=""
     size="md"
   >
     heading-foo
-  </dds-card-group-item>
-  <dds-card-group
-    data-autoid="dds--card-group"
+  </c4d-card-group-item>
+  <c4d-card-group
+    data-autoid="c4d--card-group"
     grid-mode="collapsed"
-    style="--dds--card-group--cards-in-row: 3;"
+    style="--c4d--card-group--cards-in-row: 3;"
   >
-    <dds-card-group-item
+    <c4d-card-group-item
       color-scheme=""
-      data-autoid="dds--card-group-item"
+      data-autoid="c4d--card-group-item"
       href="https://example.com"
       pictogram-placement=""
       size="md"
     >
-      <dds-card-heading
+      <c4d-card-heading
         aria-level="3"
-        data-autoid="dds--card-heading"
+        data-autoid="c4d--card-heading"
         role="heading"
         slot="heading"
       >
         Nunc convallis lobortis
-      </dds-card-heading>
+      </c4d-card-heading>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
                 et ultricies est. Mauris iaculis eget dolor nec hendrerit.
                 Phasellus at elit sollicitudin, sodales nulla quis, consequat
                 libero.
       </p>
-      <dds-card-cta-footer
+      <c4d-card-cta-footer
         color-scheme=""
         cta-type=""
-        data-autoid="dds--card-cta-footer"
+        data-autoid="c4d--card-cta-footer"
         icon-placement="right"
         slot="footer"
       >
-      </dds-card-cta-footer>
-    </dds-card-group-item>
-  </dds-card-group>
-  <dds-content-item data-autoid="dds--content-item">
-    <dds-content-item-heading
+      </c4d-card-cta-footer>
+    </c4d-card-group-item>
+  </c4d-card-group>
+  <c4d-content-item data-autoid="c4d--content-item">
+    <c4d-content-item-heading
       aria-level="4"
-      data-autoid="dds--content-item__heading"
+      data-autoid="c4d--content-item__heading"
       role="heading"
       slot="heading"
     >
       Lorem ipsum
-    </dds-content-item-heading>
-    <dds-content-item-copy data-autoid="dds--content-item__copy">
-      <dds-content-item-paragraph data-autoid="dds--content-item-paragraph">
+    </c4d-content-item-heading>
+    <c4d-content-item-copy data-autoid="c4d--content-item__copy">
+      <c4d-content-item-paragraph data-autoid="c4d--content-item-paragraph">
         ipsum dolor sit amet
-      </dds-content-item-paragraph>
-    </dds-content-item-copy>
-  </dds-content-item>
-  <dds-button-group
-    data-autoid="dds--button-group"
+      </c4d-content-item-paragraph>
+    </c4d-content-item-copy>
+  </c4d-content-item>
+  <c4d-button-group
+    data-autoid="c4d--button-group"
     role="list"
-    style="--dds--button-group--item-count: 2;"
+    style="--c4d--button-group--item-count: 2;"
   >
-    <dds-button-group-item
+    <c4d-button-group-item
       cta-type=""
-      data-autoid="dds--button-group-item"
+      data-autoid="c4d--button-group-item"
       isexpressive=""
       kind="primary"
       role="listitem"
@@ -145,10 +145,10 @@
       type="button"
     >
       Button 1
-    </dds-button-group-item>
-    <dds-button-group-item
+    </c4d-button-group-item>
+    <c4d-button-group-item
       cta-type=""
-      data-autoid="dds--button-group-item"
+      data-autoid="c4d--button-group-item"
       isexpressive=""
       kind="tertiary"
       role="listitem"
@@ -158,9 +158,9 @@
       type="button"
     >
       Buuton 2
-    </dds-button-group-item>
-  </dds-button-group>
-</dds-content-block-card-static>
+    </c4d-button-group-item>
+  </c4d-button-group>
+</c4d-content-block-card-static>
 
 ```
 

--- a/packages/web-components/tests/snapshots/dds-filter-panel-composite.md
+++ b/packages/web-components/tests/snapshots/dds-filter-panel-composite.md
@@ -1,4 +1,4 @@
-# `dds-filter-panel-composite`
+# `c4d-filter-panel-composite`
 
 ## `Misc attributes`
 
@@ -11,13 +11,13 @@
   <div class="bx--filter__modal__button">
   </div>
 </button>
-<dds-filter-panel-modal
-  data-autoid="dds-filter-panel-modal"
+<c4d-filter-panel-modal
+  data-autoid="c4d-filter-panel-modal"
   heading=""
 >
   <slot>
   </slot>
-</dds-filter-panel-modal>
+</c4d-filter-panel-modal>
 
 ```
 
@@ -30,13 +30,13 @@
   <div class="bx--filter__modal__button">
   </div>
 </button>
-<dds-filter-panel-modal
-  data-autoid="dds-filter-panel-modal"
+<c4d-filter-panel-modal
+  data-autoid="c4d-filter-panel-modal"
   heading=""
 >
   <slot>
   </slot>
-</dds-filter-panel-modal>
+</c4d-filter-panel-modal>
 
 ```
 

--- a/packages/web-components/tests/snapshots/dds-locale-modal-composite.md
+++ b/packages/web-components/tests/snapshots/dds-locale-modal-composite.md
@@ -1,62 +1,62 @@
-# `dds-locale-modal-composite`
+# `c4d-locale-modal-composite`
 
 ## `Misc attributes`
 
 ####   `should render minimum attributes`
 
 ```
-<dds-locale-modal
+<c4d-locale-modal
   close-button-assistive-text="Close modal"
-  data-autoid="dds--locale-modal"
+  data-autoid="c4d--locale-modal"
   header-title="Select geographic area"
 >
-  <dds-regions
-    data-autoid="dds--regions"
+  <c4d-regions
+    data-autoid="c4d--regions"
     title="Select geographic area"
   >
-  </dds-regions>
-  <dds-locale-search
+  </c4d-regions>
+  <c4d-locale-search
     availability-label-text="This page is available in the following locations and languages"
     close-button-assistive-text="Clear search input"
-    data-autoid="dds--locale-search"
+    data-autoid="c4d--locale-search"
     label-text="Search by location or language"
     placeholder="Search by location or language"
     unavailability-label-text="This page is unavailable in your preferred location or language"
   >
-  </dds-locale-search>
-</dds-locale-modal>
+  </c4d-locale-search>
+</c4d-locale-modal>
 
 ```
 
 ####   `should render various attributes`
 
 ```
-<dds-locale-modal
+<c4d-locale-modal
   close-button-assistive-text="modal-close-foo"
-  data-autoid="dds--locale-modal"
+  data-autoid="c4d--locale-modal"
   header-title="header-title-foo"
   lang-display="lang-display-foo"
   open=""
 >
-  <dds-regions
-    data-autoid="dds--regions"
+  <c4d-regions
+    data-autoid="c4d--regions"
     title="header-title-foo"
   >
-    <dds-region-item name="region-name-foo">
-    </dds-region-item>
-    <dds-region-item name="region-name-bar">
-    </dds-region-item>
-  </dds-regions>
-  <dds-locale-search
+    <c4d-region-item name="region-name-foo">
+    </c4d-region-item>
+    <c4d-region-item name="region-name-bar">
+    </c4d-region-item>
+  </c4d-regions>
+  <c4d-locale-search
     availability-label-text="availability-text-foo"
     close-button-assistive-text="search-clear-text-foo"
-    data-autoid="dds--locale-search"
+    data-autoid="c4d--locale-search"
     label-text="search-label-foo"
     placeholder="search-placeholder-foo"
     unavailability-label-text="unavailability-text-foo"
   >
-  </dds-locale-search>
-</dds-locale-modal>
+  </c4d-locale-search>
+</c4d-locale-modal>
 
 ```
 


### PR DESCRIPTION
### Description

Deprecated component name in Storybook story was causing the components to render incorrectly.

### Changelog

**Changed**

- use `c4d-card-footer` instead of `c4d-card-cta-footer`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
