### PR TITLE
feat(cta-block): add CSS shadowpart

### DIFF
--- a/packages/web-components/src/components/content-block/content-block.ts
+++ b/packages/web-components/src/components/content-block/content-block.ts
@@ -221,7 +221,7 @@ class DDSContentBlock extends StableSelectorMixin(LitElement) {
 
   render() {
     return html`
-      <div class="${this._getContainerClasses()}">
+      <div part="content-layout" class="${this._getContainerClasses()}">
         ${this._renderHeading()}${this._renderBody()}${this._renderComplementary()}
       </div>
     `;

--- a/packages/web-components/tests/snapshots/dds-callout-with-media.md
+++ b/packages/web-components/tests/snapshots/dds-callout-with-media.md
@@ -7,7 +7,10 @@
 ```
 <div class="bx--callout__column">
   <div class="bx--callout__content">
-    <div class="bx--content-layout">
+    <div
+      class="bx--content-layout"
+      part="content-layout"
+    >
       <slot name="heading">
       </slot>
       <div
@@ -42,7 +45,10 @@
 ```
 <div class="bx--callout__column">
   <div class="bx--callout__content">
-    <div class="bx--content-layout">
+    <div
+      class="bx--content-layout"
+      part="content-layout"
+    >
       <slot name="heading">
       </slot>
       <div
@@ -77,7 +83,10 @@
 ```
 <div class="bx--callout__column">
   <div class="bx--callout__content">
-    <div class="bx--content-layout">
+    <div
+      class="bx--content-layout"
+      part="content-layout"
+    >
       <slot name="heading">
       </slot>
       <div

--- a/packages/web-components/tests/snapshots/dds-content-block-cards.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-cards.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--card-group">
+<div
+  class="bx--content-layout bx--content-layout--card-group"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--card-group">
+<div
+  class="bx--content-layout bx--content-layout--card-group"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-block-headlines.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-headlines.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--with-headlines bx--layout--border">
+<div
+  class="bx--content-layout bx--content-layout--with-headlines bx--layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-block-horizontal.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-horizontal.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-block-media.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-media.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-block-segmented.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-segmented.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-block-simple.md
+++ b/packages/web-components/tests/snapshots/dds-content-block-simple.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--with-complementary bx--layout--border">
+<div
+  class="bx--content-layout bx--content-layout--with-complementary bx--layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-group-banner.md
+++ b/packages/web-components/tests/snapshots/dds-content-group-banner.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-group-cards.md
+++ b/packages/web-components/tests/snapshots/dds-content-group-cards.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -45,7 +48,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/dds-content-group-simple.md
+++ b/packages/web-components/tests/snapshots/dds-content-group-simple.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -36,7 +39,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div class="bx--content-layout__body">

--- a/packages/web-components/tests/snapshots/dds-cta-block.md
+++ b/packages/web-components/tests/snapshots/dds-cta-block.md
@@ -3,7 +3,10 @@
 #### `Renders Default`
 
 ```
-<div class="bx--content-layout">
+<div
+  class="bx--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -52,7 +55,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--border">
+<div
+  class="bx--content-layout bx--content-layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -99,7 +105,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-layout bx--content-layout--border">
+<div
+  class="bx--content-layout bx--content-layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div class="bx--content-layout__body">


### PR DESCRIPTION
Replaces #11774 

### Related Ticket(s)

[ADCMS-4976](https://jsw.ibm.com/browse/ADCMS-4976)

### Description

As per https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/11750

Adding a `part` attribute to the shadowroot's `.bx--content-layout` element so that it can be styled outside the shadow tree and have its padding manipulated if needed. 

![image](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/7583437/ea8efe3f-db89-412e-9bbd-723008d0c3a3)

