### PR TITLE
feat(cta-block): add CSS shadowpart

### DIFF
--- a/packages/carbon-web-components/tests/snapshots/bx-checkbox.md
+++ b/packages/carbon-web-components/tests/snapshots/bx-checkbox.md
@@ -6,6 +6,7 @@
 
 ```
 <input
+  aria-checked="false"
   class="bx--checkbox"
   id="checkbox"
   part="input"
@@ -28,6 +29,7 @@
 
 ```
 <input
+  aria-checked="mixed"
   class="bx--checkbox"
   disabled=""
   id="checkbox"

--- a/packages/carbon-web-components/tests/snapshots/bx-pagination.md
+++ b/packages/carbon-web-components/tests/snapshots/bx-pagination.md
@@ -109,14 +109,11 @@
 <div class="bx--select__page-number">
   <label
     class="bx--label bx--visually-hidden"
-    for="select-page"
+    for="select"
   >
     Page number, of 10 pages
   </label>
-  <select
-    class="bx--select-input"
-    id="select-page"
-  >
+  <select class="bx--select-input">
     <option
       selected=""
       value="0"

--- a/packages/web-components/src/components/content-block-horizontal/content-block-horizontal.scss
+++ b/packages/web-components/src/components/content-block-horizontal/content-block-horizontal.scss
@@ -6,3 +6,4 @@
 //
 
 @import '@carbon/ibmdotcom-styles/scss/components/content-block-horizontal/content-block-horizontal';
+@import '../../../../styles/scss/components/content-block-horizontal/content-block-horizontal';

--- a/packages/web-components/src/components/content-block/content-block.ts
+++ b/packages/web-components/src/components/content-block/content-block.ts
@@ -221,7 +221,7 @@ class DDSContentBlock extends StableSelectorMixin(LitElement) {
 
   render() {
     return html`
-      <div class="${this._getContainerClasses()}">
+      <div part="content-layout" class="${this._getContainerClasses()}">
         ${this._renderHeading()}${this._renderBody()}${this._renderComplementary()}
       </div>
     `;

--- a/packages/web-components/src/components/content-group/content-group-heading.ts
+++ b/packages/web-components/src/components/content-group/content-group-heading.ts
@@ -29,11 +29,17 @@ class DDSContentGroupHeading extends StableSelectorMixin(LitElement) {
   slot = 'heading';
 
   connectedCallback() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'heading');
+    }
+    if (!this.hasAttribute('aria-level')) {
+      this.setAttribute('aria-level', '3');
+    }
     super.connectedCallback();
   }
 
   render() {
-    return html` <h3><slot></slot></h3>`;
+    return html` <slot></slot> `;
   }
 
   static get stableSelector() {

--- a/packages/web-components/src/components/content-group/content-group.scss
+++ b/packages/web-components/src/components/content-group/content-group.scss
@@ -21,13 +21,3 @@
 :host(#{$dds-prefix}-content-group-copy) {
   @include carbon--type-style('body-long-02');
 }
-
-:host(#{$dds-prefix}-content-group-heading) {
-  @include carbon--type-style('expressive-heading-04', true);
-
-  h3 {
-    font: inherit;
-    letter-spacing: inherit;
-    line-height: inherit;
-  }
-}

--- a/packages/web-components/src/components/content-item/content-item-heading.ts
+++ b/packages/web-components/src/components/content-item/content-item-heading.ts
@@ -29,11 +29,17 @@ class DDSContentItemHeading extends StableSelectorMixin(LitElement) {
   slot = 'heading';
 
   connectedCallback() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'heading');
+    }
+    if (!this.hasAttribute('aria-level')) {
+      this.setAttribute('aria-level', '4');
+    }
     super.connectedCallback();
   }
 
   render() {
-    return html` <h4><slot></slot></h4>`;
+    return html` <slot></slot> `;
   }
 
   static get stableSelector() {

--- a/packages/web-components/src/components/content-item/content-item.scss
+++ b/packages/web-components/src/components/content-item/content-item.scss
@@ -22,13 +22,3 @@
   margin-top: 1rem;
   margin-bottom: 2rem;
 }
