### PR TITLE
feat(structured-list): add shadow parts

### DIFF
--- a/packages/web-components/src/components/structured-list/structured-list-cell.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-cell.ts
@@ -74,7 +74,7 @@ class C4DStructuredListCell extends CDSStructuredListCell {
         .map(
           (tag) =>
             html`
-              <cds-tag part="tags" size="sm" type="green"
+              <cds-tag part="tag" size="sm" type="green"
                 >${tag.trim()}</cds-tag
               >
             `

--- a/packages/web-components/src/components/structured-list/structured-list-cell.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-cell.ts
@@ -24,6 +24,9 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * StructuredListCell
  *
  * @element c4d-structured-list-cell
+ * @csspart icon-text - Descriptive text of the cell. Usage `c4d-structured-list-cell::part(icon-text)`
+ * @csspart tags - Tags of the cell. Usage `c4d-structured-list-cell::part(tags)`
+ * @csspart icon - An icon. Usage `c4d-structured-list-cell::part(icon)`
  */
 @customElement(`${c4dPrefix}-structured-list-cell`)
 class C4DStructuredListCell extends CDSStructuredListCell {
@@ -57,7 +60,7 @@ class C4DStructuredListCell extends CDSStructuredListCell {
     const { icon, _iconsAllowed: iconMap } = this;
 
     return html`${iconMap[icon!.toLowerCase()].call()}
-      <span class="${prefix}--structured-list-cell-icon-text">
+      <span class="${prefix}--structured-list-cell-icon-text" part="icon-text">
         <slot></slot>
       </span>`;
   }
@@ -70,7 +73,11 @@ class C4DStructuredListCell extends CDSStructuredListCell {
         .split(',')
         .map(
           (tag) =>
-            html` <cds-tag size="sm" type="green">${tag.trim()}</cds-tag> `
+            html`
+              <cds-tag part="tags" size="sm" type="green"
+                >${tag.trim()}</cds-tag
+              >
+            `
         )}
     `;
   }
@@ -80,6 +87,7 @@ class C4DStructuredListCell extends CDSStructuredListCell {
 
     return html`
       <cds-tooltip-icon
+        part="icon"
         alignment="start"
         body-text="${tooltip}"
         direction="right">

--- a/packages/web-components/src/components/structured-list/structured-list-cell.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-cell.ts
@@ -25,7 +25,7 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  *
  * @element c4d-structured-list-cell
  * @csspart icon-text - Descriptive text of the cell. Usage `c4d-structured-list-cell::part(icon-text)`
- * @csspart tags - Tags of the cell. Usage `c4d-structured-list-cell::part(tags)`
+ * @csspart tag - Tags of the cell. Usage `c4d-structured-list-cell::part(tag)`
  * @csspart icon - An icon. Usage `c4d-structured-list-cell::part(icon)`
  */
 @customElement(`${c4dPrefix}-structured-list-cell`)
@@ -74,9 +74,7 @@ class C4DStructuredListCell extends CDSStructuredListCell {
         .map(
           (tag) =>
             html`
-              <cds-tag part="tag" size="sm" type="green"
-                >${tag.trim()}</cds-tag
-              >
+              <cds-tag part="tag" size="sm" type="green">${tag.trim()}</cds-tag>
             `
         )}
     `;

--- a/packages/web-components/src/components/structured-list/structured-list-group.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-group.ts
@@ -21,6 +21,8 @@ const { stablePrefix: c4dPrefix } = settings;
  * StructuredListGroup
  *
  * @element c4d-structured-list-group
+ * @csspart flex-container - The table header. Usage `c4d-structured-list-group::part(flex-container)`
+ * @csspart flex-item - The header item. Usage `c4d-structured-list-group::part(flex-item)`
  */
 @customElement(`${c4dPrefix}-structured-list-group`)
 class C4DStructuredListGroup extends StableSelectorMixin(LitElement) {
@@ -38,8 +40,8 @@ class C4DStructuredListGroup extends StableSelectorMixin(LitElement) {
   private _renderTitle() {
     // set colspan to max value to ensure it spans all columns
     return html`
-      <tr>
-        <th colspan="999">${this.groupTitle}</th>
+      <tr part="flex-container">
+        <th part="flex-item" colspan="999">${this.groupTitle}</th>
       </tr>
     `;
   }

--- a/packages/web-components/src/components/structured-list/structured-list-group.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-group.ts
@@ -40,7 +40,7 @@ class C4DStructuredListGroup extends StableSelectorMixin(LitElement) {
   private _renderTitle() {
     // set colspan to max value to ensure it spans all columns
     return html`
-      <tr part="flex-container">
+      <tr part="row row--group-title">
         <th part="flex-item" colspan="999">${this.groupTitle}</th>
       </tr>
     `;

--- a/packages/web-components/src/components/structured-list/structured-list-group.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-group.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,8 +21,9 @@ const { stablePrefix: c4dPrefix } = settings;
  * StructuredListGroup
  *
  * @element c4d-structured-list-group
- * @csspart flex-container - The table header. Usage `c4d-structured-list-group::part(flex-container)`
- * @csspart flex-item - The header item. Usage `c4d-structured-list-group::part(flex-item)`
+ * @csspart row - The table group title row. Usage `c4d-structured-list-group::part(row)`
+ * @csspart row--group-title - The table group title row. Usage `c4d-structured-list-group::part(row--group-title)`
+ * @csspart group-title - The group title. Usage `c4d-structured-list-group::part(group-title)`
  */
 @customElement(`${c4dPrefix}-structured-list-group`)
 class C4DStructuredListGroup extends StableSelectorMixin(LitElement) {
@@ -38,7 +39,7 @@ class C4DStructuredListGroup extends StableSelectorMixin(LitElement) {
   }
 
   private _renderTitle() {
-    // set colspan to max value to ensure it spans all columns
+    // Set colspan to max value to ensure it spans all columns.
     return html`
       <tr part="row row--group-title">
         <th part="group-title" colspan="999">${this.groupTitle}</th>

--- a/packages/web-components/src/components/structured-list/structured-list-group.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-group.ts
@@ -41,7 +41,7 @@ class C4DStructuredListGroup extends StableSelectorMixin(LitElement) {
     // set colspan to max value to ensure it spans all columns
     return html`
       <tr part="row row--group-title">
-        <th part="flex-item" colspan="999">${this.groupTitle}</th>
+        <th part="group-title" colspan="999">${this.groupTitle}</th>
       </tr>
     `;
   }

--- a/packages/web-components/src/components/structured-list/structured-list.ts
+++ b/packages/web-components/src/components/structured-list/structured-list.ts
@@ -19,8 +19,8 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * StructuredList
  *
  * @element c4d-structured-list
- * @csspart overflow-indicator left - Overflow indicator left. Usage `c4d-structured-list::part(overflow-indicator left)`
- * @csspart overflow-indicator right - Overflow indicator left. Usage `c4d-structured-list::part(overflow-indicator right)`
+ * @csspart overflow-indicator overflow-left - Overflow indicator left. Usage `c4d-structured-list::part(overflow-indicator overflow-left)`
+ * @csspart overflow-indicator overflow-right - Overflow indicator left. Usage `c4d-structured-list::part(overflow-indicator overflow-right)`
  * @csspart section - List section. Usage `c4d-structured-list::part(section)`
  */
 @customElement(`${c4dPrefix}-structured-list`)
@@ -107,7 +107,9 @@ class C4DStructuredList extends StableSelectorMixin(LitElement) {
 
   render() {
     return html`
-      <div class="overflow-indicator overflow-left" part="overflow-indicator left"></div>
+      <div
+        class="overflow-indicator overflow-left"
+        part="overflow-indicator overflow-left"></div>
       ${this.renderInner()}
       <div
         class="overflow-indicator right"

--- a/packages/web-components/src/components/structured-list/structured-list.ts
+++ b/packages/web-components/src/components/structured-list/structured-list.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,8 +19,9 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * StructuredList
  *
  * @element c4d-structured-list
- * @csspart overflow-indicator overflow-left - Overflow indicator left. Usage `c4d-structured-list::part(overflow-indicator overflow-left)`
- * @csspart overflow-indicator overflow-right - Overflow indicator left. Usage `c4d-structured-list::part(overflow-indicator overflow-right)`
+ * @csspart overflow-indicator - Overflow indicator. Usage `c4d-structured-list::part(overflow-indicator)`
+ * @csspart overflow-indicator--left - Overflow indicator left. Usage `c4d-structured-list::part(overflow-indicator--left)`
+ * @csspart overflow-indicator--right - Overflow indicator right. Usage `c4d-structured-list::part(overflow-indicator--right)`
  * @csspart section - List section. Usage `c4d-structured-list::part(section)`
  */
 @customElement(`${c4dPrefix}-structured-list`)
@@ -109,11 +110,11 @@ class C4DStructuredList extends StableSelectorMixin(LitElement) {
     return html`
       <div
         class="overflow-indicator left"
-        part="overflow-indicator overflow-left"></div>
+        part="overflow-indicator overflow-indicator--left"></div>
       ${this.renderInner()}
       <div
         class="overflow-indicator right"
-        part="overflow-indicator overflow-right"></div>
+        part="overflow-indicator overflow-indicator--right"></div>
     `;
   }
 

--- a/packages/web-components/src/components/structured-list/structured-list.ts
+++ b/packages/web-components/src/components/structured-list/structured-list.ts
@@ -19,6 +19,9 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * StructuredList
  *
  * @element c4d-structured-list
+ * @csspart overflow-indicator left - Overflow indicator left. Usage `c4d-structured-list::part(overflow-indicator left)`
+ * @csspart overflow-indicator right - Overflow indicator left. Usage `c4d-structured-list::part(overflow-indicator right)`
+ * @csspart section - List section. Usage `c4d-structured-list::part(section)`
  */
 @customElement(`${c4dPrefix}-structured-list`)
 class C4DStructuredList extends StableSelectorMixin(LitElement) {
@@ -104,16 +107,21 @@ class C4DStructuredList extends StableSelectorMixin(LitElement) {
 
   render() {
     return html`
-      <div class="overflow-indicator left"></div>
+      <div class="overflow-indicator left" part="overflow-indicator left"></div>
       ${this.renderInner()}
-      <div class="overflow-indicator right"></div>
+      <div
+        class="overflow-indicator right"
+        part="overflow-indicator right"></div>
     `;
   }
 
   protected renderInner() {
     const { wrapperId } = this.constructor as typeof C4DStructuredList;
     return html`
-      <section id="${wrapperId}" class="${prefix}--structured-list">
+      <section
+        id="${wrapperId}"
+        class="${prefix}--structured-list"
+        part="section">
         <slot></slot>
       </section>
     `;

--- a/packages/web-components/src/components/structured-list/structured-list.ts
+++ b/packages/web-components/src/components/structured-list/structured-list.ts
@@ -108,7 +108,7 @@ class C4DStructuredList extends StableSelectorMixin(LitElement) {
   render() {
     return html`
       <div
-        class="overflow-indicator overflow-left"
+        class="overflow-indicator left"
         part="overflow-indicator overflow-left"></div>
       ${this.renderInner()}
       <div

--- a/packages/web-components/src/components/structured-list/structured-list.ts
+++ b/packages/web-components/src/components/structured-list/structured-list.ts
@@ -107,7 +107,7 @@ class C4DStructuredList extends StableSelectorMixin(LitElement) {
 
   render() {
     return html`
-      <div class="overflow-indicator left" part="overflow-indicator left"></div>
+      <div class="overflow-indicator overflow-left" part="overflow-indicator left"></div>
       ${this.renderInner()}
       <div
         class="overflow-indicator right"

--- a/packages/web-components/src/components/structured-list/structured-list.ts
+++ b/packages/web-components/src/components/structured-list/structured-list.ts
@@ -111,7 +111,7 @@ class C4DStructuredList extends StableSelectorMixin(LitElement) {
       ${this.renderInner()}
       <div
         class="overflow-indicator right"
-        part="overflow-indicator right"></div>
+        part="overflow-indicator overflow-right"></div>
     `;
   }
 


### PR DESCRIPTION
[ADCMS-5178](https://jsw.ibm.com/browse/ADCMS-5178)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "structured-list" component.

Changelog

New

Adding the shadow parts for the "structured-list" component and documentation