### PR TITLE
feat(background-media): add shadow parts to bg-media

### DIFF
--- a/packages/web-components/src/components/background-media/background-media.ts
+++ b/packages/web-components/src/components/background-media/background-media.ts
@@ -145,6 +145,7 @@ class C4DBackgroundMedia extends C4DImage {
 
     return html`
       <button
+        part="video-player__controls"
         @click=${toggleVideoState}
         class="${prefix}--video-player__controls"
         aria-pressed="${!videoIsPlaying}"
@@ -156,7 +157,11 @@ class C4DBackgroundMedia extends C4DImage {
   }
 
   renderGradient() {
-    return html` <div class="${this._getGradientClass()}"></div> `;
+    return html`
+      <div
+        part="background-media--gradient"
+        class="${this._getGradientClass()}"></div>
+    `;
   }
 
   _getMediaOpacity() {
@@ -186,9 +191,12 @@ class C4DBackgroundMedia extends C4DImage {
 
   render() {
     return html`
-      <div class="${this._getMobilePositionClass()}">
+      <div
+        part="background-media--container"
+        class="${this._getMobilePositionClass()}">
         ${this.gradientHidden ? '' : this.renderGradient()}
         <div
+          part="background-media--item"
           class="${prefix}--background-media--item"
           style="${this._getMediaOpacity()}">
           ${this.containsOnlyImages ? super.render() : ''}

--- a/packages/web-components/src/components/background-media/background-media.ts
+++ b/packages/web-components/src/components/background-media/background-media.ts
@@ -145,7 +145,7 @@ class C4DBackgroundMedia extends C4DImage {
 
     return html`
       <button
-        part="video-player__controls"
+        part="controls"
         @click=${toggleVideoState}
         class="${prefix}--video-player__controls"
         aria-pressed="${!videoIsPlaying}"
@@ -158,9 +158,7 @@ class C4DBackgroundMedia extends C4DImage {
 
   renderGradient() {
     return html`
-      <div
-        part="background-media--gradient"
-        class="${this._getGradientClass()}"></div>
+      <div part="gradient" class="${this._getGradientClass()}"></div>
     `;
   }
 
@@ -191,12 +189,10 @@ class C4DBackgroundMedia extends C4DImage {
 
   render() {
     return html`
-      <div
-        part="background-media--container"
-        class="${this._getMobilePositionClass()}">
+      <div part="container" class="${this._getMobilePositionClass()}">
         ${this.gradientHidden ? '' : this.renderGradient()}
         <div
-          part="background-media--item"
+          part="item"
           class="${prefix}--background-media--item"
           style="${this._getMediaOpacity()}">
           ${this.containsOnlyImages ? super.render() : ''}

--- a/packages/web-components/tests/snapshots/c4d-background-media.md
+++ b/packages/web-components/tests/snapshots/c4d-background-media.md
@@ -7,16 +7,16 @@
 ```
 <div
   class="cds--background-media--container cds--background-media--image cds--background-media--mobile-position cds--background-media--mobile-position--bottom"
-  part="background-media--container"
+  part="container"
 >
   <div
     class="cds--background-media--gradient cds--background-media--gradient--left-to-right"
-    part="background-media--gradient"
+    part="gradient"
   >
   </div>
   <div
     class="cds--background-media--item"
-    part="background-media--item"
+    part="item"
     style="opacity:1"
   >
     <slot>
@@ -31,16 +31,16 @@
 ```
 <div
   class="cds--background-media--container cds--background-media--image cds--background-media--mobile-position cds--background-media--mobile-position--bottom"
-  part="background-media--container"
+  part="container"
 >
   <div
     class="cds--background-media--gradient cds--background-media--gradient--left-to-right"
-    part="background-media--gradient"
+    part="gradient"
   >
   </div>
   <div
     class="cds--background-media--item"
-    part="background-media--item"
+    part="item"
     style="opacity:1"
   >
     <slot>

--- a/packages/web-components/tests/snapshots/c4d-background-media.md
+++ b/packages/web-components/tests/snapshots/c4d-background-media.md
@@ -5,11 +5,18 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--background-media--container cds--background-media--image cds--background-media--mobile-position cds--background-media--mobile-position--bottom">
-  <div class="cds--background-media--gradient cds--background-media--gradient--left-to-right">
+<div
+  class="cds--background-media--container cds--background-media--image cds--background-media--mobile-position cds--background-media--mobile-position--bottom"
+  part="background-media--container"
+>
+  <div
+    class="cds--background-media--gradient cds--background-media--gradient--left-to-right"
+    part="background-media--gradient"
+  >
   </div>
   <div
     class="cds--background-media--item"
+    part="background-media--item"
     style="opacity:1"
   >
     <slot>
@@ -22,11 +29,18 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--background-media--container cds--background-media--image cds--background-media--mobile-position cds--background-media--mobile-position--bottom">
-  <div class="cds--background-media--gradient cds--background-media--gradient--left-to-right">
+<div
+  class="cds--background-media--container cds--background-media--image cds--background-media--mobile-position cds--background-media--mobile-position--bottom"
+  part="background-media--container"
+>
+  <div
+    class="cds--background-media--gradient cds--background-media--gradient--left-to-right"
+    part="background-media--gradient"
+  >
   </div>
   <div
     class="cds--background-media--item"
+    part="background-media--item"
     style="opacity:1"
   >
     <slot>

--- a/packages/web-components/tests/snapshots/c4d-callout-with-media.md
+++ b/packages/web-components/tests/snapshots/c4d-callout-with-media.md
@@ -21,6 +21,8 @@
         <slot name="media">
         </slot>
         <div
+          class="false"
+          grid-mode=""
           hidden=""
           style=""
         >
@@ -55,6 +57,8 @@
         <slot name="media">
         </slot>
         <div
+          class="false"
+          grid-mode=""
           hidden=""
           style=""
         >
@@ -89,6 +93,8 @@
         <slot name="media">
         </slot>
         <div
+          class="false"
+          grid-mode=""
           hidden=""
           style=""
         >

--- a/packages/web-components/tests/snapshots/c4d-content-block-cards.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-cards.md
@@ -19,7 +19,9 @@
     <slot name="media">
     </slot>
     <div
+      card-group=""
       class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -50,7 +52,9 @@
     <slot name="media">
     </slot>
     <div
+      card-group=""
       class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-headlines.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-headlines.md
@@ -22,6 +22,8 @@
       </slot>
     </div>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-horizontal.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-horizontal.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-media.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-media.md
@@ -19,6 +19,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-segmented.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-segmented.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-simple.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-simple.md
@@ -19,6 +19,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-group-cards.md
+++ b/packages/web-components/tests/snapshots/c4d-content-group-cards.md
@@ -28,6 +28,8 @@
       </div>
     </div>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -67,6 +69,8 @@
       </div>
     </div>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-group-simple.md
+++ b/packages/web-components/tests/snapshots/c4d-content-group-simple.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -35,7 +37,7 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout">
+<div class="cds--content-layout cds--content-layout--with-footer">
   <slot name="heading">
   </slot>
   <div class="cds--content-layout__body">
@@ -45,7 +47,11 @@
     </slot>
     <slot>
     </slot>
-    <div style="">
+    <div
+      class="c4d--content-block-footer"
+      grid-mode=""
+      style=""
+    >
       <slot name="footer">
       </slot>
     </div>

--- a/packages/web-components/tests/snapshots/c4d-cta-block.md
+++ b/packages/web-components/tests/snapshots/c4d-cta-block.md
@@ -99,7 +99,7 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout cds--content-layout--border">
+<div class="cds--content-layout cds--content-layout--border cds--content-layout--with-children">
   <slot name="heading">
   </slot>
   <div class="cds--content-layout__body">

--- a/packages/web-components/tests/snapshots/c4d-in-page-banner.md
+++ b/packages/web-components/tests/snapshots/c4d-in-page-banner.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-search-with-typeahead.md
+++ b/packages/web-components/tests/snapshots/c4d-search-with-typeahead.md
@@ -87,6 +87,7 @@
       part="search-input"
       placeholder="Search all of IBM"
       type="text"
+      value=""
     >
     <div
       class="react-autosuggest__suggestions-container"


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-5036](https://jsw.ibm.com/browse/ADCMS-5036)

### Description

Adding shadow parts to Background Media component so that it can be styled outside the shadow tree.

### Changelog

Shadow parts added to Background Media. 
Snapshots updated
