### PR TITLE
chore(percy): skip notice-choice component

### DIFF
--- a/packages/web-components/src/components/notice-choice/__stories__/notice-choice.stories.ts
+++ b/packages/web-components/src/components/notice-choice/__stories__/notice-choice.stories.ts
@@ -160,6 +160,9 @@ export default {
     `,
   ],
   parameters: {
+    percy: {
+      skip: true,
+    },
     ...readme.parameters,
     hasStoryPadding: true,
     knobs: {


### PR DESCRIPTION
### Description

Remove `notice-choice` from Percy snapshots.

### Changelog

**Changed**

- skip `notice-choice` in Percy snapshot tests

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
