### PR TITLE
fix (structured-list): Enable custom max-cols values

### DIFF
--- a/packages/styles/scss/components/structured-list/_structured-list.scss
+++ b/packages/styles/scss/components/structured-list/_structured-list.scss
@@ -120,20 +120,10 @@
   :host(#{$dds-prefix}-structured-list-header-row),
   :host(#{$dds-prefix}-structured-list-row),
   :host(#{$dds-prefix}-structured-list-group) tr {
-    --max-cols: 4;
-
     @include carbon--breakpoint('sm') {
       @include carbon--make-row();
 
       flex-wrap: nowrap;
-    }
-
-    @include carbon--breakpoint('md') {
-      --max-cols: 8;
-    }
-
-    @include carbon--breakpoint('lg') {
-      --max-cols: 16;
     }
 
     @for $i from 1 through 8 {
@@ -178,6 +168,16 @@
     overflow-x: auto;
     scroll-snap-type: x;
     position: relative;
+
+    --max-cols: 4;
+
+    @include carbon--breakpoint('md') {
+      --max-cols: 8;
+    }
+
+    @include carbon--breakpoint('lg') {
+      --max-cols: 16;
+    }
 
     .#{$prefix}--structured-list {
       margin: 0;


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-5014

### Description

This PR moves the `--max-cols` definitions to the top-level `structured-list` and `pricing-table` components. Previously, each row element set this value, leading to `lg` breakpoints always calculating against an assumed value of 16-cols

This change was needed to make the table work more intuitively in situations where it isn't displayed in a full 16-column container, for example within the `table-of-contents` component.

Before this PR, a pricing table 12-cols wide, with three table-columns each set to be 4-cols wide would set each table-column to be 25% width (4/16).
<img width="1476" alt="Screenshot 2024-05-17 at 11 14 54 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/25532785/adf3c571-448b-4f2f-af83-c14773439755">

With this PR, the pricing table can set `--max-cols: 12` and have those same table-columns set to 33.333% width (4/12)
<img width="1449" alt="Screenshot 2024-05-17 at 11 15 39 AM" src="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/25532785/0919f89a-0223-4f73-aad7-682aefb789d0">

### Changelog

**Changed**

- Enable custom `--max-col` values in structured-list and pricing-table components
