### PR TITLE
fix(leadspace): be explicit about svg closing tags

### DIFF
--- a/packages/web-components/.storybook/main.js
+++ b/packages/web-components/.storybook/main.js
@@ -217,7 +217,6 @@ module.exports = {
         test: /\.scss$/,
         sideEffects: true,
         use: [
-          'cache-loader',
           require.resolve('../tools/css-result-loader'),
           {
             loader: 'postcss-loader',

--- a/packages/web-components/.storybook/main.js
+++ b/packages/web-components/.storybook/main.js
@@ -248,6 +248,7 @@ module.exports = {
               sourceMap: useStyleSourceMap,
               webpackImporter: false,
               sassOptions: {
+                outputStyle: 'expanded',
                 includePaths: [
                   path.resolve(__dirname, '..', 'node_modules'),
                   path.resolve(__dirname, '../../..', 'node_modules'),

--- a/packages/web-components/.storybook/main.js
+++ b/packages/web-components/.storybook/main.js
@@ -217,7 +217,7 @@ module.exports = {
         test: /\.scss$/,
         sideEffects: true,
         use: [
-          'cache-loader',
+          { loader: 'cache-loader', options: { compare: () => false } },
           require.resolve('../tools/css-result-loader'),
           {
             loader: 'postcss-loader',

--- a/packages/web-components/.storybook/main.js
+++ b/packages/web-components/.storybook/main.js
@@ -248,7 +248,6 @@ module.exports = {
               sourceMap: useStyleSourceMap,
               webpackImporter: false,
               sassOptions: {
-                outputStyle: 'expanded',
                 includePaths: [
                   path.resolve(__dirname, '..', 'node_modules'),
                   path.resolve(__dirname, '../../..', 'node_modules'),

--- a/packages/web-components/.storybook/main.js
+++ b/packages/web-components/.storybook/main.js
@@ -217,7 +217,7 @@ module.exports = {
         test: /\.scss$/,
         sideEffects: true,
         use: [
-          { loader: 'cache-loader', options: { compare: () => false } },
+          'cache-loader',
           require.resolve('../tools/css-result-loader'),
           {
             loader: 'postcss-loader',

--- a/packages/web-components/.storybook/main.js
+++ b/packages/web-components/.storybook/main.js
@@ -217,6 +217,7 @@ module.exports = {
         test: /\.scss$/,
         sideEffects: true,
         use: [
+          'cache-loader',
           require.resolve('../tools/css-result-loader'),
           {
             loader: 'postcss-loader',

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -154,13 +154,42 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
 
   render() {
     const { gradientStyleScheme, type, size } = this;
+
+    const svgGradientStops = type === LEADSPACE_TYPE.CENTERED
+      ? svg`
+        <stop offset="0%" />
+        <stop offset="54%" />
+        <stop offset="77%" />
+        <stop offset="100%" />
+      `
+      : svg`
+        <stop offset="0%" />
+        <stop offset="25%" />
+        <stop offset="50%" />
+        <stop offset="75%" />
+      `
+
+    const svgGradientTransform = type === LEADSPACE_TYPE.CENTERED ? 'rotate(90)' : '';
+
+    const svgGradient = svg`
+      <defs>
+        <linearGradient
+          id="stops"
+          class="${prefix}--leadspace__gradient__stops"
+          gradientTransform="${svgGradientTransform}"
+        >
+          ${svgGradientStops}
+        </linearGradient>
+      </defs>
+      <rect class="${prefix}--leadspace__gradient__rect" width="100" height="100" />
+    `
     return html`
       <section class="${this._getTypeClass()}" part="section">
         <div class="${prefix}--leadspace__container">
           <div class="${this._getGradientClass()}">
             ${gradientStyleScheme === LEADSPACE_GRADIENT_STYLE_SCHEME.NONE
               ? undefined
-              : svg`
+              : html`
                 <svg
                   class="${prefix}--leadspace__gradient"
                   viewBox="0 0 100 100"
@@ -168,28 +197,7 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
                   xmlns="http://www.w3.org/2000/svg"
                   xmlns:xlink="http://www.w3.org/1999/xlink"
                 >
-                  <defs>
-                    <linearGradient id="stops" class="${prefix}--leadspace__gradient__stops" gradientTransform="${
-                  type === LEADSPACE_TYPE.CENTERED ? 'rotate(90)' : ''
-                }">
-                      ${
-                        type === LEADSPACE_TYPE.CENTERED
-                          ? svg`
-                          <stop offset="0%"></stop>
-                          <stop offset="54%"></stop>
-                          <stop offset="77%"></stop>
-                          <stop offset="100%"></stop>
-                        `
-                          : svg`
-                          <stop offset="0%"></stop>
-                          <stop offset="25%"></stop>
-                          <stop offset="50%"></stop>
-                          <stop offset="75%"></stop>
-                        `
-                      }
-                    </linearGradient>
-                  </defs>
-                  <rect class="${prefix}--leadspace__gradient__rect" width="100" height="100" />
+                  ${svgGradient}
                 </svg>
               `}
             <div class="${prefix}--leadspace--content__container">

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -158,16 +158,16 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
     const svgGradientStops =
       type === LEADSPACE_TYPE.CENTERED
         ? svg`
-        <stop offset="0%" />
-        <stop offset="54%" />
-        <stop offset="77%" />
-        <stop offset="100%" />
+        <stop offset="0%"></stop>
+        <stop offset="54%"></stop>
+        <stop offset="77%"></stop>
+        <stop offset="100%"></stop>
       `
         : svg`
-        <stop offset="0%" />
-        <stop offset="25%" />
-        <stop offset="50%" />
-        <stop offset="75%" />
+        <stop offset="0%"></stop>
+        <stop offset="25%"></stop>
+        <stop offset="50%"></stop>
+        <stop offset="75%"></stop>
       `;
 
     const svgGradientTransform =

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -175,16 +175,16 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
                       ${
                         type === LEADSPACE_TYPE.CENTERED
                           ? svg`
-                          <stop offset="0%" />
-                          <stop offset="54%" />
-                          <stop offset="77%" />
-                          <stop offset="100%" />
+                          <stop offset="0%"></stop>
+                          <stop offset="54%"></stop>
+                          <stop offset="77%"></stop>
+                          <stop offset="100%"></stop>
                         `
                           : svg`
-                          <stop offset="0%" />
-                          <stop offset="25%" />
-                          <stop offset="50%" />
-                          <stop offset="75%" />
+                          <stop offset="0%"></stop>
+                          <stop offset="25%"></stop>
+                          <stop offset="50%"></stop>
+                          <stop offset="75%"></stop>
                         `
                       }
                     </linearGradient>

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -155,21 +155,23 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
   render() {
     const { gradientStyleScheme, type, size } = this;
 
-    const svgGradientStops = type === LEADSPACE_TYPE.CENTERED
-      ? svg`
+    const svgGradientStops =
+      type === LEADSPACE_TYPE.CENTERED
+        ? svg`
         <stop offset="0%" />
         <stop offset="54%" />
         <stop offset="77%" />
         <stop offset="100%" />
       `
-      : svg`
+        : svg`
         <stop offset="0%" />
         <stop offset="25%" />
         <stop offset="50%" />
         <stop offset="75%" />
-      `
+      `;
 
-    const svgGradientTransform = type === LEADSPACE_TYPE.CENTERED ? 'rotate(90)' : '';
+    const svgGradientTransform =
+      type === LEADSPACE_TYPE.CENTERED ? 'rotate(90)' : '';
 
     const svgGradient = svg`
       <defs>
@@ -182,7 +184,7 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
         </linearGradient>
       </defs>
       <rect class="${prefix}--leadspace__gradient__rect" width="100" height="100" />
-    `
+    `;
     return html`
       <section class="${this._getTypeClass()}" part="section">
         <div class="${prefix}--leadspace__container">
@@ -190,16 +192,15 @@ class DDSLeadSpace extends StableSelectorMixin(LitElement) {
             ${gradientStyleScheme === LEADSPACE_GRADIENT_STYLE_SCHEME.NONE
               ? undefined
               : html`
-                <svg
-                  class="${prefix}--leadspace__gradient"
-                  viewBox="0 0 100 100"
-                  preserveAspectRatio="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlns:xlink="http://www.w3.org/1999/xlink"
-                >
-                  ${svgGradient}
-                </svg>
-              `}
+                  <svg
+                    class="${prefix}--leadspace__gradient"
+                    viewBox="0 0 100 100"
+                    preserveAspectRatio="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink">
+                    ${svgGradient}
+                  </svg>
+                `}
             <div class="${prefix}--leadspace--content__container">
               <div class="${prefix}--leadspace__row">
                 <slot


### PR DESCRIPTION
### Related Ticket(s)

Closes #11690 

https://jsw.ibm.com/browse/ADCMS-4848

### Description

Updates leadspace background gradient stops to use explicit closing tabs. Previously gradient stops were authored as self-closing tabs which seem to render as nested stops

<img width="766" alt="Screenshot 2024-04-04 at 3 03 43 PM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/25532785/70bb9e47-b9a0-4c13-93d7-fb4639c263ad">

### Testing Instructions

Replace the tagged releases in [this codepen](https://codepen.io/andy-blum/pen/oNOEgxN/c58d6ab48ee80510e0c8124a535e7e5e) with the preview CDN URLs

### Changelog

**Changed**

- Fixes a bug where leadspace gradients don't render correctly