### PR TITLE
chore(percy): update config and story snapshots

### DIFF
--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -37,35 +37,6 @@ jobs:
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_WEBCOMPONENTS }}
       - name: Run percy storybook
-        run: yarn build-storybook && visual-snapshot
+        run: yarn build-storybook && yarn visual-snapshot
         working-directory: packages/web-components
-  carbon-web-components:
-    if: github.repository == 'carbon-design-system/carbon-for-ibm-dotcom'
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: ['18.x']
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - name: Install dependencies
-        run: yarn install --immutable --immutable-cache
-      - name: Install xvfb
-        run: sudo apt-get install xvfb
-      - name: Build
-        run: yarn lerna run --stream --ignore @carbon/ibmdotcom-web-components --ignore @carbon/ibmdotcom-styles --ignore @carbon/ibmdotcom-services-store --ignore @carbon/ibmdotcom-utilities --ignore @carbon/ibmdotcom-services build
-      - name: Set env vars
-        uses: ./.github/actions/set-dotenv
-        with:
-          env-file: packages/carbon-web-components/.env
-        env:
-          KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
-          KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_CARBONWEBCOMPONENTS }}
-      - name: Run percy storybook
-        run: yarn build-storybook && visual-snapshot
-        working-directory: packages/carbon-web-components
+

--- a/packages/web-components/src/components/back-to-top/__stories__/back-to-top.stories.ts
+++ b/packages/web-components/src/components/back-to-top/__stories__/back-to-top.stories.ts
@@ -29,6 +29,9 @@ export const Default = () => {
 export default {
   title: 'Components/Back to top',
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
   },
 };

--- a/packages/web-components/src/components/background-media/__stories__/background-media.stories.ts
+++ b/packages/web-components/src/components/background-media/__stories__/background-media.stories.ts
@@ -84,6 +84,15 @@ export const WithDefaultSource = (args) => {
   `;
 };
 
+WithDefaultSource.story = {
+  name: 'with default source',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
+};
+
 export default {
   title: 'Components/Background media',
   decorators: [
@@ -96,6 +105,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/button/__stories__/button.stories.ts
+++ b/packages/web-components/src/components/button/__stories__/button.stories.ts
@@ -56,6 +56,9 @@ export default {
   title: 'Components/Button',
   decorators: [(story) => html` <div class="cds--grid">${story()}</div> `],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/callout-with-media/__stories__/callout-with-media.stories.ts
+++ b/packages/web-components/src/components/callout-with-media/__stories__/callout-with-media.stories.ts
@@ -64,6 +64,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
+++ b/packages/web-components/src/components/card-group/__stories__/card-group.stories.ts
@@ -317,6 +317,9 @@ export const withCardInCard = (args) => {
 withCardInCard.story = {
   name: 'With card in card',
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {
@@ -357,6 +360,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/card-in-card/__stories__/card-in-card.stories.ts
+++ b/packages/web-components/src/components/card-in-card/__stories__/card-in-card.stories.ts
@@ -72,6 +72,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/card-section-offset/__stories__/card-section-offset.stories.ts
+++ b/packages/web-components/src/components/card-section-offset/__stories__/card-section-offset.stories.ts
@@ -112,6 +112,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/card/__stories__/card.stories.ts
+++ b/packages/web-components/src/components/card/__stories__/card.stories.ts
@@ -451,6 +451,9 @@ export const Logo = (args) => {
 
 Logo.story = {
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     knobs: {
       Card: () => ({

--- a/packages/web-components/src/components/carousel/__stories__/carousel.stories.ts
+++ b/packages/web-components/src/components/carousel/__stories__/carousel.stories.ts
@@ -88,7 +88,6 @@ export const Default = () => {
       copy: copyOdd,
     })}${Card()}
   `;
-  // }
 };
 
 export const CardsWithImages = () => {
@@ -101,6 +100,15 @@ export const CardsWithImages = () => {
       copy: copyOdd,
     })}${Card({ image: imgLg2x1 })}
   `;
+};
+
+CardsWithImages.story = {
+  name: 'With cards with images',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export const CardsWithVideos = () => {
@@ -121,6 +129,15 @@ export const CardsWithMedia = () => {
       href: '0_ibuqxqbe',
     })}${Card({ image: imgLg4x3 })}${CardWithVideo({ href: '0_ibuqxqbe' })}
   `;
