### PR TITLE
feat(masthead): use more visible box shadow

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -131,7 +131,6 @@ $search-transition-timing: 95ms;
     }
 
     .#{$prefix}--masthead__l1-dropdown {
-      border-bottom: 1px solid $ui-03;
       position: absolute;
       inset-block-start: 100%;
       inset-inline: 0;
@@ -139,7 +138,7 @@ $search-transition-timing: 95ms;
       color: $text-02;
 
       &.is-open {
-        box-shadow: 0 0 6px #c6c6c6;
+        box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.3);
       }
 
       &:not(.is-open) {


### PR DESCRIPTION
### Related Ticket(s)

Addresses internal ticket [ADCMS-5023](https://jsw.ibm.com/browse/ADCMS-5023)

### Description

Recent changes to the mobile L1 dropdown necessitated this visual change.

### Changelog

**Changed**

- Applies darker shadow under mobile L1 dropdown when open.

### Testing
1. Visit the Dotcom Shell > With L1 story and reduce the viewport to a mobile size
2. Open the L1 dropdown and verify the shadow at the bottom is a dark, natural-looking shadow.