### PR TITLE
fix(card-group): support RTL borders & padding

### DIFF
--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2022
+ * Copyright IBM Corp. 2016, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -66,7 +66,7 @@
         &__img {
           position: absolute;
           height: 100%;
-          top: 0;
+          inset-block-start: 0;
         }
       }
     }
@@ -86,8 +86,8 @@
 
   :host(#{$dds-prefix}-card-group-item),
   :host(#{$dds-prefix}-card-group-card-link-item) {
-    padding-bottom: 1px;
-    padding-right: 1px;
+    padding-block-end: 1px;
+    padding-inline-end: 1px;
 
     &[border] {
       border: none;
@@ -122,7 +122,7 @@
 
     &[pattern-background] {
       .#{$prefix}--card {
-        border-bottom: 1px solid $ui-03;
+        border-block-end: 1px solid $ui-03;
       }
 
       .#{$prefix}--card,
@@ -142,10 +142,7 @@
         content: '';
         position: absolute;
         z-index: 2;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        right: 0;
+        inset: 0;
         outline: 2px solid $focus;
         outline-offset: -2px;
         pointer-events: none;
@@ -186,8 +183,8 @@
     // `@include carbon--make-row()` has negative margin adjustment assuming that it's placed in Carbon grid.
     // Such adjustment has adverse effect when card group is placed in non-Carbon-grid,
     // but keeps it for React for backward-compatibility reason.
-    margin-left: calc(-1 * #{$carbon--grid-gutter} / 2);
-    margin-right: calc(-1 * #{$carbon--grid-gutter} / 2);
+    margin-inline-start: calc(-1 * #{$carbon--grid-gutter} / 2);
+    margin-inline-end: calc(-1 * #{$carbon--grid-gutter} / 2);
 
     position: relative;
     &::after {
@@ -196,8 +193,8 @@
       width: 100%;
       height: 100%;
       position: absolute;
-      left: 0;
-      top: 0;
+      inset-inline-start: 0;
+      inset-block-start: 0;
       pointer-events: none;
       box-shadow: inset 0 0 0 1px $ui-background;
     }
@@ -207,11 +204,11 @@
     padding: 0;
     background: $decorative-01;
 
-    border-right: 1px solid $decorative-01;
-    border-top: 1px solid $decorative-01;
+    border-inline-end: 1px solid $decorative-01;
+    border-block-start: 1px solid $decorative-01;
 
     &:last-of-type {
-      border-right: 0;
+      border-inline-end: 0;
       width: calc(100% - 1px);
     }
 
@@ -224,12 +221,12 @@
   :host(#{$dds-prefix}-card-group)[grid-mode='narrow'],
   .#{$prefix}--card-group--narrow {
     @include carbon--breakpoint('sm') {
-      padding-top: $carbon--spacing-03;
+      padding-block-start: $carbon--spacing-03;
       gap: $carbon--spacing-03;
     }
 
     @include carbon--breakpoint('md') {
-      padding-top: $carbon--spacing-05;
+      padding-block-start: $carbon--spacing-05;
       gap: $carbon--spacing-05;
     }
 
@@ -259,10 +256,7 @@
           content: '';
           position: absolute;
           z-index: 2;
-          top: 0;
-          left: 0;
-          bottom: 0;
-          right: 0;
+          inset: 0;
           box-shadow: inset 0 0 0 2px $focus;
           pointer-events: none;
         }
@@ -279,23 +273,23 @@
     .#{$prefix}--card-group__cards__col {
       padding: 0;
       border: 1px solid $decorative-01;
-      border-bottom: 0;
+      border-block-end: 0;
     }
 
     .#{$prefix}--card-group__cards__col:last-of-type {
-      border-bottom: 1px solid $decorative-01;
-      padding-right: 0;
+      border-block-end: 1px solid $decorative-01;
+      padding-inline-end: 0;
     }
 
     @include carbon--breakpoint('md') {
       .#{$prefix}--card-group__cards__col {
-        border-bottom: 0;
-        border-right: 0;
+        border-block-end: 0;
+        border-inline-end: 0;
       }
 
       .#{$prefix}--card-group__cards__col:nth-child(2n),
       .#{$prefix}--card-group__cards__col:last-of-type {
-        border-right: 1px solid $decorative-01;
+        border-inline-end: 1px solid $decorative-01;
       }
 
       .#{$prefix}--card-group__cards__col:last-of-type:not(:nth-child(2n)) {
@@ -303,7 +297,7 @@
       }
 
       .#{$prefix}--card-group__cards__col:nth-last-of-type(-n + 2) {
-        border-bottom: 1px solid $decorative-01;
+        border-block-end: 1px solid $decorative-01;
         height: calc(100% + 1px);
       }
     }
@@ -311,19 +305,19 @@
     @include carbon--breakpoint('lg') {
       .#{$prefix}--card-group__cards__col:nth-child(2n),
       .#{$prefix}--card-group__cards__col:nth-last-of-type(-n + 2) {
-        border-bottom: 0;
-        border-right: 0;
+        border-block-end: 0;
+        border-inline-end: 0;
         height: auto;
       }
 
       .#{$prefix}--card-group__cards__col:nth-child(3n),
       .#{$prefix}--card-group__cards__col:last-of-type {
-        border-right: 1px solid $decorative-01;
+        border-inline-end: 1px solid $decorative-01;
         width: calc(100% + 1px);
       }
 
       .#{$prefix}--card-group__cards__col:nth-last-of-type(-n + 3) {
