### PR TITLE
feat(filter-panel): add shadow parts

### DIFF
--- a/packages/web-components/src/components/filter-panel/filter-panel-composite.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-composite.ts
@@ -415,6 +415,7 @@ class C4DFilterPanelComposite extends MediaQueryMixin(
    */
   protected _renderModal = (): TemplateResult => html`
     <c4d-filter-panel-modal
+      part="panel-modal"
       ?open=${this.openFilterModal}
       heading="${this._getComposedHeadingFilterCount()}"
       ?has-selections="${this._selectedValues.length}">
@@ -423,7 +424,7 @@ class C4DFilterPanelComposite extends MediaQueryMixin(
   `;
 
   protected _renderMobile = (): TemplateResult => html`
-    <cds-button kind="tertiary" @click=${this._openModal}>
+    <cds-button part="button" kind="tertiary" @click=${this._openModal}>
       ${this._getComposedHeadingFilterCount()} ${Filter({ slot: 'icon' })}
     </cds-button>
 
@@ -435,6 +436,7 @@ class C4DFilterPanelComposite extends MediaQueryMixin(
    */
   protected _renderDesktop = (): TemplateResult => html`
     <c4d-filter-panel
+      part="filter-panel"
       heading="${this._getComposedHeadingFilterCount()}"
       ?has-selections="${this._selectedValues.length}">
       <slot @slotchange="${this._handleSlotChange}"></slot>

--- a/packages/web-components/src/components/filter-panel/filter-panel-input-select-item.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-input-select-item.ts
@@ -85,7 +85,7 @@ class C4DFilterPanelInputSelectItem extends FocusMixin(
   render() {
     return html`
       <slot @slotchange=${this._handleSlotChange}></slot>
-      <div class="${prefix}--close__icon">
+      <div class="${prefix}--close__icon" part="icon">
         ${this.selected ? Close() : null}
       </div>
     `;

--- a/packages/web-components/src/components/filter-panel/filter-panel-input-select.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-input-select.ts
@@ -194,9 +194,10 @@ class C4DFilterPanelInputSelect extends FocusMixin(
   render() {
     const { title } = this;
     return html`
-      <div class="${prefix}--input-container">
+      <div class="${prefix}--input-container" part="container">
         <div
           class="${prefix}--input-container__heading"
+          part="heading"
           tabindex="1"
           @click=${this._handleClickHeader}
           @keydown=${this._handleKeydown}
@@ -204,7 +205,7 @@ class C4DFilterPanelInputSelect extends FocusMixin(
           aria-label="${this.ariaLabel}"
           role="button">
           ${title}
-          <div class="${prefix}--close__icon">
+          <div class="${prefix}--close__icon" part="icon">
             ${this.selected && this.isOpen ? Close() : null}
           </div>
         </div>
@@ -214,7 +215,8 @@ class C4DFilterPanelInputSelect extends FocusMixin(
           @keydown=${this._handleKeydownInner}
           class="${this.isOpen
             ? ''
-            : `${prefix}--selected-option-dropdown__hidden`} ${prefix}--selected-option-dropdown">
+            : `${prefix}--selected-option-dropdown__hidden`} ${prefix}--selected-option-dropdown"
+          part="dropdown">
           <slot @slotchange="${this._handleSlotChange}"></slot>
         </ul>
       </div>

--- a/packages/web-components/src/components/filter-panel/filter-panel-modal.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-modal.ts
@@ -113,25 +113,32 @@ class C4DFilterPanelModal extends HostListenerMixin(
       <button
         id="start-sentinel"
         class="${prefix}--visually-hidden"
+        part="button"
         @focusin="${handleFocusIn}">
         START
       </button>
       <section
-        class="${prefix}--filter-panel__section ${prefix}--modal-container">
-        <cds-modal-header>
+        class="${prefix}--filter-panel__section ${prefix}--modal-container"
+        part="section">
+        <cds-modal-header part="modal-header">
           <cds-modal-close-button
+            part="modal-button"
             @click=${this._handleUserClose}></cds-modal-close-button>
-          <c4d-filter-modal-heading>${this.heading}</c4d-filter-modal-heading>
+          <c4d-filter-modal-heading part="modal-heading"
+            >${this.heading}</c4d-filter-modal-heading
+          >
         </cds-modal-header>
-        <div class="${prefix}--modal-body"><slot></slot></div>
-        <c4d-filter-modal-footer>
+        <div class="${prefix}--modal-body" part="modal-body"><slot></slot></div>
+        <c4d-filter-modal-footer part="modal-footer">
           <c4d-filter-modal-footer-button
+            part="modal-button"
             ?disabled="${!this.hasSelections}"
             @click=${this._handleClear}
             kind="secondary"
             >Clear</c4d-filter-modal-footer-button
           >
           <c4d-filter-modal-footer-button
+            part="modal-button"
             @click=${this._handleUserClose}
             kind="primary"
             >See Results</c4d-filter-modal-footer-button
@@ -141,6 +148,7 @@ class C4DFilterPanelModal extends HostListenerMixin(
       <button
         id="end-sentinel"
         class="${prefix}--visually-hidden"
+        part="button"
         @focusin="${handleFocusIn}">
         END
       </button>

--- a/packages/web-components/src/components/filter-panel/filter-panel-modal.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel-modal.ts
@@ -113,7 +113,7 @@ class C4DFilterPanelModal extends HostListenerMixin(
       <button
         id="start-sentinel"
         class="${prefix}--visually-hidden"
-        part="button"
+        part="sentinel-button sentinel-button--start"
         @focusin="${handleFocusIn}">
         START
       </button>
@@ -122,7 +122,7 @@ class C4DFilterPanelModal extends HostListenerMixin(
         part="section">
         <cds-modal-header part="modal-header">
           <cds-modal-close-button
-            part="modal-button"
+            part="modal-close-button"
             @click=${this._handleUserClose}></cds-modal-close-button>
           <c4d-filter-modal-heading part="modal-heading"
             >${this.heading}</c4d-filter-modal-heading
@@ -131,14 +131,14 @@ class C4DFilterPanelModal extends HostListenerMixin(
         <div class="${prefix}--modal-body" part="modal-body"><slot></slot></div>
         <c4d-filter-modal-footer part="modal-footer">
           <c4d-filter-modal-footer-button
-            part="modal-button"
+            part="modal-footer-button modal-footer-button--clear"
             ?disabled="${!this.hasSelections}"
             @click=${this._handleClear}
             kind="secondary"
             >Clear</c4d-filter-modal-footer-button
           >
           <c4d-filter-modal-footer-button
-            part="modal-button"
+            part="modal-footer-button modal-footer-button--close"
             @click=${this._handleUserClose}
             kind="primary"
             >See Results</c4d-filter-modal-footer-button
@@ -148,7 +148,7 @@ class C4DFilterPanelModal extends HostListenerMixin(
       <button
         id="end-sentinel"
         class="${prefix}--visually-hidden"
-        part="button"
+        part="sentinel-button sentinel-button--end"
         @focusin="${handleFocusIn}">
         END
       </button>

--- a/packages/web-components/src/components/filter-panel/filter-panel.ts
+++ b/packages/web-components/src/components/filter-panel/filter-panel.ts
@@ -69,16 +69,19 @@ class C4DFilterPanel extends HostListenerMixin(
 
   render() {
     return html`
-      <section class="${prefix}--filter-panel__section">
-        <div class="${prefix}--heading-clear">
-          <div class="${prefix}--filter__heading">${this.heading}</div>
+      <section class="${prefix}--filter-panel__section" part="section">
+        <div class="${prefix}--heading-clear" part="heading-clear">
+          <div class="${prefix}--filter__heading" part="filter-heading">
+            ${this.heading}
+          </div>
           <button
             class="${prefix}--clear"
+            part="button-clear"
             @click=${this._handleClear}
             ?disabled="${!this.hasSelections}">
-            <div class="${prefix}--clear__container">
+            <div class="${prefix}--clear__container" part="container">
               Clear
-              <div class="${prefix}--reset__icon">${Reset()}</div>
+              <div class="${prefix}--reset__icon" part="icon">${Reset()}</div>
             </div>
           </button>
         </div>

--- a/packages/web-components/tests/snapshots/c4d-filter-panel-composite.md
+++ b/packages/web-components/tests/snapshots/c4d-filter-panel-composite.md
@@ -7,11 +7,15 @@
 ```
 <slot name="heading">
 </slot>
-<cds-button kind="tertiary">
+<cds-button
+  kind="tertiary"
+  part="button"
+>
 </cds-button>
 <c4d-filter-panel-modal
   data-autoid="c4d-filter-panel-modal"
   heading=""
+  part="panel-modal"
 >
   <slot>
   </slot>


### PR DESCRIPTION
[ADCMS-5146](https://jsw.ibm.com/browse/ADCMS-5146)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "filter-panel" component.

Changelog

New

Adding the shadow parts for the "filter-panel" component