-
-:host(#{$dds-prefix}-content-item-heading) {
-  @include carbon--type-style('expressive-heading-02');
-
-  h4 {
-    font: inherit;
-    letter-spacing: inherit;
-    line-height: inherit;
-  }
-}

--- a/packages/web-components/tests/snapshots/dds-callout-with-media.md
+++ b/packages/web-components/tests/snapshots/dds-callout-with-media.md
@@ -7,7 +7,10 @@
 ```
 <div class="bx--callout__column">
   <div class="bx--callout__content">
-    <div class="bx--content-layout">
+    <div
+      class="bx--content-layout"
+      part="content-layout"
+    >
       <slot name="heading">
       </slot>
       <div
@@ -42,7 +45,10 @@
 ```
 <div class="bx--callout__column">
   <div class="bx--callout__content">
-    <div class="bx--content-layout">
+    <div
+      class="bx--content-layout"
+      part="content-layout"
+    >
       <slot name="heading">
       </slot>
       <div
@@ -77,7 +83,10 @@
 ```
 <div class="bx--callout__column">
   <div class="bx--callout__content">
-    <div class="bx--content-layout">
+    <div
+      class="bx--content-layout"
+      part="content-layout"
+    >
       <slot name="heading">
       </slot>
       <div

--- a/packages/web-components/tests/snapshots/dds-content-block-card-static.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-card-static.md
@@ -21,7 +21,9 @@
   </dds-card-group>
   <dds-content-item data-autoid="dds--content-item">
     <dds-content-item-heading
+      aria-level="4"
       data-autoid="dds--content-item__heading"
+      role="heading"
       slot="heading"
     >
     </dds-content-item-heading>
@@ -110,7 +112,9 @@
   </dds-card-group>
   <dds-content-item data-autoid="dds--content-item">
     <dds-content-item-heading
+      aria-level="4"
       data-autoid="dds--content-item__heading"
+      role="heading"
       slot="heading"
     >
       Lorem ipsum

--- a/packages/web-components/tests/snapshots/dds-content-block-cards.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-cards.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--card-group">
+<div
+  class="bx--content-layout bx--content-layout--card-group"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--card-group">
+<div
+  class="bx--content-layout bx--content-layout--card-group"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-block-headlines.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-headlines.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--with-headlines bx--layout--border">
+<div
+  class="bx--content-layout bx--content-layout--with-headlines bx--layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-block-horizontal.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-horizontal.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-block-media.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-media.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-block-segmented.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-segmented.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-block-simple.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-simple.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--with-complementary bx--layout--border">
+<div
+  class="bx--content-layout bx--content-layout--with-complementary bx--layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-group-banner.md
+++ b/packages/web-components/tests/snapshots/dds-content-group-banner.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-group-cards.md
+++ b/packages/web-components/tests/snapshots/dds-content-group-cards.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -45,7 +48,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-group-simple.md
+++ b/packages/web-components/tests/snapshots/dds-content-group-simple.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div class="bx--content-layout__body">

--- a/packages/web-components/tests/snapshots/dds-cta-block.md
+++ b/packages/web-components/tests/snapshots/dds-cta-block.md
@@ -3,7 +3,10 @@
 #### `Renders Default`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -52,7 +55,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--border">
+<div
+  class="bx--content-layout bx--content-layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -99,7 +105,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--border">
+<div
+  class="bx--content-layout bx--content-layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div class="bx--content-layout__body">


### PR DESCRIPTION
Replaces #11774 

### Related Ticket(s)

[ADCMS-4976](https://jsw.ibm.com/browse/ADCMS-4976)

### Description

As per https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/11750

Adding a `part` attribute to the shadowroot's `.bx--content-layout` element so that it can be styled outside the shadow tree and have its padding manipulated if needed. 

![image](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/7583437/ea8efe3f-db89-412e-9bbd-723008d0c3a3)

