### PR TITLE
feat(search-with-typeahead): add shadow parts

### DIFF
--- a/packages/web-components/src/components/search-with-typeahead/scoped-search-dropdown-mobile.ts
+++ b/packages/web-components/src/components/search-with-typeahead/scoped-search-dropdown-mobile.ts
@@ -27,6 +27,13 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  *
  * @element c4d-scoped-search-dropdown-mobile
  * @internal
+ * @csspart select-option - The selector. Usage `c4d-scoped-search-dropdown-mobile::part(select-option)`
+ * @csspart select-optgroup - The optgroup selector. Usage `c4d-scoped-search-dropdown-mobile::part(select-optgroup)`
+ * @csspart helper-text - The helper text. Usage `c4d-scoped-search-dropdown-mobile::part(helper-text)`
+ * @csspart form-requirement - The form requirement. Usage `c4d-scoped-search-dropdown-mobile::part(form-requirement)`
+ * @csspart label-text - The label text. Usage `c4d-scoped-search-dropdown-mobile::part(label-text)`
+ * @csspart select-input-wrapper - The select input wrapper. Usage `c4d-scoped-search-dropdown-mobile::part(select-input-wrapper)`
+ * @csspart select-input - The input selector. Usage `c4d-scoped-search-dropdown-mobile::part(select-input)`
  */
 @customElement(`${c4dPrefix}-scoped-search-dropdown-mobile`)
 class C4DScopedSearchDropdownMobile extends CDSSelect {
@@ -84,6 +91,7 @@ class C4DScopedSearchDropdownMobile extends CDSSelect {
           ? html`
               <option
                 class="${prefix}--select-option"
+                part="select-option"
                 ?disabled="${disabled}"
                 label="${ifDefined(label ?? textContent)}"
                 ?selected="${selected}"
@@ -94,6 +102,7 @@ class C4DScopedSearchDropdownMobile extends CDSSelect {
           : html`
               <optgroup
                 class="${prefix}--select-optgroup"
+                part="select-optgroup"
                 ?disabled="${disabled}"
                 label="${ifDefined(label)}">
                 ${this._renderItemsMobile(item)}
@@ -142,24 +151,31 @@ class C4DScopedSearchDropdownMobile extends CDSSelect {
 
     const supplementalText = !invalid
       ? html`
-          <div class="${helperTextClasses}">
+          <div class="${helperTextClasses}" part="helper-text">
             <slot name="helper-text"> ${helperText} </slot>
           </div>
         `
       : html`
-          <div class="${prefix}--form-requirement" id="validity-message">
+          <div
+            class="${prefix}--form-requirement"
+            part="form-requirement"
+            id="validity-message">
             <slot name="validity-message"> ${invalidText} </slot>
           </div>
         `;
 
     return html`
-      <label class="${labelClasses}" for="input">
+      <label class="${labelClasses}" part="label-text" for="input">
         <slot name="label-text"> ${labelText} </slot>
       </label>
-      <div class="${prefix}--select-input__wrapper" ?data-invalid="${invalid}">
+      <div
+        class="${prefix}--select-input__wrapper"
+        part="select-input-wrapper"
+        ?data-invalid="${invalid}">
         <select
           id="input"
           class="${inputClasses}"
+          part="select-input"
           ?disabled="${disabled}"
           aria-invalid="${String(Boolean(invalid))}"
           aria-describedby="${ifDefined(

--- a/packages/web-components/src/components/search-with-typeahead/scoped-search-dropdown-mobile.ts
+++ b/packages/web-components/src/components/search-with-typeahead/scoped-search-dropdown-mobile.ts
@@ -27,10 +27,10 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  *
  * @element c4d-scoped-search-dropdown-mobile
  * @internal
- * @csspart select-option - The selector. Usage `c4d-scoped-search-dropdown-mobile::part(select-option)`
- * @csspart select-optgroup - The optgroup selector. Usage `c4d-scoped-search-dropdown-mobile::part(select-optgroup)`
+ * @csspart select-option - An option in the select list. Usage `c4d-scoped-search-dropdown-mobile::part(select-option)`
+ * @csspart select-optgroup - An optgroup in the select list. Usage `c4d-scoped-search-dropdown-mobile::part(select-optgroup)`
  * @csspart helper-text - The helper text. Usage `c4d-scoped-search-dropdown-mobile::part(helper-text)`
- * @csspart form-requirement - The form requirement. Usage `c4d-scoped-search-dropdown-mobile::part(form-requirement)`
+ * @csspart form-requirement - The message that appears on invalid input. Usage `c4d-scoped-search-dropdown-mobile::part(form-requirement)`
  * @csspart label-text - The label text. Usage `c4d-scoped-search-dropdown-mobile::part(label-text)`
  * @csspart select-input-wrapper - The select input wrapper. Usage `c4d-scoped-search-dropdown-mobile::part(select-input-wrapper)`
  * @csspart select-input - The input selector. Usage `c4d-scoped-search-dropdown-mobile::part(select-input)`

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead-item.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead-item.ts
@@ -20,6 +20,8 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * Search result item in masthead.
  *
  * @element c4d-search-with-typeahead-item
+ * @csspart search-with-typeahead-item-highlighted - The highlighted item. Usage `c4d-search-with-typeahead-item::part(search-with-typeahead-item-highlighted)`
+ * @csspart search-with-typeahead-item-container - The item container. Usage `c4d-search-with-typeahead-item::part(search-with-typeahead-item-container)`
  */
 @customElement(`${c4dPrefix}-search-with-typeahead-item`)
 class C4DSearchWithTypeaheadItem extends LitElement {
@@ -83,6 +85,7 @@ class C4DSearchWithTypeaheadItem extends LitElement {
     }
     const highlightedResult = html`<span
       class="${c4dPrefix}-ce--search-with-typeahead-item__highlighted"
+      part="search-with-typeahead-item-highlighted"
       >${searchQueryString}</span
     >`;
     const content = text
@@ -133,7 +136,12 @@ class C4DSearchWithTypeaheadItem extends LitElement {
       [`${prefix}--container-highlight-class`]: highlighted,
     });
     return html`
-      <div class="${containerClasses}" tabindex="-1">${content}</div>
+      <div
+        class="${containerClasses}"
+        part="search-with-typeahead-item-container"
+        tabindex="-1">
+        ${content}
+      </div>
     `;
   }
 

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead-item.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead-item.ts
@@ -138,7 +138,7 @@ class C4DSearchWithTypeaheadItem extends LitElement {
     return html`
       <div
         class="${containerClasses}"
-        part="search-with-typeahead-item-container"
+        part="item-container"
         tabindex="-1">
         ${content}
       </div>

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead-item.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead-item.ts
@@ -85,7 +85,7 @@ class C4DSearchWithTypeaheadItem extends LitElement {
     }
     const highlightedResult = html`<span
       class="${c4dPrefix}-ce--search-with-typeahead-item__highlighted"
-      part="search-with-typeahead-item-highlighted"
+      part="item item-highlighted"
       >${searchQueryString}</span
     >`;
     const content = text

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead-item.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead-item.ts
@@ -20,8 +20,8 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * Search result item in masthead.
  *
  * @element c4d-search-with-typeahead-item
- * @csspart search-with-typeahead-item-highlighted - The highlighted item. Usage `c4d-search-with-typeahead-item::part(search-with-typeahead-item-highlighted)`
- * @csspart search-with-typeahead-item-container - The item container. Usage `c4d-search-with-typeahead-item::part(search-with-typeahead-item-container)`
+ * @csspart item item-highlighted - The highlighted item. Usage `c4d-search-with-typeahead-item::part(item item-highlighted)`
+ * @csspart item-container - The item container. Usage `c4d-search-with-typeahead-item::part(item-container)`
  */
 @customElement(`${c4dPrefix}-search-with-typeahead-item`)
 class C4DSearchWithTypeaheadItem extends LitElement {
@@ -136,10 +136,7 @@ class C4DSearchWithTypeaheadItem extends LitElement {
       [`${prefix}--container-highlight-class`]: highlighted,
     });
     return html`
-      <div
-        class="${containerClasses}"
-        part="item-container"
-        tabindex="-1">
+      <div class="${containerClasses}" part="item-container" tabindex="-1">
         ${content}
       </div>
     `;

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -766,7 +766,7 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
                       (item) =>
                         html`
                           <c4d-search-with-typeahead-item
-                            part="search-with-typeahead-item"
+                            part="suggestion-item"
                             text="${item}"></c4d-search-with-typeahead-item>
                         `
                     )}

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -1020,7 +1020,7 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
                   (item) =>
                     html`
                       <c4d-search-with-typeahead-item
-                        part="search-with-typeahead-item"
+                        part="suggestion-item"
                         text="${item}"
                         @click=${handleClickItem}></c4d-search-with-typeahead-item>
                     `

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -722,7 +722,7 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
           ${this.scopeParameters
             ? html`
                 <c4d-scoped-search-dropdown
-                  part="search-dropdown"
+                  part="dropdown"
                   value="${this.appId}">
                   ${this.scopeParameters.map(
                     (scope) => html`

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -775,7 +775,7 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
                       (group) =>
                         html`
                           <c4d-search-with-typeahead-item
-                            part="search-with-typeahead-item"
+                            part="suggestion-item"
                             groupTitle
                             text="${group.title}"></c4d-search-with-typeahead-item>
                           ${group.items.map(

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -735,7 +735,7 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
                   )}
                 </c4d-scoped-search-dropdown>
                 <c4d-scoped-search-dropdown-mobile
-                  part="search-dropdown-mobile"
+                  part="dropdown-mobile"
                   value="${this.appId}">
                   ${this.scopeParameters.map(
                     (scope) => html`

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -782,7 +782,7 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
                             (item) =>
                               html`
                                 <c4d-search-with-typeahead-item
-                                  part="search-with-typeahead-item"
+                                  part="suggestion-item"
                                   text="${item.name}"
                                   href="${item.href}"></c4d-search-with-typeahead-item>
                               `

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -36,9 +36,18 @@ const gridBreakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
  * Search with Typeahead
  *
  * @element c4d-search-with-typeahead
+ * @csspart search-input - The input box for search. Usage `c4d-search-with-typeahead::part(search-input)`
+ * @csspart search-form - The search form. Usage `c4d-search-with-typeahead::part(search-form)`
+ * @csspart combobox-form - The combobox search form. Usage `c4d-search-with-typeahead::part(combobox-form)`
+ * @csspart search-dropdown - The search dropdown. Usage `c4d-search-with-typeahead::part(search-dropdown)`
+ * @csspart dropdown-item - The search dropdown item. Usage `c4d-search-with-typeahead::part(dropdown-item)`
+ * @csspart search-dropdown-mobile - The search dropdown for mobile. Usage `c4d-search-with-typeahead::part(search-dropdown-mobile)`
+ * @csspart select-item - The item selector. Usage `c4d-search-with-typeahead::part(select-item)`
+ * @csspart suggestions-container - The suggestions container. Usage `c4d-search-with-typeahead::part(suggestions-container)`
+ * @csspart suggestions-list - The suggestions list. Usage `c4d-search-with-typeahead::part(suggestions-list)`
+ * @csspart search-with-typeahead-item - The search item. Usage `c4d-search-with-typeahead::part(search-with-typeahead-item`
  * @csspart open-button - The button to show the search box. Usage `c4d-search-with-typeahead::part(open-button)`
  * @csspart close-button - The button to hide the search box. Usage `c4d-search-with-typeahead::part(close-button)`
- * @csspart search-input - The input box for search. Usage `c4d-search-with-typeahead::part(search-input)`
  * @csspart header-search-actions - The container for the search bar. Usage `c4d-search-with-typeahead::part(header-search-actions)`
  * @fires c4d-search-with-typeahead-beingredirected
  *   The custom event fired before the page is being redirected to the search result page.
@@ -678,6 +687,7 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
     return html`
       <form
         role="search"
+        part="search-form"
         method="get"
         action="${redirectUrl}"
         @submit="${handleSubmit}">
@@ -701,6 +711,7 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
         <div
           role="combobox"
           class="${classes}"
+          part="combobox-form"
           aria-haspopup="listbox"
           aria-owns="result-list"
           aria-expanded="${Boolean(this.active)}"
@@ -710,19 +721,26 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
           @keypress="${handleKeypressInner}">
           ${this.scopeParameters
             ? html`
-                <c4d-scoped-search-dropdown value="${this.appId}">
+                <c4d-scoped-search-dropdown
+                  part="search-dropdown"
+                  value="${this.appId}">
                   ${this.scopeParameters.map(
                     (scope) => html`
-                      <cds-dropdown-item value="${scope.appId}"
+                      <cds-dropdown-item
+                        part="dropdown-item"
+                        value="${scope.appId}"
                         >${scope.name}</cds-dropdown-item
                       >
                     `
                   )}
                 </c4d-scoped-search-dropdown>
-                <c4d-scoped-search-dropdown-mobile value="${this.appId}">
+                <c4d-scoped-search-dropdown-mobile
+                  part="search-dropdown-mobile"
+                  value="${this.appId}">
                   ${this.scopeParameters.map(
                     (scope) => html`
                       <cds-select-item
+                        part="select-item"
                         label="${scope.name}"
                         value="${scope.appId}"
                         >${scope.name}</cds-select-item
@@ -737,15 +755,18 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
             ? html`
                 <div
                   id="result-list"
-                  class="react-autosuggest__suggestions-container">
+                  class="react-autosuggest__suggestions-container"
+                  part="suggestions-container">
                   <ul
                     role="listbox"
-                    class="${c4dPrefix}-ce__search__list react-autosuggest__suggestions-list">
+                    class="${c4dPrefix}-ce__search__list react-autosuggest__suggestions-list"
+                    part="suggestions-list">
                     ${this.searchResults &&
                     this.searchResults.map(
                       (item) =>
                         html`
                           <c4d-search-with-typeahead-item
+                            part="search-with-typeahead-item"
                             text="${item}"></c4d-search-with-typeahead-item>
                         `
                     )}
@@ -754,12 +775,14 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
                       (group) =>
                         html`
                           <c4d-search-with-typeahead-item
+                            part="search-with-typeahead-item"
                             groupTitle
                             text="${group.title}"></c4d-search-with-typeahead-item>
                           ${group.items.map(
                             (item) =>
                               html`
                                 <c4d-search-with-typeahead-item
+                                  part="search-with-typeahead-item"
                                   text="${item.name}"
                                   href="${item.href}"></c4d-search-with-typeahead-item>
                               `
@@ -986,15 +1009,18 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
             </div>
             <div
               id="result-list"
-              class="react-autosuggest__suggestions-container">
+              class="react-autosuggest__suggestions-container"
+              part="suggestions-container">
               <ul
                 role="listbox"
-                class="${c4dPrefix}-ce__search__list react-autosuggest__suggestions-list">
+                class="${c4dPrefix}-ce__search__list react-autosuggest__suggestions-list"
+                part="suggestions-list">
                 ${this.searchResults &&
                 this.searchResults.map(
                   (item) =>
                     html`
                       <c4d-search-with-typeahead-item
+                        part="search-with-typeahead-item"
                         text="${item}"
                         @click=${handleClickItem}></c4d-search-with-typeahead-item>
                     `

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -38,17 +38,18 @@ const gridBreakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
  * @element c4d-search-with-typeahead
  * @csspart search-input - The input box for search. Usage `c4d-search-with-typeahead::part(search-input)`
  * @csspart search-form - The search form. Usage `c4d-search-with-typeahead::part(search-form)`
- * @csspart combobox-form - The combobox search form. Usage `c4d-search-with-typeahead::part(combobox-form)`
- * @csspart search-dropdown - The search dropdown. Usage `c4d-search-with-typeahead::part(search-dropdown)`
- * @csspart dropdown-item - The search dropdown item. Usage `c4d-search-with-typeahead::part(dropdown-item)`
- * @csspart search-dropdown-mobile - The search dropdown for mobile. Usage `c4d-search-with-typeahead::part(search-dropdown-mobile)`
+ * @csspart container - The search form container. Usage `c4d-search-with-typeahead::part(container)`
+ * @csspart dropdown - The search dropdown. Usage `c4d-search-with-typeahead::part(dropdown)`
+ * @csspart dropdown-item - The dropdown item. Usage `c4d-search-with-typeahead::part(dropdown-item)`
+ * @csspart dropdown-mobile - The search dropdown for mobile. Usage `c4d-search-with-typeahead::part(dropdown-mobile)`
  * @csspart select-item - The item selector. Usage `c4d-search-with-typeahead::part(select-item)`
  * @csspart suggestions-container - The suggestions container. Usage `c4d-search-with-typeahead::part(suggestions-container)`
  * @csspart suggestions-list - The suggestions list. Usage `c4d-search-with-typeahead::part(suggestions-list)`
- * @csspart search-with-typeahead-item - The search item. Usage `c4d-search-with-typeahead::part(search-with-typeahead-item`
+ * @csspart search-with-typeahead-item - The search item. Usage `c4d-search-with-typeahead::part(search-with-typeahead-item)`
  * @csspart open-button - The button to show the search box. Usage `c4d-search-with-typeahead::part(open-button)`
  * @csspart close-button - The button to hide the search box. Usage `c4d-search-with-typeahead::part(close-button)`
  * @csspart header-search-actions - The container for the search bar. Usage `c4d-search-with-typeahead::part(header-search-actions)`
+ * @csspart suggestion-item - The search item. Usage `c4d-search-with-typeahead::part(suggestion-item)`
  * @fires c4d-search-with-typeahead-beingredirected
  *   The custom event fired before the page is being redirected to the search result page.
  *   Cancellation of this event stops the user-initiated action of redirection.

--- a/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
+++ b/packages/web-components/src/components/search-with-typeahead/search-with-typeahead.ts
@@ -711,7 +711,7 @@ class C4DSearchWithTypeahead extends HostListenerMixin(
         <div
           role="combobox"
           class="${classes}"
-          part="combobox-form"
+          part="container"
           aria-haspopup="listbox"
           aria-owns="result-list"
           aria-expanded="${Boolean(this.active)}"


### PR DESCRIPTION
[ADCMS-5176](https://jsw.ibm.com/browse/ADCMS-5176)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "search-with-typeahead" component.

Changelog

New

Adding the shadow parts for the "search-with-typeahead" component and documentation