### PR TITLE
[v1] feat(rtl-arrow): Fix arrows used for CTA's when in RTL

### DIFF
--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -434,7 +434,7 @@
   :host(#{$dds-prefix}-card-cta-footer) a,
   :host(#{$dds-prefix}-card-in-card-footer) a {
     @include carbon--breakpoint('md') {
-      padding-inline-end: $carbon--spacing-07;
+      padding-right: $carbon--spacing-07;
     }
   }
 

--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -434,7 +434,7 @@
   :host(#{$dds-prefix}-card-cta-footer) a,
   :host(#{$dds-prefix}-card-in-card-footer) a {
     @include carbon--breakpoint('md') {
-      padding-right: $carbon--spacing-07;
+      padding-inline-end: $carbon--spacing-07;
     }
   }
 

--- a/packages/web-components/src/component-mixins/cta/cta.ts
+++ b/packages/web-components/src/component-mixins/cta/cta.ts
@@ -11,6 +11,7 @@ import { html } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import ArrowDown20 from '../../internal/vendor/@carbon/web-components/icons/arrow--down/20.js';
 import ArrowRight20 from '../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import ArrowLeft20 from '../../internal/vendor/@carbon/web-components/icons/arrow--left/20.js';
 import Download20 from '../../internal/vendor/@carbon/web-components/icons/download/20.js';
 import Launch20 from '../../internal/vendor/@carbon/web-components/icons/launch/20.js';
 import PlayOutline20 from '../../internal/vendor/@carbon/web-components/icons/play--outline/20.js';
@@ -33,6 +34,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  */
 export const icons = {
   [CTA_TYPE.LOCAL]: ArrowRight20,
+  [`${CTA_TYPE.LOCAL}-rtl`]: ArrowLeft20,
   [CTA_TYPE.DOWNLOAD]: Download20,
   [CTA_TYPE.EXTERNAL]: Launch20,
   [CTA_TYPE.NEW_TAB]: NewTab20,
@@ -118,10 +120,11 @@ const CTAMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
      */
     _renderIcon() {
       const { ctaType } = this;
+      const icon = icons[`${ctaType}-${document.dir}`] ?? icons[ctaType];
       return html`
         <slot name="icon">
           <span class="bx--visually-hidden">${ariaLabels[ctaType]}</span>
-          ${icons[ctaType]?.({
+          ${icon?.({
             class: `${prefix}--card__cta ${ddsPrefix}-ce--cta__icon`,
           })}
         </slot>

--- a/packages/web-components/src/components/button-group/__stories__/button-group.stories.ts
+++ b/packages/web-components/src/components/button-group/__stories__/button-group.stories.ts
@@ -10,6 +10,7 @@
 import { number, select, text } from '@storybook/addon-knobs';
 import { html } from 'lit-element';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import ArrowDown20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--down/20.js';
 import Pdf20 from '../../../internal/vendor/@carbon/web-components/icons/PDF/20.js';
 import readme from './README.stories.mdx';
@@ -18,15 +19,18 @@ import textNullable from '../../../../.storybook/knob-text-nullable';
 
 const iconMap = {
   ArrowRight20: ArrowRight20({ slot: 'icon' }),
+  ArrowLeft20: ArrowLeft20({ slot: 'icon' }),
   ArrowDown20: ArrowDown20({ slot: 'icon' }),
   Pdf20: Pdf20({ slot: 'icon' }),
 };
 
-const iconOptions = {
-  Default: null,
-  'Arrow Right': 'ArrowRight20',
-  'Arrow Down': 'ArrowDown20',
-  PDF: 'Pdf20',
+const iconOptions = () => {
+  return {
+    Default: null,
+    'Arrow Inline End': document.dir === 'rtl' ? 'ArrowLeft20' : 'ArrowRight20',
+    'Arrow Down': 'ArrowDown20',
+    PDF: 'Pdf20',
+  };
 };
 
 export const Default = (args) => {
@@ -67,7 +71,7 @@ export default {
           copy: text(`Button ${i + 1}`, `Button ${i + 1}`),
           renderIcon:
             iconMap[
-              select(`Icon ${i + 1}`, iconOptions, iconOptions.Default) ?? 0
+              select(`Icon ${i + 1}`, iconOptions(), iconOptions().Default) ?? 0
             ],
         })),
       }),

--- a/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
+++ b/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
@@ -39,8 +39,7 @@ export const Default = (args) => {
       <dds-callout-link-with-icon
         slot="footer"
         href="https://example.com"
-        cta-type="local"
-      >
+        cta-type="local">
         Link with icon
       </dds-callout-link-with-icon>
     </dds-callout-quote>

--- a/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
+++ b/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
@@ -9,7 +9,6 @@
 
 import '../index';
 import '../callout-link-with-icon';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
 import { html } from 'lit-element';
 import { select } from '@storybook/addon-knobs';
 import { QUOTE_TYPES } from '../../quote/quote';
@@ -37,8 +36,12 @@ export const Default = (args) => {
       <dds-quote-source-bottom-copy>
         ${sourceBottomCopy}
       </dds-quote-source-bottom-copy>
-      <dds-callout-link-with-icon slot="footer" href="https://example.com">
-        Link with icon ${ArrowRight20({ slot: 'icon' })}
+      <dds-callout-link-with-icon
+        slot="footer"
+        href="https://example.com"
+        cta-type="local"
+      >
+        Link with icon
       </dds-callout-link-with-icon>
     </dds-callout-quote>
   `;

--- a/packages/web-components/src/components/card-in-card/__stories__/card-in-card.stories.ts
+++ b/packages/web-components/src/components/card-in-card/__stories__/card-in-card.stories.ts
@@ -33,8 +33,7 @@ export const Default = (args) => {
           <dds-card-eyebrow>${eyebrow}</dds-card-eyebrow>
           <dds-card-cta-footer
             cta-type="video"
-            href="0_ibuqxqbe"
-          ></dds-card-cta-footer>
+            href="0_ibuqxqbe"></dds-card-cta-footer>
         </dds-card-in-card>
       </dds-video-cta-container>
     `;
@@ -44,8 +43,7 @@ export const Default = (args) => {
       <dds-card-in-card-image
         slot="image"
         alt="${ifNonNull(alt)}"
-        default-src="${ifNonNull(defaultSrc)}"
-      >
+        default-src="${ifNonNull(defaultSrc)}">
         <dds-image-item media="(min-width: 1312px)" srcset="${imgXlg16x9}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${imgMd16x9}">

--- a/packages/web-components/src/components/card-in-card/__stories__/card-in-card.stories.ts
+++ b/packages/web-components/src/components/card-in-card/__stories__/card-in-card.stories.ts
@@ -12,7 +12,6 @@ import '../../image/image';
 import '../index';
 import '../../cta/card-cta-footer';
 import '../../cta/video-cta-container';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
 import { html } from 'lit-element';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import { boolean } from '@storybook/addon-knobs';
@@ -34,17 +33,19 @@ export const Default = (args) => {
           <dds-card-eyebrow>${eyebrow}</dds-card-eyebrow>
           <dds-card-cta-footer
             cta-type="video"
-            href="0_ibuqxqbe"></dds-card-cta-footer>
+            href="0_ibuqxqbe"
+          ></dds-card-cta-footer>
         </dds-card-in-card>
       </dds-video-cta-container>
     `;
   }
   return html`
-    <dds-card-in-card href=${ifNonNull(href || undefined)}>
+    <dds-card-in-card href=${ifNonNull(href || undefined)} cta-type="local">
       <dds-card-in-card-image
         slot="image"
         alt="${ifNonNull(alt)}"
-        default-src="${ifNonNull(defaultSrc)}">
+        default-src="${ifNonNull(defaultSrc)}"
+      >
         <dds-image-item media="(min-width: 1312px)" srcset="${imgXlg16x9}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${imgMd16x9}">
@@ -54,9 +55,7 @@ export const Default = (args) => {
       </dds-card-in-card-image>
       <dds-card-eyebrow>${eyebrow}</dds-card-eyebrow>
       <dds-card-heading>${heading}</dds-card-heading>
-      <dds-card-cta-footer>
-        ${ArrowRight20({ slot: 'icon' })}
-      </dds-card-cta-footer>
+      <dds-card-cta-footer></dds-card-cta-footer>
     </dds-card-in-card>
   `;
 };

--- a/packages/web-components/src/components/card-link/__stories__/card-link.stories.ts
+++ b/packages/web-components/src/components/card-link/__stories__/card-link.stories.ts
@@ -10,6 +10,7 @@
 import { boolean } from '@storybook/addon-knobs';
 import { html } from 'lit-element';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import Error20 from '../../../internal/vendor/@carbon/web-components/icons/error/20.js';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import readme from './README.stories.mdx';
@@ -23,7 +24,11 @@ export const Default = (args) => {
       <dds-card-link-heading>${heading}</dds-card-link-heading>
       ${copy ? html` <p>${copy}</p> ` : ``}
       <dds-card-footer ?disabled=${disabled}>
-        ${disabled ? Error20({ slot: 'icon' }) : ArrowRight20({ slot: 'icon' })}
+        ${disabled
+          ? Error20({ slot: 'icon' })
+          : document.dir === 'rtl'
+          ? ArrowLeft20({ slot: 'icon' })
+          : ArrowRight20({ slot: 'icon' })}
       </dds-card-footer>
     </dds-card-link>
   `;
@@ -36,7 +41,8 @@ export default {
       <div class="bx--grid">
         <div class="bx--row">
           <div
-            class="bx--col-sm-4 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter">
+            class="bx--col-sm-4 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter"
+          >
             ${story()}
           </div>
         </div>

--- a/packages/web-components/src/components/card-link/__stories__/card-link.stories.ts
+++ b/packages/web-components/src/components/card-link/__stories__/card-link.stories.ts
@@ -41,8 +41,7 @@ export default {
       <div class="bx--grid">
         <div class="bx--row">
           <div
-            class="bx--col-sm-4 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter"
-          >
+            class="bx--col-sm-4 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter">
             ${story()}
           </div>
         </div>

--- a/packages/web-components/src/components/card-section-carousel/__stories__/card-section-carousel.stories.ts
+++ b/packages/web-components/src/components/card-section-carousel/__stories__/card-section-carousel.stories.ts
@@ -53,8 +53,7 @@ export const Default = () => {
       <dds-link-with-icon
         slot="footer"
         href="${ifNonNull(hrefDefault)}"
-        cta-type="local"
-      >
+        cta-type="local">
         Link text
       </dds-link-with-icon>
       <dds-carousel>

--- a/packages/web-components/src/components/card-section-carousel/__stories__/card-section-carousel.stories.ts
+++ b/packages/web-components/src/components/card-section-carousel/__stories__/card-section-carousel.stories.ts
@@ -9,7 +9,6 @@
 
 import { html } from 'lit-element';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
 import '../index';
 import styles from './card-section-carousel.stories.scss';
 import readme from './README.stories.mdx';
@@ -28,10 +27,10 @@ const Card = ({
   heading = headingDefault,
   href = hrefDefault,
 } = {}) => html`
-  <dds-card href="${ifNonNull(href)}">
+  <dds-card href="${ifNonNull(href)}" cta-type="local">
     <dds-card-heading>${heading}</dds-card-heading>
     <p>${copy}</p>
-    <dds-card-footer> ${ArrowRight20({ slot: 'icon' })} </dds-card-footer>
+    <dds-card-footer></dds-card-footer>
   </dds-card>
 `;
 
@@ -45,8 +44,12 @@ export const Default = () => {
         >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et
         ultricies est.
       </dds-content-section-copy>
-      <dds-link-with-icon slot="footer" href="${ifNonNull(hrefDefault)}">
-        Link text ${ArrowRight20({ slot: 'icon' })}
+      <dds-link-with-icon
+        slot="footer"
+        href="${ifNonNull(hrefDefault)}"
+        cta-type="local"
+      >
+        Link text
       </dds-link-with-icon>
       <dds-carousel>
         ${Card()}${Card({ copy: copyOdd })}${Card()}${Card({

--- a/packages/web-components/src/components/card-section-carousel/__stories__/card-section-carousel.stories.ts
+++ b/packages/web-components/src/components/card-section-carousel/__stories__/card-section-carousel.stories.ts
@@ -9,6 +9,8 @@
 
 import { html } from 'lit-element';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
+import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20.js';
 import '../index';
 import styles from './card-section-carousel.stories.scss';
 import readme from './README.stories.mdx';
@@ -27,10 +29,14 @@ const Card = ({
   heading = headingDefault,
   href = hrefDefault,
 } = {}) => html`
-  <dds-card href="${ifNonNull(href)}" cta-type="local">
+  <dds-card href="${ifNonNull(href)}">
     <dds-card-heading>${heading}</dds-card-heading>
     <p>${copy}</p>
-    <dds-card-footer></dds-card-footer>
+    <dds-card-footer>
+      ${document.dir === 'rtl'
+        ? ArrowLeft20({ slot: 'icon' })
+        : ArrowRight20({ slot: 'icon' })}
+    </dds-card-footer>
   </dds-card>
 `;
 

--- a/packages/web-components/src/components/card-section-offset/__stories__/card-section-offset.stories.ts
+++ b/packages/web-components/src/components/card-section-offset/__stories__/card-section-offset.stories.ts
@@ -8,7 +8,6 @@
  */
 
 import { html } from 'lit-element';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import { select } from '@storybook/addon-knobs';
 import readme from './README.stories.mdx';
@@ -40,7 +39,7 @@ const knobNamesForType = {
 };
 
 const defaultCardGroupItem = html`
-  <dds-card-group-item href="https://example.com">
+  <dds-card-group-item href="https://example.com" cta-type="local">
     <dds-card-eyebrow>Label</dds-card-eyebrow>
     <dds-card-heading
       >Lorem ipsum dolor sit amet, pro graeco tibique an</dds-card-heading
@@ -49,9 +48,7 @@ const defaultCardGroupItem = html`
       Lorem ipsum dolor sit amet, habeo iisque eum ex. Vel postea singulis
       democritum ex. Illud ullum graecis
     </p>
-    <dds-card-cta-footer slot="footer">
-      ${ArrowRight20({ slot: 'icon' })}
-    </dds-card-cta-footer>
+    <dds-card-cta-footer></dds-card-cta-footer>
   </dds-card-group-item>
 `;
 
@@ -64,7 +61,8 @@ export const Default = (args) => {
         gradient-direction="left-to-right"
         slot="image-top"
         alt="${ifNonNull(alt)}"
-        default-src="${ifNonNull(defaultSrc)}">
+        default-src="${ifNonNull(defaultSrc)}"
+      >
       </dds-background-media>
       <dds-content-block-heading slot="heading"
         >${heading}</dds-content-block-heading
@@ -74,7 +72,8 @@ export const Default = (args) => {
         icon-placement="right"
         cta-type="${ifNonNull(ctaType)}"
         download="${ifNonNull(download)}"
-        href="${ifNonNull(href)}">
+        href="${ifNonNull(href)}"
+      >
         ${ctaCopy}
       </dds-text-cta>
       <dds-card-group slot="card-group" cards-per-row="2">

--- a/packages/web-components/src/components/card-section-offset/__stories__/card-section-offset.stories.ts
+++ b/packages/web-components/src/components/card-section-offset/__stories__/card-section-offset.stories.ts
@@ -61,8 +61,7 @@ export const Default = (args) => {
         gradient-direction="left-to-right"
         slot="image-top"
         alt="${ifNonNull(alt)}"
-        default-src="${ifNonNull(defaultSrc)}"
-      >
+        default-src="${ifNonNull(defaultSrc)}">
       </dds-background-media>
       <dds-content-block-heading slot="heading"
         >${heading}</dds-content-block-heading
@@ -72,8 +71,7 @@ export const Default = (args) => {
         icon-placement="right"
         cta-type="${ifNonNull(ctaType)}"
         download="${ifNonNull(download)}"
-        href="${ifNonNull(href)}"
-      >
+        href="${ifNonNull(href)}">
         ${ctaCopy}
       </dds-text-cta>
       <dds-card-group slot="card-group" cards-per-row="2">

--- a/packages/web-components/src/components/card/__stories__/card.stories.ts
+++ b/packages/web-components/src/components/card/__stories__/card.stories.ts
@@ -13,6 +13,7 @@ import '../../../internal/vendor/@carbon/web-components/components/tag/tag.js';
 import '../index';
 import { boolean, select } from '@storybook/addon-knobs';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import { html } from 'lit-element';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import imgXlg4x3 from '../../../../../storybook-images/assets/1312/fpo--4x3--1312x984--003.jpg';
@@ -50,13 +51,15 @@ export const Default = (args) => {
         ? 'light'
         : ''}
       ?border=${cardStyles === 'Outlined card'}
-      href=${ifNonNull(href || undefined)}>
+      href=${ifNonNull(href || undefined)}
+    >
       ${image
         ? html`
             <dds-image
               slot="image"
               alt="${ifNonNull(alt)}"
-              default-src="${ifNonNull(defaultSrc)}"></dds-image>
+              default-src="${ifNonNull(defaultSrc)}"
+            ></dds-image>
           `
         : ``}
       <dds-card-eyebrow>${eyebrow}</dds-card-eyebrow>
@@ -64,7 +67,9 @@ export const Default = (args) => {
       ${copy ? html` <p>${copy}</p> ` : ``}
       ${tagGroup ? html` ${tagGroupContent} ` : ``}
       <dds-card-footer>
-        ${footer}${ArrowRight20({ slot: 'icon' })}
+        ${footer}${document.dir === 'rtl'
+          ? ArrowLeft20({ slot: 'icon' })
+          : ArrowRight20({ slot: 'icon' })}
       </dds-card-footer>
     </dds-card>
   `;
@@ -128,7 +133,8 @@ export const Pictogram = (args) => {
         : cardStyles === 'Outlined card'
         ? 'light'
         : ''}
-      ?border=${cardStyles === 'Outlined card'}>
+      ?border=${cardStyles === 'Outlined card'}
+    >
       <dds-card-heading>${heading}</dds-card-heading>
       ${copy ? html` <p>${copy}</p> ` : ``}
       ${tagGroup ? html` ${tagGroupContent} ` : ``}
@@ -143,13 +149,15 @@ export const Pictogram = (args) => {
         height="48"
         viewBox="0 0 32 32"
         role="img"
-        class="bx--card__pictogram">
+        class="bx--card__pictogram"
+      >
         <path
           id="desktop_1_"
           d="M23,29.36H9v-0.72h6.64v-4.28H3c-1.301,0-2.36-1.059-2.36-2.36V5c0-1.301,1.059-2.36,2.36-2.36h26
           c1.302,0,2.36,1.059,2.36,2.36v17c0,1.302-1.059,2.36-2.36,2.36H16.36v4.279H23V29.36z M1.36,19.36V22c0,
           0.904,0.736,1.64,1.64,1.64h26c0.904,0,1.64-0.735,1.64-1.64v-2.64H1.36z M1.36,
-          18.64h29.28V5c0-0.904-0.735-1.64-1.64-1.64H3C2.096,3.36,1.36,4.096,1.36,5V18.64z" />
+          18.64h29.28V5c0-0.904-0.735-1.64-1.64-1.64H3C2.096,3.36,1.36,4.096,1.36,5V18.64z"
+        />
       </svg>
     </dds-card>
   `;
@@ -221,13 +229,15 @@ export const Static = (args) => {
   return html`
     <dds-card
       color-scheme=${outlinedCard ? 'light' : ''}
-      ?border=${outlinedCard}>
+      ?border=${outlinedCard}
+    >
       ${image
         ? html`
             <dds-image
               slot="image"
               alt="${ifNonNull(alt)}"
-              default-src="${ifNonNull(defaultSrc)}"></dds-image>
+              default-src="${ifNonNull(defaultSrc)}"
+            ></dds-image>
           `
         : ``}
       ${eyebrow ? html` <dds-card-eyebrow>${eyebrow}</dds-card-eyebrow> ` : ``}
@@ -237,7 +247,9 @@ export const Static = (args) => {
       ${cta
         ? html`
             <dds-card-footer href="https://www.example.com">
-              ${ctaCopy}${ArrowRight20({ slot: 'icon' })}
+              ${ctaCopy}${document.dir === 'rtl'
+                ? ArrowLeft20({ slot: 'icon' })
+                : ArrowRight20({ slot: 'icon' })}
             </dds-card-footer>
           `
         : ``}
@@ -306,7 +318,8 @@ export const Logo = (args) => {
       <dds-image-logo
         slot="image"
         alt="${ifNonNull(alt)}"
-        default-src="${ifNonNull(defaultSrc)}"></dds-image-logo>
+        default-src="${ifNonNull(defaultSrc)}"
+      ></dds-image-logo>
       ${eyebrow ? html` <dds-card-eyebrow>${eyebrow}</dds-card-eyebrow> ` : ``}
       ${heading ? html` <dds-card-heading>${heading}</dds-card-heading> ` : ``}
       ${copy ? html` <p>${copy}</p> ` : ``}
@@ -359,7 +372,8 @@ export default {
       <div class="bx--grid">
         <div class="bx--row">
           <div
-            class="bx--col-sm-4 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter">
+            class="bx--col-sm-4 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter"
+          >
             ${story()}
           </div>
         </div>

--- a/packages/web-components/src/components/card/__stories__/card.stories.ts
+++ b/packages/web-components/src/components/card/__stories__/card.stories.ts
@@ -51,15 +51,13 @@ export const Default = (args) => {
         ? 'light'
         : ''}
       ?border=${cardStyles === 'Outlined card'}
-      href=${ifNonNull(href || undefined)}
-    >
+      href=${ifNonNull(href || undefined)}>
       ${image
         ? html`
             <dds-image
               slot="image"
               alt="${ifNonNull(alt)}"
-              default-src="${ifNonNull(defaultSrc)}"
-            ></dds-image>
+              default-src="${ifNonNull(defaultSrc)}"></dds-image>
           `
         : ``}
       <dds-card-eyebrow>${eyebrow}</dds-card-eyebrow>
@@ -133,8 +131,7 @@ export const Pictogram = (args) => {
         : cardStyles === 'Outlined card'
         ? 'light'
         : ''}
-      ?border=${cardStyles === 'Outlined card'}
-    >
+      ?border=${cardStyles === 'Outlined card'}>
       <dds-card-heading>${heading}</dds-card-heading>
       ${copy ? html` <p>${copy}</p> ` : ``}
       ${tagGroup ? html` ${tagGroupContent} ` : ``}
@@ -149,15 +146,13 @@ export const Pictogram = (args) => {
         height="48"
         viewBox="0 0 32 32"
         role="img"
-        class="bx--card__pictogram"
-      >
+        class="bx--card__pictogram">
         <path
           id="desktop_1_"
           d="M23,29.36H9v-0.72h6.64v-4.28H3c-1.301,0-2.36-1.059-2.36-2.36V5c0-1.301,1.059-2.36,2.36-2.36h26
           c1.302,0,2.36,1.059,2.36,2.36v17c0,1.302-1.059,2.36-2.36,2.36H16.36v4.279H23V29.36z M1.36,19.36V22c0,
           0.904,0.736,1.64,1.64,1.64h26c0.904,0,1.64-0.735,1.64-1.64v-2.64H1.36z M1.36,
-          18.64h29.28V5c0-0.904-0.735-1.64-1.64-1.64H3C2.096,3.36,1.36,4.096,1.36,5V18.64z"
-        />
+          18.64h29.28V5c0-0.904-0.735-1.64-1.64-1.64H3C2.096,3.36,1.36,4.096,1.36,5V18.64z" />
       </svg>
     </dds-card>
   `;
@@ -229,15 +224,13 @@ export const Static = (args) => {
   return html`
     <dds-card
       color-scheme=${outlinedCard ? 'light' : ''}
-      ?border=${outlinedCard}
-    >
+      ?border=${outlinedCard}>
       ${image
         ? html`
             <dds-image
               slot="image"
               alt="${ifNonNull(alt)}"
-              default-src="${ifNonNull(defaultSrc)}"
-            ></dds-image>
+              default-src="${ifNonNull(defaultSrc)}"></dds-image>
           `
         : ``}
       ${eyebrow ? html` <dds-card-eyebrow>${eyebrow}</dds-card-eyebrow> ` : ``}
@@ -318,8 +311,7 @@ export const Logo = (args) => {
       <dds-image-logo
         slot="image"
         alt="${ifNonNull(alt)}"
-        default-src="${ifNonNull(defaultSrc)}"
-      ></dds-image-logo>
+        default-src="${ifNonNull(defaultSrc)}"></dds-image-logo>
       ${eyebrow ? html` <dds-card-eyebrow>${eyebrow}</dds-card-eyebrow> ` : ``}
       ${heading ? html` <dds-card-heading>${heading}</dds-card-heading> ` : ``}
       ${copy ? html` <p>${copy}</p> ` : ``}
@@ -372,8 +364,7 @@ export default {
       <div class="bx--grid">
         <div class="bx--row">
           <div
-            class="bx--col-sm-4 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter"
-          >
+            class="bx--col-sm-4 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter">
             ${story()}
           </div>
         </div>

--- a/packages/web-components/src/components/carousel/__stories__/carousel.stories.ts
+++ b/packages/web-components/src/components/carousel/__stories__/carousel.stories.ts
@@ -48,8 +48,7 @@ const Card = ({
           <dds-image
             slot="image"
             alt="example image"
-            default-src="${image}"
-          ></dds-image>
+            default-src="${image}"></dds-image>
         `
       : null}
     <dds-card-footer>
@@ -74,8 +73,7 @@ const CardWithLongHeading = ({
           <dds-image
             slot="image"
             alt="example image"
-            default-src="${image}"
-          ></dds-image>
+            default-src="${image}"></dds-image>
         `
       : null}
     <dds-card-footer>

--- a/packages/web-components/src/components/carousel/__stories__/carousel.stories.ts
+++ b/packages/web-components/src/components/carousel/__stories__/carousel.stories.ts
@@ -14,6 +14,7 @@ import { html } from 'lit-element';
 // @ts-ignore
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20.js';
 import '../../card/index';
 import '../../cta/index';
 import '../../image/index';
@@ -47,10 +48,15 @@ const Card = ({
           <dds-image
             slot="image"
             alt="example image"
-            default-src="${image}"></dds-image>
+            default-src="${image}"
+          ></dds-image>
         `
       : null}
-    <dds-card-footer> ${ArrowRight20({ slot: 'icon' })} </dds-card-footer>
+    <dds-card-footer>
+      ${document.dir === 'rtl'
+        ? ArrowLeft20({ slot: 'icon' })
+        : ArrowRight20({ slot: 'icon' })}
+    </dds-card-footer>
   </dds-card>
 `;
 
@@ -68,10 +74,15 @@ const CardWithLongHeading = ({
           <dds-image
             slot="image"
             alt="example image"
-            default-src="${image}"></dds-image>
+            default-src="${image}"
+          ></dds-image>
         `
       : null}
-    <dds-card-footer> ${ArrowRight20({ slot: 'icon' })} </dds-card-footer>
+    <dds-card-footer>
+      ${document.dir === 'rtl'
+        ? ArrowLeft20({ slot: 'icon' })
+        : ArrowRight20({ slot: 'icon' })}
+    </dds-card-footer>
   </dds-card>
 `;
 
@@ -80,7 +91,9 @@ const CardWithVideo = ({ copy = copyDefault, href = hrefDefault } = {}) => html`
     <dds-card-cta cta-type="video" href="${href}">
       <p>${copy}</p>
       <dds-card-cta-footer href="${href}">
-        ${ArrowRight20({ slot: 'icon' })}
+        ${document.dir === 'rtl'
+          ? ArrowLeft20({ slot: 'icon' })
+          : ArrowRight20({ slot: 'icon' })}
       </dds-card-cta-footer>
     </dds-card-cta>
   </dds-video-cta-container>

--- a/packages/web-components/src/components/content-block-card-static/__stories__/content-block-card-static.stories.ts
+++ b/packages/web-components/src/components/content-block-card-static/__stories__/content-block-card-static.stories.ts
@@ -9,7 +9,8 @@
 
 import '../index';
 import { html } from 'lit-element';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import Chat20 from '../../../internal/vendor/@carbon/web-components/icons/chat/20.js';
 // eslint-disable-next-line sort-imports
 import readme from './README.stories.mdx';
@@ -62,7 +63,10 @@ export const Default = (args) => {
           Contact us ${Chat20({ slot: 'icon' })}
         </dds-button-group-item>
         <dds-button-group-item href="${href}">
-          Free trial ${ArrowRight20({ slot: 'icon' })}
+          Free trial
+          ${document.dir === 'rtl'
+            ? ArrowLeft20({ slot: 'icon' })
+            : ArrowRight20({ slot: 'icon' })}
         </dds-button-group-item>
       </dds-button-group>
     </dds-content-block-card-static>

--- a/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.ts
+++ b/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.ts
@@ -14,6 +14,7 @@ import '../../content-group-cards/index';
 import '../../content-group-pictograms/index';
 import '../../content-group-simple/index';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import { html } from 'lit-element';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import { select } from '@storybook/addon-knobs';
@@ -71,7 +72,8 @@ const image = ({ heading: imageHeading } = { heading: undefined }) => html`
     slot="media"
     alt="Image alt text"
     default-src="${imgLg16x9}"
-    heading="${ifNonNull(imageHeading)}">
+    heading="${ifNonNull(imageHeading)}"
+  >
     <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}">
     </dds-image-item>
     <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}">
@@ -166,7 +168,9 @@ export const Default = (args) => {
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </p>
           <dds-card-footer icon-placement="left">
-            ${ArrowRight20({ slot: 'icon' })}
+            ${document.dir === 'rtl'
+              ? ArrowLeft20({ slot: 'icon' })
+              : ArrowRight20({ slot: 'icon' })}
           </dds-card-footer>
         </dds-content-group-cards-item>
         <dds-content-group-cards-item href="www.ibm.com">
@@ -179,7 +183,9 @@ export const Default = (args) => {
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </p>
           <dds-card-footer icon-placement="left">
-            ${ArrowRight20({ slot: 'icon' })}
+            ${document.dir === 'rtl'
+              ? ArrowLeft20({ slot: 'icon' })
+              : ArrowRight20({ slot: 'icon' })}
           </dds-card-footer>
         </dds-content-group-cards-item>
       </dds-content-group-cards>
@@ -199,7 +205,8 @@ export const Default = (args) => {
                 width="64"
                 height="64"
                 viewBox="8 8 32 32"
-                xml:space="preserve">
+                xml:space="preserve"
+              >
                 <g>
                   <g>
                     <path
@@ -208,7 +215,8 @@ export const Default = (args) => {
                       M34,26h-7 M15,26H9 M30,29v8h9V21h-5 M30,34h9 M20.998,27.621c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v2.378
                       l-0.005-6.962c0-0.573-0.447-1.037-0.998-1.037S17,22.464,17,23.037v5.882v4.924C17,36.139,18.792,38,21.002,38
                       S25,36.121,25,33.842v-5.04c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v1.196l-0.005-1.935
-                      c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z" />
+                      c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z"
+                    />
                   </g>
                 </g>
                 <g></g>
@@ -217,8 +225,12 @@ export const Default = (args) => {
                 >${itemHeading}</dds-content-item-heading
               >
               <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
-              <dds-link-with-icon href="${linkWithIcon.href}" slot="footer">
-                ${linkWithIcon.copy} ${ArrowRight20({ slot: 'icon' })}
+              <dds-link-with-icon
+                href="${linkWithIcon.href}"
+                slot="footer"
+                cta-type="local"
+              >
+                ${linkWithIcon.copy}
               </dds-link-with-icon>
             </dds-pictogram-item>
           `
@@ -231,7 +243,8 @@ export const Default = (args) => {
         <dds-card-link-cta
           slot="footer"
           cta-type=${ctaType}
-          href="https://example.com">
+          href="https://example.com"
+        >
           <dds-card-link-heading
             >Lorem ipsum dolor sit amet</dds-card-link-heading
           >
@@ -253,7 +266,8 @@ export const WithLinkList = (args) => {
   } = args?.ContentBlockMixed ?? {};
   return html`
     <dds-content-block-mixed
-      complementary-style-scheme="${ifNonNull(complementaryStyleScheme)}">
+      complementary-style-scheme="${ifNonNull(complementaryStyleScheme)}"
+    >
       <dds-content-block-heading>${heading}</dds-content-block-heading>
       <dds-content-block-copy>${groupCopy}</dds-content-block-copy>
       <dds-content-group-cards>
@@ -270,7 +284,9 @@ export const WithLinkList = (args) => {
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </p>
           <dds-card-footer icon-placement="left">
-            ${ArrowRight20({ slot: 'icon' })}
+            ${document.dir === 'rtl'
+              ? ArrowLeft20({ slot: 'icon' })
+              : ArrowRight20({ slot: 'icon' })}
           </dds-card-footer>
         </dds-content-group-cards-item>
         <dds-content-group-cards-item href="www.ibm.com">
@@ -283,7 +299,9 @@ export const WithLinkList = (args) => {
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </p>
           <dds-card-footer icon-placement="left">
-            ${ArrowRight20({ slot: 'icon' })}
+            ${document.dir === 'rtl'
+              ? ArrowLeft20({ slot: 'icon' })
+              : ArrowRight20({ slot: 'icon' })}
           </dds-card-footer>
         </dds-content-group-cards-item>
       </dds-content-group-cards>
@@ -321,8 +339,8 @@ export const WithLinkList = (args) => {
               </svg>
               <dds-content-item-heading>${itemHeading}</dds-content-item-heading>
               <dds-content-item-copy>${itemCopy}</dds-content-item-copy>
-              <dds-link-with-icon href="${linkWithIcon.href}" slot="footer">
-                ${linkWithIcon.copy} ${ArrowRight20({ slot: 'icon' })}
+              <dds-link-with-icon href="${linkWithIcon.href}" slot="footer" cta-type="local">
+                ${linkWithIcon.copy}
               </dds-link-with-icon>
             </dds-pictogram-item>
           `
@@ -335,7 +353,8 @@ export const WithLinkList = (args) => {
         <dds-card-link-cta
           slot="footer"
           cta-type=${ctaType}
-          href="https://example.com">
+          href="https://example.com"
+        >
           <dds-card-link-heading
             >Lorem ipsum dolor sit amet</dds-card-link-heading
           >
@@ -346,13 +365,15 @@ export const WithLinkList = (args) => {
         <dds-link-list-heading>${linkListHeading}</dds-link-list-heading>
         <dds-link-list-item-card-cta
           href="https://example.com"
-          cta-type="local">
+          cta-type="local"
+        >
           <p>Containerization A Complete Guide</p>
           <dds-card-cta-footer></dds-card-cta-footer>
         </dds-link-list-item-card-cta>
         <dds-link-list-item-card-cta
           href="https://example.com"
-          cta-type="external">
+          cta-type="external"
+        >
           <p>Why should you use microservices and containers</p>
           <dds-card-cta-footer></dds-card-cta-footer>
         </dds-link-list-item-card-cta>

--- a/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.ts
+++ b/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.ts
@@ -72,8 +72,7 @@ const image = ({ heading: imageHeading } = { heading: undefined }) => html`
     slot="media"
     alt="Image alt text"
     default-src="${imgLg16x9}"
-    heading="${ifNonNull(imageHeading)}"
-  >
+    heading="${ifNonNull(imageHeading)}">
     <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}">
     </dds-image-item>
     <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}">
@@ -205,8 +204,7 @@ export const Default = (args) => {
                 width="64"
                 height="64"
                 viewBox="8 8 32 32"
-                xml:space="preserve"
-              >
+                xml:space="preserve">
                 <g>
                   <g>
                     <path
@@ -215,8 +213,7 @@ export const Default = (args) => {
                       M34,26h-7 M15,26H9 M30,29v8h9V21h-5 M30,34h9 M20.998,27.621c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v2.378
                       l-0.005-6.962c0-0.573-0.447-1.037-0.998-1.037S17,22.464,17,23.037v5.882v4.924C17,36.139,18.792,38,21.002,38
                       S25,36.121,25,33.842v-5.04c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v1.196l-0.005-1.935
-                      c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z"
-                    />
+                      c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z" />
                   </g>
                 </g>
                 <g></g>
@@ -228,8 +225,7 @@ export const Default = (args) => {
               <dds-link-with-icon
                 href="${linkWithIcon.href}"
                 slot="footer"
-                cta-type="local"
-              >
+                cta-type="local">
                 ${linkWithIcon.copy}
               </dds-link-with-icon>
             </dds-pictogram-item>
@@ -243,8 +239,7 @@ export const Default = (args) => {
         <dds-card-link-cta
           slot="footer"
           cta-type=${ctaType}
-          href="https://example.com"
-        >
+          href="https://example.com">
           <dds-card-link-heading
             >Lorem ipsum dolor sit amet</dds-card-link-heading
           >
@@ -266,8 +261,7 @@ export const WithLinkList = (args) => {
   } = args?.ContentBlockMixed ?? {};
   return html`
     <dds-content-block-mixed
-      complementary-style-scheme="${ifNonNull(complementaryStyleScheme)}"
-    >
+      complementary-style-scheme="${ifNonNull(complementaryStyleScheme)}">
       <dds-content-block-heading>${heading}</dds-content-block-heading>
       <dds-content-block-copy>${groupCopy}</dds-content-block-copy>
       <dds-content-group-cards>
@@ -353,8 +347,7 @@ export const WithLinkList = (args) => {
         <dds-card-link-cta
           slot="footer"
           cta-type=${ctaType}
-          href="https://example.com"
-        >
+          href="https://example.com">
           <dds-card-link-heading
             >Lorem ipsum dolor sit amet</dds-card-link-heading
           >
@@ -365,15 +358,13 @@ export const WithLinkList = (args) => {
         <dds-link-list-heading>${linkListHeading}</dds-link-list-heading>
         <dds-link-list-item-card-cta
           href="https://example.com"
-          cta-type="local"
-        >
+          cta-type="local">
           <p>Containerization A Complete Guide</p>
           <dds-card-cta-footer></dds-card-cta-footer>
         </dds-link-list-item-card-cta>
         <dds-link-list-item-card-cta
           href="https://example.com"
-          cta-type="external"
-        >
+          cta-type="external">
           <p>Why should you use microservices and containers</p>
           <dds-card-cta-footer></dds-card-cta-footer>
         </dds-link-list-item-card-cta>

--- a/packages/web-components/src/components/content-group-banner/__stories__/content-group-banner.stories.ts
+++ b/packages/web-components/src/components/content-group-banner/__stories__/content-group-banner.stories.ts
@@ -56,15 +56,13 @@ export const Default = (args) => {
             <dds-link-list-item
               icon-placement="${iconPlacement}"
               href="https://example.com"
-              cta-type="local"
-            >
+              cta-type="local">
               Learn more about Kubernetes
             </dds-link-list-item>
             <dds-link-list-item
               icon-placement="${iconPlacement}"
               href="https://example.com"
-              cta-type="local"
-            >
+              cta-type="local">
               Containerization A Complete Guide
             </dds-link-list-item>
           </dds-link-list>
@@ -79,16 +77,14 @@ export const Default = (args) => {
               icon-placement="${iconPlacement}"
               href="${ifNonNull(href)}"
               cta-type="${ifNonNull(ctaType)}"
-              download="${ifNonNull(download)}"
-            >
+              download="${ifNonNull(download)}">
               Learn more about Kubernetes
             </dds-link-list-item-cta>
             <dds-link-list-item-cta
               icon-placement="${iconPlacement}"
               href="${ifNonNull(href)}"
               cta-type="${ifNonNull(ctaType)}"
-              download="${ifNonNull(download)}"
-            >
+              download="${ifNonNull(download)}">
               Containerization A Complete Guide
             </dds-link-list-item-cta>
           </dds-link-list>

--- a/packages/web-components/src/components/content-group-banner/__stories__/content-group-banner.stories.ts
+++ b/packages/web-components/src/components/content-group-banner/__stories__/content-group-banner.stories.ts
@@ -8,7 +8,6 @@
  */
 
 import { html } from 'lit-element';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import { select } from '@storybook/addon-knobs';
 import textNullable from '../../../../.storybook/knob-text-nullable';
@@ -56,14 +55,17 @@ export const Default = (args) => {
           <dds-link-list type="vertical" slot="complementary">
             <dds-link-list-item
               icon-placement="${iconPlacement}"
-              href="https://example.com">
-              Learn more about Kubernetes ${ArrowRight20({ slot: 'icon' })}
+              href="https://example.com"
+              cta-type="local"
+            >
+              Learn more about Kubernetes
             </dds-link-list-item>
             <dds-link-list-item
               icon-placement="${iconPlacement}"
-              href="https://example.com">
+              href="https://example.com"
+              cta-type="local"
+            >
               Containerization A Complete Guide
-              ${ArrowRight20({ slot: 'icon' })}
             </dds-link-list-item>
           </dds-link-list>
         </dds-content-group-banner>
@@ -77,14 +79,16 @@ export const Default = (args) => {
               icon-placement="${iconPlacement}"
               href="${ifNonNull(href)}"
               cta-type="${ifNonNull(ctaType)}"
-              download="${ifNonNull(download)}">
+              download="${ifNonNull(download)}"
+            >
               Learn more about Kubernetes
             </dds-link-list-item-cta>
             <dds-link-list-item-cta
               icon-placement="${iconPlacement}"
               href="${ifNonNull(href)}"
               cta-type="${ifNonNull(ctaType)}"
-              download="${ifNonNull(download)}">
+              download="${ifNonNull(download)}"
+            >
               Containerization A Complete Guide
             </dds-link-list-item-cta>
           </dds-link-list>

--- a/packages/web-components/src/components/content-group-cards/__stories__/content-group-cards.stories.ts
+++ b/packages/web-components/src/components/content-group-cards/__stories__/content-group-cards.stories.ts
@@ -9,6 +9,7 @@
 
 import { html } from 'lit-element';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 import '../index';
@@ -24,7 +25,9 @@ const card1 = html`
       tempor incididunt ut labore et dolore magna aliqua.
     </p>
     <dds-card-footer icon-placement="left">
-      ${ArrowRight20({ slot: 'icon' })}
+      ${document.dir === 'rtl'
+        ? ArrowLeft20({ slot: 'icon' })
+        : ArrowRight20({ slot: 'icon' })}
     </dds-card-footer>
   </dds-content-group-cards-item>
 `;
@@ -37,7 +40,9 @@ const card2 = html`
     </dds-card-heading>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
     <dds-card-footer icon-placement="left">
-      ${ArrowRight20({ slot: 'icon' })}
+      ${document.dir === 'rtl'
+        ? ArrowLeft20({ slot: 'icon' })
+        : ArrowRight20({ slot: 'icon' })}
     </dds-card-footer>
   </dds-content-group-cards-item>
 `;

--- a/packages/web-components/src/components/content-group-pictograms/__stories__/content-group-pictograms.stories.ts
+++ b/packages/web-components/src/components/content-group-pictograms/__stories__/content-group-pictograms.stories.ts
@@ -10,7 +10,6 @@
 
 import '../index';
 import { html } from 'lit-element';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
 import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 import styles from './content-group-pictograms.stories.scss';

--- a/packages/web-components/src/components/content-group-pictograms/__stories__/content-group-pictograms.stories.ts
+++ b/packages/web-components/src/components/content-group-pictograms/__stories__/content-group-pictograms.stories.ts
@@ -102,8 +102,7 @@ export const Default = (args) => {
               width="64"
               height="64"
               viewBox="8 8 32 32"
-              xml:space="preserve"
-            >
+              xml:space="preserve">
               <title></title>
               <g>
                 <g>
@@ -113,8 +112,7 @@ export const Default = (args) => {
                     M34,26h-7 M15,26H9 M30,29v8h9V21h-5 M30,34h9 M20.998,27.621c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v2.378
                     l-0.005-6.962c0-0.573-0.447-1.037-0.998-1.037S17,22.464,17,23.037v5.882v4.924C17,36.139,18.792,38,21.002,38
                     S25,36.121,25,33.842v-5.04c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v1.196l-0.005-1.935
-                    c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z"
-                  />
+                    c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z" />
                 </g>
               </g>
               <g></g>
@@ -124,8 +122,7 @@ export const Default = (args) => {
             <dds-link-with-icon
               href="${linkWithIcon.href}"
               slot="footer"
-              cta-type="local"
-            >
+              cta-type="local">
               ${linkWithIcon.copy}
             </dds-link-with-icon>
           </dds-pictogram-item>

--- a/packages/web-components/src/components/content-group-pictograms/__stories__/content-group-pictograms.stories.ts
+++ b/packages/web-components/src/components/content-group-pictograms/__stories__/content-group-pictograms.stories.ts
@@ -103,7 +103,8 @@ export const Default = (args) => {
               width="64"
               height="64"
               viewBox="8 8 32 32"
-              xml:space="preserve">
+              xml:space="preserve"
+            >
               <title></title>
               <g>
                 <g>
@@ -113,15 +114,20 @@ export const Default = (args) => {
                     M34,26h-7 M15,26H9 M30,29v8h9V21h-5 M30,34h9 M20.998,27.621c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v2.378
                     l-0.005-6.962c0-0.573-0.447-1.037-0.998-1.037S17,22.464,17,23.037v5.882v4.924C17,36.139,18.792,38,21.002,38
                     S25,36.121,25,33.842v-5.04c0-0.573-0.447-1.037-0.998-1.037s-0.998,0.464-0.998,1.037v1.196l-0.005-1.935
-                    c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z" />
+                    c0-0.573-0.447-1.037-0.998-1.037s-1.002,0.464-1.002,1.037l0.004,1.935L20.998,27.621z"
+                  />
                 </g>
               </g>
               <g></g>
             </svg>
             <dds-content-item-heading>${heading}</dds-content-item-heading>
             <dds-content-item-copy>${copy}</dds-content-item-copy>
-            <dds-link-with-icon href="${linkWithIcon.href}" slot="footer">
-              ${linkWithIcon.copy} ${ArrowRight20({ slot: 'icon' })}
+            <dds-link-with-icon
+              href="${linkWithIcon.href}"
+              slot="footer"
+              cta-type="local"
+            >
+              ${linkWithIcon.copy}
             </dds-link-with-icon>
           </dds-pictogram-item>
         `

--- a/packages/web-components/src/components/content-section/__stories__/content-section.stories.ts
+++ b/packages/web-components/src/components/content-section/__stories__/content-section.stories.ts
@@ -112,8 +112,7 @@ export const Default = (args) => {
               >
               <dds-video-player-container
                 slot="media"
-                video-id="0_ibuqxqbe"
-              ></dds-video-player-container>
+                video-id="0_ibuqxqbe"></dds-video-player-container>
               <dds-text-cta
                 slot="footer"
                 cta-type="jump"

--- a/packages/web-components/src/components/content-section/__stories__/content-section.stories.ts
+++ b/packages/web-components/src/components/content-section/__stories__/content-section.stories.ts
@@ -9,6 +9,7 @@
 
 import { html } from 'lit-element';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import { optionsKnob } from '@storybook/addon-knobs';
 import '../../card-group/index';
@@ -41,7 +42,9 @@ const card1 = html`
       tempor incididunt ut labore et dolore magna aliqua.
     </p>
     <dds-card-footer icon-placement="left">
-      ${ArrowRight20({ slot: 'icon' })}
+      ${document.dir === 'rtl'
+        ? ArrowLeft20({ slot: 'icon' })
+        : ArrowRight20({ slot: 'icon' })}
     </dds-card-footer>
   </dds-content-group-cards-item>
 `;
@@ -54,7 +57,9 @@ const card2 = html`
     </dds-card-heading>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
     <dds-card-footer icon-placement="left">
-      ${ArrowRight20({ slot: 'icon' })}
+      ${document.dir === 'rtl'
+        ? ArrowLeft20({ slot: 'icon' })
+        : ArrowRight20({ slot: 'icon' })}
     </dds-card-footer>
   </dds-content-group-cards-item>
 `;
@@ -76,7 +81,11 @@ const Card = ({
   <dds-card href="${ifNonNull(href)}">
     <dds-card-heading>${heading}</dds-card-heading>
     ${copy}
-    <dds-card-footer> ${ArrowRight20({ slot: 'icon' })} </dds-card-footer>
+    <dds-card-footer>
+      ${document.dir === 'rtl'
+        ? ArrowLeft20({ slot: 'icon' })
+        : ArrowRight20({ slot: 'icon' })}</dds-card-footer
+    >
   </dds-card>
 `;
 
@@ -103,7 +112,8 @@ export const Default = (args) => {
               >
               <dds-video-player-container
                 slot="media"
-                video-id="0_ibuqxqbe"></dds-video-player-container>
+                video-id="0_ibuqxqbe"
+              ></dds-video-player-container>
               <dds-text-cta
                 slot="footer"
                 cta-type="jump"
@@ -121,26 +131,23 @@ export const Default = (args) => {
       ${addChildren.includes('Link list')
         ? html`
             <dds-link-list>
-              <dds-link-list-item href="https://example.com">
+              <dds-link-list-item href="https://example.com" cta-type="local">
                 Learn more about Kubernetes and automating deployment
-                ${ArrowRight20({ slot: 'icon' })}
               </dds-link-list-item>
-              <dds-link-list-item href="https://example.com">
+              <dds-link-list-item href="https://example.com" cta-type="local">
                 Containerization A Complete Guide
-                ${ArrowRight20({ slot: 'icon' })}
               </dds-link-list-item>
-              <dds-link-list-item href="https://example.com">
-                Microservices and containers ${ArrowRight20({ slot: 'icon' })}
+              <dds-link-list-item href="https://example.com" cta-type="local">
+                Microservices and containers
               </dds-link-list-item>
-              <dds-link-list-item href="https://example.com">
-                Learn more about Kubernetes ${ArrowRight20({ slot: 'icon' })}
+              <dds-link-list-item href="https://example.com" cta-type="local">
+                Learn more about Kubernetes
               </dds-link-list-item>
-              <dds-link-list-item href="https://example.com">
+              <dds-link-list-item href="https://example.com" cta-type="local">
                 Containerization A Complete Guide
-                ${ArrowRight20({ slot: 'icon' })}
               </dds-link-list-item>
-              <dds-link-list-item href="https://example.com">
-                Microservices and containers ${ArrowRight20({ slot: 'icon' })}
+              <dds-link-list-item href="https://example.com" cta-type="local">
+                Microservices and containers
               </dds-link-list-item>
             </dds-link-list>
           `

--- a/packages/web-components/src/components/cta-block/__stories__/cta-block.stories.ts
+++ b/packages/web-components/src/components/cta-block/__stories__/cta-block.stories.ts
@@ -9,6 +9,7 @@
 
 import { boolean, number, select } from '@storybook/addon-knobs';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import Launch20 from '../../../internal/vendor/@carbon/web-components/icons/launch/20';
 import { html } from 'lit-element';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
@@ -23,12 +24,15 @@ import content from '../../cta-section/__stories__/content';
 
 const iconMap = {
   ArrowRight20: ArrowRight20({ slot: 'icon' }),
+  ArrowLeft20: ArrowLeft20({ slot: 'icon' }),
   Launch20: Launch20({ slot: 'icon' }),
 };
 
-const iconOptions = {
-  'Arrow Right': 'ArrowRight20',
-  'External Launch': 'Launch20',
+const iconOptions = () => {
+  return {
+    'Arrow Inline End': document.dir === 'rtl' ? 'ArrowLeft20' : 'ArrowRight20',
+    'External Launch': 'Launch20',
+  };
 };
 
 const renderCTA = {
@@ -182,23 +186,23 @@ export const WithLinkList = (args) => {
         <dds-link-list-heading
           >More ways to explore DevOps</dds-link-list-heading
         >
-        <dds-link-list-item href="https://example.com">
-          Events ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          Events
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          Blogs ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          Blogs
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          Training ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          Training
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          Developer resources ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          Developer resources
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          Research ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          Research
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          News ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          News
         </dds-link-list-item>
       </dds-link-list>
     </dds-cta-block>
@@ -281,7 +285,10 @@ export default {
         copy: 'Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.',
         cta: select('CTA type', ctaTypeOptions, ctaTypeOptions['Button group']),
         renderIcon:
-          iconMap[select(`Icon`, iconOptions, iconOptions['Arrow Right']) ?? 0],
+          iconMap[
+            select(`Icon`, iconOptions(), iconOptions()['Arrow Inline End']) ??
+              0
+          ],
       }),
     },
     ...readme.parameters,
@@ -293,7 +300,7 @@ export default {
           border: false,
           cta: 'buttonGroup',
           copy: 'Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.',
-          renderIcon: iconOptions['Arrow Right'],
+          renderIcon: iconOptions()['Arrow Inline End'],
         },
       },
     },

--- a/packages/web-components/src/components/cta-section/__stories__/cta-section.stories.ts
+++ b/packages/web-components/src/components/cta-section/__stories__/cta-section.stories.ts
@@ -8,7 +8,6 @@
  */
 
 import { select, number, boolean } from '@storybook/addon-knobs';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
 import { html } from 'lit-element';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import readme from './README.stories.mdx';
@@ -74,7 +73,8 @@ const contentItemTypeMap = {
         height="48"
         viewBox="0 0 48 48"
         role="img"
-        class="bx--pictogram-item__pictogram">
+        class="bx--pictogram-item__pictogram"
+      >
         <path
           fill="none"
           stroke-linejoin="round"
@@ -83,7 +83,8 @@ const contentItemTypeMap = {
           d="M 44.211009,36.137939 H 3.7889912 c -1.7101623,0 -3.10938596,-1.365518
           -3.10938596,-3.034485 V 7.3103341 c 0,-1.6689666 1.39922366,-3.0344847 3.10938596,-3.0344847 H 44.211009 c 1.710162,0
           3.109386,1.3655181 3.109386,3.0344847 V 33.103454 c 0,1.668967 -1.399224,3.034485 -3.109386,3.034485 z m
-          -31.09386,7.586212 H 34.882851 M 24,36.137939 v 7.586212 M 0.67960524,28.551727 H 47.320395" />
+          -31.09386,7.586212 H 34.882851 M 24,36.137939 v 7.586212 M 0.67960524,28.551727 H 47.320395"
+        />
       </svg>
       <dds-content-item-heading>${heading}</dds-content-item-heading>
       <dds-content-item-copy>${copy}</dds-content-item-copy>
@@ -108,7 +109,8 @@ const contentItemTypeMap = {
         aspect-ratio="4x3"
         slot="media"
         hide-caption
-        playing-mode="lightbox">
+        playing-mode="lightbox"
+      >
       </dds-video-player-container>
       <dds-content-item-heading>${heading}</dds-content-item-heading>
       <dds-content-item-copy>${copy}</dds-content-item-copy>
@@ -131,7 +133,8 @@ const contentItemTypeMap = {
       <dds-image-logo
         alt="Microsoft logo"
         slot="media"
-        default-src="${logoMicrosoft2x1}"></dds-image-logo>
+        default-src="${logoMicrosoft2x1}"
+      ></dds-image-logo>
       <dds-content-item-heading>${heading}</dds-content-item-heading>
       <dds-content-item-copy>${copy}</dds-content-item-copy>
       ${links.map(
@@ -309,23 +312,23 @@ export const WithLinkList = (args) => {
           <dds-link-list-heading
             >More ways to explore DevOps</dds-link-list-heading
           >
-          <dds-link-list-item href="https://example.com">
-            Events ${ArrowRight20({ slot: 'icon' })}
+          <dds-link-list-item href="https://example.com" cta-type="local">
+            Events
           </dds-link-list-item>
-          <dds-link-list-item href="https://example.com">
-            Blogs ${ArrowRight20({ slot: 'icon' })}
+          <dds-link-list-item href="https://example.com" cta-type="local">
+            Blogs
           </dds-link-list-item>
-          <dds-link-list-item href="https://example.com">
-            Training ${ArrowRight20({ slot: 'icon' })}
+          <dds-link-list-item href="https://example.com" cta-type="local">
+            Training
           </dds-link-list-item>
-          <dds-link-list-item href="https://example.com">
-            Developer resources ${ArrowRight20({ slot: 'icon' })}
+          <dds-link-list-item href="https://example.com" cta-type="local">
+            Developer resources
           </dds-link-list-item>
-          <dds-link-list-item href="https://example.com">
-            Research ${ArrowRight20({ slot: 'icon' })}
+          <dds-link-list-item href="https://example.com" cta-type="local">
+            Research
           </dds-link-list-item>
-          <dds-link-list-item href="https://example.com">
-            News ${ArrowRight20({ slot: 'icon' })}
+          <dds-link-list-item href="https://example.com" cta-type="local">
+            News
           </dds-link-list-item>
         </dds-link-list>
       </dds-cta-block>

--- a/packages/web-components/src/components/cta-section/__stories__/cta-section.stories.ts
+++ b/packages/web-components/src/components/cta-section/__stories__/cta-section.stories.ts
@@ -73,8 +73,7 @@ const contentItemTypeMap = {
         height="48"
         viewBox="0 0 48 48"
         role="img"
-        class="bx--pictogram-item__pictogram"
-      >
+        class="bx--pictogram-item__pictogram">
         <path
           fill="none"
           stroke-linejoin="round"
@@ -83,8 +82,7 @@ const contentItemTypeMap = {
           d="M 44.211009,36.137939 H 3.7889912 c -1.7101623,0 -3.10938596,-1.365518
           -3.10938596,-3.034485 V 7.3103341 c 0,-1.6689666 1.39922366,-3.0344847 3.10938596,-3.0344847 H 44.211009 c 1.710162,0
           3.109386,1.3655181 3.109386,3.0344847 V 33.103454 c 0,1.668967 -1.399224,3.034485 -3.109386,3.034485 z m
-          -31.09386,7.586212 H 34.882851 M 24,36.137939 v 7.586212 M 0.67960524,28.551727 H 47.320395"
-        />
+          -31.09386,7.586212 H 34.882851 M 24,36.137939 v 7.586212 M 0.67960524,28.551727 H 47.320395" />
       </svg>
       <dds-content-item-heading>${heading}</dds-content-item-heading>
       <dds-content-item-copy>${copy}</dds-content-item-copy>
@@ -109,8 +107,7 @@ const contentItemTypeMap = {
         aspect-ratio="4x3"
         slot="media"
         hide-caption
-        playing-mode="lightbox"
-      >
+        playing-mode="lightbox">
       </dds-video-player-container>
       <dds-content-item-heading>${heading}</dds-content-item-heading>
       <dds-content-item-copy>${copy}</dds-content-item-copy>
@@ -133,8 +130,7 @@ const contentItemTypeMap = {
       <dds-image-logo
         alt="Microsoft logo"
         slot="media"
-        default-src="${logoMicrosoft2x1}"
-      ></dds-image-logo>
+        default-src="${logoMicrosoft2x1}"></dds-image-logo>
       <dds-content-item-heading>${heading}</dds-content-item-heading>
       <dds-content-item-copy>${copy}</dds-content-item-copy>
       ${links.map(

--- a/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
@@ -40,8 +40,7 @@ export const image = html`
   <dds-image
     alt="Image alt text"
     default-src="${imgLg16x9}"
-    heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-  >
+    heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit.">
     <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}">
     </dds-image-item>
     <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}">
@@ -115,15 +114,13 @@ export const contentItemHorizontal = html`
       <dds-link-list-item-cta
         icon-placement="right"
         href="https://www.ibm.com"
-        cta-type="local"
-      >
+        cta-type="local">
         Link text
       </dds-link-list-item-cta>
       <dds-link-list-item-cta
         icon-placement="right"
         href="https://www.ibm.com"
-        cta-type="external"
-      >
+        cta-type="external">
         External link text
       </dds-link-list-item-cta>
     </dds-link-list>
@@ -134,8 +131,7 @@ export const universalBanner = (srcImage) => html`
   <dds-universal-banner image-width="4-col">
     <dds-universal-banner-image
       slot="image"
-      default-src="${srcImage}"
-    ></dds-universal-banner-image>
+      default-src="${srcImage}"></dds-universal-banner-image>
     <dds-universal-banner-heading slot="heading"
       >heading</dds-universal-banner-heading
     >
@@ -144,8 +140,7 @@ export const universalBanner = (srcImage) => html`
       slot="cta"
       cta-type="local"
       kind="tertiary"
-      href="https://www.example.com"
-    >
+      href="https://www.example.com">
       cta copy
     </dds-button-cta>
   </dds-universal-banner>
@@ -166,8 +161,7 @@ export const contentLeadspace = html`
     size="medium"
     gradient-style-scheme="true"
     alt=""
-    default-src="${leadspaceImg}"
-  >
+    default-src="${leadspaceImg}">
     <dds-leadspace-heading>Leadspace Title</dds-leadspace-heading>
     Use this area for a short line of copy to support the title
     <dds-button-group slot="action">
@@ -177,16 +171,13 @@ export const contentLeadspace = html`
       slot="image"
       class="bx--image"
       alt=""
-      default-src="${leadspaceImg}"
-    >
+      default-src="${leadspaceImg}">
       <dds-image-item
         media="(min-width: 672px)"
-        srcset="${leadspaceImg}"
-      ></dds-image-item>
+        srcset="${leadspaceImg}"></dds-image-item>
       <dds-image-item
         media="(min-width: 0)"
-        srcset="${leadspaceImg}"
-      ></dds-image-item>
+        srcset="${leadspaceImg}"></dds-image-item>
     </dds-image>
   </dds-leadspace>
 `;
@@ -211,8 +202,7 @@ export const contentLeadspaceSearch = html`
       slot="search"
       leadspace-search
       active
-      should-remain-open
-    ></dds-search-with-typeahead>
+      should-remain-open></dds-search-with-typeahead>
   </dds-leadspace-with-search>
 `;
 
@@ -232,8 +222,7 @@ export const tocContent = html`
       </dds-content-block-copy>
       <dds-leadspace-block-media slot="media">
         <dds-video-player-container
-          video-id="0_ibuqxqbe"
-        ></dds-video-player-container>
+          video-id="0_ibuqxqbe"></dds-video-player-container>
       </dds-leadspace-block-media>
       <dds-link-list type="end">
         <dds-link-list-heading>Featured products</dds-link-list-heading>
@@ -270,8 +259,7 @@ export const tocContent = html`
     <dds-image slot="image" alt="Image alt text" default-src="${imgLg1x1}">
       <dds-image-item
         media="(min-width: 991px)"
-        srcset="${imgLg1x1}"
-      ></dds-image-item>
+        srcset="${imgLg1x1}"></dds-image-item>
     </dds-image>
     <dds-card-eyebrow>scelerisque purus</dds-card-eyebrow>
     <dds-card-heading>Elementum nibh tellus molestie nunc?</dds-card-heading>
@@ -309,8 +297,7 @@ export const tocContent = html`
       velit egestas dui.
     </dds-callout-with-media-copy>
     <dds-callout-with-media-video
-      video-id="0_ibuqxqbe"
-    ></dds-callout-with-media-video>
+      video-id="0_ibuqxqbe"></dds-callout-with-media-video>
   </dds-callout-with-media>
 
   <a name="4" data-title="Tincidunt ornare massa"></a>
@@ -331,8 +318,7 @@ export const tocContent = html`
       (elem) => html`
         <dds-logo-grid-item
           default-src="${elem.imgSrc}"
-          alt="${elem.altText}"
-        ></dds-logo-grid-item>
+          alt="${elem.altText}"></dds-logo-grid-item>
       `
     )}
   </dds-logo-grid>
@@ -356,8 +342,7 @@ export const tocContent = html`
     <dds-callout-link-with-icon
       slot="footer"
       href="https://example.com"
-      cta-type="local"
-    >
+      cta-type="local">
       Link with Icon
     </dds-callout-link-with-icon>
   </dds-callout-quote>
@@ -388,8 +373,7 @@ export const tocContent = html`
           slot="footer"
           cta-type="local"
           icon-placement="right"
-          href="example.com"
-        >
+          href="example.com">
           Find a partner
         </dds-text-cta>
       </dds-cta-block-item>
@@ -403,8 +387,7 @@ export const tocContent = html`
           slot="footer"
           cta-type="local"
           icon-placement="right"
-          href="example.com"
-        >
+          href="example.com">
           Browse tutorials
         </dds-text-cta>
       </dds-cta-block-item>
@@ -435,8 +418,7 @@ export const StoryContent = (
         ? html`
             <dds-table-of-contents
               stickyOffset="48"
-              toc-layout=${config.tocLayout}
-            >
+              toc-layout=${config.tocLayout}>
               <div class="bx--row">
                 <div class="bx--col-lg-12">${tocContent}</div>
               </div>
@@ -445,8 +427,7 @@ export const StoryContent = (
         : html`
             <dds-table-of-contents
               stickyOffset="48"
-              toc-layout=${config.tocLayout}
-            >
+              toc-layout=${config.tocLayout}>
               ${tocContent}
             </dds-table-of-contents>
           `}
@@ -458,8 +439,7 @@ export const StoryContentNoToC = () =>
   html`
     <div
       class="dds-ce-demo-devenv--ui-shell-content"
-      style="padding-right:1rem"
-    >
+      style="padding-right:1rem">
       <div class="bx--grid bx--col-lg-8">
         ${contentLeadspaceSearch}
 
@@ -475,12 +455,10 @@ export const StoryContentNoToC = () =>
           <dds-image
             slot="image"
             alt="Image alt text"
-            default-src="${imgLg1x1}"
-          >
+            default-src="${imgLg1x1}">
             <dds-image-item
               media="(min-width: 991px)"
-              srcset="${imgLg1x1}"
-            ></dds-image-item>
+              srcset="${imgLg1x1}"></dds-image-item>
           </dds-image>
           <dds-card-eyebrow>scelerisque purus</dds-card-eyebrow>
           <dds-card-heading
@@ -505,8 +483,7 @@ export const StoryContentNoToC = () =>
           <dds-card-cta
             slot="footer"
             cta-type="local"
-            href="https://example.com"
-          >
+            href="https://example.com">
             Lorem ipsum dolor
             <dds-card-cta-footer></dds-card-cta-footer>
           </dds-card-cta>
@@ -523,8 +500,7 @@ export const StoryContentNoToC = () =>
             facilisis volutpat est velit egestas dui.
           </dds-callout-with-media-copy>
           <dds-callout-with-media-video
-            video-id="0_ibuqxqbe"
-          ></dds-callout-with-media-video>
+            video-id="0_ibuqxqbe"></dds-callout-with-media-video>
         </dds-callout-with-media>
 
         <dds-content-block-horizontal>
@@ -543,8 +519,7 @@ export const StoryContentNoToC = () =>
             (elem) => html`
               <dds-logo-grid-item
                 default-src="${elem.imgSrc}"
-                alt="${elem.altText}"
-              ></dds-logo-grid-item>
+                alt="${elem.altText}"></dds-logo-grid-item>
             `
           )}
         </dds-logo-grid>
@@ -572,8 +547,7 @@ export const StoryContentNoToC = () =>
           <dds-callout-link-with-icon
             slot="footer"
             href="https://example.com"
-            cta-type="local"
-          >
+            cta-type="local">
             Link with Icon
           </dds-callout-link-with-icon>
         </dds-callout-quote>
@@ -608,8 +582,7 @@ export const StoryContentNoToC = () =>
                 slot="footer"
                 cta-type="local"
                 icon-placement="right"
-                href="example.com"
-              >
+                href="example.com">
                 Find a partner
               </dds-text-cta>
             </dds-cta-block-item>
@@ -624,8 +597,7 @@ export const StoryContentNoToC = () =>
                 slot="footer"
                 cta-type="local"
                 icon-placement="right"
-                href="example.com"
-              >
+                href="example.com">
                 Browse tutorials
               </dds-text-cta>
             </dds-cta-block-item>

--- a/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/data/content.ts
@@ -8,6 +8,7 @@
 
 import { html } from 'lit-element';
 import ArrowRight20 from '../../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import logosGroup from '../../../logo-grid/__stories__/data/logos.js';
 import { TOC_TYPES } from '../../../table-of-contents/defs';
 
@@ -39,7 +40,8 @@ export const image = html`
   <dds-image
     alt="Image alt text"
     default-src="${imgLg16x9}"
-    heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit.">
+    heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+  >
     <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}">
     </dds-image-item>
     <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}">
@@ -113,13 +115,15 @@ export const contentItemHorizontal = html`
       <dds-link-list-item-cta
         icon-placement="right"
         href="https://www.ibm.com"
-        cta-type="local">
+        cta-type="local"
+      >
         Link text
       </dds-link-list-item-cta>
       <dds-link-list-item-cta
         icon-placement="right"
         href="https://www.ibm.com"
-        cta-type="external">
+        cta-type="external"
+      >
         External link text
       </dds-link-list-item-cta>
     </dds-link-list>
@@ -130,7 +134,8 @@ export const universalBanner = (srcImage) => html`
   <dds-universal-banner image-width="4-col">
     <dds-universal-banner-image
       slot="image"
-      default-src="${srcImage}"></dds-universal-banner-image>
+      default-src="${srcImage}"
+    ></dds-universal-banner-image>
     <dds-universal-banner-heading slot="heading"
       >heading</dds-universal-banner-heading
     >
@@ -139,21 +144,20 @@ export const universalBanner = (srcImage) => html`
       slot="cta"
       cta-type="local"
       kind="tertiary"
-      href="https://www.example.com">
+      href="https://www.example.com"
+    >
       cta copy
     </dds-button-cta>
   </dds-universal-banner>
 `;
 
 export const cardGroupItems = html`
-  <dds-card-group-item href="https://example.com">
+  <dds-card-group-item href="https://example.com" cta-type="local">
     <dds-image slot="image" alt="Image alt text" default-src="${imgXlg4x3}">
     </dds-image>
     <dds-card-eyebrow>Topic</dds-card-eyebrow>
     <dds-card-heading>Natural Language Processing.</dds-card-heading>
-    <dds-card-cta-footer slot="footer">
-      ${ArrowRight20({ slot: 'icon' })}
-    </dds-card-cta-footer>
+    <dds-card-cta-footer></dds-card-cta-footer>
   </dds-card-group-item>
 `;
 
@@ -162,7 +166,8 @@ export const contentLeadspace = html`
     size="medium"
     gradient-style-scheme="true"
     alt=""
-    default-src="${leadspaceImg}">
+    default-src="${leadspaceImg}"
+  >
     <dds-leadspace-heading>Leadspace Title</dds-leadspace-heading>
     Use this area for a short line of copy to support the title
     <dds-button-group slot="action">
@@ -172,13 +177,16 @@ export const contentLeadspace = html`
       slot="image"
       class="bx--image"
       alt=""
-      default-src="${leadspaceImg}">
+      default-src="${leadspaceImg}"
+    >
       <dds-image-item
         media="(min-width: 672px)"
-        srcset="${leadspaceImg}"></dds-image-item>
+        srcset="${leadspaceImg}"
+      ></dds-image-item>
       <dds-image-item
         media="(min-width: 0)"
-        srcset="${leadspaceImg}"></dds-image-item>
+        srcset="${leadspaceImg}"
+      ></dds-image-item>
     </dds-image>
   </dds-leadspace>
 `;
@@ -203,7 +211,8 @@ export const contentLeadspaceSearch = html`
       slot="search"
       leadspace-search
       active
-      should-remain-open></dds-search-with-typeahead>
+      should-remain-open
+    ></dds-search-with-typeahead>
   </dds-leadspace-with-search>
 `;
 
@@ -223,18 +232,19 @@ export const tocContent = html`
       </dds-content-block-copy>
       <dds-leadspace-block-media slot="media">
         <dds-video-player-container
-          video-id="0_ibuqxqbe"></dds-video-player-container>
+          video-id="0_ibuqxqbe"
+        ></dds-video-player-container>
       </dds-leadspace-block-media>
       <dds-link-list type="end">
         <dds-link-list-heading>Featured products</dds-link-list-heading>
-        <dds-link-list-item href="https://example.com">
-          IBM Cloud Continuous Delivery ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          IBM Cloud Continuous Delivery
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          UrbanCode ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          UrbanCode
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          View all products ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          View all products
         </dds-link-list-item>
       </dds-link-list>
       <dds-leadspace-block-cta>
@@ -260,7 +270,8 @@ export const tocContent = html`
     <dds-image slot="image" alt="Image alt text" default-src="${imgLg1x1}">
       <dds-image-item
         media="(min-width: 991px)"
-        srcset="${imgLg1x1}"></dds-image-item>
+        srcset="${imgLg1x1}"
+      ></dds-image-item>
     </dds-image>
     <dds-card-eyebrow>scelerisque purus</dds-card-eyebrow>
     <dds-card-heading>Elementum nibh tellus molestie nunc?</dds-card-heading>
@@ -269,7 +280,9 @@ export const tocContent = html`
       morbu tristique.
     </p>
     <dds-feature-card-footer>
-      ${ArrowRight20({ slot: 'icon' })}
+      ${document.dir === 'rtl'
+        ? ArrowLeft20({ slot: 'icon' })
+        : ArrowRight20({ slot: 'icon' })}
     </dds-feature-card-footer>
   </dds-feature-card>
 
@@ -296,7 +309,8 @@ export const tocContent = html`
       velit egestas dui.
     </dds-callout-with-media-copy>
     <dds-callout-with-media-video
-      video-id="0_ibuqxqbe"></dds-callout-with-media-video>
+      video-id="0_ibuqxqbe"
+    ></dds-callout-with-media-video>
   </dds-callout-with-media>
 
   <a name="4" data-title="Tincidunt ornare massa"></a>
@@ -317,7 +331,8 @@ export const tocContent = html`
       (elem) => html`
         <dds-logo-grid-item
           default-src="${elem.imgSrc}"
-          alt="${elem.altText}"></dds-logo-grid-item>
+          alt="${elem.altText}"
+        ></dds-logo-grid-item>
       `
     )}
   </dds-logo-grid>
@@ -338,8 +353,12 @@ export const tocContent = html`
     </dds-quote-source-heading>
     <dds-quote-source-copy> consectetur adipiscing elit </dds-quote-source-copy>
     <dds-quote-source-bottom-copy> IBM Cloud </dds-quote-source-bottom-copy>
-    <dds-callout-link-with-icon slot="footer" href="https://example.com">
-      Link with Icon ${ArrowRight20({ slot: 'icon' })}
+    <dds-callout-link-with-icon
+      slot="footer"
+      href="https://example.com"
+      cta-type="local"
+    >
+      Link with Icon
     </dds-callout-link-with-icon>
   </dds-callout-quote>
 
@@ -369,7 +388,8 @@ export const tocContent = html`
           slot="footer"
           cta-type="local"
           icon-placement="right"
-          href="example.com">
+          href="example.com"
+        >
           Find a partner
         </dds-text-cta>
       </dds-cta-block-item>
@@ -383,7 +403,8 @@ export const tocContent = html`
           slot="footer"
           cta-type="local"
           icon-placement="right"
-          href="example.com">
+          href="example.com"
+        >
           Browse tutorials
         </dds-text-cta>
       </dds-cta-block-item>
@@ -414,7 +435,8 @@ export const StoryContent = (
         ? html`
             <dds-table-of-contents
               stickyOffset="48"
-              toc-layout=${config.tocLayout}>
+              toc-layout=${config.tocLayout}
+            >
               <div class="bx--row">
                 <div class="bx--col-lg-12">${tocContent}</div>
               </div>
@@ -423,7 +445,8 @@ export const StoryContent = (
         : html`
             <dds-table-of-contents
               stickyOffset="48"
-              toc-layout=${config.tocLayout}>
+              toc-layout=${config.tocLayout}
+            >
               ${tocContent}
             </dds-table-of-contents>
           `}
@@ -435,7 +458,8 @@ export const StoryContentNoToC = () =>
   html`
     <div
       class="dds-ce-demo-devenv--ui-shell-content"
-      style="padding-right:1rem">
+      style="padding-right:1rem"
+    >
       <div class="bx--grid bx--col-lg-8">
         ${contentLeadspaceSearch}
 
@@ -451,10 +475,12 @@ export const StoryContentNoToC = () =>
           <dds-image
             slot="image"
             alt="Image alt text"
-            default-src="${imgLg1x1}">
+            default-src="${imgLg1x1}"
+          >
             <dds-image-item
               media="(min-width: 991px)"
-              srcset="${imgLg1x1}"></dds-image-item>
+              srcset="${imgLg1x1}"
+            ></dds-image-item>
           </dds-image>
           <dds-card-eyebrow>scelerisque purus</dds-card-eyebrow>
           <dds-card-heading
@@ -465,7 +491,9 @@ export const StoryContentNoToC = () =>
             Habitant morbu tristique.
           </p>
           <dds-feature-card-footer>
-            ${ArrowRight20({ slot: 'icon' })}
+            ${document.dir === 'rtl'
+              ? ArrowLeft20({ slot: 'icon' })
+              : ArrowRight20({ slot: 'icon' })}
           </dds-feature-card-footer>
         </dds-feature-card>
 
@@ -477,7 +505,8 @@ export const StoryContentNoToC = () =>
           <dds-card-cta
             slot="footer"
             cta-type="local"
-            href="https://example.com">
+            href="https://example.com"
+          >
             Lorem ipsum dolor
             <dds-card-cta-footer></dds-card-cta-footer>
           </dds-card-cta>
@@ -494,7 +523,8 @@ export const StoryContentNoToC = () =>
             facilisis volutpat est velit egestas dui.
           </dds-callout-with-media-copy>
           <dds-callout-with-media-video
-            video-id="0_ibuqxqbe"></dds-callout-with-media-video>
+            video-id="0_ibuqxqbe"
+          ></dds-callout-with-media-video>
         </dds-callout-with-media>
 
         <dds-content-block-horizontal>
@@ -513,7 +543,8 @@ export const StoryContentNoToC = () =>
             (elem) => html`
               <dds-logo-grid-item
                 default-src="${elem.imgSrc}"
-                alt="${elem.altText}"></dds-logo-grid-item>
+                alt="${elem.altText}"
+              ></dds-logo-grid-item>
             `
           )}
         </dds-logo-grid>
@@ -538,8 +569,12 @@ export const StoryContentNoToC = () =>
           <dds-quote-source-bottom-copy>
             IBM Cloud
           </dds-quote-source-bottom-copy>
-          <dds-callout-link-with-icon slot="footer" href="https://example.com">
-            Link with Icon ${ArrowRight20({ slot: 'icon' })}
+          <dds-callout-link-with-icon
+            slot="footer"
+            href="https://example.com"
+            cta-type="local"
+          >
+            Link with Icon
           </dds-callout-link-with-icon>
         </dds-callout-quote>
 
@@ -573,7 +608,8 @@ export const StoryContentNoToC = () =>
                 slot="footer"
                 cta-type="local"
                 icon-placement="right"
-                href="example.com">
+                href="example.com"
+              >
                 Find a partner
               </dds-text-cta>
             </dds-cta-block-item>
@@ -588,7 +624,8 @@ export const StoryContentNoToC = () =>
                 slot="footer"
                 cta-type="local"
                 icon-placement="right"
-                href="example.com">
+                href="example.com"
+              >
                 Browse tutorials
               </dds-text-cta>
             </dds-cta-block-item>

--- a/packages/web-components/src/components/expressive-modal/__stories__/expressive-modal.stories.ts
+++ b/packages/web-components/src/components/expressive-modal/__stories__/expressive-modal.stories.ts
@@ -45,8 +45,7 @@ export const Default = (args) => {
       ?open="${open}"
       expressive-size="${ifNonNull(size)}"
       @dds-expressive-modal-beingclosed="${handleBeforeClose}"
-      @dds-expressive-modal-closed="${onClose}"
-    >
+      @dds-expressive-modal-closed="${onClose}">
       <dds-expressive-modal-header>
         <dds-expressive-modal-close-button></dds-expressive-modal-close-button>
         <dds-expressive-modal-heading>Modal Title</dds-expressive-modal-heading>

--- a/packages/web-components/src/components/expressive-modal/__stories__/expressive-modal.stories.ts
+++ b/packages/web-components/src/components/expressive-modal/__stories__/expressive-modal.stories.ts
@@ -10,7 +10,8 @@
 import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import '../../../internal/vendor/@carbon/web-components/components/button/button.js';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import textNullable from '../../../../.storybook/knob-text-nullable';
@@ -44,7 +45,8 @@ export const Default = (args) => {
       ?open="${open}"
       expressive-size="${ifNonNull(size)}"
       @dds-expressive-modal-beingclosed="${handleBeforeClose}"
-      @dds-expressive-modal-closed="${onClose}">
+      @dds-expressive-modal-closed="${onClose}"
+    >
       <dds-expressive-modal-header>
         <dds-expressive-modal-close-button></dds-expressive-modal-close-button>
         <dds-expressive-modal-heading>Modal Title</dds-expressive-modal-heading>
@@ -61,7 +63,9 @@ export const Default = (args) => {
       </dds-expressive-modal-body>
       <dds-expressive-modal-footer>
         <dds-button-expressive href="https://www.example.com">
-          ${buttonContent}${ArrowRight20({ slot: 'icon' })}
+          ${buttonContent}${document.dir === 'rtl'
+            ? ArrowLeft20({ slot: 'icon' })
+            : ArrowRight20({ slot: 'icon' })}
         </dds-button-expressive>
       </dds-expressive-modal-footer>
     </dds-expressive-modal>

--- a/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.ts
+++ b/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.ts
@@ -11,7 +11,8 @@ import '../../card/index';
 import '../../image/image';
 import '../index';
 
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import { html } from 'lit-element';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import mediumImgLg1x1 from '../../../../../storybook-images/assets/720/fpo--1x1--720x720--004.jpg';
@@ -32,10 +33,13 @@ export const Medium = (args) => {
       <dds-image
         slot="image"
         alt="Image alt text"
-        default-src="${mediumImgLg1x1}"></dds-image>
+        default-src="${mediumImgLg1x1}"
+      ></dds-image>
       <dds-card-heading>${heading}</dds-card-heading>
       <dds-feature-card-footer>
-        ${ArrowRight20({ slot: 'icon' })}
+        ${document.dir === 'rtl'
+          ? ArrowLeft20({ slot: 'icon' })
+          : ArrowRight20({ slot: 'icon' })}
       </dds-feature-card-footer>
     </dds-feature-card>
   `;
@@ -61,7 +65,9 @@ export const Large = (args) => {
       <dds-card-heading>${heading}</dds-card-heading>
       <p>${copy}</p>
       <dds-feature-card-footer>
-        ${ArrowRight20({ slot: 'icon' })}
+        ${document.dir === 'rtl'
+          ? ArrowLeft20({ slot: 'icon' })
+          : ArrowRight20({ slot: 'icon' })}
       </dds-feature-card-footer>
     </dds-feature-card>
   `;

--- a/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.ts
+++ b/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.ts
@@ -33,8 +33,7 @@ export const Medium = (args) => {
       <dds-image
         slot="image"
         alt="Image alt text"
-        default-src="${mediumImgLg1x1}"
-      ></dds-image>
+        default-src="${mediumImgLg1x1}"></dds-image>
       <dds-card-heading>${heading}</dds-card-heading>
       <dds-feature-card-footer>
         ${document.dir === 'rtl'

--- a/packages/web-components/src/components/leadspace-block/__stories__/leadspace-block.stories.ts
+++ b/packages/web-components/src/components/leadspace-block/__stories__/leadspace-block.stories.ts
@@ -27,8 +27,7 @@ const image = html`
   <dds-image
     alt="Image alt text"
     default-src="${imgLg16x9}"
-    heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-  >
+    heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit.">
     <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}">
     </dds-image-item>
     <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}">
@@ -91,8 +90,7 @@ export const WithVideo = (args) => {
         <dds-content-block-copy>${copy}</dds-content-block-copy>
         <dds-leadspace-block-media slot="media"
           ><dds-video-player-container
-            video-id="0_ibuqxqbe"
-          ></dds-video-player-container
+            video-id="0_ibuqxqbe"></dds-video-player-container
         ></dds-leadspace-block-media>
         ${linkList} ${buttonCTA}
       </dds-leadspace-block-content>

--- a/packages/web-components/src/components/leadspace-block/__stories__/leadspace-block.stories.ts
+++ b/packages/web-components/src/components/leadspace-block/__stories__/leadspace-block.stories.ts
@@ -26,7 +26,8 @@ const image = html`
   <dds-image
     alt="Image alt text"
     default-src="${imgLg16x9}"
-    heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit.">
+    heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+  >
     <dds-image-item media="(min-width: 672px)" srcset="${imgLg16x9}">
     </dds-image-item>
     <dds-image-item media="(min-width: 400px)" srcset="${imgMd16x9}">
@@ -39,11 +40,11 @@ const image = html`
 const linkList = html`
   <dds-link-list type="end">
     <dds-link-list-heading>Featured products</dds-link-list-heading>
-    <dds-link-list-item href="https://example.com">
-      IBM Cloud Continuous Delivery ${ArrowRight20({ slot: 'icon' })}
+    <dds-link-list-item href="https://example.com" cta-type="local">
+      IBM Cloud Continuous Delivery
     </dds-link-list-item>
-    <dds-link-list-item href="https://example.com">
-      UrbanCode ${ArrowRight20({ slot: 'icon' })}
+    <dds-link-list-item href="https://example.com" cta-type="local">
+      UrbanCode
     </dds-link-list-item>
     <dds-link-list-item href="https://example.com">
       View all products ${Download20({ slot: 'icon' })}
@@ -86,7 +87,8 @@ export const WithVideo = (args) => {
         <dds-content-block-copy>${copy}</dds-content-block-copy>
         <dds-leadspace-block-media slot="media"
           ><dds-video-player-container
-            video-id="0_ibuqxqbe"></dds-video-player-container
+            video-id="0_ibuqxqbe"
+          ></dds-video-player-container
         ></dds-leadspace-block-media>
         ${linkList} ${buttonCTA}
       </dds-leadspace-block-content>

--- a/packages/web-components/src/components/leadspace-block/__stories__/leadspace-block.stories.ts
+++ b/packages/web-components/src/components/leadspace-block/__stories__/leadspace-block.stories.ts
@@ -10,6 +10,7 @@
 import { html } from 'lit-element';
 import { text } from '@storybook/addon-knobs';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import Download20 from '../../../internal/vendor/@carbon/web-components/icons/download/20';
 
 import '../index';
@@ -55,7 +56,10 @@ const linkList = html`
 const buttonCTA = html`
   <dds-leadspace-block-cta>
     <dds-button-group-item href="www.ibm.com"
-      >Contact sales ${ArrowRight20({ slot: 'icon' })}</dds-button-group-item
+      >Contact sales
+      ${document.dir === 'rtl'
+        ? ArrowLeft20({ slot: 'icon' })
+        : ArrowRight20({ slot: 'icon' })}</dds-button-group-item
     >
   </dds-leadspace-block-cta>
 `;

--- a/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
+++ b/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
@@ -98,8 +98,7 @@ export const SuperWithImage = (args) => {
       size="${LEADSPACE_SIZE.SUPER}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}"
-    >
+      default-src="${ifNonNull(defaultSrc)}">
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -119,8 +118,7 @@ export const SuperWithImage = (args) => {
         slot="image"
         alt="${ifNonNull(alt)}"
         default-src="${defaultSrc}"
-        opacity="100"
-      >
+        opacity="100">
         <dds-image-item media="(min-width: 1312px)" srcset="${image}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${image}">
@@ -153,8 +151,7 @@ export const SuperWithVideo = (args) => {
       size="${LEADSPACE_SIZE.SUPER}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}"
-    >
+      default-src="${ifNonNull(defaultSrc)}">
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -173,8 +170,7 @@ export const SuperWithVideo = (args) => {
       <dds-background-media slot="image" opacity="100">
         <dds-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"
-        ></dds-video-player-container>
+          background-mode="true"></dds-video-player-container>
       </dds-background-media>
     </dds-leadspace>
   `;
@@ -223,8 +219,7 @@ export const TallWithImage = (args) => {
       size="${LEADSPACE_SIZE.TALL}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}"
-    >
+      default-src="${ifNonNull(defaultSrc)}">
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -244,8 +239,7 @@ export const TallWithImage = (args) => {
         slot="image"
         alt="${ifNonNull(alt)}"
         default-src="${defaultSrc}"
-        opacity="100"
-      >
+        opacity="100">
         <dds-image-item media="(min-width: 1312px)" srcset="${image}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${image}">
@@ -278,8 +272,7 @@ export const TallWithVideo = (args) => {
       size="${LEADSPACE_SIZE.TALL}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}"
-    >
+      default-src="${ifNonNull(defaultSrc)}">
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -298,8 +291,7 @@ export const TallWithVideo = (args) => {
       <dds-background-media slot="image" opacity="100">
         <dds-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"
-        ></dds-video-player-container>
+          background-mode="true"></dds-video-player-container>
       </dds-background-media>
     </dds-leadspace>
   `;
@@ -348,8 +340,7 @@ export const MediumWithImage = (args) => {
       size="${LEADSPACE_SIZE.MEDIUM}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}"
-    >
+      default-src="${ifNonNull(defaultSrc)}">
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -369,8 +360,7 @@ export const MediumWithImage = (args) => {
         slot="image"
         alt="${ifNonNull(alt)}"
         default-src="${defaultSrc}"
-        opacity="100"
-      >
+        opacity="100">
         <dds-image-item media="(min-width: 1312px)" srcset="${image}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${image}">
@@ -403,8 +393,7 @@ export const MediumWithVideo = (args) => {
       size="${LEADSPACE_SIZE.MEDIUM}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}"
-    >
+      default-src="${ifNonNull(defaultSrc)}">
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -423,8 +412,7 @@ export const MediumWithVideo = (args) => {
       <dds-background-media slot="image" opacity="100">
         <dds-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"
-        ></dds-video-player-container>
+          background-mode="true"></dds-video-player-container>
       </dds-background-media>
     </dds-leadspace>
   `;
@@ -480,8 +468,7 @@ export const ShortWithImage = (args) => {
       size="${LEADSPACE_SIZE.SHORT}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}"
-    >
+      default-src="${ifNonNull(defaultSrc)}">
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -489,8 +476,7 @@ export const ShortWithImage = (args) => {
         slot="image"
         alt="${ifNonNull(alt)}"
         default-src="${defaultSrc}"
-        opacity="100"
-      >
+        opacity="100">
         <dds-image-item media="(min-width: 1312px)" srcset="${image}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${image}">
@@ -543,16 +529,14 @@ export const ShortWithVideo = (args) => {
       size="${LEADSPACE_SIZE.SHORT}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}"
-    >
+      default-src="${ifNonNull(defaultSrc)}">
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
       <dds-background-media slot="image" opacity="100">
         <dds-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"
-        ></dds-video-player-container>
+          background-mode="true"></dds-video-player-container>
       </dds-background-media>
     </dds-leadspace>
   `;
@@ -595,8 +579,7 @@ export const CenteredWithImage = (args) => {
       ?gradient="${ifNonNull(gradient)}"
       alt="${ifNonNull(alt)}"
       default-src="${ifNonNull(defaultSrc)}"
-      type="centered"
-    >
+      type="centered">
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -616,8 +599,7 @@ export const CenteredWithImage = (args) => {
         slot="image"
         alt="${ifNonNull(alt)}"
         default-src="${defaultSrc}"
-        opacity="100"
-      >
+        opacity="100">
         <dds-image-item media="(min-width: 1312px)" srcset="${image}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${image}">
@@ -644,8 +626,7 @@ export const CenteredWithVideo = (args) => {
       ?gradient="${ifNonNull(gradient)}"
       alt="${ifNonNull(alt)}"
       default-src="${ifNonNull(defaultSrc)}"
-      type="centered"
-    >
+      type="centered">
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -664,8 +645,7 @@ export const CenteredWithVideo = (args) => {
       <dds-background-media slot="image" opacity="100">
         <dds-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"
-        ></dds-video-player-container>
+          background-mode="true"></dds-video-player-container>
       </dds-background-media>
     </dds-leadspace>
   `;

--- a/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
+++ b/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
@@ -10,6 +10,7 @@
 import { text, select, number } from '@storybook/addon-knobs';
 import { html } from 'lit-element';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import ArrowDown20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--down/20.js';
 import Pdf20 from '../../../internal/vendor/@carbon/web-components/icons/PDF/20.js';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
@@ -97,7 +98,8 @@ export const SuperWithImage = (args) => {
       size="${LEADSPACE_SIZE.SUPER}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}">
+      default-src="${ifNonNull(defaultSrc)}"
+    >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -117,7 +119,8 @@ export const SuperWithImage = (args) => {
         slot="image"
         alt="${ifNonNull(alt)}"
         default-src="${defaultSrc}"
-        opacity="100">
+        opacity="100"
+      >
         <dds-image-item media="(min-width: 1312px)" srcset="${image}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${image}">
@@ -150,7 +153,8 @@ export const SuperWithVideo = (args) => {
       size="${LEADSPACE_SIZE.SUPER}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}">
+      default-src="${ifNonNull(defaultSrc)}"
+    >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -169,7 +173,8 @@ export const SuperWithVideo = (args) => {
       <dds-background-media slot="image" opacity="100">
         <dds-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></dds-video-player-container>
+          background-mode="true"
+        ></dds-video-player-container>
       </dds-background-media>
     </dds-leadspace>
   `;
@@ -218,7 +223,8 @@ export const TallWithImage = (args) => {
       size="${LEADSPACE_SIZE.TALL}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}">
+      default-src="${ifNonNull(defaultSrc)}"
+    >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -238,7 +244,8 @@ export const TallWithImage = (args) => {
         slot="image"
         alt="${ifNonNull(alt)}"
         default-src="${defaultSrc}"
-        opacity="100">
+        opacity="100"
+      >
         <dds-image-item media="(min-width: 1312px)" srcset="${image}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${image}">
@@ -271,7 +278,8 @@ export const TallWithVideo = (args) => {
       size="${LEADSPACE_SIZE.TALL}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}">
+      default-src="${ifNonNull(defaultSrc)}"
+    >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -290,7 +298,8 @@ export const TallWithVideo = (args) => {
       <dds-background-media slot="image" opacity="100">
         <dds-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></dds-video-player-container>
+          background-mode="true"
+        ></dds-video-player-container>
       </dds-background-media>
     </dds-leadspace>
   `;
@@ -339,7 +348,8 @@ export const MediumWithImage = (args) => {
       size="${LEADSPACE_SIZE.MEDIUM}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}">
+      default-src="${ifNonNull(defaultSrc)}"
+    >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -359,7 +369,8 @@ export const MediumWithImage = (args) => {
         slot="image"
         alt="${ifNonNull(alt)}"
         default-src="${defaultSrc}"
-        opacity="100">
+        opacity="100"
+      >
         <dds-image-item media="(min-width: 1312px)" srcset="${image}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${image}">
@@ -392,7 +403,8 @@ export const MediumWithVideo = (args) => {
       size="${LEADSPACE_SIZE.MEDIUM}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}">
+      default-src="${ifNonNull(defaultSrc)}"
+    >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -411,7 +423,8 @@ export const MediumWithVideo = (args) => {
       <dds-background-media slot="image" opacity="100">
         <dds-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></dds-video-player-container>
+          background-mode="true"
+        ></dds-video-player-container>
       </dds-background-media>
     </dds-leadspace>
   `;
@@ -467,7 +480,8 @@ export const ShortWithImage = (args) => {
       size="${LEADSPACE_SIZE.SHORT}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}">
+      default-src="${ifNonNull(defaultSrc)}"
+    >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -475,7 +489,8 @@ export const ShortWithImage = (args) => {
         slot="image"
         alt="${ifNonNull(alt)}"
         default-src="${defaultSrc}"
-        opacity="100">
+        opacity="100"
+      >
         <dds-image-item media="(min-width: 1312px)" srcset="${image}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${image}">
@@ -528,14 +543,16 @@ export const ShortWithVideo = (args) => {
       size="${LEADSPACE_SIZE.SHORT}"
       gradient-style-scheme="${ifNonNull(gradientStyleScheme)}"
       alt="${ifNonNull(alt)}"
-      default-src="${ifNonNull(defaultSrc)}">
+      default-src="${ifNonNull(defaultSrc)}"
+    >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
       <dds-background-media slot="image" opacity="100">
         <dds-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></dds-video-player-container>
+          background-mode="true"
+        ></dds-video-player-container>
       </dds-background-media>
     </dds-leadspace>
   `;
@@ -578,7 +595,8 @@ export const CenteredWithImage = (args) => {
       ?gradient="${ifNonNull(gradient)}"
       alt="${ifNonNull(alt)}"
       default-src="${ifNonNull(defaultSrc)}"
-      type="centered">
+      type="centered"
+    >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -598,7 +616,8 @@ export const CenteredWithImage = (args) => {
         slot="image"
         alt="${ifNonNull(alt)}"
         default-src="${defaultSrc}"
-        opacity="100">
+        opacity="100"
+      >
         <dds-image-item media="(min-width: 1312px)" srcset="${image}">
         </dds-image-item>
         <dds-image-item media="(min-width: 672px)" srcset="${image}">
@@ -625,7 +644,8 @@ export const CenteredWithVideo = (args) => {
       ?gradient="${ifNonNull(gradient)}"
       alt="${ifNonNull(alt)}"
       default-src="${ifNonNull(defaultSrc)}"
-      type="centered">
+      type="centered"
+    >
       ${navElements === navigationOptions[0] ? navigationWithTagGroup : ``}
       ${navElements === navigationOptions[1] ? navigationWithBreadcrumbs : ``}
       <dds-leadspace-heading>${ifNonNull(title)}</dds-leadspace-heading>
@@ -644,7 +664,8 @@ export const CenteredWithVideo = (args) => {
       <dds-background-media slot="image" opacity="100">
         <dds-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></dds-video-player-container>
+          background-mode="true"
+        ></dds-video-player-container>
       </dds-background-media>
     </dds-leadspace>
   `;
@@ -667,15 +688,18 @@ const getAriaLabel = (type) => {
 
 const iconMap = {
   ArrowRight20: ArrowRight20({ slot: 'icon' }),
+  ArrowLeft20: ArrowLeft20({ slot: 'icon' }),
   ArrowDown20: ArrowDown20({ slot: 'icon' }),
   Pdf20: Pdf20({ slot: 'icon' }),
 };
 
-const iconOptions = {
-  None: null,
-  'Arrow Right': 'ArrowRight20',
-  'Arrow Down': 'ArrowDown20',
-  PDF: 'Pdf20',
+const iconOptions = () => {
+  return {
+    None: null,
+    'Arrow Inline End': document.dir === 'rtl' ? 'ArrowLeft20' : 'ArrowRight20',
+    'Arrow Down': 'ArrowDown20',
+    PDF: 'Pdf20',
+  };
 };
 
 export default {
@@ -703,8 +727,11 @@ export default {
           length: number('Number of buttons', 2, {}),
         }).map((_, i) => {
           const icon =
-            select(`Icon ${i + 1}`, iconOptions, iconOptions['Arrow Right']) ??
-            0;
+            select(
+              `Icon ${i + 1}`,
+              iconOptions(),
+              iconOptions()['Arrow Inline End']
+            ) ?? 0;
           return {
             href: textNullable(`Link ${i + 1}`, `https://example.com`),
             copy: text(`Button ${i + 1}`, `Button ${i + 1}`),
@@ -731,13 +758,13 @@ export default {
             {
               href: 'https://example.com',
               copy: 'Button 1',
-              renderIcon: iconOptions['Arrow Right'],
+              renderIcon: iconOptions()['Arrow Inline End'],
               label: '',
             },
             {
               href: 'https://example.com',
               copy: 'Button 2',
-              renderIcon: iconOptions['Arrow Right'],
+              renderIcon: iconOptions()['Arrow Inline End'],
               label: '',
             },
           ],

--- a/packages/web-components/src/components/link-list-section/__stories__/link-list-section.stories.ts
+++ b/packages/web-components/src/components/link-list-section/__stories__/link-list-section.stories.ts
@@ -8,7 +8,6 @@
  */
 
 import { html } from 'lit-element';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
 import '../index';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 import readme from './README.stories.mdx';
@@ -19,24 +18,23 @@ export const Default = (args) => {
     <dds-link-list-section>
       <dds-link-list-heading>${heading}</dds-link-list-heading>
       <dds-link-list>
-        <dds-link-list-item href="https://example.com">
+        <dds-link-list-item href="https://example.com" cta-type="local">
           Learn more about Kubernetes and automating deployment
-          ${ArrowRight20({ slot: 'icon' })}
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          Containerization A Complete Guide ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          Containerization A Complete Guide
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          Microservices and containers ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          Microservices and containers
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          Learn more about Kubernetes ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          Learn more about Kubernetes
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          Containerization A Complete Guide ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          Containerization A Complete Guide
         </dds-link-list-item>
-        <dds-link-list-item href="https://example.com">
-          Microservices and containers ${ArrowRight20({ slot: 'icon' })}
+        <dds-link-list-item href="https://example.com" cta-type="local">
+          Microservices and containers
         </dds-link-list-item>
       </dds-link-list>
     </dds-link-list-section>

--- a/packages/web-components/src/components/link-list/__stories__/link-list.stories.ts
+++ b/packages/web-components/src/components/link-list/__stories__/link-list.stories.ts
@@ -80,8 +80,7 @@ export const Default = (args) => {
           <dds-link-list-item-card-cta
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}"
-          >
+            download="${ifNonNull(download)}">
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` <p>Learn more about Kubernetes</p> `
               : null}
@@ -90,8 +89,7 @@ export const Default = (args) => {
           <dds-link-list-item-card-cta
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}"
-          >
+            download="${ifNonNull(download)}">
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` <p>Containerization A Complete Guide</p> `
               : null}
@@ -150,15 +148,13 @@ export const Horizontal = (args) => {
           <dds-link-list-item
             icon-placement="${iconPlacement}"
             href="https://example.com"
-            cta-type="local"
-          >
+            cta-type="local">
             Learn more about Kubernetes
           </dds-link-list-item>
           <dds-link-list-item
             icon-placement="${iconPlacement}"
             href="https://example.com"
-            cta-type="local"
-          >
+            cta-type="local">
             Containerization A Complete Guide
           </dds-link-list-item>
         </dds-link-list>
@@ -170,8 +166,7 @@ export const Horizontal = (args) => {
             icon-placement="${iconPlacement}"
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}"
-          >
+            download="${ifNonNull(download)}">
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Learn more about Kubernetes `
               : null}
@@ -180,8 +175,7 @@ export const Horizontal = (args) => {
             icon-placement="${iconPlacement}"
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}"
-          >
+            download="${ifNonNull(download)}">
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Containerization A Complete Guide `
               : null}
@@ -239,15 +233,13 @@ export const Vertical = (args) => {
           <dds-link-list-item
             icon-placement="${iconPlacement}"
             href="https://example.com"
-            cta-type="local"
-          >
+            cta-type="local">
             Learn more about Kubernetes
           </dds-link-list-item>
           <dds-link-list-item
             icon-placement="${iconPlacement}"
             href="https://example.com"
-            cta-type="local"
-          >
+            cta-type="local">
             Containerization A Complete Guide
           </dds-link-list-item>
         </dds-link-list>
@@ -259,8 +251,7 @@ export const Vertical = (args) => {
             icon-placement="${iconPlacement}"
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}"
-          >
+            download="${ifNonNull(download)}">
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Learn more about Kubernetes `
               : null}
@@ -269,8 +260,7 @@ export const Vertical = (args) => {
             icon-placement="${iconPlacement}"
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}"
-          >
+            download="${ifNonNull(download)}">
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Containerization A Complete Guide `
               : null}
@@ -318,8 +308,7 @@ export const EndOfSection = (args) => {
           <dds-link-list-item-cta
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}"
-          >
+            download="${ifNonNull(download)}">
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Learn more about Kubernetes `
               : null}
@@ -327,8 +316,7 @@ export const EndOfSection = (args) => {
           <dds-link-list-item-cta
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}"
-          >
+            download="${ifNonNull(download)}">
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Containerization A Complete Guide `
               : null}
@@ -336,8 +324,7 @@ export const EndOfSection = (args) => {
           <dds-link-list-item-cta
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}"
-          >
+            download="${ifNonNull(download)}">
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Microservices and containers `
               : null}

--- a/packages/web-components/src/components/link-list/__stories__/link-list.stories.ts
+++ b/packages/web-components/src/components/link-list/__stories__/link-list.stories.ts
@@ -9,6 +9,7 @@
 
 import { html } from 'lit-element';
 import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import { select } from '@storybook/addon-knobs';
 import textNullable from '../../../../.storybook/knob-text-nullable';
@@ -58,13 +59,17 @@ export const Default = (args) => {
           <dds-link-list-item-card href="https://example.com">
             <p>Learn more about Kubernetes</p>
             <dds-card-footer>
-              ${ArrowRight20({ slot: 'icon' })}
+              ${document.dir === 'rtl'
+                ? ArrowLeft20({ slot: 'icon' })
+                : ArrowRight20({ slot: 'icon' })}
             </dds-card-footer>
           </dds-link-list-item-card>
           <dds-link-list-item-card href="https://example.com">
             <p>Containerization A Complete Guide</p>
             <dds-card-footer>
-              ${ArrowRight20({ slot: 'icon' })}
+              ${document.dir === 'rtl'
+                ? ArrowLeft20({ slot: 'icon' })
+                : ArrowRight20({ slot: 'icon' })}
             </dds-card-footer>
           </dds-link-list-item-card>
         </dds-link-list>
@@ -75,7 +80,8 @@ export const Default = (args) => {
           <dds-link-list-item-card-cta
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}">
+            download="${ifNonNull(download)}"
+          >
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` <p>Learn more about Kubernetes</p> `
               : null}
@@ -84,7 +90,8 @@ export const Default = (args) => {
           <dds-link-list-item-card-cta
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}">
+            download="${ifNonNull(download)}"
+          >
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` <p>Containerization A Complete Guide</p> `
               : null}
@@ -142,13 +149,17 @@ export const Horizontal = (args) => {
           <dds-link-list-heading>Tutorial</dds-link-list-heading>
           <dds-link-list-item
             icon-placement="${iconPlacement}"
-            href="https://example.com">
-            Learn more about Kubernetes ${ArrowRight20({ slot: 'icon' })}
+            href="https://example.com"
+            cta-type="local"
+          >
+            Learn more about Kubernetes
           </dds-link-list-item>
           <dds-link-list-item
             icon-placement="${iconPlacement}"
-            href="https://example.com">
-            Containerization A Complete Guide ${ArrowRight20({ slot: 'icon' })}
+            href="https://example.com"
+            cta-type="local"
+          >
+            Containerization A Complete Guide
           </dds-link-list-item>
         </dds-link-list>
       `
@@ -159,7 +170,8 @@ export const Horizontal = (args) => {
             icon-placement="${iconPlacement}"
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}">
+            download="${ifNonNull(download)}"
+          >
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Learn more about Kubernetes `
               : null}
@@ -168,7 +180,8 @@ export const Horizontal = (args) => {
             icon-placement="${iconPlacement}"
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}">
+            download="${ifNonNull(download)}"
+          >
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Containerization A Complete Guide `
               : null}
@@ -225,13 +238,17 @@ export const Vertical = (args) => {
           <dds-link-list-heading>Tutorial</dds-link-list-heading>
           <dds-link-list-item
             icon-placement="${iconPlacement}"
-            href="https://example.com">
-            Learn more about Kubernetes ${ArrowRight20({ slot: 'icon' })}
+            href="https://example.com"
+            cta-type="local"
+          >
+            Learn more about Kubernetes
           </dds-link-list-item>
           <dds-link-list-item
             icon-placement="${iconPlacement}"
-            href="https://example.com">
-            Containerization A Complete Guide ${ArrowRight20({ slot: 'icon' })}
+            href="https://example.com"
+            cta-type="local"
+          >
+            Containerization A Complete Guide
           </dds-link-list-item>
         </dds-link-list>
       `
@@ -242,7 +259,8 @@ export const Vertical = (args) => {
             icon-placement="${iconPlacement}"
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}">
+            download="${ifNonNull(download)}"
+          >
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Learn more about Kubernetes `
               : null}
@@ -251,7 +269,8 @@ export const Vertical = (args) => {
             icon-placement="${iconPlacement}"
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}">
+            download="${ifNonNull(download)}"
+          >
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Containerization A Complete Guide `
               : null}
@@ -282,14 +301,14 @@ export const EndOfSection = (args) => {
     ? html`
         <dds-link-list type="end">
           <dds-link-list-heading>Tutorial</dds-link-list-heading>
-          <dds-link-list-item href="https://example.com">
-            Learn more about Kubernetes ${ArrowRight20({ slot: 'icon' })}
+          <dds-link-list-item href="https://example.com" cta-type="local">
+            Learn more about Kubernetes
           </dds-link-list-item>
-          <dds-link-list-item href="https://example.com">
-            Containerization A Complete Guide ${ArrowRight20({ slot: 'icon' })}
+          <dds-link-list-item href="https://example.com" cta-type="local">
+            Containerization A Complete Guide
           </dds-link-list-item>
-          <dds-link-list-item href="https://example.com">
-            Microservices and containers ${ArrowRight20({ slot: 'icon' })}
+          <dds-link-list-item href="https://example.com" cta-type="local">
+            Microservices and containers
           </dds-link-list-item>
         </dds-link-list>
       `
@@ -299,7 +318,8 @@ export const EndOfSection = (args) => {
           <dds-link-list-item-cta
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}">
+            download="${ifNonNull(download)}"
+          >
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Learn more about Kubernetes `
               : null}
@@ -307,7 +327,8 @@ export const EndOfSection = (args) => {
           <dds-link-list-item-cta
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}">
+            download="${ifNonNull(download)}"
+          >
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Containerization A Complete Guide `
               : null}
@@ -315,7 +336,8 @@ export const EndOfSection = (args) => {
           <dds-link-list-item-cta
             href="${ifNonNull(href)}"
             cta-type="${ifNonNull(ctaType)}"
-            download="${ifNonNull(download)}">
+            download="${ifNonNull(download)}"
+          >
             ${ctaType !== CTA_TYPE.VIDEO
               ? html` Microservices and containers `
               : null}

--- a/packages/web-components/src/components/link-with-icon/__stories__/link-with-icon.stories.ts
+++ b/packages/web-components/src/components/link-with-icon/__stories__/link-with-icon.stories.ts
@@ -10,7 +10,6 @@
 import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 import readme from './README.stories.mdx';

--- a/packages/web-components/src/components/link-with-icon/__stories__/link-with-icon.stories.ts
+++ b/packages/web-components/src/components/link-with-icon/__stories__/link-with-icon.stories.ts
@@ -24,8 +24,10 @@ export const Default = (args) => {
       icon-placement="${iconPlacement}"
       ?disabled="${disabled}"
       href="${ifNonNull(href)}"
-      @click="${onClick}">
-      ${children}${ArrowRight20({ slot: 'icon' })}
+      @click="${onClick}"
+      cta-type="local"
+    >
+      ${children}
     </dds-link-with-icon>
   `;
 };

--- a/packages/web-components/src/components/link-with-icon/__stories__/link-with-icon.stories.ts
+++ b/packages/web-components/src/components/link-with-icon/__stories__/link-with-icon.stories.ts
@@ -24,8 +24,7 @@ export const Default = (args) => {
       ?disabled="${disabled}"
       href="${ifNonNull(href)}"
       @click="${onClick}"
-      cta-type="local"
-    >
+      cta-type="local">
       ${children}
     </dds-link-with-icon>
   `;

--- a/packages/web-components/src/components/link-with-icon/link-with-icon.ts
+++ b/packages/web-components/src/components/link-with-icon/link-with-icon.ts
@@ -15,6 +15,8 @@ import { ICON_PLACEMENT } from '../../globals/defs';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './link-with-icon.scss';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
+import CTAMixin from '../../component-mixins/cta/cta';
+import { CTA_TYPE } from '../cta/defs';
 
 export { ICON_PLACEMENT };
 
@@ -29,7 +31,10 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * @slot icon-left - The CTA icon to place at the left.
  */
 @customElement(`${ddsPrefix}-link-with-icon`)
-class DDSLinkWithIcon extends StableSelectorMixin(BXLink) {
+class DDSLinkWithIcon extends CTAMixin(StableSelectorMixin(BXLink)) {
+  @property({ attribute: 'cta-type', reflect: true })
+  ctaType = CTA_TYPE['LOCAL'];
+
   /**
    * Icon placement(right (default) | left)
    */
@@ -56,14 +61,6 @@ class DDSLinkWithIcon extends StableSelectorMixin(BXLink) {
   // eslint-disable-next-line class-methods-use-this
   protected _renderContent(): TemplateResult | string | void {
     return html` <span><slot></slot></span> `;
-  }
-
-  /**
-   * @returns The icon content.
-   */
-  // eslint-disable-next-line class-methods-use-this
-  protected _renderIcon(): TemplateResult | string | void {
-    return html` <slot name="icon"></slot> `;
   }
 
   protected _renderInner() {

--- a/packages/web-components/src/components/link-with-icon/link-with-icon.ts
+++ b/packages/web-components/src/components/link-with-icon/link-with-icon.ts
@@ -33,7 +33,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 @customElement(`${ddsPrefix}-link-with-icon`)
 class DDSLinkWithIcon extends CTAMixin(StableSelectorMixin(BXLink)) {
   @property({ attribute: 'cta-type', reflect: true })
-  ctaType = CTA_TYPE['LOCAL'];
+  ctaType = CTA_TYPE.REGULAR;
 
   /**
    * Icon placement(right (default) | left)

--- a/packages/web-components/src/components/logo-grid/__stories__/logo-grid.stories.ts
+++ b/packages/web-components/src/components/logo-grid/__stories__/logo-grid.stories.ts
@@ -15,7 +15,8 @@ import '../../card-link/card-link-heading';
 import '../../card/card-footer';
 import { boolean, text, select } from '@storybook/addon-knobs';
 import { html } from 'lit-element';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
+import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
+import ArrowLeft20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--left/20';
 import logos from './data/logos.js';
 import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';
@@ -36,14 +37,16 @@ export const Default = (args) => {
     <dds-logo-grid
       ?hide-border="${hideBorder}"
       logo-count="${logoCount}"
-      logo-ratio="${logoRatio}">
+      logo-ratio="${logoRatio}"
+    >
       <dds-content-block-heading> ${heading} </dds-content-block-heading>
       ${logosGroup &&
       logosGroup.map(
         (elem) => html`
           <dds-logo-grid-item
             default-src="${elem.imgSrc}"
-            alt="${elem.altText}"></dds-logo-grid-item>
+            alt="${elem.altText}"
+          ></dds-logo-grid-item>
         `
       )}
       ${showCta
@@ -51,7 +54,9 @@ export const Default = (args) => {
             <dds-logo-grid-link href="${ctaHref}">
               <dds-card-link-heading>${ctaCopy}</dds-card-link-heading>
               <dds-card-footer>
-                ${ArrowRight20({ slot: 'icon' })}
+                ${document.dir === 'rtl'
+                  ? ArrowLeft20({ slot: 'icon' })
+                  : ArrowRight20({ slot: 'icon' })}
               </dds-card-footer>
             </dds-logo-grid-link>
           `

--- a/packages/web-components/src/components/logo-grid/__stories__/logo-grid.stories.ts
+++ b/packages/web-components/src/components/logo-grid/__stories__/logo-grid.stories.ts
@@ -37,16 +37,14 @@ export const Default = (args) => {
     <dds-logo-grid
       ?hide-border="${hideBorder}"
       logo-count="${logoCount}"
-      logo-ratio="${logoRatio}"
-    >
+      logo-ratio="${logoRatio}">
       <dds-content-block-heading> ${heading} </dds-content-block-heading>
       ${logosGroup &&
       logosGroup.map(
         (elem) => html`
           <dds-logo-grid-item
             default-src="${elem.imgSrc}"
-            alt="${elem.altText}"
-          ></dds-logo-grid-item>
+            alt="${elem.altText}"></dds-logo-grid-item>
         `
       )}
       ${showCta

--- a/packages/web-components/src/components/pictogram-item/__stories__/pictogram-item.stories.ts
+++ b/packages/web-components/src/components/pictogram-item/__stories__/pictogram-item.stories.ts
@@ -29,16 +29,14 @@ const Desktop = html`
     height="64"
     viewBox="8 8 32 32"
     role="img"
-    class="bx--pictogram-item__pictogram"
-  >
+    class="bx--pictogram-item__pictogram">
     <path
       fill="none"
       stroke-linejoin="round"
       stroke-miterlimit="10"
       stroke-width=".72"
       d="M37,32 H11c-1.1,0-2-0.9-2-2V13c0-1.1,0.9-2,2-2h26c1.1,
-  0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"
-    ></path>
+  0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"></path>
   </svg>
 `;
 const Pattern = html`
@@ -55,8 +53,7 @@ const Pattern = html`
     viewBox="0 0 32 32"
     role="img"
     class="bx--pictogram-item__pictogram"
-    style="enable-background:new 0 0 32 32;"
-  >
+    style="enable-background:new 0 0 32 32;">
     <path
       id="pattern_1_"
       d="M29,31.36H13c-1.301,0-2.36-1.059-2.36-2.36v-7.64H3c-1.301,0-2.36-1.059-2.36-2.36V3
@@ -81,14 +78,12 @@ const Pattern = html`
       C15.36,14.75,14.75,15.36,14,15.36z M13,12.36c-0.353,0-0.64,0.287-0.64,0.64v1c0,0.353,0.287,0.64,0.64,0.64h1
       c0.353,0,0.64-0.287,0.64-0.64v-1c0-0.353-0.287-0.64-0.64-0.64H13z M9,10.36H8c-0.75,0-1.36-0.61-1.36-1.36V8
       c0-0.75,0.61-1.36,1.36-1.36h1c0.75,0,1.36,0.61,1.36,1.36v1C10.36,9.75,9.75,10.36,9,10.36z M8,7.36C7.647,7.36,7.36,7.647,7.36,8
-      v1c0,0.353,0.287,0.64,0.64,0.64h1c0.353,0,0.64-0.287,0.64-0.64V8c0-0.353-0.287-0.64-0.64-0.64H8z"
-    />
+      v1c0,0.353,0.287,0.64,0.64,0.64h1c0.353,0,0.64-0.287,0.64-0.64V8c0-0.353-0.287-0.64-0.64-0.64H8z" />
     <rect
       id="_Transparent_Rectangle"
       style="fill:none;"
       width="32"
-      height="32"
-    />
+      height="32" />
   </svg>
 `;
 const Touch = html`
@@ -104,8 +99,7 @@ const Touch = html`
     height="64"
     viewBox="0 0 32 32"
     role="img"
-    class="bx--pictogram-item__pictogram"
-  >
+    class="bx--pictogram-item__pictogram">
     <path
       id="touch_1_"
       d="M19.77,31.36c-5.067,0-7.409-2.218-10.404-5.602c-0.844-0.953-3.435-3.76-3.435-3.76L5.43,21.444
@@ -119,14 +113,12 @@ const Touch = html`
 	c-0.413,0.203-0.65,0.463-0.65,0.711c0.057,0.274,1.063,1.38,1.603,1.975L6.465,21.516z M10.755,11.729
 	C9.407,10.535,8.634,8.811,8.634,7c0-3.507,2.853-6.36,6.36-6.36s6.36,2.853,6.36,6.36c0,1.811-0.773,3.534-2.121,4.729
 	l-0.479-0.539c1.194-1.058,1.879-2.585,1.879-4.19c0-3.11-2.529-5.64-5.64-5.64c-3.11,0-5.64,2.53-5.64,5.64
-	c0,1.605,0.685,3.133,1.879,4.19L10.755,11.729z"
-    />
+	c0,1.605,0.685,3.133,1.879,4.19L10.755,11.729z" />
     <rect
       id="_Transparent_Rectangle"
       style="fill:none;"
       width="32"
-      height="32"
-    />
+      height="32" />
   </svg>
 `;
 /* eslint-enable max-len */

--- a/packages/web-components/src/components/pictogram-item/__stories__/pictogram-item.stories.ts
+++ b/packages/web-components/src/components/pictogram-item/__stories__/pictogram-item.stories.ts
@@ -9,7 +9,6 @@
 
 import { html } from 'lit-element';
 import '../index';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
 import { select } from '@storybook/addon-knobs';
 import styles from './pictogram-item.stories.scss';
 import { COLOR_OPTIONS } from '../defs';
@@ -30,14 +29,16 @@ const Desktop = html`
     height="64"
     viewBox="8 8 32 32"
     role="img"
-    class="bx--pictogram-item__pictogram">
+    class="bx--pictogram-item__pictogram"
+  >
     <path
       fill="none"
       stroke-linejoin="round"
       stroke-miterlimit="10"
       stroke-width=".72"
       d="M37,32 H11c-1.1,0-2-0.9-2-2V13c0-1.1,0.9-2,2-2h26c1.1,
-  0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"></path>
+  0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"
+    ></path>
   </svg>
 `;
 const Pattern = html`
@@ -54,7 +55,8 @@ const Pattern = html`
     viewBox="0 0 32 32"
     role="img"
     class="bx--pictogram-item__pictogram"
-    style="enable-background:new 0 0 32 32;">
+    style="enable-background:new 0 0 32 32;"
+  >
     <path
       id="pattern_1_"
       d="M29,31.36H13c-1.301,0-2.36-1.059-2.36-2.36v-7.64H3c-1.301,0-2.36-1.059-2.36-2.36V3
@@ -79,12 +81,14 @@ const Pattern = html`
       C15.36,14.75,14.75,15.36,14,15.36z M13,12.36c-0.353,0-0.64,0.287-0.64,0.64v1c0,0.353,0.287,0.64,0.64,0.64h1
       c0.353,0,0.64-0.287,0.64-0.64v-1c0-0.353-0.287-0.64-0.64-0.64H13z M9,10.36H8c-0.75,0-1.36-0.61-1.36-1.36V8
       c0-0.75,0.61-1.36,1.36-1.36h1c0.75,0,1.36,0.61,1.36,1.36v1C10.36,9.75,9.75,10.36,9,10.36z M8,7.36C7.647,7.36,7.36,7.647,7.36,8
-      v1c0,0.353,0.287,0.64,0.64,0.64h1c0.353,0,0.64-0.287,0.64-0.64V8c0-0.353-0.287-0.64-0.64-0.64H8z" />
+      v1c0,0.353,0.287,0.64,0.64,0.64h1c0.353,0,0.64-0.287,0.64-0.64V8c0-0.353-0.287-0.64-0.64-0.64H8z"
+    />
     <rect
       id="_Transparent_Rectangle"
       style="fill:none;"
       width="32"
-      height="32" />
+      height="32"
+    />
   </svg>
 `;
 const Touch = html`
@@ -100,7 +104,8 @@ const Touch = html`
     height="64"
     viewBox="0 0 32 32"
     role="img"
-    class="bx--pictogram-item__pictogram">
+    class="bx--pictogram-item__pictogram"
+  >
     <path
       id="touch_1_"
       d="M19.77,31.36c-5.067,0-7.409-2.218-10.404-5.602c-0.844-0.953-3.435-3.76-3.435-3.76L5.43,21.444
@@ -114,12 +119,14 @@ const Touch = html`
 	c-0.413,0.203-0.65,0.463-0.65,0.711c0.057,0.274,1.063,1.38,1.603,1.975L6.465,21.516z M10.755,11.729
 	C9.407,10.535,8.634,8.811,8.634,7c0-3.507,2.853-6.36,6.36-6.36s6.36,2.853,6.36,6.36c0,1.811-0.773,3.534-2.121,4.729
 	l-0.479-0.539c1.194-1.058,1.879-2.585,1.879-4.19c0-3.11-2.529-5.64-5.64-5.64c-3.11,0-5.64,2.53-5.64,5.64
-	c0,1.605,0.685,3.133,1.879,4.19L10.755,11.729z" />
+	c0,1.605,0.685,3.133,1.879,4.19L10.755,11.729z"
+    />
     <rect
       id="_Transparent_Rectangle"
       style="fill:none;"
       width="32"
-      height="32" />
+      height="32"
+    />
   </svg>
 `;
 /* eslint-enable max-len */
@@ -162,8 +169,8 @@ export const Default = (args) => {
       ${pictogram?.src}
       <dds-content-item-heading>${heading}</dds-content-item-heading>
       <dds-content-item-copy>${copy}</dds-content-item-copy>
-      <dds-link-with-icon href="${href}" slot="footer">
-        ${linkCopy} ${ArrowRight20({ slot: 'icon' })}
+      <dds-link-with-icon href="${href}" slot="footer" cta-type="local">
+        ${linkCopy}
       </dds-link-with-icon>
     </dds-pictogram-item>
   `;

--- a/packages/web-components/src/components/quote/__stories__/quote.stories.ts
+++ b/packages/web-components/src/components/quote/__stories__/quote.stories.ts
@@ -34,8 +34,12 @@ export const Default = (args) => {
       <dds-quote-source-bottom-copy>
         ${sourceBottomCopy}
       </dds-quote-source-bottom-copy>
-      <dds-quote-link-with-icon slot="footer" href="https://example.com">
-        Link with Icon ${ArrowRight20({ slot: 'icon' })}
+      <dds-quote-link-with-icon
+        slot="footer"
+        href="https://example.com"
+        cta-type="local"
+      >
+        Link with Icon
       </dds-quote-link-with-icon>
     </dds-quote>
   `;

--- a/packages/web-components/src/components/quote/__stories__/quote.stories.ts
+++ b/packages/web-components/src/components/quote/__stories__/quote.stories.ts
@@ -9,7 +9,6 @@
 
 import { select } from '@storybook/addon-knobs';
 import { html } from 'lit-element';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20.js';
 import { QUOTE_TYPES, QUOTE_COLOR_SCHEMES } from '../quote';
 import '../index';
 import '../quote-link-with-icon';

--- a/packages/web-components/src/components/quote/__stories__/quote.stories.ts
+++ b/packages/web-components/src/components/quote/__stories__/quote.stories.ts
@@ -36,8 +36,7 @@ export const Default = (args) => {
       <dds-quote-link-with-icon
         slot="footer"
         href="https://example.com"
-        cta-type="local"
-      >
+        cta-type="local">
         Link with Icon
       </dds-quote-link-with-icon>
     </dds-quote>

--- a/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
+++ b/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
@@ -34,8 +34,7 @@ export const Default = (args) => {
     <dds-tabs-extended orientation="${ifNonNull(orientation)}">
       <dds-tab
         label="First tab with long text that wraps multiple lines. Lorem ipsum dolor sit amet consectetur adipiscing elit"
-        selected
-      >
+        selected>
         <dds-content-block-media-content>
           <dds-content-item>
             <dds-content-item-heading
@@ -47,8 +46,7 @@ export const Default = (args) => {
           <dds-card-link-cta
             slot="footer"
             href="https://example.com"
-            cta-type="local"
-          >
+            cta-type="local">
             <dds-card-link-heading
               >Lorem ipsum dolor sit amet</dds-card-link-heading
             >

--- a/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
+++ b/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
@@ -35,7 +35,8 @@ export const Default = (args) => {
     <dds-tabs-extended orientation="${ifNonNull(orientation)}">
       <dds-tab
         label="First tab with long text that wraps multiple lines. Lorem ipsum dolor sit amet consectetur adipiscing elit"
-        selected>
+        selected
+      >
         <dds-content-block-media-content>
           <dds-content-item>
             <dds-content-item-heading
@@ -44,13 +45,15 @@ export const Default = (args) => {
             <dds-content-item-copy>${copy}</dds-content-item-copy>
           </dds-content-item>
 
-          <dds-card-link-cta slot="footer" href="https://example.com">
+          <dds-card-link-cta
+            slot="footer"
+            href="https://example.com"
+            cta-type="local"
+          >
             <dds-card-link-heading
               >Lorem ipsum dolor sit amet</dds-card-link-heading
             >
-            <dds-card-cta-footer>
-              ${ArrowRight20({ slot: 'icon' })}
-            </dds-card-cta-footer>
+            <dds-card-cta-footer></dds-card-cta-footer>
           </dds-card-link-cta>
         </dds-content-block-media-content>
       </dds-tab>

--- a/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
+++ b/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
@@ -13,7 +13,6 @@ import '../../content-block-media/index';
 import '../../card-group/index';
 import ifNonNull from '../../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';
 import { select } from '@storybook/addon-knobs';
-import ArrowRight20 from '../../../internal/vendor/@carbon/web-components/icons/arrow--right/20';
 import { ORIENTATION } from '../defs';
 import readme from './README.stories.mdx';
 

--- a/packages/web-components/tests/snapshots/dds-link-with-icon.md
+++ b/packages/web-components/tests/snapshots/dds-link-with-icon.md
@@ -15,6 +15,8 @@
     </slot>
   </span>
   <slot name="icon">
+    <span class="bx--visually-hidden">
+    </span>
   </slot>
 </a>
 
@@ -33,6 +35,8 @@
     </slot>
   </span>
   <slot name="icon">
+    <span class="bx--visually-hidden">
+    </span>
   </slot>
 </p>
 


### PR DESCRIPTION
### Related Ticket(s)

Closes https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/11725
[Jira Ticket](https://jsw.ibm.com/browse/ADCMS-4922)

### Description

Checks `document.dir` and uses the appropriate arrow icon for the text direction (right in LTR and left in RTL). For many stories involving CTA's, CTA derivatives, or buttons, avoid using the slotted icon when all we're going for is `cta-type="local"`, in other words the arrow icon. In non-CTA cases, there isn't support for a default arrow icon, so we adjust stories to slot the right icon base on `document.dir`.

Note that in v1, only 'CTA' components have the `CTAMixin`, whereas it's more broadly used in v2. This means that for non-CTA components its up to the client to slot the right arrow icon (as evidenced by the many `*.stories.ts` changes). This isn't great, but it felt OK for now 🤷 . Open to ideas however.

### Testing instructions

1. Navigate to any Story making use of a CTA and/or button
2. Compare LTR and RTL
3. In LTR, where the arrow icon is used, the arrow should be pointing right
4. In RTL, where the arrow icon is used, the arrow should be pointing left

### Changelog

**Changed**

- Change the direction of the CTA arrow when in RTL languages.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
