### PR TITLE
feat(cta): add shadow parts

### DIFF
--- a/packages/web-components/src/components/cta/card-cta-footer.ts
+++ b/packages/web-components/src/components/cta/card-cta-footer.ts
@@ -49,7 +49,7 @@ class C4DCardCTAFooter extends VideoCTAMixin(CTAMixin(C4DCardFooter)) {
           }),
         });
     return html`
-      <span class="${prefix}--card__cta__copy"
+      <span class="${prefix}--card__cta__copy" part="copy"
         ><slot @slotchange="${this._handleSlotChange}"></slot>${caption}</span
       >
     `;

--- a/packages/web-components/src/components/cta/card-cta.ts
+++ b/packages/web-components/src/components/cta/card-cta.ts
@@ -81,7 +81,7 @@ class C4DCardCTA extends VideoCTAMixin(CTAMixin(C4DCard)) {
         : html`
             <c4d-card-cta-image
               class="${prefix}--card__video-thumbnail"
-              part="thumbnail"
+              part="video-thumbnail"
               alt="${ifDefined(videoName)}"
               default-src="${ifDefined(thumbnail || videoThumbnailUrl)}">
               ${PlayVideo({ slot: 'icon' })}

--- a/packages/web-components/src/components/cta/card-cta.ts
+++ b/packages/web-components/src/components/cta/card-cta.ts
@@ -81,6 +81,7 @@ class C4DCardCTA extends VideoCTAMixin(CTAMixin(C4DCard)) {
         : html`
             <c4d-card-cta-image
               class="${prefix}--card__video-thumbnail"
+              part="thumbnail"
               alt="${ifDefined(videoName)}"
               default-src="${ifDefined(thumbnail || videoThumbnailUrl)}">
               ${PlayVideo({ slot: 'icon' })}

--- a/packages/web-components/src/components/cta/cta.ts
+++ b/packages/web-components/src/components/cta/cta.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -124,16 +124,28 @@ class C4DCTAHead extends HostListenerMixin(StableSelectorMixin(LitElement)) {
         ? html` <c4d-feature-cta part="cta cta--feature"></c4d-feature-cta> `
         : ``}
       ${this.ctaStyle === 'card'
-        ? html` <c4d-card-cta part="cta cta--card"><slot></slot></c4d-card-cta> `
+        ? html`
+            <c4d-card-cta part="cta cta--card"><slot></slot></c4d-card-cta>
+          `
         : ``}
       ${this.ctaStyle === 'card-link'
-        ? html` <c4d-card-link-cta part="cta cta--card-link"><slot></slot></c4d-card-link-cta> `
+        ? html`
+            <c4d-card-link-cta part="cta cta--card-link"
+              ><slot></slot
+            ></c4d-card-link-cta>
+          `
         : ``}
       ${this.ctaStyle === 'text'
-        ? html` <c4d-text-cta part="cta cta--text"><slot></slot></c4d-text-cta> `
+        ? html`
+            <c4d-text-cta part="cta cta--text"><slot></slot></c4d-text-cta>
+          `
         : ``}
       ${this.ctaStyle === 'button'
-        ? html` <c4d-button-cta part="cta cta--button"><slot></slot></c4d-button-cta> `
+        ? html`
+            <c4d-button-cta part="cta cta--button"
+              ><slot></slot
+            ></c4d-button-cta>
+          `
         : ``}
     `;
   }

--- a/packages/web-components/src/components/cta/cta.ts
+++ b/packages/web-components/src/components/cta/cta.ts
@@ -121,19 +121,19 @@ class C4DCTAHead extends HostListenerMixin(StableSelectorMixin(LitElement)) {
   render() {
     return html`
       ${this.ctaStyle === 'feature'
-        ? html` <c4d-feature-cta part="cta cta--card-feature"></c4d-feature-cta> `
+        ? html` <c4d-feature-cta part="cta cta--feature"></c4d-feature-cta> `
         : ``}
       ${this.ctaStyle === 'card'
-        ? html` <c4d-card-cta part="cta cta--card-cta"><slot></slot></c4d-card-cta> `
+        ? html` <c4d-card-cta part="cta cta--card"><slot></slot></c4d-card-cta> `
         : ``}
       ${this.ctaStyle === 'card-link'
         ? html` <c4d-card-link-cta part="cta cta--card-link"><slot></slot></c4d-card-link-cta> `
         : ``}
       ${this.ctaStyle === 'text'
-        ? html` <c4d-text-cta part="cta cta--card-text"><slot></slot></c4d-text-cta> `
+        ? html` <c4d-text-cta part="cta cta--text"><slot></slot></c4d-text-cta> `
         : ``}
       ${this.ctaStyle === 'button'
-        ? html` <c4d-button-cta part="cta cta--card-button"><slot></slot></c4d-button-cta> `
+        ? html` <c4d-button-cta part="cta cta--button"><slot></slot></c4d-button-cta> `
         : ``}
     `;
   }

--- a/packages/web-components/src/components/cta/cta.ts
+++ b/packages/web-components/src/components/cta/cta.ts
@@ -121,19 +121,19 @@ class C4DCTAHead extends HostListenerMixin(StableSelectorMixin(LitElement)) {
   render() {
     return html`
       ${this.ctaStyle === 'feature'
-        ? html` <c4d-feature-cta></c4d-feature-cta> `
+        ? html` <c4d-feature-cta part="cta cta--card-feature"></c4d-feature-cta> `
         : ``}
       ${this.ctaStyle === 'card'
-        ? html` <c4d-card-cta><slot></slot></c4d-card-cta> `
+        ? html` <c4d-card-cta part="cta cta--card-cta"><slot></slot></c4d-card-cta> `
         : ``}
       ${this.ctaStyle === 'card-link'
-        ? html` <c4d-card-link-cta><slot></slot></c4d-card-link-cta> `
+        ? html` <c4d-card-link-cta part="cta cta--card-link"><slot></slot></c4d-card-link-cta> `
         : ``}
       ${this.ctaStyle === 'text'
-        ? html` <c4d-text-cta><slot></slot></c4d-text-cta> `
+        ? html` <c4d-text-cta part="cta cta--card-text"><slot></slot></c4d-text-cta> `
         : ``}
       ${this.ctaStyle === 'button'
-        ? html` <c4d-button-cta><slot></slot></c4d-button-cta> `
+        ? html` <c4d-button-cta part="cta cta--card-button"><slot></slot></c4d-button-cta> `
         : ``}
     `;
   }

--- a/packages/web-components/src/components/cta/feature-cta.ts
+++ b/packages/web-components/src/components/cta/feature-cta.ts
@@ -62,7 +62,7 @@ class C4DFeatureCTA extends VideoCTAMixin(CTAMixin(C4DFeatureCard)) {
     this.captionHeading = caption;
 
     return html`
-      <div class="${prefix}--card__copy">
+      <div class="${prefix}--card__copy" part="copy">
         <slot @slotchange="${this._handleSlotChange}"></slot>
       </div>
     `;


### PR DESCRIPTION
[ADCMS-5065](https://jsw.ibm.com/browse/ADCMS-5065)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "cta" component.

Changelog

New

Adding the shadow parts for the "cta" component