### PR TITLE
feat(callout-quote): add shadow parts

### DIFF
--- a/packages/web-components/src/components/callout-quote/callout-quote.ts
+++ b/packages/web-components/src/components/callout-quote/callout-quote.ts
@@ -45,10 +45,10 @@ class C4DCalloutQuote extends C4DCalloutMixin(C4DQuote) {
 
   render() {
     return html`
-      <div class="${prefix}--callout__column" part="callout__column">
-        <div class="${prefix}--callout__content" part="callout__content">
-          <div class="${prefix}--quote__container" part="quote__container">
-            <div class="${prefix}--quote__wrapper" part="quote__wrapper">
+      <div class="${prefix}--callout__column" part="column">
+        <div class="${prefix}--callout__content" part="content">
+          <div class="${prefix}--quote__container" part="container">
+            <div class="${prefix}--quote__wrapper" part="wrapper">
               ${this._renderQuote()}${this._renderSource()}${this._renderFooter()}
             </div>
           </div>

--- a/packages/web-components/src/components/callout-quote/callout-quote.ts
+++ b/packages/web-components/src/components/callout-quote/callout-quote.ts
@@ -45,10 +45,10 @@ class C4DCalloutQuote extends C4DCalloutMixin(C4DQuote) {
 
   render() {
     return html`
-      <div class="${prefix}--callout__column" part="callout__quote">
-        <div class="${prefix}--callout__content">
-          <div class="${prefix}--quote__container">
-            <div class="${prefix}--quote__wrapper">
+      <div class="${prefix}--callout__column" part="callout__column">
+        <div class="${prefix}--callout__content" part="callout__content">
+          <div class="${prefix}--quote__container" part="quote__container">
+            <div class="${prefix}--quote__wrapper" part="quote__wrapper">
               ${this._renderQuote()}${this._renderSource()}${this._renderFooter()}
             </div>
           </div>

--- a/packages/web-components/src/components/callout-quote/callout-quote.ts
+++ b/packages/web-components/src/components/callout-quote/callout-quote.ts
@@ -45,7 +45,7 @@ class C4DCalloutQuote extends C4DCalloutMixin(C4DQuote) {
 
   render() {
     return html`
-      <div class="${prefix}--callout__column">
+      <div class="${prefix}--callout__column" part="callout__quote">
         <div class="${prefix}--callout__content">
           <div class="${prefix}--quote__container">
             <div class="${prefix}--quote__wrapper">

--- a/packages/web-components/tests/snapshots/c4d-callout-quote.md
+++ b/packages/web-components/tests/snapshots/c4d-callout-quote.md
@@ -5,11 +5,20 @@
 ```
 <div
   class="cds--callout__column"
-  part="callout__quote"
+  part="callout__column"
 >
-  <div class="cds--callout__content">
-    <div class="cds--quote__container">
-      <div class="cds--quote__wrapper">
+  <div
+    class="cds--callout__content"
+    part="callout__content"
+  >
+    <div
+      class="cds--quote__container"
+      part="quote__container"
+    >
+      <div
+        class="cds--quote__wrapper"
+        part="quote__wrapper"
+      >
         <span class="cds--quote__mark">
           “
         </span>

--- a/packages/web-components/tests/snapshots/c4d-callout-quote.md
+++ b/packages/web-components/tests/snapshots/c4d-callout-quote.md
@@ -5,19 +5,19 @@
 ```
 <div
   class="cds--callout__column"
-  part="callout__column"
+  part="column"
 >
   <div
     class="cds--callout__content"
-    part="callout__content"
+    part="content"
   >
     <div
       class="cds--quote__container"
-      part="quote__container"
+      part="container"
     >
       <div
         class="cds--quote__wrapper"
-        part="quote__wrapper"
+        part="wrapper"
       >
         <span class="cds--quote__mark">
           “

--- a/packages/web-components/tests/snapshots/c4d-callout-quote.md
+++ b/packages/web-components/tests/snapshots/c4d-callout-quote.md
@@ -3,7 +3,10 @@
 #### `Renders as expected`
 
 ```
-<div class="cds--callout__column">
+<div
+  class="cds--callout__column"
+  part="callout__quote"
+>
   <div class="cds--callout__content">
     <div class="cds--quote__container">
       <div class="cds--quote__wrapper">

--- a/packages/web-components/tests/snapshots/c4d-callout-with-media.md
+++ b/packages/web-components/tests/snapshots/c4d-callout-with-media.md
@@ -21,6 +21,8 @@
         <slot name="media">
         </slot>
         <div
+          class="false"
+          grid-mode=""
           hidden=""
           style=""
         >
@@ -55,6 +57,8 @@
         <slot name="media">
         </slot>
         <div
+          class="false"
+          grid-mode=""
           hidden=""
           style=""
         >
@@ -89,6 +93,8 @@
         <slot name="media">
         </slot>
         <div
+          class="false"
+          grid-mode=""
           hidden=""
           style=""
         >

--- a/packages/web-components/tests/snapshots/c4d-content-block-cards.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-cards.md
@@ -19,7 +19,9 @@
     <slot name="media">
     </slot>
     <div
+      card-group=""
       class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -50,7 +52,9 @@
     <slot name="media">
     </slot>
     <div
+      card-group=""
       class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-headlines.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-headlines.md
@@ -22,6 +22,8 @@
       </slot>
     </div>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-horizontal.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-horizontal.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-media.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-media.md
@@ -19,6 +19,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-segmented.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-segmented.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-block-simple.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-simple.md
@@ -19,6 +19,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot name="media">
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-group-cards.md
+++ b/packages/web-components/tests/snapshots/c4d-content-group-cards.md
@@ -28,6 +28,8 @@
       </div>
     </div>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -67,6 +69,8 @@
       </div>
     </div>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-content-group-simple.md
+++ b/packages/web-components/tests/snapshots/c4d-content-group-simple.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -35,7 +37,7 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout">
+<div class="cds--content-layout cds--content-layout--with-footer">
   <slot name="heading">
   </slot>
   <div class="cds--content-layout__body">
@@ -45,7 +47,11 @@
     </slot>
     <slot>
     </slot>
-    <div style="">
+    <div
+      class="c4d--content-block-footer"
+      grid-mode=""
+      style=""
+    >
       <slot name="footer">
       </slot>
     </div>

--- a/packages/web-components/tests/snapshots/c4d-cta-block.md
+++ b/packages/web-components/tests/snapshots/c4d-cta-block.md
@@ -99,7 +99,7 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout cds--content-layout--border">
+<div class="cds--content-layout cds--content-layout--border cds--content-layout--with-children">
   <slot name="heading">
   </slot>
   <div class="cds--content-layout__body">

--- a/packages/web-components/tests/snapshots/c4d-in-page-banner.md
+++ b/packages/web-components/tests/snapshots/c4d-in-page-banner.md
@@ -19,6 +19,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >
@@ -49,6 +51,8 @@
     <slot>
     </slot>
     <div
+      class="false"
+      grid-mode=""
       hidden=""
       style=""
     >

--- a/packages/web-components/tests/snapshots/c4d-search-with-typeahead.md
+++ b/packages/web-components/tests/snapshots/c4d-search-with-typeahead.md
@@ -87,6 +87,7 @@
       part="search-input"
       placeholder="Search all of IBM"
       type="text"
+      value=""
     >
     <div
       class="react-autosuggest__suggestions-container"


### PR DESCRIPTION
### Related Ticket(s)

[JIRA](https://jsw.ibm.com/browse/ADCMS-5039)

### Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. 
This PR is for the callout-quote component.

### Changelog

**New**
adding the part attribute to html elements inside the render methotd