### PR TITLE
feat(lightbox-media-viewer): add shadow parts

### DIFF
--- a/packages/web-components/src/components/lightbox-media-viewer/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/lightbox-media-viewer/__stories__/README.stories.mdx
@@ -110,4 +110,12 @@ to see how Web Components selector and `data-autoid` should be used.
 
 <Props of="c4d-lightbox-media-viewer" />
 
+### `<c4d-lightbox-image-viewer>`
+
+<Props of="c4d-lightbox-image-viewer" />
+
+### `<c4d-lightbox-video-player>`
+
+<Props of="c4d-lightbox-video-player" />
+
 <Description markdown={contributing} />

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-image-viewer.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-image-viewer.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,6 +24,14 @@ const { stablePrefix: c4dPrefix } = settings;
  * @element c4d-lightbox-image-viewer
  * @slot title - The title content.
  * @slot description - The description content.
+ * @csspart container - The wrapper around the lightbox media. Usage: c4d-lightbox-video-player::part(container)
+ * @csspart row - The wrapper around the row. Usage: c4d-lightbox-video-player::part(row)
+ * @csspart media - The wrapper around media. Usage: c4d-lightbox-video-player::part(media)
+ * @csspart content-wrapper - The wrapper around content. Usage: c4d-lightbox-video-player::part(content-wrapper)
+ * @csspart content - The inner wrapper around content. Usage: c4d-lightbox-video-player::part(content)
+ * @csspart title - The title of the media. Usage: c4d-lightbox-video-player::part(title)
+ * @csspart description - The description of the media. Usage: c4d-lightbox-video-player::part(description)
+ * @csspart image - The image displayed in the lightbox image viewer. Usage: c4d-lightbox-video-player::part(image)
  */
 @customElement(`${c4dPrefix}-lightbox-image-viewer`)
 class C4DLightboxImageViewer extends C4DLightboxMediaViewerBody {
@@ -40,7 +48,8 @@ class C4DLightboxImageViewer extends C4DLightboxMediaViewerBody {
         class="${c4dPrefix}--image__img"
         alt="${ifDefined(alt)}"
         src="${ifDefined(defaultSrc)}"
-        loading="lazy" />
+        loading="lazy"
+        part="image" />
     `;
   }
 

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-image-viewer.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-image-viewer.ts
@@ -24,14 +24,14 @@ const { stablePrefix: c4dPrefix } = settings;
  * @element c4d-lightbox-image-viewer
  * @slot title - The title content.
  * @slot description - The description content.
- * @csspart container - The wrapper around the lightbox media. Usage: c4d-lightbox-video-player::part(container)
- * @csspart row - The wrapper around the row. Usage: c4d-lightbox-video-player::part(row)
- * @csspart media - The wrapper around media. Usage: c4d-lightbox-video-player::part(media)
- * @csspart content-wrapper - The wrapper around content. Usage: c4d-lightbox-video-player::part(content-wrapper)
- * @csspart content - The inner wrapper around content. Usage: c4d-lightbox-video-player::part(content)
- * @csspart title - The title of the media. Usage: c4d-lightbox-video-player::part(title)
- * @csspart description - The description of the media. Usage: c4d-lightbox-video-player::part(description)
- * @csspart image - The image displayed in the lightbox image viewer. Usage: c4d-lightbox-video-player::part(image)
+ * @csspart container - The wrapper around the lightbox media. Usage: `c4d-lightbox-video-player::part(container)`
+ * @csspart row - The wrapper around the row. Usage: `c4d-lightbox-video-player::part(row)`
+ * @csspart media - The wrapper around media. Usage: `c4d-lightbox-video-player::part(media)`
+ * @csspart content-wrapper - The wrapper around content. Usage: `c4d-lightbox-video-player::part(content-wrapper)`
+ * @csspart content - The inner wrapper around content. Usage: `c4d-lightbox-video-player::part(content)`
+ * @csspart title - The title of the media. Usage: `c4d-lightbox-video-player::part(title)`
+ * @csspart description - The description of the media. Usage: `c4d-lightbox-video-player::part(description)`
+ * @csspart image - The image displayed in the lightbox image viewer. Usage: `c4d-lightbox-video-player::part(image)`
  */
 @customElement(`${c4dPrefix}-lightbox-image-viewer`)
 class C4DLightboxImageViewer extends C4DLightboxMediaViewerBody {

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer-body.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer-body.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -35,13 +35,19 @@ abstract class C4DLightboxMediaViewerBody extends FocusMixin(LitElement) {
 
   render() {
     return html`
-      <div class="${c4dPrefix}--lightbox-media-viewer__container">
-        <div class="${c4dPrefix}--lightbox-media-viewer__row">
-          <div class="${c4dPrefix}--lightbox-media-viewer__media">
+      <div
+        class="${c4dPrefix}--lightbox-media-viewer__container"
+        part="container">
+        <div class="${c4dPrefix}--lightbox-media-viewer__row" part="row">
+          <div class="${c4dPrefix}--lightbox-media-viewer__media" part="media">
             ${this._renderMedia()}
           </div>
-          <div class="${c4dPrefix}--lightbox-media-viewer__media-description">
-            <div class="${c4dPrefix}--lightbox-media-viewer__content">
+          <div
+            class="${c4dPrefix}--lightbox-media-viewer__media-description"
+            part="content-wrapper">
+            <div
+              class="${c4dPrefix}--lightbox-media-viewer__content"
+              part="content">
               <div
                 part="title"
                 class="${c4dPrefix}--lightbox-media-viewer__content__title"

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer.ts
@@ -24,13 +24,13 @@ const { stablePrefix: c4dPrefix } = settings;
  * @element c4d-lightbox-media-viewer
  * @slot title - The title content.
  * @slot description - The description content.
- * @csspart container - The wrapper around the lightbox media. Usage: c4d-lightbox-video-player::part(container)
- * @csspart row - The wrapper around the row. Usage: c4d-lightbox-video-player::part(row)
- * @csspart media - The wrapper around media. Usage: c4d-lightbox-video-player::part(media)
- * @csspart content-wrapper - The wrapper around content. Usage: c4d-lightbox-video-player::part(content-wrapper)
- * @csspart content - The inner wrapper around content. Usage: c4d-lightbox-video-player::part(content)
- * @csspart title - The title of the media. Usage: c4d-lightbox-video-player::part(title)
- * @csspart description - The description of the media. Usage: c4d-lightbox-video-player::part(description)
+ * @csspart container - The wrapper around the lightbox media. Usage: `c4d-lightbox-video-player::part(container)`
+ * @csspart row - The wrapper around the row. Usage: `c4d-lightbox-video-player::part(row)`
+ * @csspart media - The wrapper around media. Usage: `c4d-lightbox-video-player::part(media)`
+ * @csspart content-wrapper - The wrapper around content. Usage: `c4d-lightbox-video-player::part(content-wrapper)`
+ * @csspart content - The inner wrapper around content. Usage: `c4d-lightbox-video-player::part(content)`
+ * @csspart title - The title of the media. Usage: `c4d-lightbox-video-player::part(title)`
+ * @csspart description - The description of the media. Usage: `c4d-lightbox-video-player::part(description)`
  */
 @customElement(`${c4dPrefix}-lightbox-media-viewer`)
 class C4DLightboxMediaViewer extends C4DLightboxMediaViewerBody {

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,9 +21,16 @@ const { stablePrefix: c4dPrefix } = settings;
 /**
  * The image content of lightbox media viewer.
  *
- * @element c4d-lightbox-image-viewer
+ * @element c4d-lightbox-media-viewer
  * @slot title - The title content.
  * @slot description - The description content.
+ * @csspart container - The wrapper around the lightbox media. Usage: c4d-lightbox-video-player::part(container)
+ * @csspart row - The wrapper around the row. Usage: c4d-lightbox-video-player::part(row)
+ * @csspart media - The wrapper around media. Usage: c4d-lightbox-video-player::part(media)
+ * @csspart content-wrapper - The wrapper around content. Usage: c4d-lightbox-video-player::part(content-wrapper)
+ * @csspart content - The inner wrapper around content. Usage: c4d-lightbox-video-player::part(content)
+ * @csspart title - The title of the media. Usage: c4d-lightbox-video-player::part(title)
+ * @csspart description - The description of the media. Usage: c4d-lightbox-video-player::part(description)
  */
 @customElement(`${c4dPrefix}-lightbox-media-viewer`)
 class C4DLightboxMediaViewer extends C4DLightboxMediaViewerBody {

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -216,15 +216,18 @@ class C4DLightboxVideoPlayerComposite extends ModalRenderMixin(
       <c4d-expressive-modal
         ?open="${open}"
         expressive-size="full-width"
-        mode="lightbox">
-        <c4d-expressive-modal-close-button></c4d-expressive-modal-close-button>
+        mode="lightbox"
+        part="modal">
+        <c4d-expressive-modal-close-button
+          part="close-button"></c4d-expressive-modal-close-button>
         <c4d-lightbox-video-player
           description="${ifDefined(videoDescription)}"
           duration="${ifDefined(duration)}"
           name="${ifDefined(videoName)}"
           ?hide-caption="${hideCaption}"
           .formatCaption="${ifDefined(formatCaption)}"
-          .formatDuration="${ifDefined(formatDuration)}">
+          .formatDuration="${ifDefined(formatDuration)}"
+          part="lightbox-video-player">
         </c4d-lightbox-video-player>
       </c4d-expressive-modal>
     `;

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -26,6 +26,15 @@ const { stablePrefix: c4dPrefix } = settings;
  * @element c4d-lightbox-video-player
  * @slot title - The title content.
  * @slot description - The description content.
+ * @csspart container - The wrapper around the lightbox media. Usage: c4d-lightbox-video-player::part(container)
+ * @csspart row - The wrapper around the row. Usage: c4d-lightbox-video-player::part(row)
+ * @csspart media - The wrapper around media. Usage: c4d-lightbox-video-player::part(media)
+ * @csspart content-wrapper - The wrapper around content. Usage: c4d-lightbox-video-player::part(content-wrapper)
+ * @csspart content - The inner wrapper around content. Usage: c4d-lightbox-video-player::part(content)
+ * @csspart title - The title of the media. Usage: c4d-lightbox-video-player::part(title)
+ * @csspart description - The description of the media. Usage: c4d-lightbox-video-player::part(description)
+ * @csspart video-player - The wrapper around the video player. Usage: c4d-lightbox-video-player::part(video-player)
+ * @csspart video-container - The inner wrapper around the slotted video player. Usage: c4d-lightbox-video-player::part(video-container)
  */
 @customElement(`${c4dPrefix}-lightbox-video-player`)
 class C4DLightboxVideoPlayer extends C4DLightboxMediaViewerBody {
@@ -39,8 +48,10 @@ class C4DLightboxVideoPlayer extends C4DLightboxMediaViewerBody {
   // eslint-disable-next-line class-methods-use-this
   _renderMedia() {
     return html`
-      <div class="${c4dPrefix}--video-player">
-        <div class="${c4dPrefix}--video-player__video-container">
+      <div class="${c4dPrefix}--video-player" part="video-player">
+        <div
+          class="${c4dPrefix}--video-player__video-container"
+          part="video-container">
           <slot></slot>
         </div>
       </div>

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player.ts
@@ -26,15 +26,15 @@ const { stablePrefix: c4dPrefix } = settings;
  * @element c4d-lightbox-video-player
  * @slot title - The title content.
  * @slot description - The description content.
- * @csspart container - The wrapper around the lightbox media. Usage: c4d-lightbox-video-player::part(container)
- * @csspart row - The wrapper around the row. Usage: c4d-lightbox-video-player::part(row)
- * @csspart media - The wrapper around media. Usage: c4d-lightbox-video-player::part(media)
- * @csspart content-wrapper - The wrapper around content. Usage: c4d-lightbox-video-player::part(content-wrapper)
- * @csspart content - The inner wrapper around content. Usage: c4d-lightbox-video-player::part(content)
- * @csspart title - The title of the media. Usage: c4d-lightbox-video-player::part(title)
- * @csspart description - The description of the media. Usage: c4d-lightbox-video-player::part(description)
- * @csspart video-player - The wrapper around the video player. Usage: c4d-lightbox-video-player::part(video-player)
- * @csspart video-container - The inner wrapper around the slotted video player. Usage: c4d-lightbox-video-player::part(video-container)
+ * @csspart container - The wrapper around the lightbox media. Usage: `c4d-lightbox-video-player::part(container)`
+ * @csspart row - The wrapper around the row. Usage: `c4d-lightbox-video-player::part(row)`
+ * @csspart media - The wrapper around media. Usage: `c4d-lightbox-video-player::part(media)`
+ * @csspart content-wrapper - The wrapper around content. Usage: `c4d-lightbox-video-player::part(content-wrapper)`
+ * @csspart content - The inner wrapper around content. Usage: `c4d-lightbox-video-player::part(content)`
+ * @csspart title - The title of the media. Usage: `c4d-lightbox-video-player::part(title)`
+ * @csspart description - The description of the media. Usage: `c4d-lightbox-video-player::part(description)`
+ * @csspart video-player - The wrapper around the video player. Usage: `c4d-lightbox-video-player::part(video-player)`
+ * @csspart video-container - The inner wrapper around the slotted video player. Usage: `c4d-lightbox-video-player::part(video-container)`
  */
 @customElement(`${c4dPrefix}-lightbox-video-player`)
 class C4DLightboxVideoPlayer extends C4DLightboxMediaViewerBody {

--- a/packages/web-components/tests/snapshots/c4d-lightbox-image-viewer.md
+++ b/packages/web-components/tests/snapshots/c4d-lightbox-image-viewer.md
@@ -3,18 +3,34 @@
 #### `should render with minimum attributes`
 
 ```
-<div class="c4d--lightbox-media-viewer__container">
-  <div class="c4d--lightbox-media-viewer__row">
-    <div class="c4d--lightbox-media-viewer__media">
+<div
+  class="c4d--lightbox-media-viewer__container"
+  part="container"
+>
+  <div
+    class="c4d--lightbox-media-viewer__row"
+    part="row"
+  >
+    <div
+      class="c4d--lightbox-media-viewer__media"
+      part="media"
+    >
       <img
         alt=""
         class="c4d--image__img"
         loading="lazy"
+        part="image"
         src=""
       >
     </div>
-    <div class="c4d--lightbox-media-viewer__media-description">
-      <div class="c4d--lightbox-media-viewer__content">
+    <div
+      class="c4d--lightbox-media-viewer__media-description"
+      part="content-wrapper"
+    >
+      <div
+        class="c4d--lightbox-media-viewer__content"
+        part="content"
+      >
         <div
           class="c4d--lightbox-media-viewer__content__title"
           data-autoid="c4d--lightbox-media-viewer__content__title"
@@ -41,18 +57,34 @@
 #### `should render with various attributes`
 
 ```
-<div class="c4d--lightbox-media-viewer__container">
-  <div class="c4d--lightbox-media-viewer__row">
-    <div class="c4d--lightbox-media-viewer__media">
+<div
+  class="c4d--lightbox-media-viewer__container"
+  part="container"
+>
+  <div
+    class="c4d--lightbox-media-viewer__row"
+    part="row"
+  >
+    <div
+      class="c4d--lightbox-media-viewer__media"
+      part="media"
+    >
       <img
         alt="image-alt-foo"
         class="c4d--image__img"
         loading="lazy"
+        part="image"
         src="https://example.com/image"
       >
     </div>
-    <div class="c4d--lightbox-media-viewer__media-description">
-      <div class="c4d--lightbox-media-viewer__content">
+    <div
+      class="c4d--lightbox-media-viewer__media-description"
+      part="content-wrapper"
+    >
+      <div
+        class="c4d--lightbox-media-viewer__content"
+        part="content"
+      >
         <div
           class="c4d--lightbox-media-viewer__content__title"
           data-autoid="c4d--lightbox-media-viewer__content__title"

--- a/packages/web-components/tests/snapshots/c4d-lightbox-video-player-composite.md
+++ b/packages/web-components/tests/snapshots/c4d-lightbox-video-player-composite.md
@@ -8,13 +8,18 @@
     data-autoid="c4d--expressive-modal"
     expressive-size="full-width"
     mode="lightbox"
+    part="modal"
   >
-    <c4d-expressive-modal-close-button data-autoid="c4d--expressive-modal-close-button">
+    <c4d-expressive-modal-close-button
+      data-autoid="c4d--expressive-modal-close-button"
+      part="close-button"
+    >
     </c4d-expressive-modal-close-button>
     <c4d-lightbox-video-player
       description="video-description-foo"
       duration="120"
       name="video-name-foo"
+      part="lightbox-video-player"
       role="dialog"
     >
     </c4d-lightbox-video-player>

--- a/packages/web-components/tests/snapshots/c4d-lightbox-video-player.md
+++ b/packages/web-components/tests/snapshots/c4d-lightbox-video-player.md
@@ -3,18 +3,39 @@
 #### `should render with minimum attributes`
 
 ```
-<div class="c4d--lightbox-media-viewer__container">
-  <div class="c4d--lightbox-media-viewer__row">
-    <div class="c4d--lightbox-media-viewer__media">
-      <div class="c4d--video-player">
-        <div class="c4d--video-player__video-container">
+<div
+  class="c4d--lightbox-media-viewer__container"
+  part="container"
+>
+  <div
+    class="c4d--lightbox-media-viewer__row"
+    part="row"
+  >
+    <div
+      class="c4d--lightbox-media-viewer__media"
+      part="media"
+    >
+      <div
+        class="c4d--video-player"
+        part="video-player"
+      >
+        <div
+          class="c4d--video-player__video-container"
+          part="video-container"
+        >
           <slot>
           </slot>
         </div>
       </div>
     </div>
-    <div class="c4d--lightbox-media-viewer__media-description">
-      <div class="c4d--lightbox-media-viewer__content">
+    <div
+      class="c4d--lightbox-media-viewer__media-description"
+      part="content-wrapper"
+    >
+      <div
+        class="c4d--lightbox-media-viewer__content"
+        part="content"
+      >
         <div
           class="c4d--lightbox-media-viewer__content__title"
           data-autoid="c4d--lightbox-media-viewer__content__title"
@@ -43,18 +64,39 @@
 #### `should render with various attributes`
 
 ```
-<div class="c4d--lightbox-media-viewer__container">
-  <div class="c4d--lightbox-media-viewer__row">
-    <div class="c4d--lightbox-media-viewer__media">
-      <div class="c4d--video-player">
-        <div class="c4d--video-player__video-container">
+<div
+  class="c4d--lightbox-media-viewer__container"
+  part="container"
+>
+  <div
+    class="c4d--lightbox-media-viewer__row"
+    part="row"
+  >
+    <div
+      class="c4d--lightbox-media-viewer__media"
+      part="media"
+    >
+      <div
+        class="c4d--video-player"
+        part="video-player"
+      >
+        <div
+          class="c4d--video-player__video-container"
+          part="video-container"
+        >
           <slot>
           </slot>
         </div>
       </div>
     </div>
-    <div class="c4d--lightbox-media-viewer__media-description">
-      <div class="c4d--lightbox-media-viewer__content">
+    <div
+      class="c4d--lightbox-media-viewer__media-description"
+      part="content-wrapper"
+    >
+      <div
+        class="c4d--lightbox-media-viewer__content"
+        part="content"
+      >
         <div
           class="c4d--lightbox-media-viewer__content__title"
           data-autoid="c4d--lightbox-media-viewer__content__title"


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-5163](https://jsw.ibm.com/browse/ADCMS-5163)
#11673

### Description

Add shadow parts to the elements of lightbox-media-viewer and friends.

### Changelog

**New**

- Added shadow parts to the lightbox-media-viewer component and related components.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