-        border-bottom: 1px solid $decorative-01;
+        border-block-end: 1px solid $decorative-01;
         height: calc(100% + 1px);
       }
 

--- a/packages/web-components/src/components/card-group/card-group.scss
+++ b/packages/web-components/src/components/card-group/card-group.scss
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,7 +21,7 @@
 
   ::slotted(#{$dds-prefix}-card-group-card-link-item) {
     @include carbon--breakpoint('md') {
-      padding-right: $carbon--spacing-05;
+      padding-inline-end: $carbon--spacing-05;
     }
   }
 

--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -234,6 +234,8 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
   };
 
   private _borderAdjustments = (columnCount) => {
+    const { gridMode } = this;
+
     const isEmpty = (element) => element.hasAttribute('empty');
     const inFirstColumn = (index) => (index + 1) % columnCount === 1;
     const inLastColumn = (index) => (index + 1) % columnCount === 0;
@@ -243,58 +245,57 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
       Math.floor((this._childItems.length - 1) / columnCount);
 
     this._childItems.forEach((e, index) => {
-      const { gridMode } = this;
       if (gridMode === GRID_MODE.COLLAPSED) {
         e.toggleAttribute('border', false);
         if (isEmpty(e)) {
-          e.style.paddingBottom = '0';
-          e.style.paddingRight = '0';
+          e.style.paddingBlockEnd = '0';
+          e.style.paddingInlineEnd = '0';
         } else {
           if (inFirstColumn(index)) {
-            e.style.paddingLeft = '0';
+            e.style.paddingInlineStart = '0';
           }
           if (inLastColumn(index)) {
-            e.style.paddingRight = '0';
-            e.style.borderRight = `1px solid var(--cds-ui-background)`;
+            e.style.paddingInlineEnd = '0';
+            e.style.borderInlineEnd = `1px solid var(--cds-ui-background)`;
           } else {
-            e.style.paddingRight = '1px';
-            e.style.borderRight = 'none';
+            e.style.paddingInlineEnd = '1px';
+            e.style.borderInlineEnd = 'none';
           }
           if (inFirstRow(index)) {
-            e.style.paddingTop = '0';
+            e.style.paddingBlockStart = '0';
           }
           if (inLastRow(index)) {
-            e.style.paddingBottom = '0';
+            e.style.paddingBlockEnd = '0';
           } else {
-            e.style.paddingBottom = '1px';
+            e.style.paddingBlockEnd = '1px';
           }
         }
       }
       if (gridMode === GRID_MODE.BORDER) {
         e.toggleAttribute('border', true);
         if (isEmpty(e)) {
-          e.style.paddingBottom = '1px';
-          e.style.paddingRight = '1px';
+          e.style.paddingBlockEnd = '1px';
+          e.style.paddingInlineEnd = '1px';
         } else {
-          e.style.paddingTop = '0';
+          e.style.paddingBlockStart = '0';
           if (inFirstRow(index)) {
-            e.style.paddingTop = '1px';
+            e.style.paddingBlockStart = '1px';
           }
           if (inLastRow(index)) {
-            e.style.paddingBottom = '1px';
+            e.style.paddingBlockEnd = '1px';
           }
           if (inFirstColumn(index)) {
-            e.style.paddingLeft = '1px';
+            e.style.paddingInlineStart = '1px';
           } else {
-            e.style.paddingLeft = '0';
+            e.style.paddingInlineStart = '0';
           }
           if (inLastColumn(index)) {
-            e.style.paddingRight = '1px';
+            e.style.paddingInlineEnd = '1px';
           }
         }
         // if one column and first item is empty then set top border for second item
         if (columnCount === 1 && isEmpty(this._childItems[0]) && index === 1) {
-          e.style.paddingTop = '1px';
+          e.style.paddingBlockStart = '1px';
         }
       }
     });
@@ -303,10 +304,10 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
   private _resetBorders = () => {
     this._childItems.forEach((elem) => {
       elem.toggleAttribute('border', false);
-      elem.style.paddingTop = '';
-      elem.style.paddingRight = '';
-      elem.style.paddingBottom = '';
-      elem.style.paddingLeft = '';
+      elem.style.paddingBlockStart = '';
+      elem.style.paddingInlineEnd = '';
+      elem.style.paddingBlockEnd = '';
+      elem.style.paddingInlineStart = '';
     });
   };
 

--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -214,18 +214,18 @@ class DDSCardGroup extends StableSelectorMixin(LitElement) {
       // add tag group height to heading to the cards lacking tag group
       if (
         e &&
-        !e.nextElementSibling?.matches(
+        !e?.nextElementSibling?.matches(
           (this.constructor as typeof DDSCardGroup).selectorItemTagGroup
         ) &&
         tagGroupHeight > 0
       ) {
         e.style.marginBottom = `${tagGroupHeight + paragraphBottomMargin}px`;
       } else if (
-        e.nextElementSibling?.matches(
+        e?.nextElementSibling?.matches(
           (this.constructor as typeof DDSCardGroup).selectorItemTagGroup
         )
       ) {
-        let siblingTagGroup = e.nextElementSibling;
+        let siblingTagGroup = e?.nextElementSibling;
         siblingTagGroup.style.marginTop = `${
           tagGroupHeight - siblingTagGroup.offsetHeight
         }px`;


### PR DESCRIPTION
### Related Ticket(s)

Closes #11755

### Description

We programmatically set borders & padding for cards within `<dds-card-group>` elements, and we've only been accounting for LTR writing directions. This PR uses logical properties so these borders and paddings look correct in RTL documents.

While working on this I noticed an issue where certain tracked elements could be undefined, causing an error that halts execution. Ultimately this resulted in the "empty" elements we generate for certain card groups to fail to be created, and the dark gray background appearing when it shouldn't. I fixed this with simple optional accessors.

### Testing

Verify the borders and gaps between Cards appear correctly in [the Card Group story in the RTL deploy preview](https://ibmdotcom-web-components-rtl.s3.us-east.cloud-object-storage.appdomain.cloud/deploy-previews/11760/index.html?path=/story/components-card-group--default). Compare to [the Card Group in the default deploy preview](https://ibmdotcom-webcomponents.s3.us-east.cloud-object-storage.appdomain.cloud/deploy-previews/11760/index.html?path=/story/components-card-group--default) if necessary.

Specifically check that no background is visible in the last row's empty space when using the "Outlined cards (1px border)" **Grid mode** option.

### Changelog

**Changed**

- `<dds-card-group>` children will receive correct border & padding values in RTL writing mode documents.
- Prevents undefined elements from halting code execution and causing gray background to show when it shouldn't.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
