### PR TITLE
feat(global-banner): add shadow parts

### DIFF
--- a/packages/web-components/src/components/global-banner/global-banner.ts
+++ b/packages/web-components/src/components/global-banner/global-banner.ts
@@ -176,7 +176,7 @@ class C4DGlobalBanner extends StableSelectorMixin(LitElement) {
 
         <div
           class="${prefix}--global-banner-cta-container"
-          part="banner-cta-container">
+          part="cta-container">
           <slot name="cta" @slotchange="${this._handleButtonSlotChange}"></slot>
         </div>
 

--- a/packages/web-components/src/components/global-banner/global-banner.ts
+++ b/packages/web-components/src/components/global-banner/global-banner.ts
@@ -130,7 +130,9 @@ class C4DGlobalBanner extends StableSelectorMixin(LitElement) {
    */
   _renderAsStatic() {
     return html`
-      <div class="${prefix}--global-banner-layout-container">
+      <div
+        class="${prefix}--global-banner-layout-container"
+        part="banner-container">
         ${this._renderInnerContents()}
       </div>
     `;
@@ -140,7 +142,8 @@ class C4DGlobalBanner extends StableSelectorMixin(LitElement) {
     return html`
       <a
         href="${this.buttonHref}"
-        class="${prefix}--global-banner-layout-container">
+        class="${prefix}--global-banner-layout-container"
+        part="banner-button">
         ${this._renderInnerContents()}
       </a>
     `;
@@ -152,25 +155,32 @@ class C4DGlobalBanner extends StableSelectorMixin(LitElement) {
 
   _renderInnerContents() {
     return html`
-      <div class="${prefix}--global-banner-content-wrapper">
+      <div
+        class="${prefix}--global-banner-content-wrapper"
+        part="banner-content-wrapper">
         <div
           ?hidden="${!this.hasImage}"
-          class="${prefix}--global-banner-image-container">
+          class="${prefix}--global-banner-image-container"
+          part="banner-image-container">
           <slot
             name="image"
             @slotchange="${this._handleImageSlotChange}"></slot>
         </div>
 
-        <div class="${prefix}--global-banner-text-container">
+        <div
+          class="${prefix}--global-banner-text-container"
+          part="banner-text-container">
           <slot name="heading"></slot>
           <slot name="copy"></slot>
         </div>
 
-        <div class="${prefix}--global-banner-cta-container">
+        <div
+          class="${prefix}--global-banner-cta-container"
+          part="banner-cta-container">
           <slot name="cta" @slotchange="${this._handleButtonSlotChange}"></slot>
         </div>
 
-        <div class="${prefix}--global-banner-icon">
+        <div class="${prefix}--global-banner-icon" part="banner-icon">
           ${this.ctaType ? this._renderIcon() : ''}
         </div>
       </div>

--- a/packages/web-components/src/components/global-banner/global-banner.ts
+++ b/packages/web-components/src/components/global-banner/global-banner.ts
@@ -169,7 +169,7 @@ class C4DGlobalBanner extends StableSelectorMixin(LitElement) {
 
         <div
           class="${prefix}--global-banner-text-container"
-          part="banner-text-container">
+          part="text-container">
           <slot name="heading"></slot>
           <slot name="copy"></slot>
         </div>

--- a/packages/web-components/src/components/global-banner/global-banner.ts
+++ b/packages/web-components/src/components/global-banner/global-banner.ts
@@ -132,7 +132,7 @@ class C4DGlobalBanner extends StableSelectorMixin(LitElement) {
     return html`
       <div
         class="${prefix}--global-banner-layout-container"
-        part="banner-container">
+        part="container container--static">
         ${this._renderInnerContents()}
       </div>
     `;

--- a/packages/web-components/src/components/global-banner/global-banner.ts
+++ b/packages/web-components/src/components/global-banner/global-banner.ts
@@ -143,7 +143,7 @@ class C4DGlobalBanner extends StableSelectorMixin(LitElement) {
       <a
         href="${this.buttonHref}"
         class="${prefix}--global-banner-layout-container"
-        part="banner-button">
+        part="container container--link">
         ${this._renderInnerContents()}
       </a>
     `;

--- a/packages/web-components/src/components/global-banner/global-banner.ts
+++ b/packages/web-components/src/components/global-banner/global-banner.ts
@@ -161,7 +161,7 @@ class C4DGlobalBanner extends StableSelectorMixin(LitElement) {
         <div
           ?hidden="${!this.hasImage}"
           class="${prefix}--global-banner-image-container"
-          part="banner-image-container">
+          part="image-container">
           <slot
             name="image"
             @slotchange="${this._handleImageSlotChange}"></slot>

--- a/packages/web-components/src/components/global-banner/global-banner.ts
+++ b/packages/web-components/src/components/global-banner/global-banner.ts
@@ -180,7 +180,7 @@ class C4DGlobalBanner extends StableSelectorMixin(LitElement) {
           <slot name="cta" @slotchange="${this._handleButtonSlotChange}"></slot>
         </div>
 
-        <div class="${prefix}--global-banner-icon" part="banner-icon">
+        <div class="${prefix}--global-banner-icon" part="icon">
           ${this.ctaType ? this._renderIcon() : ''}
         </div>
       </div>

--- a/packages/web-components/src/components/global-banner/global-banner.ts
+++ b/packages/web-components/src/components/global-banner/global-banner.ts
@@ -157,7 +157,7 @@ class C4DGlobalBanner extends StableSelectorMixin(LitElement) {
     return html`
       <div
         class="${prefix}--global-banner-content-wrapper"
-        part="banner-content-wrapper">
+        part="content">
         <div
           ?hidden="${!this.hasImage}"
           class="${prefix}--global-banner-image-container"


### PR DESCRIPTION
[ADCMS-5148](https://jsw.ibm.com/browse/ADCMS-5148)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "global-banner" component.

Changelog

New

Adding the shadow parts for the "global-banner" component