### PR TITLE
feat(expressive-modal): add shadow parts

### DIFF
--- a/packages/web-components/src/components/expressive-modal/expressive-modal.ts
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal.ts
@@ -441,13 +441,13 @@ class C4DExpressiveModal extends StableSelectorMixin(
       <button
         id="start-sentinel"
         class="${prefix}--visually-hidden"
-        part="button"
+        part="sentinel-button sentinel-button--start"
         @focusin="${handleFocusIn}">
         START
       </button>
       <div
         class="${containerClasses}"
-        part="modal-header"
+        part="modal-container"
         tabindex="-1"
         role="dialog"
         aria-labelledby="${c4dPrefix}--modal-header"
@@ -460,7 +460,7 @@ class C4DExpressiveModal extends StableSelectorMixin(
       <button
         id="end-sentinel"
         class="${prefix}--visually-hidden"
-        part="button"
+        part="sentinel-button sentinel-button--end"
         @focusin="${handleFocusIn}">
         END
       </button>

--- a/packages/web-components/src/components/expressive-modal/expressive-modal.ts
+++ b/packages/web-components/src/components/expressive-modal/expressive-modal.ts
@@ -365,7 +365,10 @@ class C4DExpressiveModal extends StableSelectorMixin(
         hasHeader && (hasBody || hasFooter),
     });
     return html`
-      <div id="${prefix}--modal-header" class="${headerClasses}">
+      <div
+        id="${prefix}--modal-header"
+        class="${headerClasses}"
+        part="modal-header">
         <slot name="header"></slot>
       </div>
     `;
@@ -380,7 +383,9 @@ class C4DExpressiveModal extends StableSelectorMixin(
       [`${c4dPrefix}-ce--modal__body`]: true,
       [`${c4dPrefix}-ce--modal__body--with-footer`]: hasBody && hasFooter,
     });
