### PR TITLE
docs(feature-card): syncing stories and docs from web-components to react wrapper

### DIFF
--- a/packages/web-components/src/components/feature-card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/feature-card/__stories__/README.stories.mdx
@@ -109,8 +109,8 @@ Notes:
 
 - When using `video`, you need to pass the video ID as the `href` attribute.
 - The Feature Card component will need to be wrapped within a
-  `cds-video-cta-container` components for videos to play.
-- Custom icons can replace the built-in ones within `cds-card-footer`, they only
+  `c4d-video-cta-container` components for videos to play.
+- Custom icons can replace the built-in ones within `c4d-card-footer`, they only
   need to be assigned to the `icon` slot.
 
 ## Props

--- a/packages/web-components/src/components/feature-card/__stories__/README.stories.react.mdx
+++ b/packages/web-components/src/components/feature-card/__stories__/README.stories.react.mdx
@@ -42,6 +42,65 @@ function App() {
 }
 ```
 
+Here's an example using the Feature Card Large variant (previously known as
+`FeatureCardBlockLarge`)
+
+```javascript
+<C4DFeatureCard size="large" href="https://example.com">
+  <img />
+  <C4DCardEyebrow>This is an eyebrow</C4DCardEyebrow>
+  <C4DCardHeading>Explore AI use cases in all industries</C4DCardHeading>
+  <C4DCardCopy>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua.
+  </C4DCardCopy>
+  <C4DFeatureCardFooter>
+    <svg
+      slot="icon"
+      focusable="false"
+      preserveAspectRatio="xMidYMid meet"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      aria-hidden="true"
+      width="20"
+      height="20"
+      viewBox="0 0 20 20">
+      <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+    </svg>
+  </C4DFeatureCardFooter>
+</C4DFeatureCard>
+```
+
+### CTA features
+
+The `cta-type` attribute allows every type of CTA and icon available in the
+Carbon for IBM.com library. The default CTA style is `local`, which provides a
+basic link and arrow icon.
+
+In order to use the desired type, modify the `cta-type` attribute to one of the
+following:
+
+- local
+- jump
+- external
+- new tab
+- download
+- video
+- pdf
+- blog
+- email
+- schedule
+- chat
+- call
+
+Notes:
+
+- When using `video`, you need to pass the video ID as the `href` attribute.
+- The Feature Card component will need to be wrapped within a
+  `C4DVideoCTAContainer` components for videos to play.
+- Custom icons can replace the built-in ones within `C4DCardFooter`, they only
+  need to be assigned to the `icon` slot.
+
 ## Props
 
 <Props of={PropTypesRef} />

--- a/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.react.tsx
+++ b/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.react.tsx
@@ -18,12 +18,12 @@ import C4DCardHeading from '@carbon/ibmdotcom-web-components/es/components-react
 import C4DCardEyebrow from '@carbon/ibmdotcom-web-components/es/components-react/card/card-eyebrow';
 import C4DImage from '@carbon/ibmdotcom-web-components/es/components-react/image/image';
 import C4DImageItem from '@carbon/ibmdotcom-web-components/es/components-react/image/image-item';
-import mediumImgLg1x1 from '../../../../.storybook/storybook-images/assets/720/fpo--1x1--720x720--004.jpg';
+import mediumImgSm4x3 from '../../../../.storybook/storybook-images/assets/320/fpo--4x3--320x160--004.jpg';
+import imgSm4x3 from '../../../../.storybook/storybook-images/assets/480/fpo--4x3--480x360--005.jpg';
+import imgMd1x1 from '../../../../.storybook/storybook-images/assets/480/fpo--1x1--480x480--005.jpg';
 import imgLg1x1 from '../../../../.storybook/storybook-images/assets/720/fpo--1x1--720x720--002.jpg';
-import imgLg2x1 from '../../../../.storybook/storybook-images/assets/720/fpo--2x1--720x360--002.jpg';
-import imgMax2x1 from '../../../../.storybook/storybook-images/assets/1584/fpo--2x1--1312x656--002.jpg';
-import imgSm2x1 from '../../../../.storybook/storybook-images/assets/320/fpo--2x1--320x160--002.jpg';
-import imgXlg2x1 from '../../../../.storybook/storybook-images/assets/1312/fpo--2x1--1312x656--002.jpg';
+import imgXlg1x1 from '../../../../.storybook/storybook-images/assets/1312/fpo--1x1--1312x1312--002.jpg';
+import imgMax1x1 from '../../../../.storybook/storybook-images/assets/1584/fpo--1x1--1584x1584--002.jpg';
 
 import readme from './README.stories.react.mdx';
 
@@ -36,7 +36,13 @@ export const Medium = (args) => {
   const { heading, href } = args?.FeatureCard ?? {};
   return (
     <C4DFeatureCard href={href}>
-      <C4DImage alt="Image alt text" defaultSrc={mediumImgLg1x1} slot="image" />
+      <C4DImage alt="Image alt text" defaultSrc={imgMax1x1} slot="image">
+        <C4DImageItem media="(min-width: 1312px)" srcset={imgXlg1x1} />
+        <C4DImageItem media="(min-width: 1056px)" srcset={imgXlg1x1} />
+        <C4DImageItem media="(min-width: 991px)" srcset={imgLg1x1} />
+        <C4DImageItem media="(min-width: 672px)" srcset={imgMd1x1} />
+        <C4DImageItem media="(min-width: 0px)" srcset={mediumImgSm4x3} />
+      </C4DImage>
       <C4DCardHeading>{heading}</C4DCardHeading>
       <C4DFeatureCardFooter>
         <ArrowRight {...iconProps} />
@@ -50,11 +56,11 @@ export const Large = (args) => {
   return (
     <C4DFeatureCard href={href} size="large">
       <C4DImage alt="Image alt text" defaultSrc={imgLg1x1} slot="image">
-        <C4DImageItem media="(min-width: 1312px)" srcset={imgMax2x1} />
-        <C4DImageItem media="(min-width: 1056px)" srcset={imgXlg2x1} />
-        <C4DImageItem media="(min-width: 991px)" srcset={imgXlg2x1} />
-        <C4DImageItem media="(min-width: 672px)" srcset={imgLg2x1} />
-        <C4DImageItem media="(min-width: 0px)" srcset={imgSm2x1} />
+        <C4DImageItem media="(min-width: 1312px)" srcset={imgXlg1x1} />
+        <C4DImageItem media="(min-width: 1056px)" srcset={imgXlg1x1} />
+        <C4DImageItem media="(min-width: 991px)" srcset={imgLg1x1} />
+        <C4DImageItem media="(min-width: 672px)" srcset={imgMd1x1} />
+        <C4DImageItem media="(min-width: 0px)" srcset={imgSm4x3} />
       </C4DImage>
       <C4DCardEyebrow>{eyebrow}</C4DCardEyebrow>
       <C4DCardHeading>{heading}</C4DCardHeading>


### PR DESCRIPTION
### Related Ticket(s)

Closes # {{Provide issue number link(s) to the related ticket(s) that this pull request addresses}}

### Description

React wrapper docs for FeatureCard in storybook seem outdated, syncing up the stories and the docs from web components

### Changelog

**Changed**

- use same image imports in the react wrapper story as used in web components
- updated `mdx` docs file to be same as web components
- web components docs was using wrong prefix, fixed to use `c4d`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
