### PR TITLE
feat(logo-grid):  add shadow parts

### DIFF
--- a/packages/web-components/src/components/logo-grid/logo-grid-item.ts
+++ b/packages/web-components/src/components/logo-grid/logo-grid-item.ts
@@ -19,6 +19,7 @@ const { stablePrefix: c4dPrefix } = settings;
  * Logo-grid-item.
  *
  * @element c4d-logo-grid-item
+ * @csspart logo - the logo container - Usage: `4d-logo-grid-item::part(logo)`
  */
 @customElement(`${c4dPrefix}-logo-grid-item`)
 class C4DLogoGridItem extends StableSelectorMixin(C4DImage) {
@@ -29,7 +30,9 @@ class C4DLogoGridItem extends StableSelectorMixin(C4DImage) {
   }
 
   render() {
-    return html` <div class="cds--logo-grid__logo">${super.render()}</div> `;
+    return html`
+      <div class="cds--logo-grid__logo" part="logo">${super.render()}</div>
+    `;
   }
 }
 

--- a/packages/web-components/src/components/logo-grid/logo-grid.ts
+++ b/packages/web-components/src/components/logo-grid/logo-grid.ts
@@ -29,6 +29,7 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * @csspart content - The content. Usage 'c4d-logo-grid::part(content)'
  * @csspart footer-container - The footer container. Usage: 'c4d-logo-grid::part(footer-containe)'
  * @csspart footer - The footer. Usage: 'c4d-logo-grid::part(footer)'
+ * @csspart hr - The horizontal rule. Usage: 'c4d-logo-grid::part(hr)'
  */
 @customElement(`${c4dPrefix}-logo-grid`)
 class C4DLogoGrid extends StableSelectorMixin(C4DContentBlock) {
@@ -113,7 +114,7 @@ class C4DLogoGrid extends StableSelectorMixin(C4DContentBlock) {
         <slot name="heading"></slot>
         ${this._renderBody()}
       </div>
-      ${!this.hideBorder ? html` <c4d-hr></c4d-hr> ` : ``}
+      ${!this.hideBorder ? html` <c4d-hr part="hr"></c4d-hr> ` : ``}
     `;
   }
 

--- a/packages/web-components/src/components/logo-grid/logo-grid.ts
+++ b/packages/web-components/src/components/logo-grid/logo-grid.ts
@@ -24,6 +24,11 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * Logo grid.
  *
  * @element c4d-logo-grid
+ * @csspart content-wrapper - The wrapper. Usage: 'c4d-logo-grid::part(content-wrapper)'
+ * @csspart content-body - The content body. Usage: 'c4d-logo-grid::part(content-body)'
+ * @csspart content - The content. Usage 'c4d-logo-grid::part(content)'
+ * @csspart footer-container - The footer container. Usage: 'c4d-logo-grid::part(footer-containe)'
+ * @csspart footer - The footer. Usage: 'c4d-logo-grid::part(footer)'
  */
 @customElement(`${c4dPrefix}-logo-grid`)
 class C4DLogoGrid extends StableSelectorMixin(C4DContentBlock) {
@@ -38,8 +43,9 @@ class C4DLogoGrid extends StableSelectorMixin(C4DContentBlock) {
     return html`
       <div
         ?hidden="${!hasContent && !hasMedia}"
-        class="${prefix}--content-block__children ${prefix}--content-layout__body">
-        <div class="${classMap(rowClasses)}">
+        class="${prefix}--content-block__children ${prefix}--content-layout__body"
+        part="content-body">
+        <div class="${classMap(rowClasses)}" part="content">
           ${this._renderContent()}${this._renderMedia()}
         </div>
       </div>
@@ -52,9 +58,13 @@ class C4DLogoGrid extends StableSelectorMixin(C4DContentBlock) {
   protected _renderFooter(): TemplateResult | string | void {
     const { _hasFooter: hasFooter, _handleSlotChange: handleSlotChange } = this;
     return html`
-      <div ?hidden="${!hasFooter}" class="${prefix}--content-block__cta-row">
+      <div
+        ?hidden="${!hasFooter}"
+        class="${prefix}--content-block__cta-row"
+        part="footer-container">
         <div
-          class="${prefix}--content-block__cta ${prefix}-content-block__cta-col">
+          class="${prefix}--content-block__cta ${prefix}-content-block__cta-col"
+          part="footer">
           <slot name="footer" @slotchange="${handleSlotChange}"></slot>
         </div>
       </div>
@@ -99,7 +109,7 @@ class C4DLogoGrid extends StableSelectorMixin(C4DContentBlock) {
 
   render() {
     return html`
-      <div class="${prefix}--content-layout--logo-grid">
+      <div class="${prefix}--content-layout--logo-grid" part="content-wrapper">
         <slot name="heading"></slot>
         ${this._renderBody()}
       </div>

--- a/packages/web-components/tests/snapshots/c4d-logo-grid.md
+++ b/packages/web-components/tests/snapshots/c4d-logo-grid.md
@@ -3,7 +3,10 @@
 #### `renders c4d-logo-grid properly`
 
 ```
-<div class="cds--content-layout--logo-grid">
+<div
+  class="cds--content-layout--logo-grid"
+  part="content-wrapper"
+>
   <slot name="heading">
   </slot>
   <div
@@ -16,8 +19,12 @@
     <div
       class="cds--content-block__children cds--content-layout__body"
       hidden=""
+      part="content-body"
     >
-      <div class="cds--logo-grid__row">
+      <div
+        class="cds--logo-grid__row"
+        part="content"
+      >
         <slot>
         </slot>
         <slot name="media">
@@ -27,8 +34,12 @@
     <div
       class="cds--content-block__cta-row"
       hidden=""
+      part="footer-container"
     >
-      <div class="cds--content-block__cta cds-content-block__cta-col">
+      <div
+        class="cds--content-block__cta cds-content-block__cta-col"
+        part="footer"
+      >
         <slot name="footer">
         </slot>
       </div>


### PR DESCRIPTION
### Related Ticket(s)

[JIRA](https://jsw.ibm.com/browse/ADCMS-5168)
### Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles.

### Changelog

**New**

Adding Shadow parts to the logo-grid component
