### PR TITLE
feat(card-in-card): add shadow parts

### DIFF
--- a/packages/web-components/src/components/card-in-card/card-in-card.ts
+++ b/packages/web-components/src/components/card-in-card/card-in-card.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021, 2023
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -34,7 +34,8 @@ class C4DCardInCard extends StableSelectorMixin(C4DCard) {
         : html`
             <c4d-card-in-card-image
               alt="${ifDefined(videoName)}"
-              default-src="${videoThumbnailUrl}">
+              default-src="${videoThumbnailUrl}"
+              part="image">
             </c4d-card-in-card-image>
           `;
     return html`


### PR DESCRIPTION
### Related Ticket(s)

[Internal](https://jsw.ibm.com/browse/ADCMS-5043)

### Description

Allows adopters to style elements in `<c4d-card-in-card>`s' shadow roots via `part` attributes, which are selectable across shadow root boundaries.

### Changelog

**New**

- Adds `part` attributes to `<c4d-card-in-card>`s' shadow root elements.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