+};
+
+CardsWithMedia.story = {
+  name: 'With cards with media',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export default {

--- a/packages/web-components/src/components/content-block-cards/__stories__/content-block-cards.stories.ts
+++ b/packages/web-components/src/components/content-block-cards/__stories__/content-block-cards.stories.ts
@@ -99,6 +99,11 @@ export const withImages = (args) => {
 
 withImages.story = {
   name: 'With images',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export const withVideos = (args) => {
@@ -145,6 +150,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/content-block-horizontal/__stories__/content-block-horizontal.stories.react.tsx
+++ b/packages/web-components/src/components/content-block-horizontal/__stories__/content-block-horizontal.stories.react.tsx
@@ -33,9 +33,7 @@ const copy =
 
 const linkListItem = (
   <C4DContentItemRow>
-    <C4DContentItemRowEyebrow>
-      Lorem ipsum
-    </C4DContentItemRowEyebrow>
+    <C4DContentItemRowEyebrow>Lorem ipsum</C4DContentItemRowEyebrow>
     <C4DContentItemHeading>Aliquam condimentum</C4DContentItemHeading>
     <C4DContentItemRowCopy>{copy}</C4DContentItemRowCopy>
     <C4DLinkList slot="footer" type="vertical">
@@ -83,6 +81,9 @@ export default {
     ),
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/content-block-media/__stories__/content-block-media.stories.ts
+++ b/packages/web-components/src/components/content-block-media/__stories__/content-block-media.stories.ts
@@ -314,6 +314,9 @@ export const withLinkList = (args) => {
 withLinkList.story = {
   name: 'With link list',
   parameters: {
+    percy: {
+      skip: true,
+    },
     gridContentClasses: 'cds--col-lg-12',
     knobs: {
       ContentBlockMedia: () => ({
@@ -367,6 +370,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     gridContentClasses: 'cds--col-lg-8',
     hasStoryPadding: true,

--- a/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.ts
+++ b/packages/web-components/src/components/content-block-mixed/__stories__/content-block-mixed.stories.ts
@@ -97,6 +97,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     gridContentClasses: 'cds--col-lg-8',
     hasStoryPadding: true,
@@ -358,6 +361,9 @@ export const WithLinkList = (args) => {
 WithLinkList.story = {
   name: 'With link list',
   parameters: {
+    percy: {
+      skip: true,
+    },
     gridContentClasses: 'cds--col-lg-12',
     knobs: {
       ContentBlockMixed: () => ({

--- a/packages/web-components/src/components/content-block-segmented/__stories__/content-block-segmented.stories.ts
+++ b/packages/web-components/src/components/content-block-segmented/__stories__/content-block-segmented.stories.ts
@@ -237,6 +237,9 @@ export const withLinkList = (args) => {
 withLinkList.story = {
   name: 'With link list',
   parameters: {
+    percy: {
+      skip: true,
+    },
     gridContentClasses: 'cds--col-lg-12',
     knobs: {
       ContentBlockSegmented: () => ({
@@ -296,6 +299,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     gridContentClasses: 'cds--col-lg-8',
     hasStoryPadding: true,

--- a/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.ts
+++ b/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.ts
@@ -146,6 +146,11 @@ export const WithImage = (args) => {
 
 WithImage.story = {
   name: 'With image',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export const WithVideo = (args) => {
@@ -190,6 +195,9 @@ export const WithVideo = (args) => {
 WithVideo.story = {
   name: 'With video',
   parameters: {
+    percy: {
+      skip: true,
+    },
     gridContentClasses: 'cds--col-lg-12',
   },
 };
@@ -249,6 +257,9 @@ export const WithLinkList = (args) => {
 WithLinkList.story = {
   name: 'With link list',
   parameters: {
+    percy: {
+      skip: true,
+    },
     gridContentClasses: 'cds--col-lg-12',
   },
 };

--- a/packages/web-components/src/components/content-block/__stories__/content-block.stories.ts
+++ b/packages/web-components/src/components/content-block/__stories__/content-block.stories.ts
@@ -160,6 +160,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/content-group-simple/__stories__/content-group-simple.stories.ts
+++ b/packages/web-components/src/components/content-group-simple/__stories__/content-group-simple.stories.ts
@@ -163,6 +163,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/content-item-row/__stories__/content-item-row.stories.ts
+++ b/packages/web-components/src/components/content-item-row/__stories__/content-item-row.stories.ts
@@ -155,6 +155,9 @@ export const WithMediaFeatured = (args) => {
 
 Default.story = {
   parameters: {
+    percy: {
+      skip: true,
+    },
     gridContentClasses: 'cds--col-lg-12',
   },
 };
@@ -162,6 +165,9 @@ Default.story = {
 WithThumbnail.story = {
   name: 'With thumbnail',
   parameters: {
+    percy: {
+      skip: true,
+    },
     gridContentClasses: 'cds--col-lg-12',
     knobs: {
       ContentItemRow: () => ({
@@ -183,6 +189,9 @@ WithThumbnail.story = {
 WithMedia.story = {
   name: 'With media',
   parameters: {
+    percy: {
+      skip: true,
+    },
     gridContentClasses: 'cds--col-lg-12',
     knobs: {
       ContentItemRow: () => ({
@@ -211,6 +220,9 @@ WithMedia.story = {
 WithMediaFeatured.story = {
   name: 'With featured media',
   parameters: {
+    percy: {
+      skip: true,
+    },
     gridContentClasses: 'cds--col-lg-12',
     knobs: {
       ContentItemRow: () => ({
@@ -246,6 +258,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -981,9 +981,6 @@ WithHorizontalTOC.story = {
       skip: true,
     },
     ...readme.parameters,
-    percy: {
-      skip: true,
-    },
   },
 };
 

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -229,6 +229,9 @@ export const DefaultFooterLanguageOnly = (args) => {
 DefaultFooterLanguageOnly.story = {
   name: 'Default footer language only',
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       FooterComposite: () => ({
         disableLocaleButton: boolean(
@@ -323,6 +326,11 @@ export const searchOpenOnload = (args) => {
 
 searchOpenOnload.story = {
   name: 'Search open onload',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export const withPlatform = (args) => {
@@ -393,6 +401,9 @@ export const withPlatform = (args) => {
 withPlatform.story = {
   name: 'With platform',
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       MastheadComposite: () => ({
         hasProfile: boolean('show the profile functionality (profile)', true),
@@ -496,6 +507,11 @@ export const withShortFooter = (args) => {
 
 withShortFooter.story = {
   name: 'With short footer',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export const withShortFooterLanguageOnly = (args) => {
@@ -578,6 +594,9 @@ export const withShortFooterLanguageOnly = (args) => {
 withShortFooterLanguageOnly.story = {
   name: 'With short footer language only',
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       FooterComposite: () => ({
         disableLocaleButton: boolean(
@@ -748,6 +767,9 @@ export const withMicroFooterLanguageOnly = (args) => {
 withMicroFooterLanguageOnly.story = {
   name: 'With micro footer language only',
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       FooterComposite: () => ({
         disableLocaleButton: boolean(
@@ -839,6 +861,9 @@ export const withL1 = (args) => {
 withL1.story = {
   name: 'With L1',
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       DotcomShell: () => ({
         hasProfile: boolean(
@@ -952,6 +977,9 @@ export const WithHorizontalTOC = (args) => {
 WithHorizontalTOC.story = {
   name: 'With ToC horizontal',
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     percy: {
       skip: true,
@@ -1028,6 +1056,9 @@ export const WithLeadspaceSearch = (args) => {
 WithLeadspaceSearch.story = {
   name: 'With Lead space search',
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     'carbon-theme': { disabled: true },
   },
@@ -1137,6 +1168,9 @@ export const WithGlobalBanner = (args) => {
 WithGlobalBanner.story = {
   name: 'With Global banner',
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       DotcomShell: () => ({
         hasProfile: boolean(
@@ -1240,6 +1274,9 @@ export const WithoutShell = (args) => {
 WithoutShell.story = {
   name: 'Without Shell (Fallback Utility)',
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       DotcomShell: () => ({
         masthead: select('Masthead Version', ['L0', 'L1'], 'L0'),
@@ -1297,6 +1334,9 @@ export default {
     },
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     knobs: {
       escapeHTML: false,

--- a/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.ts
+++ b/packages/web-components/src/components/feature-card/__stories__/feature-card.stories.ts
@@ -58,6 +58,14 @@ export const Medium = (args) => {
   `;
 };
 
+Medium.story = {
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
+};
+
 export const Large = (args) => {
   const { eyebrow, heading, copy, href, colorScheme } =
     args?.[`${c4dPrefix}-feature-card`] ?? {};
@@ -96,6 +104,9 @@ export const Large = (args) => {
 
 Large.story = {
   parameters: {
+    percy: {
+      skip: true,
+    },
     storyGrid: `${prefix}--col-lg-12`,
     knobs: {
       [`${c4dPrefix}-feature-card`]: () => ({

--- a/packages/web-components/src/components/feature-section/__stories__/feature-section.stories.ts
+++ b/packages/web-components/src/components/feature-section/__stories__/feature-section.stories.ts
@@ -95,6 +95,9 @@ export default {
   title: 'Components/Feature section',
   decorators: [(story) => html` ${story()} `],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/global-banner/__stories__/global-banner.stories.ts
+++ b/packages/web-components/src/components/global-banner/__stories__/global-banner.stories.ts
@@ -84,6 +84,9 @@ export const Default = (args) => {
 
 Default.story = {
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     knobs: {
       GlobalBanner: () => ({

--- a/packages/web-components/src/components/image/__stories__/image.stories.ts
+++ b/packages/web-components/src/components/image/__stories__/image.stories.ts
@@ -106,6 +106,9 @@ export default {
       `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/leadspace-block/__stories__/leadspace-block.stories.ts
+++ b/packages/web-components/src/components/leadspace-block/__stories__/leadspace-block.stories.ts
@@ -96,6 +96,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {

--- a/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
+++ b/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
@@ -144,6 +144,11 @@ export const SuperWithImage = (args) => {
 
 SuperWithImage.story = {
   name: 'Super with image',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export const SuperWithVideo = (args) => {
@@ -284,6 +289,11 @@ export const TallWithImage = (args) => {
 
 TallWithImage.story = {
   name: 'Tall with image',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export const TallWithVideo = (args) => {
@@ -424,6 +434,11 @@ export const MediumWithImage = (args) => {
 
 MediumWithImage.story = {
   name: 'Medium with image',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export const MediumWithVideo = (args) => {
@@ -495,6 +510,9 @@ export const Short = (args) => {
 
 Short.story = {
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       LeadSpace: () => ({
         navElements: select(
@@ -562,6 +580,9 @@ export const ShortWithImage = (args) => {
 ShortWithImage.story = {
   name: 'Short with image',
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       LeadSpace: () => ({
         navElements: select(
@@ -698,6 +719,11 @@ export const CenteredWithImage = (args) => {
 
 CenteredWithImage.story = {
   name: 'Centered with image',
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
 };
 
 export const CenteredWithVideo = (args) => {
@@ -776,6 +802,9 @@ export default {
     (story) => html` <div class="cds--grid cds--no-gutter">${story()}</div> `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     'carbon-theme': { preventReload: true },

--- a/packages/web-components/src/components/logo-grid/__stories__/logo-grid.stories.ts
+++ b/packages/web-components/src/components/logo-grid/__stories__/logo-grid.stories.ts
@@ -74,6 +74,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {


### PR DESCRIPTION
### Description

This temporarily disables several story snapshots that are timing out in Percy. Once the cause of this is determined they can be re-enabled.

### Changelog

**Changed**

- temporarily `disable` Percy snapshots for stories that are timing out in Percy
- temporarily remove `visual-snapshots` entirely from `@carbon/web-components` package
- update GH workflow snapshot command for `@carbon/ibmdotcom-web-components`

**Removed**

- {{removed thing}}

- [x] update repository for `@carbon/web-components` (still pointing to old repo)

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
