### PR TITLE
fix(masthead): ensure opened L1 mobile dropdown is visible while there is also a ToC

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -131,8 +131,26 @@ $search-transition-timing: 95ms;
     }
 
     .#{$prefix}--masthead__l1-dropdown {
+      border-bottom: 1px solid $ui-03;
+      position: absolute;
+      inset-block-start: 100%;
+      inset-inline: 0;
+      background-color: $ui-background;
+      color: $text-02;
+
+      &.is-open {
+        box-shadow: 0 0 6px #c6c6c6;
+      }
+
       &:not(.is-open) {
         display: none;
+      }
+
+      &:last-child {
+        & > a,
+        & > button {
+          border-bottom: unset;
+        }
       }
 
       // Height of viewport, minus the L0/L1 combo, minus additional space to match L0 megapanels
@@ -332,6 +350,7 @@ $search-transition-timing: 95ms;
 
         background-color: $interactive-01;
         color: $ui-02;
+        border-bottom: unset;
 
         svg {
           color: inherit;

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -147,9 +147,9 @@ $search-transition-timing: 95ms;
       }
 
       &:last-child {
-        & > a,
-        & > button {
-          border-bottom: unset;
+        > a,
+        > button {
+          border-bottom: initial;
         }
       }
 
@@ -350,7 +350,7 @@ $search-transition-timing: 95ms;
 
         background-color: $interactive-01;
         color: $ui-02;
-        border-bottom: unset;
+        border-bottom: initial;
 
         svg {
           color: inherit;

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -350,7 +350,7 @@ class StickyHeader {
     } else {
       // In cases where we have both an eligible ToC and leadspace search, we want
       // the ToC to take precedence. Scroll away leadspace search.
-      if (tocIsAtSearch && tocShouldStick) {
+      if (searchIsAtTop && tocIsAtSearch && tocShouldStick) {
         this._state.maxScrollaway += leadspaceSearchBar.offsetHeight;
       }
 

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -317,7 +317,7 @@ class StickyHeader {
       tableOfContents,
       tableOfContentsInnerBar,
       leadspaceSearchBar,
-    } = StickyHeader.global._elements;
+    } = this._elements;
 
     // Reset the value before performing any further calculations.
     this._state.maxScrollaway = 0;
@@ -380,8 +380,8 @@ class StickyHeader {
       masthead,
       tableOfContentsInnerBar: tocInner,
       leadspaceSearchBar,
-    } = StickyHeader.global._elements;
-    const { scrollPosPrevious: oldY } = StickyHeader.global._state;
+    } = this._elements;
+    const { scrollPosPrevious: oldY } = this._state;
 
     /**
      * Reset to a value that is equal to the difference between the previous

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -434,8 +434,8 @@ class StickyHeader {
    * down.
    */
   _manageStickyElements() {
-    const { localeModal } = StickyHeader.global._elements;
-    const { scrollPos: scrollPosPrevious } = StickyHeader.global._state;
+    const { localeModal } = this._elements;
+    const { scrollPos: scrollPosPrevious } = this._state;
 
     // Exit early if locale modal is open.
     if (localeModal && localeModal.hasAttribute('open')) return;

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -229,7 +229,8 @@ class StickyHeader {
 
     /**
      * maxScrollaway is a calculated value matching the height of all components
-     * that are allowed to hide above the viewport.
+     * that are allowed to hide above the viewport. I.e., adding an item's height
+     * to this value indicates we expect it to be hidden above the viewport.
      *
      * We should only have one sticky header showing as the page scrolls down.
      *
@@ -253,13 +254,12 @@ class StickyHeader {
       tocShouldStick =
         toc.layout === 'horizontal' || window.innerWidth < gridBreakpoint;
 
-      if (masthead && tocIsAtTop && (tocShouldStick || mastheadL1)) {
+      // If we have a masthead and the TOC should be the stuck element, hide masthead
+      // above viewport. Otherwise, if there is an L1, just hide the L0. If there's only
+      // the L0, do nothing.
+      if (masthead && tocIsAtTop && tocShouldStick) {
         maxScrollaway += masthead.offsetHeight;
-
-        if (mastheadL1 && !tocShouldStick) {
-          maxScrollaway -= mastheadL1.offsetHeight;
-        }
-      } else if (mastheadL0 && mastheadL1) {
+      } else if (mastheadL1) {
         maxScrollaway += mastheadL0.offsetHeight;
       }
     }

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -279,13 +279,13 @@ class StickyHeader {
     // to be the stuck element (unless L1 is open). Otherwise, scroll away the
     // L0 if we have an L1.
     if (searchIsAtTop || (tocIsAtTop && tocShouldStick)) {
-      if (mastheadL1IsActive) {
+      if (mastheadL1IsActive && mastheadL0) {
         this._data.maxScrollaway = mastheadL0.offsetHeight;
       } else if (masthead) {
         this._data.maxScrollaway = masthead.offsetHeight;
       }
     }
-    else if (mastheadL1) {
+    else if (masthead && mastheadL0 && mastheadL1) {
       this._data.maxScrollaway = mastheadL0.offsetHeight;
     }
 

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -97,12 +97,11 @@ class StickyHeader {
       mobile: {
         vertical: `.${prefix}--tableofcontents__sidebar`,
         horizontal: `.${prefix}--tableofcontents__navbar`,
-      }
+      },
     };
 
-    const viewportDimension = window.innerWidth >= gridBreakpoint
-      ? 'desktop'
-      : 'mobile';
+    const viewportDimension =
+      window.innerWidth >= gridBreakpoint ? 'desktop' : 'mobile';
 
     this._elements.tableOfContentsInnerBar = tocRoot.querySelector(
       selectors[viewportDimension][toc.layout || 'vertical']
@@ -151,12 +150,15 @@ class StickyHeader {
   set masthead(component) {
     if (this._validateComponent(component, `${ddsPrefix}-masthead`)) {
       this._elements.masthead = component;
-      if (this._elements.banner) this._elements.masthead.setAttribute('with-banner', '');
+      if (this._elements.banner)
+        this._elements.masthead.setAttribute('with-banner', '');
 
       this._elements.mastheadL0 = component.shadowRoot.querySelector(
         `.${prefix}--masthead__l0`
       );
-      this._elements.mastheadL1 = component.querySelector(`${ddsPrefix}-masthead-l1`);
+      this._elements.mastheadL1 = component.querySelector(
+        `${ddsPrefix}-masthead-l1`
+      );
       this._manageStickyElements();
     }
   }
@@ -185,9 +187,7 @@ class StickyHeader {
   }
 
   _handleResize() {
-    const {
-      _hasBanner: hasBanner,
-    } = this._data;
+    const { _hasBanner: hasBanner } = this._data;
 
     const {
       masthead,
@@ -221,7 +221,7 @@ class StickyHeader {
   }
 
   _handleBanner() {
-    const { banner } = this._elements
+    const { banner } = this._elements;
     const { scrollPos } = this._data;
     this._data.cumulativeOffset += Math.max(banner.offsetHeight - scrollPos, 0);
   }
@@ -251,11 +251,8 @@ class StickyHeader {
   }
 
   _handleLeadspaceSearch() {
-    const {
-      leadspaceSearch,
-      leadspaceSearchBar,
-      leadspaceSearchInput,
-    } = this._elements;
+    const { leadspaceSearch, leadspaceSearchBar, leadspaceSearchInput } =
+      this._elements;
     const { leadspaceSearchThreshold } = this._data;
     const searchShouldBeSticky =
       leadspaceSearch.getBoundingClientRect().bottom <=
@@ -314,17 +311,22 @@ class StickyHeader {
 
     // Collect conditions we may want to test for to make logic easier to read.
     const tocShouldStick = tableOfContents
-      ? tableOfContents.layout === 'horizontal' || window.innerWidth < gridBreakpoint
+      ? tableOfContents.layout === 'horizontal' ||
+        window.innerWidth < gridBreakpoint
       : false;
     const tocIsAtTop = tableOfContentsInnerBar
-      ? tableOfContentsInnerBar.getBoundingClientRect().top <= (masthead ? masthead.offsetTop + masthead.offsetHeight : 0) + 1
+      ? tableOfContentsInnerBar.getBoundingClientRect().top <=
+        (masthead ? masthead.offsetTop + masthead.offsetHeight : 0) + 1
       : false;
     const searchIsAtTop = leadspaceSearchBar
-      ? leadspaceSearchBar.getBoundingClientRect().top <= (masthead ? masthead.offsetTop + masthead.offsetHeight : 0) + 1
+      ? leadspaceSearchBar.getBoundingClientRect().top <=
+        (masthead ? masthead.offsetTop + masthead.offsetHeight : 0) + 1
       : false;
-    const tocIsAtSearch = leadspaceSearchBar && tableOfContentsInnerBar
-      ? tableOfContentsInnerBar.getBoundingClientRect().top <= leadspaceSearchBar.getBoundingClientRect().bottom
-      : false;
+    const tocIsAtSearch =
+      leadspaceSearchBar && tableOfContentsInnerBar
+        ? tableOfContentsInnerBar.getBoundingClientRect().top <=
+          leadspaceSearchBar.getBoundingClientRect().bottom
+        : false;
     const mastheadL1IsActive = mastheadL1 && mastheadL1.hasAttribute('active');
 
     // Begin calculating maxScrollAway.
@@ -346,8 +348,7 @@ class StickyHeader {
         if (masthead) {
           this._data.maxScrollaway += masthead.offsetHeight;
         }
-      }
-      else if (masthead && mastheadL0 && mastheadL1) {
+      } else if (masthead && mastheadL0 && mastheadL1) {
         this._data.maxScrollaway += mastheadL0.offsetHeight;
       }
     }
@@ -384,7 +385,10 @@ class StickyHeader {
      *   viewport.
      */
     this._data.cumulativeOffset = Math.max(
-      Math.min((masthead ? masthead.offsetTop : 0) + oldY - this._data.scrollPos, 0),
+      Math.min(
+        (masthead ? masthead.offsetTop : 0) + oldY - this._data.scrollPos,
+        0
+      ),
       this._data.maxScrollaway * -1
     );
 
@@ -427,9 +431,8 @@ class StickyHeader {
     this._data.scrollPos = Math.max(0, window.scrollY);
 
     // Identify scroll direction.
-    this._data.scrollDir = this._data.scrollPos > scrollPosPrevious
-      ? 'down'
-      : 'up';
+    this._data.scrollDir =
+      this._data.scrollPos > scrollPosPrevious ? 'down' : 'up';
 
     // Given the current state, calculate how elements should be positioned.
     this._calculateMaxScrollaway();

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -258,35 +258,26 @@ class StickyHeader {
      * - The leadspace with search (if no TOC)
      */
     this._data.maxScrollaway = 0;
-    let tocIsAtTop = false;
-    let tocShouldStick = false;
-    let searchIsAtTop = false;
 
-    // Calculate element positions
-    if (tocInner) {
-      tocIsAtTop =
-        tocInner.getBoundingClientRect().top <=
-        (masthead ? masthead.offsetTop + masthead.offsetHeight : 0) + 1;
+    const tocShouldStick = toc
+      ? toc.layout === 'horizontal' || window.innerWidth < gridBreakpoint
+      : false;
 
-      tocShouldStick =
-        toc.layout === 'horizontal' || window.innerWidth < gridBreakpoint;
-    }
-    if (leadspaceSearchBar) {
-      searchIsAtTop =
-        leadspaceSearchBar.getBoundingClientRect().top <=
-        (masthead ? masthead.offsetTop + masthead.offsetHeight : 0) + 1;
-    }
+    const tocIsAtTop = tocInner
+      ? tocInner.getBoundingClientRect().top <= (masthead ? masthead.offsetTop + masthead.offsetHeight : 0) + 1
+      : false;
 
-    // If there is a TOC, calculate maxScrollaway values based on its positon.
-    // Else if there is a leadspace search, calculate maxScrollaway values based
-    // on its position.
-    if (masthead && tocIsAtTop && tocShouldStick) {
-      this._data.maxScrollaway += masthead.offsetHeight;
-    } else if (masthead && searchIsAtTop) {
-      this._data.maxScrollaway += masthead.offsetHeight;
+    const searchIsAtTop = leadspaceSearchBar
+      ? leadspaceSearchBar.getBoundingClientRect().top <= (masthead ? masthead.offsetTop + masthead.offsetHeight : 0) + 1
+      : false;
+
+    // Scroll away entire masthead if either TOC or leadspace search is eligible
+    // to be the stuck element. Otherwise, scroll away the L0 if we have an L1.
+    if (masthead && ((tocIsAtTop && tocShouldStick) || searchIsAtTop)) {
+      this._data.maxScrollaway = masthead.offsetHeight;
     }
     else if (mastheadL1) {
-      this._data.maxScrollaway += mastheadL0.offsetHeight;
+      this._data.maxScrollaway = mastheadL0.offsetHeight;
     }
 
     /**
@@ -322,9 +313,6 @@ class StickyHeader {
     if (tocInner) {
       tocInner.style.transition = 'none';
       tocInner.style.top = `${cumulativeOffset}px`;
-
-      tocShouldStick =
-        toc.layout === 'horizontal' || window.innerWidth < gridBreakpoint;
 
       const tocIsStuck =
         Math.round(tocInner.getBoundingClientRect().top) <=

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -225,7 +225,10 @@ class StickyHeader {
   _handleBanner() {
     const { banner } = this._elements;
     const { scrollPos } = this._state;
-    this._state.cumulativeOffset += Math.max(banner.offsetHeight - scrollPos, 0);
+    this._state.cumulativeOffset += Math.max(
+      banner.offsetHeight - scrollPos,
+      0
+    );
   }
 
   /**

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -343,12 +343,17 @@ class StickyHeader {
         ? tableOfContentsInnerBar.getBoundingClientRect().top <=
           leadspaceSearchBar.getBoundingClientRect().bottom
         : false;
+    const mastheadL0IsActive = masthead?.querySelector('[expanded]');
     const mastheadL1IsActive = mastheadL1 && mastheadL1.hasAttribute('active');
 
     // Begin calculating maxScrollAway.
 
+    // If L0 is open, lock it to the top of the page.
+    if (mastheadL0 && mastheadL0IsActive) {
+      this._state.maxScrollaway = 0;
+    }
     // If L1 is open, lock it to the top of the page.
-    if (mastheadL1IsActive && mastheadL0) {
+    else if (mastheadL1IsActive && mastheadL0) {
       this._state.maxScrollaway = mastheadL0.offsetHeight;
     } else {
       // In cases where we have both an eligible ToC and leadspace search, we want

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -26,7 +26,6 @@ class StickyHeader {
       scrollPos: 0,
       leadspaceSearchThreshold: 0,
       maxScrollaway: 0,
-      scrollDir: undefined,
     };
 
     this._elements = {
@@ -366,7 +365,6 @@ class StickyHeader {
       banner,
       masthead,
       tableOfContentsInnerBar: tocInner,
-      leadspaceSearch,
       leadspaceSearchBar,
     } = StickyHeader.global._elements;
     const { scrollPosPrevious: oldY } = StickyHeader.global._data;
@@ -397,6 +395,10 @@ class StickyHeader {
      * appear on the page. Important to do this sequentially for
      * cumulativeOffset to be correctly calculated by the time each of these
      * methods accesses it.
+     *
+     * @TODO One idea for improving this so the execution order doesn't matter
+     * is to collect our elements into an array ordered by document position,
+     * then loop over that array and execute a corresponding handler method.
      */
     if (banner) {
       this._handleBanner();
@@ -404,13 +406,11 @@ class StickyHeader {
     if (masthead) {
       this._handleMasthead();
     }
-    if (tocInner) {
-      if (leadspaceSearch) {
-        this._handleLeadspaceSearch();
-      }
-      this._handleToc();
-    } else if (leadspaceSearchBar) {
+    if (leadspaceSearchBar) {
       this._handleLeadspaceSearch();
+    }
+    if (tocInner) {
+      this._handleToc();
     }
   }
 
@@ -429,10 +429,6 @@ class StickyHeader {
     // Store scroll positions.
     this._data.scrollPosPrevious = scrollPosPrevious;
     this._data.scrollPos = Math.max(0, window.scrollY);
-
-    // Identify scroll direction.
-    this._data.scrollDir =
-      this._data.scrollPos > scrollPosPrevious ? 'down' : 'up';
 
     // Given the current state, calculate how elements should be positioned.
     this._calculateMaxScrollaway();

--- a/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
@@ -395,6 +395,7 @@ export const StoryContent = (
   config = {
     l1: false,
     leadspace: false,
+    leadspaceSearch: false,
     tocLayout: TOC_TYPES.DEFAULT,
   }
 ) => {
@@ -410,6 +411,7 @@ export const StoryContent = (
   return html`
     <div class="${mainClasses}">
       ${config?.leadspace ? contentLeadspace : null}
+      ${config?.leadspaceSearch ? contentLeadspaceSearch : null}
       ${config?.tocLayout === TOC_TYPES.HORIZONTAL
         ? html`
             <dds-table-of-contents

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -794,6 +794,7 @@ export const withL1 = (args) => {
   const contentConfig = {
     l1: true,
     leadspace: false,
+    leadspaceSearch: true,
     tocLayout: TOC_TYPES.DEFAULT,
   };
   return html`
@@ -903,7 +904,8 @@ export const WithHorizontalTOC = (args) => {
   const { useMock } = args?.Other ?? {};
   const contentConfig = {
     l1: false,
-    leadspace: true,
+    leadspace: false,
+    leadspaceSearch: true,
     tocLayout: TOC_TYPES.HORIZONTAL,
   };
   return html`
@@ -1241,6 +1243,7 @@ export const WithoutShell = (args) => {
         ? StoryContent({
             l1: false,
             leadspace: true,
+            leadspaceSearch: false,
             tocLayout: TOC_TYPES.HORIZONTAL,
           })
         : ''}
@@ -1268,6 +1271,143 @@ WithoutShell.story = {
         FooterComposite: {
           disableLocaleButton: false,
           langList: mockLangList,
+        },
+      },
+    },
+  },
+};
+
+export const StickyElementSandbox = (args) => {
+  // const {
+  //   l1,
+  //   universalBanner,
+  //   leadspaceSearch,
+  //   tocLayout,
+  // } = args?.DotcomShell ?? {};
+
+  // return html`
+  //   <style>
+  //     ${mastheadStyles}
+  //   </style>
+  //   <dds-dotcom-shell-composite>
+  //     ${universalBanner
+  //       ? html`
+  //           <dds-universal-banner-heading slot="heading">
+  //             Hybrid cloud and AI for smarter business
+  //           </dds-universal-banner-heading>
+  //           <dds-universal-banner-copy slot="copy">
+  //             Las Vegas, June 15-18, 2025
+  //           </dds-universal-banner-copy>
+  //         `
+  //       : ''
+  //     }
+  //     ${StoryContent({
+  //       l1: l1,
+  //       leadspace: false,
+  //       leadspaceSearch: leadspaceSearch,
+  //       tocLayout: tocLayout,
+  //     })}
+  //   </dds-dotcom-shell-composite>
+  // `
+  const {
+    platform,
+    hasProfile,
+    userStatus,
+    navLinks,
+    hasSearch,
+    searchPlaceholder,
+    selectedMenuItem,
+    langDisplay,
+    language,
+    footerSize,
+    legalLinks,
+    links: footerLinks,
+    localeList,
+    disableLocaleButton,
+    universalBanner,
+    l1,
+    leadspaceSearch,
+    tocLayout,
+  } = args?.DotcomShell ?? {};
+
+  const contentConfig = {
+    l1: l1,
+    leadspace: false,
+    leadspaceSearch: leadspaceSearch,
+    tocLayout: tocLayout || '',
+  };
+
+  return html`
+    <style>
+      ${mastheadStyles}
+    </style>
+    <dds-dotcom-shell-container
+      platform="${ifNonNull(platform)}"
+      platform-url="${ifNonNull(platformData.url)}"
+      language="${ifNonNull(language)}"
+      lang-display="${ifNonNull(langDisplay)}"
+      footer-size="${ifNonNull(footerSize)}"
+      user-status="${ifNonNull(userStatus)}"
+      searchPlaceholder="${ifNonNull(searchPlaceholder)}"
+      selected-menu-item="${ifNonNull(selectedMenuItem)}"
+      .legalLinks="${ifNonNull(legalLinks)}"
+      .localeList="${ifNonNull(localeList)}"
+      .footerLinks="${ifNonNull(footerLinks)}"
+      .navLinks="${navLinks}"
+      .l1Data="${ifNonNull(l1 ? l1Data : null)}"
+      ?has-profile="${hasProfile}"
+      ?has-search="${hasSearch}"
+      ?disable-locale-button="${disableLocaleButton}">
+      ${universalBanner
+        ? html`
+            <dds-universal-banner image-width="4-col">
+              <dds-universal-banner-image
+                slot="image"
+                default-src="${img4Col}"></dds-universal-banner-image>
+              <dds-universal-banner-heading slot="heading">
+                Hybrid cloud and AI for smarter business
+              </dds-universal-banner-heading>
+              <dds-universal-banner-copy slot="copy">
+                Las Vegas, June 15-18, 2025
+              </dds-universal-banner-copy>
+              <dds-button-cta
+                slot="cta"
+                cta-type="local"
+                kind="tertiary"
+                href="https://www.example.com">
+                Register for Think. Free
+              </dds-button-cta>
+            </dds-universal-banner>
+          `
+        : ''
+      }
+      ${StoryContent(contentConfig)}
+    </dds-dotcom-shell-container>
+  `;
+}
+
+StickyElementSandbox.story = {
+  name: 'Sticky Element Sandbox',
+  parameters: {
+    knobs: {
+      DotcomShell: () => ({
+        universalBanner: boolean('Has Universal Banner', true),
+        l1: boolean('Has Masthead L1', true),
+        leadspaceSearch: boolean('Has Leadspace With Search', true),
+        tocLayout: select(
+          'Table of Contents Layout',
+          { Vertical: null, Horizontal: 'horizontal' },
+          null
+        ),
+      }),
+    },
+    propsSet: {
+      default: {
+        DotcomShell: {
+          universalBanner: true,
+          l1: true,
+          leadspaceSearch: true,
+          tocLayout: null,
         },
       },
     },

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -1379,12 +1379,11 @@ export const StickyElementSandbox = (args) => {
               </dds-button-cta>
             </dds-universal-banner>
           `
-        : ''
-      }
+        : ''}
       ${StoryContent(contentConfig)}
     </dds-dotcom-shell-container>
   `;
-}
+};
 
 StickyElementSandbox.story = {
   name: 'Sticky Element Sandbox',

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -1278,37 +1278,6 @@ WithoutShell.story = {
 };
 
 export const StickyElementSandbox = (args) => {
-  // const {
-  //   l1,
-  //   universalBanner,
-  //   leadspaceSearch,
-  //   tocLayout,
-  // } = args?.DotcomShell ?? {};
-
-  // return html`
-  //   <style>
-  //     ${mastheadStyles}
-  //   </style>
-  //   <dds-dotcom-shell-composite>
-  //     ${universalBanner
-  //       ? html`
-  //           <dds-universal-banner-heading slot="heading">
-  //             Hybrid cloud and AI for smarter business
-  //           </dds-universal-banner-heading>
-  //           <dds-universal-banner-copy slot="copy">
-  //             Las Vegas, June 15-18, 2025
-  //           </dds-universal-banner-copy>
-  //         `
-  //       : ''
-  //     }
-  //     ${StoryContent({
-  //       l1: l1,
-  //       leadspace: false,
-  //       leadspaceSearch: leadspaceSearch,
-  //       tocLayout: tocLayout,
-  //     })}
-  //   </dds-dotcom-shell-composite>
-  // `
   const {
     platform,
     hasProfile,

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -794,7 +794,7 @@ export const withL1 = (args) => {
   const contentConfig = {
     l1: true,
     leadspace: false,
-    leadspaceSearch: true,
+    leadspaceSearch: false,
     tocLayout: TOC_TYPES.DEFAULT,
   };
   return html`
@@ -903,9 +903,9 @@ export const WithHorizontalTOC = (args) => {
   } = args?.DotcomShell ?? {};
   const { useMock } = args?.Other ?? {};
   const contentConfig = {
-    l1: false,
-    leadspace: false,
-    leadspaceSearch: true,
+    l1: true,
+    leadspace: true,
+    leadspaceSearch: false,
     tocLayout: TOC_TYPES.HORIZONTAL,
   };
   return html`

--- a/packages/web-components/src/components/leadspace-with-search/leadspace-with-search.ts
+++ b/packages/web-components/src/components/leadspace-with-search/leadspace-with-search.ts
@@ -107,7 +107,7 @@ class DDSLeadspaceWithSearch extends StableSelectorMixin(LitElement) {
   }
 
   protected firstUpdated() {
-    StickyHeader.global.leadspaceWithSearch = this;
+    StickyHeader.global.leadspaceSearch = this;
   }
 
   render() {

--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -100,6 +100,12 @@ function handleDropdownClose(event: FocusEvent | KeyboardEvent) {
 @customElement(`${ddsPrefix}-masthead-l1`)
 class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
   /**
+   * Whether an L1 menu is open or not.
+   */
+  @property({ attribute: 'active', reflect: true, type: Boolean })
+  active = false;
+
+  /**
    * The L1 menu data, passed from the masthead-composite.
    */
   @property()
@@ -751,6 +757,7 @@ class DDSMastheadL1 extends StableSelectorMixin(LitElement) {
       })
     );
 
+    this.active = !isOpen;
     button.classList.toggle('is-open', !isOpen);
     dropdown.classList.toggle('is-open', !isOpen);
   }


### PR DESCRIPTION
### Related Ticket(s)

none

### Description

Given the page uses both an L1 menu and a table of contents (ToC),
and the page is displaying at a mobile breakpoint,
and the ToC menu is the sticky element (i.e. stuck to the top of the viewport),
and the user scrolls up slightly to reveal the L1 dropdown,
and the user open the L1's dropdown menu,
then the dropdown menu gets hidden above the viewport, forcing the user to scroll up more to access it.
Instead, the top of L1 dropdown menu should be visible when opened.

This problem is occurring because the dropdown exists in the document flow, and the StickyHeader utility doesn't reset stuck elements' positions when the menu is opened. 

The easiest solution I found was to position the dropdown menu absolutely like most other dropdown menus you might encounter. This bypasses the tricky problem of trying to get the StickyHeader to recalculate, and in my opinion is a slight enhancement in both performance (avoids layout shifts and associated repaint costs) and overall UX (gives dropdown a more expected behavior).

### Changelog

**Changed**

- Prevents mobile L1 dropdown menu from becoming hidden above viewport when opened while there is currently a sticky table of contents menu.
- Prevents L1 from scrolling away when a submenu is open on desktop or the dropdown is open on mobile.
- Consolidates StickyHeader utility tracked data to make debugging easier.
- Refactors StickyHeader logic to support all potentially sticky elements being on page at the same time.

### Testing
To test the main fix:
1. Visit [the Dotcom Shell > With L1 story](https://ibmdotcom-webcomponents.s3.us-east.cloud-object-storage.appdomain.cloud/deploy-previews/11734/index.html?path=/story/components-dotcom-shell--with-l-1) in the deploy preview.
2. Change the preview size to "Large mobile" or "Small mobile"
3. Scroll down the page until the ToC is stuck to the top of the viewport.
4. Scroll back up just enough to see the L1.
5. Open the L1 and verify the top of it doesn't jump back up above the viewport.
6. Scroll down and verify the L1 stays stuck to the top of the viewport.
7. Close the L1 and verify the ToC gets stuck to the top of the viewport as you scroll down.

You should also test the L1 remains stuck when open at desktop widths.

This PR also changes a good amount of the StickyHeader class logic. To support regression testing the existing sticky element behaviors, I've added the [Sticky Element Sandbox story](https://ibmdotcom-webcomponents.s3.us-east.cloud-object-storage.appdomain.cloud/deploy-previews/11734/index.html?path=/story/components-dotcom-shell--sticky-element-sandbox). Test various knob configurations at both desktop and mobile viewport sizes and let me know how you were able to break it 😄 

**Note:** If you find the sticky elements aren't working correctly when switching between stories, try reloading the window.