### PR TITLE
feat(content-block): add shadowparts

### DIFF
--- a/packages/web-components/src/components/content-block/content-block.ts
+++ b/packages/web-components/src/components/content-block/content-block.ts
@@ -136,6 +136,7 @@ class C4DContentBlock extends StableSelectorMixin(LitElement) {
   protected _renderBody(): TemplateResult | string | void {
     return html`
       <div
+        part="body"
         ?hidden="${!this._hasBodyContent()}"
         class="${prefix}--content-layout__body">
         ${this._renderCopy()}${this._renderInnerBody()}${this._renderFooter()}
@@ -173,6 +174,7 @@ class C4DContentBlock extends StableSelectorMixin(LitElement) {
 
     return html`
       <div
+        part="footer"
         ?hidden="${!hasFooter}"
         class="${hasFooter && `${c4dPrefix}--content-block-footer`}"
         style="${cardGroupStyle}"
@@ -226,7 +228,7 @@ class C4DContentBlock extends StableSelectorMixin(LitElement) {
 
   render() {
     return html`
-      <div class="${this._getContainerClasses()}">
+      <div part="content-layout" class="${this._getContainerClasses()}">
         ${this._renderHeading()}${this._renderBody()}${this._renderComplementary()}
       </div>
     `;

--- a/packages/web-components/tests/snapshots/c4d-callout-with-media.md
+++ b/packages/web-components/tests/snapshots/c4d-callout-with-media.md
@@ -7,12 +7,16 @@
 ```
 <div class="cds--callout__column">
   <div class="cds--callout__content">
-    <div class="cds--content-layout">
+    <div
+      class="cds--content-layout"
+      part="content-layout"
+    >
       <slot name="heading">
       </slot>
       <div
         class="cds--content-layout__body"
         hidden=""
+        part="body"
       >
         <slot name="copy">
         </slot>
@@ -24,6 +28,7 @@
           class="false"
           grid-mode=""
           hidden=""
+          part="footer"
           style=""
         >
           <slot name="footer">
@@ -43,12 +48,16 @@
 ```
 <div class="cds--callout__column">
   <div class="cds--callout__content">
-    <div class="cds--content-layout">
+    <div
+      class="cds--content-layout"
+      part="content-layout"
+    >
       <slot name="heading">
       </slot>
       <div
         class="cds--content-layout__body"
         hidden=""
+        part="body"
       >
         <slot name="copy">
         </slot>
@@ -60,6 +69,7 @@
           class="false"
           grid-mode=""
           hidden=""
+          part="footer"
           style=""
         >
           <slot name="footer">
@@ -79,12 +89,16 @@
 ```
 <div class="cds--callout__column">
   <div class="cds--callout__content">
-    <div class="cds--content-layout">
+    <div
+      class="cds--content-layout"
+      part="content-layout"
+    >
       <slot name="heading">
       </slot>
       <div
         class="cds--content-layout__body"
         hidden=""
+        part="body"
       >
         <slot name="copy">
         </slot>
@@ -96,6 +110,7 @@
           class="false"
           grid-mode=""
           hidden=""
+          part="footer"
           style=""
         >
           <slot name="footer">

--- a/packages/web-components/tests/snapshots/c4d-content-block-cards.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-cards.md
@@ -5,12 +5,16 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-layout cds--content-layout--card-group">
+<div
+  class="cds--content-layout cds--content-layout--card-group"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -23,6 +27,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">
@@ -38,12 +43,16 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout cds--content-layout--card-group">
+<div
+  class="cds--content-layout cds--content-layout--card-group"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -56,6 +65,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">

--- a/packages/web-components/tests/snapshots/c4d-content-block-headlines.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-headlines.md
@@ -5,12 +5,16 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-layout cds--content-layout--with-headlines cds--layout--border">
+<div
+  class="cds--content-layout cds--content-layout--with-headlines cds--layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -25,6 +29,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">

--- a/packages/web-components/tests/snapshots/c4d-content-block-horizontal.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-horizontal.md
@@ -5,12 +5,16 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -22,6 +26,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">
@@ -37,12 +42,16 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -54,6 +63,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">

--- a/packages/web-components/tests/snapshots/c4d-content-block-media.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-media.md
@@ -5,12 +5,16 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -22,6 +26,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">
@@ -37,12 +42,16 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -54,6 +63,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">

--- a/packages/web-components/tests/snapshots/c4d-content-block-segmented.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-segmented.md
@@ -5,12 +5,16 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -22,6 +26,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">
@@ -37,12 +42,16 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -54,6 +63,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">

--- a/packages/web-components/tests/snapshots/c4d-content-block-simple.md
+++ b/packages/web-components/tests/snapshots/c4d-content-block-simple.md
@@ -5,12 +5,16 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -22,6 +26,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">
@@ -37,12 +42,16 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout cds--content-layout--with-complementary cds--layout--border">
+<div
+  class="cds--content-layout cds--content-layout--with-complementary cds--layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -54,6 +63,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">

--- a/packages/web-components/tests/snapshots/c4d-content-group-cards.md
+++ b/packages/web-components/tests/snapshots/c4d-content-group-cards.md
@@ -5,12 +5,16 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -38,6 +42,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">
@@ -53,12 +58,16 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -86,6 +95,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">

--- a/packages/web-components/tests/snapshots/c4d-content-group-simple.md
+++ b/packages/web-components/tests/snapshots/c4d-content-group-simple.md
@@ -5,12 +5,16 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -22,6 +26,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">
@@ -37,10 +42,16 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout cds--content-layout--with-footer">
+<div
+  class="cds--content-layout cds--content-layout--with-footer"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
-  <div class="cds--content-layout__body">
+  <div
+    class="cds--content-layout__body"
+    part="body"
+  >
     <slot name="copy">
     </slot>
     <slot name="media">
@@ -50,6 +61,7 @@
     <div
       class="c4d--content-block-footer"
       grid-mode=""
+      part="footer"
       style=""
     >
       <slot name="footer">

--- a/packages/web-components/tests/snapshots/c4d-cta-block.md
+++ b/packages/web-components/tests/snapshots/c4d-cta-block.md
@@ -3,7 +3,10 @@
 #### `Renders Default`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -52,7 +55,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-layout cds--content-layout--border">
+<div
+  class="cds--content-layout cds--content-layout--border"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
@@ -99,7 +105,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout cds--content-layout--border cds--content-layout--with-children">
+<div
+  class="cds--content-layout cds--content-layout--border cds--content-layout--with-children"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div class="cds--content-layout__body">

--- a/packages/web-components/tests/snapshots/c4d-in-page-banner.md
+++ b/packages/web-components/tests/snapshots/c4d-in-page-banner.md
@@ -5,12 +5,16 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -22,6 +26,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">
@@ -37,12 +42,16 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-layout">
+<div
+  class="cds--content-layout"
+  part="content-layout"
+>
   <slot name="heading">
   </slot>
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>
@@ -54,6 +63,7 @@
       class="false"
       grid-mode=""
       hidden=""
+      part="footer"
       style=""
     >
       <slot name="footer">

--- a/packages/web-components/tests/snapshots/c4d-logo-grid.md
+++ b/packages/web-components/tests/snapshots/c4d-logo-grid.md
@@ -9,6 +9,7 @@
   <div
     class="cds--content-layout__body"
     hidden=""
+    part="body"
   >
     <slot name="copy">
     </slot>


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-5049](https://jsw.ibm.com/browse/ADCMS-5049)
#11673

### Description

Add shadow parts to the elements of content-block.

### Changelog

**New**

- Added shadow parts to the content-block component.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
