### PR TITLE
feat(carousel): add shadowparts

### DIFF
--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -738,13 +738,14 @@ class C4DCarousel extends HostListenerMixin(StableSelectorMixin(LitElement)) {
     });
     // Use another div from the host `<c4d-carousel>` to reflect private state
     return html`
-      <div role="region" aria-labelledby="carousel-title">
-        <div id="carousel-title">
+      <div part="region" role="region" aria-labelledby="carousel-title">
+        <div part="title" id="carousel-title">
           <slot name="title">
             <span class="cds--visually-hidden">Carousel</span>
           </slot>
         </div>
         <div
+          part="scroll-container"
           class="${prefix}--carousel__scroll-container"
           @scroll="${handleScrollFocus}"
           @touchstart="${handleTouchStartEvent}"
@@ -754,11 +755,12 @@ class C4DCarousel extends HostListenerMixin(StableSelectorMixin(LitElement)) {
               ? null
               : `${customPropertyPageSize}: ${pageSizeExplicit}`
           )}">
-          <div class="${scrollContentsClasses}">
+          <div part="contents" class="${scrollContentsClasses}">
             <slot @slotchange="${handleSlotChange}"></slot>
           </div>
         </div>
         <nav
+          part="navigation"
           aria-label="Carousel Navigation"
           class="${prefix}--carousel__navigation">
           <button
@@ -771,6 +773,7 @@ class C4DCarousel extends HostListenerMixin(StableSelectorMixin(LitElement)) {
             ${CaretLeft20()}
           </button>
           <span
+            part="status"
             class="${prefix}--carousel__navigation__status"
             aria-hidden="true"
             >${formatStatus(status)}</span

--- a/packages/web-components/tests/snapshots/c4d-carousel.md
+++ b/packages/web-components/tests/snapshots/c4d-carousel.md
@@ -7,18 +7,26 @@
 ```
 <div
   aria-labelledby="carousel-title"
+  part="region"
   role="region"
 >
-  <div id="carousel-title">
+  <div
+    id="carousel-title"
+    part="title"
+  >
     <slot name="title">
       <span class="cds--visually-hidden">
         Carousel
       </span>
     </slot>
   </div>
-  <div class="cds--carousel__scroll-container">
+  <div
+    class="cds--carousel__scroll-container"
+    part="scroll-container"
+  >
     <div
       class="cds--carousel__scroll-contents"
+      part="contents"
       style="inset-inline-start: 0px;"
     >
       <slot>
@@ -28,6 +36,7 @@
   <nav
     aria-label="Carousel Navigation"
     class="cds--carousel__navigation"
+    part="navigation"
   >
     <button
       aria-label="previous"
@@ -40,6 +49,7 @@
     <span
       aria-hidden="true"
       class="cds--carousel__navigation__status"
+      part="status"
     >
       1 / 0
     </span>


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-5048](https://jsw.ibm.com/browse/ADCMS-5048)
#11673

### Description

Add shadow parts to the elements of carousel.

### Changelog

**New**

- Added shadow parts to the carousel component.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
