### PR TITLE
fix(tearsheet): tearsheet styles and codesandbox example

### DIFF
--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/.babelrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/.babelrc
@@ -1,0 +1,22 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "modules": false,
+        "targets": [
+          "last 1 version",
+          "Firefox ESR",
+          "not opera > 0",
+          "not op_mini > 0",
+          "not op_mob > 0",
+          "not android > 0",
+          "not edge > 0",
+          "not ie > 0",
+          "not ie_mob > 0"
+        ]
+      }
+    ]
+  ],
+  "plugins": [["@babel/plugin-transform-runtime", { "version": "7.3.0" }]]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/.gitignore
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/.gitignore
@@ -1,0 +1,22 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.cache
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/.sassrc
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/.sassrc
@@ -1,0 +1,6 @@
+{
+  "includePaths": [
+    "node_modules",
+    "../../node_modules"
+  ]
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/cdn.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/cdn.html
@@ -1,0 +1,122 @@
+<!--
+@license
+
+Copyright IBM Corp. 2024
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+<head>
+  <title>@carbon/ibmdotcom-web-components example</title>
+  <meta charset="UTF-8"/>
+  <link rel="stylesheet"
+        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css" />
+  <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/themes.css" />
+  <style>
+    /* Suppress custom element until styles are loaded */
+    cds-button:not(:defined) {
+      display: none;
+    }
+  </style>
+  <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/tearsheet.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/button.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/text-input.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/textarea.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/slug.min.js"></script>
+  <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/tabs.min.js"></script>
+</head>
+<body>
+  <cds-button id="toggle-tearsheet">Toggle tearsheet</cds-button>
+
+  <cds-tearsheet>
+  <!-- default slotted content -->
+  <div>
+    <h5>Section</h5>
+    <div>
+      <cds-text-input
+        label="Input A"
+        id="tearsheet-story-text-input-a"></cds-text-input>
+      <cds-text-input
+        label="Input B"
+        id="tearsheet-story-text-input-b"></cds-text-input>
+    </div>
+    <div>
+      <cds-text-input
+        label="Input C"
+        id="tearsheet-story-text-input-c"></cds-text-input>
+      <cds-text-input
+        label="Input D"
+        id="tearsheet-story-text-input-d"></cds-text-input>
+    </div>
+    <div>
+      <cds-textarea
+        label="Notes"
+        value="This is a text area"></cds-textarea>
+      <cds-textarea
+        label="Notes"
+        value="This is a text area"></cds-textarea>
+      <cds-textarea
+        label="Notes"
+        value="This is a text area"></cds-textarea>
+    </div>
+  </div>
+
+  <!-- slotted header label -->
+  <span slot="label">Optional label for context</span>
+
+  <!-- slotted header title -->
+  <span slot="title">Title used to designate the overarching flow of the tearsheet.</span>
+
+  <!-- slotted header description -->
+  <span slot="description">Description used to describe the flow if need be.</span>
+
+  <!-- slotted action items cds-buttons -->
+  <cds-button key="ghost" slot="actions" kind="ghost">
+    Ghost
+  </cds-button>
+  <cds-button key="secondary" slot="actions" kind="secondary">
+    Secondary
+  </cds-button>
+  <cds-button key="primary" slot="actions" kind="primary">
+    Primary
+  </cds-button>
+
+  <!-- slotted slug -->
+  <cds-slug size="xs" alignment="bottom-right">
+    <div slot="body-text">
+      <p class="secondary">AI Explained</p>
+      <h1>84%</h1>
+      <p class="secondary bold">Confidence score</p>
+      <p class="secondary">
+        Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut fsil labore et dolore magna aliqua.
+      </p>
+      <hr />
+      <p class="secondary">Model type</p>
+      <p class="bold">Foundation model</p>
+    </div>
+  </cds-slug>
+
+  <!-- slotted header-navigation -->
+  <div slot="header-navigation">
+    <cds-tabs value="1">
+      <cds-tab value="1">Tab 1</cds-tab>
+      <cds-tab value="2">Tab 2</cds-tab>
+      <cds-tab value="3">Tab 3</cds-tab>
+      <cds-tab value="4">Tab 4</cds-tab>
+    </cds-tabs>
+  </div>
+</cds-tearsheet>
+</body>
+<script>
+    const toggleButton = () => {
+    const tearsheet = document.querySelector(`cds-tearsheet`);
+    tearsheet?.toggleAttribute('open');
+  };
+
+  document.getElementById("toggle-tearsheet").addEventListener("click", toggleButton);
+</script>
+</html>

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/index.html
@@ -1,0 +1,117 @@
+<!--
+@license
+
+Copyright IBM Corp. 2024
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+<head>
+  <title>carbon-web-components example</title>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet"
+        href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"/>
+
+  <link rel="stylesheet" href="src/styles.scss" />
+  <style>
+    /* Suppress custom element until styles are loaded */
+    cds-tearsheet:not(:defined) {
+      display: none;
+    }
+  </style>
+  <script type="module" src="src/index.js"></script>
+</head>
+<body>
+  <cds-button id="toggle-tearsheet">Toggle tearsheet</cds-button>
+
+  <cds-tearsheet>
+  <!-- default slotted content -->
+  <div>
+    <h5>Section</h5>
+    <div>
+      <cds-text-input
+        label="Input A"
+        id="tearsheet-story-text-input-a"></cds-text-input>
+      <cds-text-input
+        label="Input B"
+        id="tearsheet-story-text-input-b"></cds-text-input>
+    </div>
+    <div>
+      <cds-text-input
+        label="Input C"
+        id="tearsheet-story-text-input-c"></cds-text-input>
+      <cds-text-input
+        label="Input D"
+        id="tearsheet-story-text-input-d"></cds-text-input>
+    </div>
+    <div>
+      <cds-textarea
+        label="Notes"
+        value="This is a text area"></cds-textarea>
+      <cds-textarea
+        label="Notes"
+        value="This is a text area"></cds-textarea>
+      <cds-textarea
+        label="Notes"
+        value="This is a text area"></cds-textarea>
+    </div>
+  </div>
+
+  <!-- slotted header label -->
+  <span slot="label">Optional label for context</span>
+
+  <!-- slotted header title -->
+  <span slot="title">Title used to designate the overarching flow of the tearsheet.</span>
+
+  <!-- slotted header description -->
+  <span slot="description">Description used to describe the flow if need be.</span>
+
+  <!-- slotted action items cds-buttons -->
+  <cds-button key="ghost" slot="actions" kind="ghost">
+    Ghost
+  </cds-button>
+  <cds-button key="secondary" slot="actions" kind="secondary">
+    Secondary
+  </cds-button>
+  <cds-button key="primary" slot="actions" kind="primary">
+    Primary
+  </cds-button>
+
+  <!-- slotted slug -->
+  <cds-slug size="xs" alignment="bottom-right">
+    <div slot="body-text">
+      <p class="secondary">AI Explained</p>
+      <h1>84%</h1>
+      <p class="secondary bold">Confidence score</p>
+      <p class="secondary">
+        Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut fsil labore et dolore magna aliqua.
+      </p>
+      <hr />
+      <p class="secondary">Model type</p>
+      <p class="bold">Foundation model</p>
+    </div>
+  </cds-slug>
+
+  <!-- slotted header-navigation -->
+  <div slot="header-navigation">
+    <cds-tabs value="1">
+      <cds-tab value="1">Tab 1</cds-tab>
+      <cds-tab value="2">Tab 2</cds-tab>
+      <cds-tab value="3">Tab 3</cds-tab>
+      <cds-tab value="4">Tab 4</cds-tab>
+    </cds-tabs>
+  </div>
+</cds-tearsheet>
+</body>
+<script>
+    const toggleButton = () => {
+    const tearsheet = document.querySelector(`cds-tearsheet`);
+    tearsheet?.toggleAttribute('open');
+  };
+
+  document.getElementById("toggle-tearsheet").addEventListener("click", toggleButton);
+</script>
+</html>

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/index.html
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/index.html
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
   <link rel="stylesheet" href="src/styles.scss" />
   <style>
     /* Suppress custom element until styles are loaded */
-    cds-tearsheet:not(:defined) {
+    cds-button:not(:defined) {
       display: none;
     }
   </style>

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/package.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "carbon-web-components-tearsheet-example",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sample project for getting started with the Web Components from Carbon.",
+  "license": "Apache-2",
+  "main": "index.html",
+  "scripts": {
+    "build": "parcel build *.html --no-minify --public-url ./",
+    "clean": "rimraf node_modules dist .cache",
+    "start": "parcel index.html --port=9000 --no-hmr"
+  },
+  "dependencies": {
+    "@carbon/styles": "^1.34.0",
+    "@carbon/web-components": "latest",
+    "sass": "^1.64.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0-0",
+    "@babel/plugin-transform-runtime": "^7.24.3",
+    "@babel/preset-env": "^7.24.5",
+    "parcel-bundler": "1.12.3",
+    "rimraf": "^3.0.2"
+  }
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/sandbox.config.json
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/src/index.js
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/src/index.js
@@ -1,0 +1,15 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '@carbon/web-components/es/components/tearsheet/index.js';
+import '@carbon/web-components/es/components/button/index.js';
+import '@carbon/web-components/es/components/text-input/index.js';
+import '@carbon/web-components/es/components/textarea/index.js';
+import '@carbon/web-components/es/components/slug/index.js';
+import '@carbon/web-components/es/components/tabs/index.js';

--- a/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/src/styles.scss
+++ b/packages/carbon-web-components/examples/codesandbox/basic/components/tearsheet/src/styles.scss
@@ -1,0 +1,16 @@
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/styles/scss/reset';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/themes';
+
+:root {
+  @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/packages/carbon-web-components/src/components/tearsheet/tearsheet-story.ts
+++ b/packages/carbon-web-components/src/components/tearsheet/tearsheet-story.ts
@@ -9,13 +9,13 @@
 
 import { TemplateResult, html } from 'lit';
 import { boolean, select, text } from '@storybook/addon-knobs';
-import '../button/button';
 import {
   TEARSHEET_INFLUENCER_PLACEMENT,
   TEARSHEET_INFLUENCER_WIDTH,
   TEARSHEET_WIDTH,
 } from './tearsheet';
 import './index';
+import '../button/button';
 import '../text-input/index';
 import '../textarea/index';
 import storyDocs from './tearsheet-story.mdx';

--- a/packages/carbon-web-components/src/components/tearsheet/tearsheet.scss
+++ b/packages/carbon-web-components/src/components/tearsheet/tearsheet.scss
@@ -39,227 +39,32 @@ $motion-duration: $duration-moderate-02;
   @extend .#{$prefix}--modal;
   @extend .#{$prefix}--tearsheet;
 
-  &[open] {
-    --overlay-color: #{$overlay};
-    --overlay-opacity: 1;
-
-    z-index: utilities.z('modal');
-    align-items: flex-end;
-    background: initial;
-    opacity: 1;
-
-    // stylelint-disable-next-line carbon/motion-duration-use, carbon/motion-easing-use
-    transition: visibility 0s linear;
-    visibility: inherit;
-
-    .#{$prefix}--tearsheet__container {
-      transform: translate3d(0, 0, 0);
-      transition: transform $duration-moderate-02 motion(entrance, expressive);
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
-    }
-
-    &::before {
-      position: absolute;
-      display: block;
-      background: var(--overlay-color);
-      content: '';
-      inset: 0;
-      opacity: var(--overlay-opacity);
-
-      transition: background-color $motion-duration motion(exit, expressive),
-        opacity $motion-duration motion(exit, expressive);
-
-      @media (prefers-reduced-motion: reduce) {
-        transition: none;
-      }
-
-      &[stack-position='1'][stack-depth='2'] {
-        --overlay-opacity: 0.67;
-      }
-
-      &[stack-position='1'][stack-depth='3'] {
-        --overlay-opacity: 0.22;
-      }
-
-      &[stack-position='2'][stack-depth='3'] {
-        --overlay-opacity: 0.5;
-      }
-
-      &[stack-position='2'][stack-depth='2'],
-      &[stack-position='3'][stack-depth='3'] {
-        --overlay-opacity: 0.5;
-      }
-    }
-  }
-
-  [hidden] {
-    @extend .#{$prefix}--visually-hidden;
-  }
-
   .#{$block-class}__header,
   .#{$block-class}__content,
   .#{$block-class}__influencer {
     padding: var(--content-padding);
   }
 
-  &[slug] {
-    --overlay-color: #{$ai-overlay};
-
-    .#{$block-class}__container {
-      border: 1px solid transparent;
-
-      /* override carbon ai removing background gradient */
-      background: linear-gradient(to top, var(--cds-layer), var(--cds-layer))
-          padding-box,
-        linear-gradient(
-            to bottom,
-            var(--cds-ai-border-start, #78a9ff),
-            var(--cds-ai-border-end, #d0e2ff)
-          )
-          border-box,
-        linear-gradient(to top, var(--cds-layer), var(--cds-layer)) border-box;
-      border-block-end: 0;
-      box-shadow: 0 24px 40px -24px $ai-drop-shadow;
-    }
-
-    .#{$block-class}__content {
-      @include utilities.ai-popover-gradient('default', 0);
-
-      box-shadow: inset 0 -80px 70px -65px $ai-inner-shadow;
-    }
-
-    /* stylelint-disable-next-line selector-type-no-unknown */
-    [has-actions] ::slotted(#{$prefix}-slug) {
-      inset-inline-end: 0;
-    }
-  }
-
   .#{$block-class}__container {
     /* lower prop is deprecated but the default in ibm products */
     @extend .#{$block-class}__container--lower;
 
-    &[stack-position='1'][stack-depth='2'],
-    &[stack-position='2'][stack-depth='3'] {
-      max-block-size: calc(
-        100% - (#{$spacing-09} + #{$spacing-08}) + #{$spacing-05}
-      );
-      transform: scale(var(--#{$block-class}--stacking-scale-factor-single));
-    }
-
-    &[stack-position='1'][stack-depth='3'] {
-      max-block-size: calc(
-        100% - (#{$spacing-09} + #{$spacing-08}) + (2 * #{$spacing-05})
-      );
-      transform: scale(var(--#{$block-class}--stacking-scale-factor-double));
-    }
+    max-block-size: calc(100% - (#{$spacing-09} + #{$spacing-08}));
   }
 
-  &[stack-position='1'][stack-depth='2'],
-  &[stack-position='2'][stack-depth='3'] {
-    z-index: utilities.z('modal') - 1;
+  .#{$block-class}__container[stack-position='1'][stack-depth='2'],
+  .#{$block-class}__container[stack-position='2'][stack-depth='3'] {
+    max-block-size: calc(
+      100% - (#{$spacing-09} + #{$spacing-08}) + #{$spacing-05}
+    );
+    transform: scale(var(--#{$block-class}--stacking-scale-factor-single));
   }
 
-  &[stack-position='1'][stack-depth='3'] {
-    z-index: utilities.z('modal') - 2;
-  }
-
-  &[width='narrow'] {
-    .#{$block-class}__header {
-      margin: 0;
-      background-color: $layer;
-      border-block-end: 1px solid $border-subtle-01;
-    }
-
-    .#{$block-class}__header-description {
-      margin-block-start: $spacing-03;
-      max-inline-size: 80%;
-    }
-
-    .#{$block-class}__main {
-      background-color: $layer;
-    }
-  }
-
-  &[width='wide'] {
-    --content-padding: #{$spacing-06 $spacing-07};
-
-    .#{$block-class}__header {
-      margin: 0;
-      background-color: $layer;
-      border-block-end: 1px solid $border-subtle-01;
-    }
-
-    .#{$block-class}__header[has-navigation] {
-      padding-block-end: 0;
-    }
-
-    .#{$block-class}__container {
-      inline-size: 100%;
-
-      @include breakpoint(md) {
-        inline-size: calc(100% - (2 * #{$spacing-10}));
-      }
-    }
-
-    .#{$prefix}--modal-header__heading.#{$block-class}__heading {
-      @include type.type-style('heading-04');
-    }
-
-    .#{$block-class}__header[has-close-icon],
-    .#{$block-class}__header[has-slug] {
-      padding-inline-end: $spacing-11;
-    }
-
-    .#{$block-class}__header[has-close-icon][has-slug] {
-      padding-inline-end: calc(#{$spacing-11 + $spacing-09});
-    }
-
-    .#{$block-class}__header-navigation {
-      margin-inline-start: calc(-1 * #{$spacing-05});
-      max-block-size: $spacing-08; /* #{$prefix}-tabs too tall */
-    }
-
-    .#{$block-class}__content {
-      // Revert background color overridden by Carbon's modal - https://github.com/carbon-design-system/carbon/blob/main/packages/styles/scss/components/modal/_modal.scss#L54
-      .#{$prefix}--pagination,
-      .#{$prefix}--pagination__control-buttons,
-      .#{$prefix}--text-input,
-      .#{$prefix}--text-area,
-      .#{$prefix}--search-input,
-      .#{$prefix}--select-input,
-      .#{$prefix}--dropdown,
-      .#{$prefix}--dropdown-list,
-      .#{$prefix}--number input[type='number'],
-      .#{$prefix}--date-picker__input {
-        background-color: $field;
-      }
-
-      .#{$prefix}--select--inline .#{$prefix}--select-input {
-        background-color: transparent;
-      }
-
-      // and restore the 'light' prop in case light fields are wanted
-      .#{$prefix}--text-input--light,
-    .#{$prefix}--text-area--light,
-    .#{$prefix}--search--light .#{$prefix}--search-input,
-    .#{$prefix}--select--light .#{$prefix}--select-input,
-    .#{$prefix}--dropdown--light,
-    .#{$prefix}--dropdown--light .#{$prefix}--dropdown-list,
-    /* stylelint-disable-next-line prettier/prettier */
-    .#{$prefix}--number--light input[type='number'],
-    .#{$prefix}--date-picker--light
-      .#{$prefix}--date-picker__input {
-        background-color: $field-02;
-      }
-    }
-
-    .#{$pkg-prefix}--action-set
-      .#{$pkg-prefix}--action-set__action-button.#{$pkg-prefix}--action-set__action-button--expressive {
-      block-size: $spacing-11;
-    }
+  .#{$block-class}__container[stack-position='1'][stack-depth='3'] {
+    max-block-size: calc(
+      100% - (#{$spacing-09} + #{$spacing-08}) + (2 * #{$spacing-05})
+    );
+    transform: scale(var(--#{$block-class}--stacking-scale-factor-double));
   }
 
   .#{$block-class}__buttons {
@@ -269,52 +74,247 @@ $motion-duration: $duration-moderate-02;
     display: flex;
     background: $background;
     inline-size: 100%;
-
-    &[hidden] {
-      @extend .#{$prefix}--visually-hidden;
-
-      display: none;
-    }
-
-    /* stylelint-disable-next-line selector-type-no-unknown */
-    ::slotted(#{$prefix}-button) {
-      @extend .#{$block-class-action-set}__action-button;
-
-      flex: 0 1 25%;
-      block-size: $spacing-11;
-      max-inline-size: to-rem(232px);
-    }
-
-    /* stylelint-disable-next-line selector-type-no-unknown */
-    ::slotted(#{$prefix}-button[kind='ghost']) {
-      flex: 1 1 25%;
-      max-inline-size: none;
-    }
-
-    ::slotted(#{$prefix}-button[hidden]) {
-      @extend .#{$prefix}--visually-hidden;
-
-      display: none;
-    }
   }
 
-  [width='narrow'] .#{$block-class}__buttons {
-    /* stylelint-disable selector-type-no-unknown */
-    &[actions-multiple='single'] ::slotted(#{$prefix}-button),
-    &[actions-multiple='double'] ::slotted(#{$prefix}-button) {
-      /* stylelint-enable selector-type-no-unknown */
-      // double and single on lg use 50%
-      flex: 0 1 50%;
-      max-inline-size: none;
-    }
+  .#{$block-class}__buttons[hidden] {
+    @extend .#{$prefix}--visually-hidden;
 
-    /* stylelint-disable-next-line selector-type-no-unknown */
-    ::slotted(#{$prefix}-button) {
-      block-size: $spacing-10;
-    }
+    display: none;
+  }
+
+  .#{$block-class}__buttons ::slotted(#{$prefix}-button) {
+    @extend .#{$block-class-action-set}__action-button;
+
+    flex: 0 1 25%;
+    block-size: $spacing-11;
+    max-inline-size: to-rem(232px);
+  }
+
+  .#{$block-class}__buttons ::slotted(#{$prefix}-button[kind='ghost']) {
+    flex: 1 1 25%;
+    max-inline-size: none;
+  }
+
+  .#{$block-class}__buttons ::slotted(#{$prefix}-button[hidden]) {
+    @extend .#{$prefix}--visually-hidden;
+
+    display: none;
   }
 
   .#{$block-class}__influencer[wide] {
     @extend .#{$block-class}__influencer--wide;
   }