-    return html` <div class="${bodyClasses}"><slot></slot></div> `;
+    return html`
+      <div class="${bodyClasses}" part="modal-body"><slot></slot></div>
+    `;
   }
 
   /**
@@ -436,23 +441,26 @@ class C4DExpressiveModal extends StableSelectorMixin(
       <button
         id="start-sentinel"
         class="${prefix}--visually-hidden"
+        part="button"
         @focusin="${handleFocusIn}">
         START
       </button>
       <div
         class="${containerClasses}"
+        part="modal-header"
         tabindex="-1"
         role="dialog"
         aria-labelledby="${c4dPrefix}--modal-header"
         @click="${handleClickContainer}"
         @slotchange="${handleSlotChange}">
-        <div class="${prefix}--modal-content">
+        <div class="${prefix}--modal-content" part="modal-content">
           ${this._renderHeader()}${this._renderBody()}${this._renderFooter()}
         </div>
       </div>
       <button
         id="end-sentinel"
         class="${prefix}--visually-hidden"
+        part="button"
         @focusin="${handleFocusIn}">
         END
       </button>

--- a/packages/web-components/tests/snapshots/c4d-expressive-modal.md
+++ b/packages/web-components/tests/snapshots/c4d-expressive-modal.md
@@ -8,24 +8,33 @@
 <button
   class="cds--visually-hidden"
   id="start-sentinel"
+  part="sentinel-button sentinel-button--start"
 >
   START
 </button>
 <div
   aria-labelledby="c4d--modal-header"
   class="cds--modal-container"
+  part="modal-container"
   role="dialog"
   tabindex="-1"
 >
-  <div class="cds--modal-content">
+  <div
+    class="cds--modal-content"
+    part="modal-content"
+  >
     <div
       class="c4d-ce--modal__header--with-body"
       id="cds--modal-header"
+      part="modal-header"
     >
       <slot name="header">
       </slot>
     </div>
-    <div class="c4d-ce--modal__body c4d-ce--modal__body--with-footer">
+    <div
+      class="c4d-ce--modal__body c4d-ce--modal__body--with-footer"
+      part="modal-body"
+    >
       <slot>
       </slot>
     </div>
@@ -38,6 +47,7 @@
 <button
   class="cds--visually-hidden"
   id="end-sentinel"
+  part="sentinel-button sentinel-button--end"
 >
   END
 </button>
@@ -50,24 +60,33 @@
 <button
   class="cds--visually-hidden"
   id="start-sentinel"
+  part="sentinel-button sentinel-button--start"
 >
   START
 </button>
 <div
   aria-labelledby="c4d--modal-header"
   class="cds--modal-container"
+  part="modal-container"
   role="dialog"
   tabindex="-1"
 >
-  <div class="cds--modal-content">
+  <div
+    class="cds--modal-content"
+    part="modal-content"
+  >
     <div
       class="c4d-ce--modal__header--with-body"
       id="cds--modal-header"
+      part="modal-header"
     >
       <slot name="header">
       </slot>
     </div>
-    <div class="c4d-ce--modal__body c4d-ce--modal__body--with-footer">
+    <div
+      class="c4d-ce--modal__body c4d-ce--modal__body--with-footer"
+      part="modal-body"
+    >
       <slot>
       </slot>
     </div>
@@ -80,6 +99,7 @@
 <button
   class="cds--visually-hidden"
   id="end-sentinel"
+  part="sentinel-button sentinel-button--end"
 >
   END
 </button>
@@ -94,24 +114,33 @@
 <button
   class="cds--visually-hidden"
   id="start-sentinel"
+  part="sentinel-button sentinel-button--start"
 >
   START
 </button>
 <div
   aria-labelledby="c4d--modal-header"
   class="cds--modal-container"
+  part="modal-container"
   role="dialog"
   tabindex="-1"
 >
-  <div class="cds--modal-content">
+  <div
+    class="cds--modal-content"
+    part="modal-content"
+  >
     <div
       class="c4d-ce--modal__header--with-body"
       id="cds--modal-header"
+      part="modal-header"
     >
       <slot name="header">
       </slot>
     </div>
-    <div class="c4d-ce--modal__body">
+    <div
+      class="c4d-ce--modal__body"
+      part="modal-body"
+    >
       <slot>
       </slot>
     </div>
@@ -124,6 +153,7 @@
 <button
   class="cds--visually-hidden"
   id="end-sentinel"
+  part="sentinel-button sentinel-button--end"
 >
   END
 </button>
@@ -136,24 +166,33 @@
 <button
   class="cds--visually-hidden"
   id="start-sentinel"
+  part="sentinel-button sentinel-button--start"
 >
   START
 </button>
 <div
   aria-labelledby="c4d--modal-header"
   class="cds--modal-container"
+  part="modal-container"
   role="dialog"
   tabindex="-1"
 >
-  <div class="cds--modal-content">
+  <div
+    class="cds--modal-content"
+    part="modal-content"
+  >
     <div
       class="c4d-ce--modal__header--with-body"
       id="cds--modal-header"
+      part="modal-header"
     >
       <slot name="header">
       </slot>
     </div>
-    <div class="c4d-ce--modal__body">
+    <div
+      class="c4d-ce--modal__body"
+      part="modal-body"
+    >
       <slot>
       </slot>
     </div>
@@ -166,6 +205,7 @@
 <button
   class="cds--visually-hidden"
   id="end-sentinel"
+  part="sentinel-button sentinel-button--end"
 >
   END
 </button>
@@ -178,24 +218,33 @@
 <button
   class="cds--visually-hidden"
   id="start-sentinel"
+  part="sentinel-button sentinel-button--start"
 >
   START
 </button>
 <div
   aria-labelledby="c4d--modal-header"
   class="cds--modal-container"
+  part="modal-container"
   role="dialog"
   tabindex="-1"
 >
-  <div class="cds--modal-content">
+  <div
+    class="cds--modal-content"
+    part="modal-content"
+  >
     <div
       class="c4d-ce--modal__header--with-body"
       id="cds--modal-header"
+      part="modal-header"
     >
       <slot name="header">
       </slot>
     </div>
-    <div class="c4d-ce--modal__body c4d-ce--modal__body--with-footer">
+    <div
+      class="c4d-ce--modal__body c4d-ce--modal__body--with-footer"
+      part="modal-body"
+    >
       <slot>
       </slot>
     </div>
@@ -208,6 +257,7 @@
 <button
   class="cds--visually-hidden"
   id="end-sentinel"
+  part="sentinel-button sentinel-button--end"
 >
   END
 </button>

--- a/packages/web-components/tests/snapshots/c4d-locale-modal.md
+++ b/packages/web-components/tests/snapshots/c4d-locale-modal.md
@@ -8,16 +8,21 @@
 <button
   class="cds--visually-hidden"
   id="start-sentinel"
+  part="sentinel-button sentinel-button--start"
 >
   START
 </button>
 <div
   aria-labelledby="c4d--modal-header"
   class="cds--modal-container"
+  part="modal-container"
   role="dialog"
   tabindex="-1"
 >
-  <div class="cds--modal-content">
+  <div
+    class="cds--modal-content"
+    part="modal-content"
+  >
     <div id="cds--modal-header">
       <c4d-expressive-modal-header data-autoid="c4d--expressive-modal-header">
         <c4d-expressive-modal-close-button data-autoid="c4d--expressive-modal-close-button">
@@ -43,6 +48,7 @@
 <button
   class="cds--visually-hidden"
   id="end-sentinel"
+  part="sentinel-button sentinel-button--end"
 >
   END
 </button>
@@ -55,16 +61,21 @@
 <button
   class="cds--visually-hidden"
   id="start-sentinel"
+  part="sentinel-button sentinel-button--start"
 >
   START
 </button>
 <div
   aria-labelledby="c4d--modal-header"
   class="cds--modal-container"
+  part="modal-container"
   role="dialog"
   tabindex="-1"
 >
-  <div class="cds--modal-content">
+  <div
+    class="cds--modal-content"
+    part="modal-content"
+  >
     <div id="cds--modal-header">
       <c4d-expressive-modal-header data-autoid="c4d--expressive-modal-header">
         <c4d-expressive-modal-close-button data-autoid="c4d--expressive-modal-close-button">
@@ -96,6 +107,7 @@
 <button
   class="cds--visually-hidden"
   id="end-sentinel"
+  part="sentinel-button sentinel-button--end"
 >
   END
 </button>
@@ -108,16 +120,21 @@
 <button
   class="cds--visually-hidden"
   id="start-sentinel"
+  part="sentinel-button sentinel-button--start"
 >
   START
 </button>
 <div
   aria-labelledby="c4d--modal-header"
   class="cds--modal-container"
+  part="modal-container"
   role="dialog"
   tabindex="-1"
 >
-  <div class="cds--modal-content">
+  <div
+    class="cds--modal-content"
+    part="modal-content"
+  >
     <div id="cds--modal-header">
       <c4d-expressive-modal-header
         close-button=""
@@ -161,6 +178,7 @@
 <button
   class="cds--visually-hidden"
   id="end-sentinel"
+  part="sentinel-button sentinel-button--end"
 >
   END
 </button>


### PR DESCRIPTION
[ADCMS-5143](https://jsw.ibm.com/browse/ADCMS-5143)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "expressive-modal" component.

Changelog

New

Adding the shadow parts for the "expressive-modal" component