### PR TITLE
feat(card-section-offset): add shadow parts

### DIFF
--- a/packages/web-components/src/components/card-section-offset/card-section-offset.ts
+++ b/packages/web-components/src/components/card-section-offset/card-section-offset.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -52,7 +52,7 @@ class C4DCardSectionOffset extends StableSelectorMixin(C4DContentBlock) {
   render() {
     return html`
       <slot name="image-top"></slot>
-      <div class="${prefix}--card-section-offset__content">
+      <div class="${prefix}--card-section-offset__content" part="content">
         ${this._renderHeading()}
         <slot name="action"></slot>
       </div>

--- a/packages/web-components/tests/snapshots/c4d-card-section-offset.md
+++ b/packages/web-components/tests/snapshots/c4d-card-section-offset.md
@@ -7,7 +7,10 @@
 ```
 <slot name="image-top">
 </slot>
-<div class="cds--card-section-offset__content">
+<div
+  class="cds--card-section-offset__content"
+  part="content"
+>
   <slot name="heading">
   </slot>
   <slot name="action">
@@ -25,7 +28,10 @@
 ```
 <slot name="image-top">
 </slot>
-<div class="cds--card-section-offset__content">
+<div
+  class="cds--card-section-offset__content"
+  part="content"
+>
   <slot name="heading">
   </slot>
   <slot name="action">

--- a/packages/web-components/tests/snapshots/c4d-card-section-simple.md
+++ b/packages/web-components/tests/snapshots/c4d-card-section-simple.md
@@ -5,8 +5,14 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--content-section cds--content-section-layout">
-  <div class="cds--content-section__leading">
+<div
+  class="cds--content-section cds--content-section-layout"
+  part="layout"
+>
+  <div
+    class="cds--content-section__leading"
+    part="leading"
+  >
     <slot name="heading">
     </slot>
     <slot name="copy">
@@ -14,7 +20,10 @@
     <slot name="footer">
     </slot>
   </div>
-  <div class="cds--content-section__body">
+  <div
+    class="cds--content-section__body"
+    part="body"
+  >
     <slot>
     </slot>
   </div>
@@ -25,8 +34,14 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--content-section cds--content-section-layout">
-  <div class="cds--content-section__leading">
+<div
+  class="cds--content-section cds--content-section-layout"
+  part="layout"
+>
+  <div
+    class="cds--content-section__leading"
+    part="leading"
+  >
     <slot name="heading">
     </slot>
     <slot name="copy">
@@ -34,7 +49,10 @@
     <slot name="footer">
     </slot>
   </div>
-  <div class="cds--content-section__body">
+  <div
+    class="cds--content-section__body"
+    part="body"
+  >
     <slot>
     </slot>
   </div>

--- a/packages/web-components/tests/snapshots/c4d-content-group-simple.md
+++ b/packages/web-components/tests/snapshots/c4d-content-group-simple.md
@@ -42,7 +42,6 @@
 ####   `should render with various attributes`
 
 ```
-
 <div
   class="cds--content-layout cds--content-layout--with-footer"
   part="content-layout"

--- a/packages/web-components/tests/snapshots/c4d-content-item-row.md
+++ b/packages/web-components/tests/snapshots/c4d-content-item-row.md
@@ -17,6 +17,7 @@
   <div
     class="cds--content-item__cta"
     hidden=""
+    part="cta"
   >
     <slot name="footer">
     </slot>
@@ -42,6 +43,7 @@
   <div
     class="cds--content-item__cta"
     hidden=""
+    part="cta"
   >
     <slot name="footer">
     </slot>
@@ -68,6 +70,7 @@
     <div
       class="cds--content-item__cta"
       hidden=""
+      part="cta"
     >
       <slot name="footer">
       </slot>
@@ -95,6 +98,7 @@
     <div
       class="cds--content-item__cta"
       hidden=""
+      part="cta"
     >
       <slot name="footer">
       </slot>
@@ -126,6 +130,7 @@
     <div
       class="cds--content-item__cta"
       hidden=""
+      part="cta"
     >
       <slot name="footer">
       </slot>
@@ -155,6 +160,7 @@
     <div
       class="cds--content-item__cta"
       hidden=""
+      part="cta"
     >
       <slot name="footer">
       </slot>
@@ -184,6 +190,7 @@
     <div
       class="cds--content-item__cta"
       hidden=""
+      part="cta"
     >
       <slot name="footer">
       </slot>
@@ -211,6 +218,7 @@
     <div
       class="cds--content-item__cta"
       hidden=""
+      part="cta"
     >
       <slot name="footer">
       </slot>

--- a/packages/web-components/tests/snapshots/c4d-content-item.md
+++ b/packages/web-components/tests/snapshots/c4d-content-item.md
@@ -5,10 +5,11 @@
 ####   `should render with minimum attributes`
 
 ```
-<div>
+<div part="heading">
   <div
     class="c4d--content-item__statitics"
     hidden=""
+    part="statistics"
   >
     <slot name="statistics">
     </slot>
@@ -16,6 +17,7 @@
   <div
     class="c4d--content-item__media"
     hidden=""
+    part="media"
   >
     <slot name="media">
     </slot>
@@ -28,6 +30,7 @@
     <div
       class="cds--content-item__cta"
       hidden=""
+      part="cta"
     >
       <slot name="footer">
       </slot>
@@ -40,15 +43,19 @@
 ####   `should render with various attributes`
 
 ```
-<div>
+<div part="heading">
   <div
     class="c4d--content-item__statitics"
     hidden=""
+    part="statistics"
   >
     <slot name="statistics">
     </slot>
   </div>
-  <div class="c4d--content-item__media">
+  <div
+    class="c4d--content-item__media"
+    part="media"
+  >
     <slot name="media">
     </slot>
   </div>
@@ -57,7 +64,10 @@
     </slot>
     <slot>
     </slot>
-    <div class="cds--content-item__cta">
+    <div
+      class="cds--content-item__cta"
+      part="cta"
+    >
       <slot name="footer">
       </slot>
     </div>

--- a/packages/web-components/tests/snapshots/c4d-content-section.md
+++ b/packages/web-components/tests/snapshots/c4d-content-section.md
@@ -3,8 +3,14 @@
 #### `renders properly`
 
 ```
-<div class="cds--content-section cds--content-section-layout">
-  <div class="cds--content-section__leading">
+<div
+  class="cds--content-section cds--content-section-layout"
+  part="layout"
+>
+  <div
+    class="cds--content-section__leading"
+    part="leading"
+  >
     <slot name="heading">
     </slot>
     <slot name="copy">
@@ -12,7 +18,10 @@
     <slot name="footer">
     </slot>
   </div>
-  <div class="cds--content-section__body">
+  <div
+    class="cds--content-section__body"
+    part="body"
+  >
     <slot>
     </slot>
   </div>


### PR DESCRIPTION
### Related Ticket(s)

[Internal](https://jsw.ibm.com/browse/ADCMS-5046)

### Description

Allows adopters to style elements in `<c4d-card-section-offset>`s' shadow roots via `part` attributes, which are selectable across shadow root boundaries.

### Changelog

**New**

- Adds `part` attributes to `<c4d-card-section-offset>`s' shadow root elements.