+}
+
+:host(#{$prefix}-tearsheet[open]) {
+  --overlay-color: #{$overlay};
+  --overlay-opacity: 1;
+
+  z-index: utilities.z('modal');
+  align-items: flex-end;
+  background: initial;
+  opacity: 1;
+
+  // stylelint-disable-next-line carbon/motion-duration-use, carbon/motion-easing-use
+  transition: visibility 0s linear;
+  visibility: inherit;
+
+  .#{$prefix}--tearsheet__container {
+    transform: translate3d(0, 0, 0);
+    transition: transform $duration-moderate-02 motion(entrance, expressive);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+
+  &::before {
+    position: absolute;
+    display: block;
+    background: var(--overlay-color);
+    content: '';
+    inset: 0;
+    opacity: var(--overlay-opacity);
+
+    transition: background-color $motion-duration motion(exit, expressive),
+      opacity $motion-duration motion(exit, expressive);
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+
+    &[stack-position='1'][stack-depth='2'] {
+      --overlay-opacity: 0.67;
+    }
+
+    &[stack-position='1'][stack-depth='3'] {
+      --overlay-opacity: 0.22;
+    }
+
+    &[stack-position='2'][stack-depth='3'] {
+      --overlay-opacity: 0.5;
+    }
+
+    &[stack-position='2'][stack-depth='2'],
+    &[stack-position='3'][stack-depth='3'] {
+      --overlay-opacity: 0.5;
+    }
+  }
+}
+
+:host(#{$prefix}-tearsheet[hidden]) {
+  @extend .#{$prefix}--visually-hidden;
+}
+
+:host(#{$prefix}-tearsheet[slug]) {
+  --overlay-color: #{$ai-overlay};
+
+  .#{$block-class}__container {
+    border: 1px solid transparent;
+
+    /* override carbon ai removing background gradient */
+    background: linear-gradient(to top, var(--cds-layer), var(--cds-layer))
+        padding-box,
+      linear-gradient(
+          to bottom,
+          var(--cds-ai-border-start, #78a9ff),
+          var(--cds-ai-border-end, #d0e2ff)
+        )
+        border-box,
+      linear-gradient(to top, var(--cds-layer), var(--cds-layer)) border-box;
+    border-block-end: 0;
+    box-shadow: 0 24px 40px -24px $ai-drop-shadow;
+  }
+
+  .#{$block-class}__content {
+    @include utilities.ai-popover-gradient('default', 0);
+
+    box-shadow: inset 0 -80px 70px -65px $ai-inner-shadow;
+  }
+}
+
+:host(#{$prefix}-tearsheet[slug][has-actions]) ::slotted(#{$prefix}-slug) {
+  inset-inline-end: 0;
+}
+
+:host(#{$prefix}-tearsheet[stack-position='1'][stack-depth='2']),
+:host(#{$prefix}-tearsheet[stack-position='2'][stack-depth='3']) {
+  z-index: utilities.z('modal') - 1;
+}
+
+:host(#{$prefix}-tearsheet[stack-position='1'][stack-depth='3']) {
+  z-index: utilities.z('modal') - 2;
+}
+
+:host(#{$prefix}-tearsheet[width='narrow']) {
+  .#{$block-class}__header {
+    margin: 0;
+    background-color: $layer;
+    border-block-end: 1px solid $border-subtle-01;
+  }
+
+  .#{$block-class}__header-description {
+    margin-block-start: $spacing-03;
+    max-inline-size: 80%;
+  }
+
+  .#{$block-class}__main {
+    background-color: $layer;
+  }
+}
+
+:host(#{$prefix}-tearsheet[width='wide']) {
+  --content-padding: #{$spacing-06 $spacing-07};
+
+  .#{$block-class}__header {
+    margin: 0;
+    background-color: $layer;
+    border-block-end: 1px solid $border-subtle-01;
+  }
+
+  .#{$block-class}__header[has-navigation] {
+    padding-block-end: 0;
+  }
+
+  .#{$block-class}__container {
+    inline-size: 100%;
+
+    @include breakpoint(md) {
+      inline-size: calc(100% - (2 * #{$spacing-10}));
+    }
+  }
+
+  .#{$prefix}--modal-header__heading.#{$block-class}__heading {
+    @include type.type-style('heading-04');
+  }
+
+  .#{$block-class}__header[has-close-icon],
+  .#{$block-class}__header[has-slug] {
+    padding-inline-end: $spacing-11;
+  }
+
+  .#{$block-class}__header[has-close-icon][has-slug] {
+    padding-inline-end: calc(#{$spacing-11 + $spacing-09});
+  }
+
+  .#{$block-class}__header-navigation {
+    margin-inline-start: calc(-1 * #{$spacing-05});
+    max-block-size: $spacing-08; /* #{$prefix}-tabs too tall */
+  }
+
+  .#{$block-class}__content {
+    // Revert background color overridden by Carbon's modal - https://github.com/carbon-design-system/carbon/blob/main/packages/styles/scss/components/modal/_modal.scss#L54
+    .#{$prefix}--pagination,
+    .#{$prefix}--pagination__control-buttons,
+    .#{$prefix}--text-input,
+    .#{$prefix}--text-area,
+    .#{$prefix}--search-input,
+    .#{$prefix}--select-input,
+    .#{$prefix}--dropdown,
+    .#{$prefix}--dropdown-list,
+    .#{$prefix}--number input[type='number'],
+    .#{$prefix}--date-picker__input {
+      background-color: $field;
+    }
+
+    .#{$prefix}--select--inline .#{$prefix}--select-input {
+      background-color: transparent;
+    }
+
+    // and restore the 'light' prop in case light fields are wanted
+    .#{$prefix}--text-input--light,
+  .#{$prefix}--text-area--light,
+  .#{$prefix}--search--light .#{$prefix}--search-input,
+  .#{$prefix}--select--light .#{$prefix}--select-input,
+  .#{$prefix}--dropdown--light,
+  .#{$prefix}--dropdown--light .#{$prefix}--dropdown-list,
+  /* stylelint-disable-next-line prettier/prettier */
+  .#{$prefix}--number--light input[type='number'],
+  .#{$prefix}--date-picker--light
+    .#{$prefix}--date-picker__input {
+      background-color: $field-02;
+    }
+  }
+
+  .#{$pkg-prefix}--action-set
+    .#{$pkg-prefix}--action-set__action-button.#{$pkg-prefix}--action-set__action-button--expressive {
+    block-size: $spacing-11;
+  }
+}
+
+:host(#{$prefix}-tearsheet[width='narrow'])
+  .#{$block-class}__buttons[actions-multiple='single']
+  ::slotted(#{$prefix}-button),
+:host(#{$prefix}-tearsheet[width='narrow'])
+  .#{$block-class}__buttons[actions-multiple='double']
+  ::slotted(#{$prefix}-button) {
+  // double and single on lg use 50%
+  flex: 0 1 50%;
+  max-inline-size: none;
+}
+
+:host(#{$prefix}-tearsheet[width='narrow'])
+  .#{$block-class}__buttons
+  ::slotted(#{$prefix}-button) {
+  block-size: $spacing-10;
 }

--- a/packages/carbon-web-components/src/components/tearsheet/tearsheet.scss
+++ b/packages/carbon-web-components/src/components/tearsheet/tearsheet.scss
@@ -193,7 +193,9 @@ $motion-duration: $duration-moderate-02;
   }
 }
 
-:host(#{$prefix}-tearsheet[slug][has-actions]) ::slotted(#{$prefix}-slug) {
+:host(#{$prefix}-tearsheet[slug])
+  .#{$prefix}--tearsheet__header[has-actions]
+  ::slotted(#{$prefix}-slug) {
   inset-inline-end: 0;
 }
 

--- a/packages/carbon-web-components/src/components/tearsheet/tearsheet.ts
+++ b/packages/carbon-web-components/src/components/tearsheet/tearsheet.ts
@@ -23,6 +23,7 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 import '../button/index';
 import '../layer/index';
 import '../button/button-set-base';
+import '../modal/index';
 import {
   TEARSHEET_INFLUENCER_PLACEMENT,
   TEARSHEET_INFLUENCER_WIDTH,


### PR DESCRIPTION
### Related Ticket(s)

Closes #11790

### Description

Adopter was running into an issue with the tearsheet not rendering when imported via npm in her application. This PR breaks out the nested styles which were not getting picked up. Also adds missing `modal` import in tearsheet

Also adds codesandbox example.

### Changelog

**New**

- codesandbox example for tearsheet

**Changed**

- break out tearsheet styles where attribute selectors were nested

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
