### PR TITLE
chore(dependency): bump up utilities version in services package

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.3",
-    "@carbon/ibmdotcom-utilities": "1.54.0",
+    "@carbon/ibmdotcom-utilities": "1.59.0-rc.0",
     "@ibm/telemetry-js": "^1.3.0",
     "axios": "^1.6.8",
     "marked": "^4.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2311,7 +2311,7 @@ __metadata:
     "@babel/plugin-transform-runtime": "npm:7.18.5"
     "@babel/preset-env": "npm:~7.23.2"
     "@babel/runtime": "npm:^7.16.3"
-    "@carbon/ibmdotcom-utilities": "npm:1.54.0"
+    "@carbon/ibmdotcom-utilities": "npm:1.59.0-rc.0"
     "@ibm/telemetry-js": "npm:^1.3.0"
     "@rollup/plugin-babel": "npm:^5.3.1"
     "@rollup/plugin-commonjs": "npm:^21.0.3"


### PR DESCRIPTION
### Description

For some reason, lerna hasn't been bumping up the `@carbon/ibmdotcom-utilities` package within `services` package automatically. Bumping it manually for now to remove a security risk dependency.

### Changelog

**Changed**

- bump up `@carbon/ibmdotcom-utilities` package within `services`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
