### PR TITLE
feat(dotcom-shell): add shadow parts

### DIFF
--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell.ts
@@ -24,7 +24,7 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
 class C4DDotcomShell extends StableSelectorMixin(LitElement) {
   render() {
     return html`
-      <div class="${prefix}--dotcom-shell__content" part="shell">
+      <div class="${prefix}--dotcom-shell__content" part="content">
         <slot></slot>
       </div>
     `;

--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell.ts
@@ -24,7 +24,7 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
 class C4DDotcomShell extends StableSelectorMixin(LitElement) {
   render() {
     return html`
-      <div class="${prefix}--dotcom-shell__content">
+      <div class="${prefix}--dotcom-shell__content" part="shell">
         <slot></slot>
       </div>
     `;


### PR DESCRIPTION
[ADCMS-5142](https://jsw.ibm.com/browse/ADCMS-5142)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "dotcom-shell" component.

Changelog

New

Adding the shadow parts for the "dotcom-shell" component