### PR TITLE
feat(content-item): add shadow parts

### DIFF
--- a/packages/web-components/src/components/content-item/content-item.ts
+++ b/packages/web-components/src/components/content-item/content-item.ts
@@ -98,7 +98,8 @@ class C4DContentItem extends StableSelectorMixin(LitElement) {
     return html`
       <div
         ?hidden="${!hasStatistic}"
-        class="${c4dPrefix}--content-item__statitics">
+        class="${c4dPrefix}--content-item__statitics"
+        part="statistics">
         <slot name="statistics" @slotchange="${handleSlotChange}"></slot>
       </div>
     `;
@@ -111,7 +112,10 @@ class C4DContentItem extends StableSelectorMixin(LitElement) {
     const { _hasMedia: hasMedia, _handleSlotChange: handleSlotChange } = this;
 
     return html`
-      <div ?hidden="${!hasMedia}" class="${c4dPrefix}--content-item__media">
+      <div
+        ?hidden="${!hasMedia}"
+        class="${c4dPrefix}--content-item__media"
+        part="media">
         <slot name="media" @slotchange="${handleSlotChange}"></slot>
       </div>
     `;
@@ -131,7 +135,10 @@ class C4DContentItem extends StableSelectorMixin(LitElement) {
   protected _renderFooter(): TemplateResult | string | void {
     const { _hasFooter: hasFooter } = this;
     return html`
-      <div ?hidden="${!hasFooter}" class="${prefix}--content-item__cta">
+      <div
+        ?hidden="${!hasFooter}"
+        class="${prefix}--content-item__cta"
+        part="cta">
         <slot name="footer" @slotchange="${this._handleSlotChange}"></slot>
       </div>
     `;
@@ -158,7 +165,7 @@ class C4DContentItem extends StableSelectorMixin(LitElement) {
     });
 
     return html`
-      <div class="${horizontalClass}">
+      <div class="${horizontalClass}" part="heading">
         ${this._renderStatistic()} ${this._renderMedia()}
         <div>
           <slot name="heading"></slot>


### PR DESCRIPTION
[ADCMS-5062](https://jsw.ibm.com/browse/ADCMS-5062)
Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "content-item" component.
Changelog

New

Adding the shadow parts for the "content-item" component