### PR TITLE
feat(quote): add shadow parts

### DIFF
--- a/packages/web-components/src/components/quote/quote.ts
+++ b/packages/web-components/src/components/quote/quote.ts
@@ -96,10 +96,14 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
     switch (this.markType) {
       case QUOTE_TYPES.SINGLE_CURVED:
         return html`
-          <span class="${prefix}--quote__mark" part="mark mark--opening">‘</span>
+          <span class="${prefix}--quote__mark" part="mark mark--opening"
+            >‘</span
+          >
           <blockquote class="${prefix}--quote__copy" part="copy">
             <slot></slot
-            ><span class="${prefix}--quote__mark-closing" part="mark mark--closing"
+            ><span
+              class="${prefix}--quote__mark-closing"
+              part="mark mark--closing"
               >’</span
             >
           </blockquote>

--- a/packages/web-components/src/components/quote/quote.ts
+++ b/packages/web-components/src/components/quote/quote.ts
@@ -96,10 +96,10 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
     switch (this.markType) {
       case QUOTE_TYPES.SINGLE_CURVED:
         return html`
-          <span class="${prefix}--quote__mark" part="mark">‘</span>
+          <span class="${prefix}--quote__mark" part="mark mark--opening">‘</span>
           <blockquote class="${prefix}--quote__copy" part="copy">
             <slot></slot
-            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+            ><span class="${prefix}--quote__mark-closing" part="mark mark--closing"
               >’</span
             >
           </blockquote>

--- a/packages/web-components/src/components/quote/quote.ts
+++ b/packages/web-components/src/components/quote/quote.ts
@@ -35,6 +35,13 @@ const slotExistencePropertyNames = {
  * @slot source-heading - The heading content of the quote source.
  * @slot source-copy - The copy content of the quote source.
  * @slot source-bottom-copy - The copy content of the quote source placed at the bottom.
+ * @csspart mark - Quote mark. Usage `c4d-quote::part(mark)`
+ * @csspart copy - Quote body copy. Usage `c4d-quote::part(copy)`
+ * @csspart mark-closing - Quote mark closing. Usage `c4d-quote::part(mark-closing)`
+ * @csspart source - Quote source slot. Usage `c4d-quote::part(source)`
+ * @csspart footer - Quote footer. Usage `c4d-quote::part(footer)`
+ * @csspart container - Quote container. Usage `c4d-quote::part(container)`
+ * @csspart wrapper - Quote wrapper. Usage `c4d-quote::part(wrapper)`
  */
 @customElement(`${c4dPrefix}-quote`)
 class C4DQuote extends StableSelectorMixin(LitElement) {
@@ -89,47 +96,66 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
     switch (this.markType) {
       case QUOTE_TYPES.SINGLE_CURVED:
         return html`
-          <span class="${prefix}--quote__mark">‘</span>
-          <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">’</span>
+          <span class="${prefix}--quote__mark" part="mark">‘</span>
+          <blockquote class="${prefix}--quote__copy" part="copy">
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+              >’</span
+            >
           </blockquote>
         `;
       case QUOTE_TYPES.DOUBLE_ANGLE:
         return html`
-          <span class="${prefix}--quote__mark">«</span>
-          <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">»</span>
+          <span class="${prefix}--quote__mark" part="mark">«</span>
+          <blockquote class="${prefix}--quote__copy" part="copy">
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+              >»</span
+            >
           </blockquote>
         `;
       case QUOTE_TYPES.SINGLE_ANGLE:
         return html`
-          <span class="${prefix}--quote__mark">‹</span>
-          <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">›</span>
+          <span class="${prefix}--quote__mark" part="mark">‹</span>
+          <blockquote class="${prefix}--quote__copy" part="copy">
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+              >›</span
+            >
           </blockquote>
         `;
       case QUOTE_TYPES.LOW_HIGH_REVERSED_DOUBLE_CURVED:
         return html`
-          <span class="${prefix}--quote__mark">„</span>
-          <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">“</span>
+          <span class="${prefix}--quote__mark" part="mark">„</span>
+          <blockquote class="${prefix}--quote__copy" part="copy">
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+              >“</span
+            >
           </blockquote>
         `;
       case QUOTE_TYPES.CORNER_BRACKET:
         return html`
           <span
             class="${prefix}--quote__mark ${prefix}--quote__mark-corner-bracket"
+            part="mark"
             >「</span
           >
-          <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">」</span>
+          <blockquote class="${prefix}--quote__copy" part="copy">
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+              >」</span
+            >
           </blockquote>
         `;
       default:
         return html`
-          <span class="${prefix}--quote__mark">“</span>
-          <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">”</span>
+          <span class="${prefix}--quote__mark" part="mark">“</span>
+          <blockquote class="${prefix}--quote__copy" part="copy">
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+              >”</span
+            >
           </blockquote>
         `;
     }
@@ -144,7 +170,8 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
     return html`
       <div
         ?hidden="${!hasSourceHeading || !hasSourceCopy}"
-        class="${prefix}--quote__source">
+        class="${prefix}--quote__source"
+        part="source">
         <slot @slotchange="${handleSlotChange}" name="source-heading"></slot>
         <slot @slotchange="${handleSlotChange}" name="source-copy"></slot>
         <slot
@@ -157,7 +184,10 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
   protected _renderFooter() {
     const { _hasFooter: hasFooter, _handleSlotChange: handleSlotChange } = this;
     return html`
-      <div ?hidden="${!hasFooter}" class="${prefix}--quote__footer">
+      <div
+        ?hidden="${!hasFooter}"
+        class="${prefix}--quote__footer"
+        part="footer">
         <c4d-hr></c4d-hr>
         <slot name="footer" @slotchange="${handleSlotChange}"></slot>
       </div>
@@ -166,8 +196,8 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
 
   render() {
     return html`
-      <div class="${prefix}--quote__container">
-        <div class="${prefix}--quote__wrapper">
+      <div class="${prefix}--quote__container" part="container">
+        <div class="${prefix}--quote__wrapper" part="wrapper">
           ${this._renderQuote()}${this._renderSource()}${this._renderFooter()}
         </div>
       </div>

--- a/packages/web-components/src/components/quote/quote.ts
+++ b/packages/web-components/src/components/quote/quote.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -36,12 +36,14 @@ const slotExistencePropertyNames = {
  * @slot source-copy - The copy content of the quote source.
  * @slot source-bottom-copy - The copy content of the quote source placed at the bottom.
  * @csspart mark - Quote mark. Usage `c4d-quote::part(mark)`
+ * @csspart mark--opening - Opening quote mark. Usage `c4d-quote::part(mark--opening)`
+ * @csspart mark--closing - Closing quote mark. Usage `c4d-quote::part(mark--closing)`
  * @csspart copy - Quote body copy. Usage `c4d-quote::part(copy)`
- * @csspart mark-closing - Quote mark closing. Usage `c4d-quote::part(mark-closing)`
  * @csspart source - Quote source slot. Usage `c4d-quote::part(source)`
  * @csspart footer - Quote footer. Usage `c4d-quote::part(footer)`
  * @csspart container - Quote container. Usage `c4d-quote::part(container)`
  * @csspart wrapper - Quote wrapper. Usage `c4d-quote::part(wrapper)`
+ * @csspart hr - Horizontal rule. Usage `c4d-quote::part(wrapper)`
  */
 @customElement(`${c4dPrefix}-quote`)
 class C4DQuote extends StableSelectorMixin(LitElement) {
@@ -110,30 +112,42 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
         `;
       case QUOTE_TYPES.DOUBLE_ANGLE:
         return html`
-          <span class="${prefix}--quote__mark" part="mark">«</span>
+          <span class="${prefix}--quote__mark" part="mark mark--opening"
+            >«</span
+          >
           <blockquote class="${prefix}--quote__copy" part="copy">
             <slot></slot
-            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+            ><span
+              class="${prefix}--quote__mark-closing"
+              part="mark mark--closing"
               >»</span
             >
           </blockquote>
         `;
       case QUOTE_TYPES.SINGLE_ANGLE:
         return html`
-          <span class="${prefix}--quote__mark" part="mark">‹</span>
+          <span class="${prefix}--quote__mark" part="mark mark--opening"
+            >‹</span
+          >
           <blockquote class="${prefix}--quote__copy" part="copy">
             <slot></slot
-            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+            ><span
+              class="${prefix}--quote__mark-closing"
+              part="mark mark--closing"
               >›</span
             >
           </blockquote>
         `;
       case QUOTE_TYPES.LOW_HIGH_REVERSED_DOUBLE_CURVED:
         return html`
-          <span class="${prefix}--quote__mark" part="mark">„</span>
+          <span class="${prefix}--quote__mark" part="mark mark--opening"
+            >„</span
+          >
           <blockquote class="${prefix}--quote__copy" part="copy">
             <slot></slot
-            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+            ><span
+              class="${prefix}--quote__mark-closing"
+              part="mark mark--closing"
               >“</span
             >
           </blockquote>
@@ -142,22 +156,28 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
         return html`
           <span
             class="${prefix}--quote__mark ${prefix}--quote__mark-corner-bracket"
-            part="mark"
+            part="mark mark--opening"
             >「</span
           >
           <blockquote class="${prefix}--quote__copy" part="copy">
             <slot></slot
-            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+            ><span
+              class="${prefix}--quote__mark-closing"
+              part="mark mark--closing"
               >」</span
             >
           </blockquote>
         `;
       default:
         return html`
-          <span class="${prefix}--quote__mark" part="mark">“</span>
+          <span class="${prefix}--quote__mark" part="mark mark--opening"
+            >“</span
+          >
           <blockquote class="${prefix}--quote__copy" part="copy">
             <slot></slot
-            ><span class="${prefix}--quote__mark-closing" part="mark-closing"
+            ><span
+              class="${prefix}--quote__mark-closing"
+              part="mark mark--closing"
               >”</span
             >
           </blockquote>
@@ -192,7 +212,7 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
         ?hidden="${!hasFooter}"
         class="${prefix}--quote__footer"
         part="footer">
-        <c4d-hr></c4d-hr>
+        <c4d-hr part="hr"></c4d-hr>
         <slot name="footer" @slotchange="${handleSlotChange}"></slot>
       </div>
     `;

--- a/packages/web-components/tests/snapshots/c4d-callout-quote.md
+++ b/packages/web-components/tests/snapshots/c4d-callout-quote.md
@@ -19,19 +19,29 @@
         class="cds--quote__wrapper"
         part="wrapper"
       >
-        <span class="cds--quote__mark">
+        <span
+          class="cds--quote__mark"
+          part="mark mark--opening"
+        >
           “
         </span>
-        <blockquote class="cds--quote__copy">
+        <blockquote
+          class="cds--quote__copy"
+          part="copy"
+        >
           <slot>
           </slot>
-          <span class="cds--quote__mark-closing">
+          <span
+            class="cds--quote__mark-closing"
+            part="mark mark--closing"
+          >
             ”
           </span>
         </blockquote>
         <div
           class="cds--quote__source"
           hidden=""
+          part="source"
         >
           <slot name="source-heading">
           </slot>
@@ -43,9 +53,11 @@
         <div
           class="cds--quote__footer"
           hidden=""
+          part="footer"
         >
           <c4d-hr
             data-autoid="c4d--hr"
+            part="hr"
             role="separator"
           >
           </c4d-hr>

--- a/packages/web-components/tests/snapshots/c4d-quote.md
+++ b/packages/web-components/tests/snapshots/c4d-quote.md
@@ -3,21 +3,37 @@
 #### `renders c4d-quote properly`
 
 ```
-<div class="cds--quote__container">
-  <div class="cds--quote__wrapper">
-    <span class="cds--quote__mark">
+<div
+  class="cds--quote__container"
+  part="container"
+>
+  <div
+    class="cds--quote__wrapper"
+    part="wrapper"
+  >
+    <span
+      class="cds--quote__mark"
+      part="mark mark--opening"
+    >
       “
     </span>
-    <blockquote class="cds--quote__copy">
+    <blockquote
+      class="cds--quote__copy"
+      part="copy"
+    >
       <slot>
       </slot>
-      <span class="cds--quote__mark-closing">
+      <span
+        class="cds--quote__mark-closing"
+        part="mark mark--closing"
+      >
         ”
       </span>
     </blockquote>
     <div
       class="cds--quote__source"
       hidden=""
+      part="source"
     >
       <slot name="source-heading">
       </slot>
@@ -29,9 +45,11 @@
     <div
       class="cds--quote__footer"
       hidden=""
+      part="footer"
     >
       <c4d-hr
         data-autoid="c4d--hr"
+        part="hr"
         role="separator"
       >
       </c4d-hr>


### PR DESCRIPTION
[ADCMS-5174](https://jsw.ibm.com/browse/ADCMS-5174)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "quote" component.

Changelog

New

Adding the shadow parts for the "quote" component and documentation