### PR TITLE
feat(pictogram-item): add shadow parts

### DIFF
--- a/packages/web-components/src/components/pictogram-item/pictogram-item.ts
+++ b/packages/web-components/src/components/pictogram-item/pictogram-item.ts
@@ -25,6 +25,11 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * @slot pictogram - The pictogram content.
  * @slot heading - The heading content.
  * @slot footer - The footer (CTA) content.
+ * @csspart item-row - An item row. Usage `c4d-pictogram-item: :part(item-row)`
+ * @csspart wrapper - The wrapper. Usage `c4d-pictogram-item: :part(wrapper)`
+ * @csspart pictogram - A pictogram. Usage `c4d-pictogram-item: :part(pictogram)`
+ * @csspart content - The content. Usage `c4d-pictogram-item: :part(content)`
+ * @csspart content-item - The content item. Usage `c4d-pictogram-item: :part(content-item)`
  */
 @customElement(`${c4dPrefix}-pictogram-item`)
 class C4DPictogramItem extends StableSelectorMixin(C4DContentItem) {
@@ -38,14 +43,17 @@ class C4DPictogramItem extends StableSelectorMixin(C4DContentItem) {
 
   render() {
     return html`
-      <div class="${prefix}--pictogram-item__row">
-        <div class="${prefix}--pictogram-item__wrapper">
+      <div class="${prefix}--pictogram-item__row" part="item-row">
+        <div class="${prefix}--pictogram-item__wrapper" part="wrapper">
           <slot
             class="${prefix}--pictogram-item__pictogram"
+            part="pictogram"
             name="pictogram"></slot>
         </div>
-        <div class="${prefix}--pictogram-item__content">
-          <div class="${prefix}--content-item">${super.render()}</div>
+        <div class="${prefix}--pictogram-item__content" part="content">
+          <div class="${prefix}--content-item" part="content-item">
+            ${super.render()}
+          </div>
         </div>
       </div>
     `;


### PR DESCRIPTION
[ADCMS-5172](https://jsw.ibm.com/browse/ADCMS-5172)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "pictogram-item" component.

Changelog

New

Adding the shadow parts for the "pictogram-item" component and documentation