### PR TITLE
feat(content-section): add shadow parts

### DIFF
--- a/packages/web-components/src/components/content-section/content-section.ts
+++ b/packages/web-components/src/components/content-section/content-section.ts
@@ -58,14 +58,17 @@ class C4DContentSection extends StableSelectorMixin(LitElement) {
 
   render() {
     return html`
-      <div class="${prefix}--content-section ${prefix}--content-section-layout">
-        <div class="${prefix}--content-section__leading">
+      <div
+        class="${prefix}--content-section ${prefix}--content-section-layout"
+        part="layout">
+        <div class="${prefix}--content-section__leading" part="leading">
           <slot name="heading"></slot>
           <slot name="copy"></slot>
           <slot name="footer"></slot>
         </div>
         <div
-          class="${prefix}--content-section__body ${this.childrenCustomClass}">
+          class="${prefix}--content-section__body ${this.childrenCustomClass}"
+          part="body">
           <slot @slotchange="${this.handleSlotChange}"></slot>
         </div>
       </div>


### PR DESCRIPTION
[ADCMS-5064](https://jsw.ibm.com/browse/ADCMS-5064)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "content-secion" component.
Changelog

New

Adding the shadow parts for the "content-section" component