### PR TITLE
feat(back-to-top-btn): adding shadow part so that the component can b…

### DIFF
--- a/packages/web-components/src/components/back-to-top/back-to-top.ts
+++ b/packages/web-components/src/components/back-to-top/back-to-top.ts
@@ -169,6 +169,7 @@ class C4DBackToTop extends HostListenerMixin(StableSelectorMixin(LitElement)) {
     const { backToTopAssistiveText, _handleOnClick: handleOnClick } = this;
     return html`
       <button
+        part="back-to-top__button"
         class="${prefix}--btn ${prefix}--btn--secondary ${prefix}--btn--icon-only ${prefix}--back-to-top__btn"
         aria-label="${backToTopAssistiveText}"
         @click="${handleOnClick}">

--- a/packages/web-components/tests/snapshots/c4d-callout-with-media.md
+++ b/packages/web-components/tests/snapshots/c4d-callout-with-media.md
@@ -21,6 +21,8 @@
         <slot name="media">
         </slot>
         <div
+          class="false"
+          grid-mode=""
           hidden=""
           style=""
         >
@@ -55,6 +57,8 @@
         <slot name="media">
         </slot>
         <div
+          class="false"
+          grid-mode=""
           hidden=""
           style=""
         >
@@ -89,6 +93,8 @@
         <slot name="media">
         </slot>
         <div
+          class="false"
+          grid-mode=""
           hidden=""
           style=""
         >

--- a/packages/web-components/tests/snapshots/c4d-content-block-cards.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-cards.md
@@ -19,7 +19,9 @@
     <slot name="media">
     </slot>
     <div
+      card-group=""
       class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -50,7 +52,9 @@
     <slot name="media">
     </slot>
     <div
+      card-group=""
       class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-headlines.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-headlines.md
@@ -22,6 +22,8 @@
       </slot>
     </div>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-horizontal.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-horizontal.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-media.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-media.md
@@ -19,6 +19,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-segmented.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-segmented.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-simple.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-simple.md
@@ -19,6 +19,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-group-cards.md
+++ b/packages/web-components/tests/snapshots/c4d-content-group-cards.md
@@ -28,6 +28,8 @@
       </div>
     </div>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -67,6 +69,8 @@
       </div>
     </div>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-group-simple.md
+++ b/packages/web-components/tests/snapshots/c4d-content-group-simple.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -35,7 +37,7 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout">
+<div class="cds--content-layout cds--content-layout--with-footer">
   <slot name="heading">
   </slot>
   <div class="cds--content-layout__body">
@@ -45,7 +47,11 @@
     </slot>
     <slot>
     </slot>
-    <div style="">
+    <div
+      class="c4d--content-block-footer"
+      grid-mode=""
+      style=""
+    >
       <slot name="footer">
       </slot>
     </div>

--- a/packages/web-components/tests/snapshots/c4d-cta-block.md
+++ b/packages/web-components/tests/snapshots/c4d-cta-block.md
@@ -99,7 +99,7 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout cds--content-layout--border">
+<div class="cds--content-layout cds--content-layout--border cds--content-layout--with-children">
   <slot name="heading">
   </slot>
   <div class="cds--content-layout__body">

--- a/packages/web-components/tests/snapshots/c4d-in-page-banner.md
+++ b/packages/web-components/tests/snapshots/c4d-in-page-banner.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-search-with-typeahead.md
+++ b/packages/web-components/tests/snapshots/c4d-search-with-typeahead.md
@@ -87,6 +87,7 @@
       part="search-input"
       placeholder="Search all of IBM"
       type="text"
+      value=""
     >
     <div
       class="react-autosuggest__suggestions-container"


### PR DESCRIPTION
…e styled from outside shadow

### Related Ticket(s)

[ADCMS-5035](https://jsw.ibm.com/browse/ADCMS-5035)

### Description

Adding a shadow "part" attribute so that the Back to Top Component can be styled from outside the shadow tree.

### Changelog

New shadow part attribute added to Back to Top component.
Snapshots updated.

