### PR TITLE
feat(image): add shadow parts

### DIFF
--- a/packages/web-components/src/components/image/image.ts
+++ b/packages/web-components/src/components/image/image.ts
@@ -37,12 +37,12 @@ export { LIGHTBOX_CONTRAST };
  * @slot long-description - The long description content.
  * @slot icon - The icon content.
  * @csspart image - The image. Usage: `c4d-image::part(image)`
- * @csspart picture - The picture tag. Usage: c4d-image::part(picture)
- * @csspart long-description - The wrapper around the long description slot. Usage: c4d-image::part(long-description)
- * @csspart lightbox-button - The button element for the lightbox when used. Usage: c4d-image::part(lightbox-button)
- * @csspart zoom-button - The wrapper around the zoom button to trigger the lightbox when used. Usage: c4d-image::part(zoom-button)
- * @csspart zoom-icon - The zoom icon used for the lightbox. Usage: c4d-image::part(zoom-icon)
- * @csspart caption - The caption for the image. Usage: c4d-image::part(caption)
+ * @csspart picture - The picture tag. Usage:` c4d-image::part(picture)`
+ * @csspart long-description - The wrapper around the long description slot. Usage: `c4d-image::part(long-description)`
+ * @csspart lightbox-button - The button element for the lightbox when used. Usage: `c4d-image::part(lightbox-button)`
+ * @csspart zoom-button - The wrapper around the zoom button to trigger the lightbox when used. Usage: `c4d-image::part(zoom-button)`
+ * @csspart zoom-icon - The zoom icon used for the lightbox. Usage: `c4d-image::part(zoom-icon)`
+ * @csspart caption - The caption for the image. Usage: `c4d-image::part(caption)`
  */
 @customElement(`${c4dPrefix}-image`)
 class C4DImage extends StableSelectorMixin(

--- a/packages/web-components/src/components/image/image.ts
+++ b/packages/web-components/src/components/image/image.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -37,6 +37,12 @@ export { LIGHTBOX_CONTRAST };
  * @slot long-description - The long description content.
  * @slot icon - The icon content.
  * @csspart image - The image. Usage: `c4d-image::part(image)`
+ * @csspart picture - The picture tag. Usage: c4d-image::part(picture)
+ * @csspart long-description - The wrapper around the long description slot. Usage: c4d-image::part(long-description)
+ * @csspart lightbox-button - The button element for the lightbox when used. Usage: c4d-image::part(lightbox-button)
+ * @csspart zoom-button - The wrapper around the zoom button to trigger the lightbox when used. Usage: c4d-image::part(zoom-button)
+ * @csspart zoom-icon - The zoom icon used for the lightbox. Usage: c4d-image::part(zoom-icon)
+ * @csspart caption - The caption for the image. Usage: c4d-image::part(caption)
  */
 @customElement(`${c4dPrefix}-image`)
 class C4DImage extends StableSelectorMixin(
@@ -183,7 +189,7 @@ class C4DImage extends StableSelectorMixin(
 
     return html`
       <slot @slotchange="${handleSlotChange}"></slot>
-      <picture>
+      <picture part="picture">
         ${images.map(
           (image) =>
             html`<source media="${image.getAttribute(
@@ -198,7 +204,10 @@ class C4DImage extends StableSelectorMixin(
           part="image"
           loading="lazy" />
       </picture>
-      <div id="long-description" class="${c4dPrefix}--image__longdescription">
+      <div
+        id="long-description"
+        class="${c4dPrefix}--image__longdescription"
+        part="long-description">
         <slot name="long-description"></slot>
       </div>
       <slot name="icon"></slot>
@@ -235,17 +244,23 @@ class C4DImage extends StableSelectorMixin(
             <button
               class="${c4dPrefix}--image-with-caption__image"
               aria-label="${ifDefined(launchLightboxButtonAssistiveText)}"
-              @click="${handleClick}">
+              @click="${handleClick}"
+              part="lightbox-button">
               ${this.renderImage()}
-              <div class="${c4dPrefix}--image-with-caption__zoom-button">
-                ${Maximize20()}
+              <div
+                class="${c4dPrefix}--image-with-caption__zoom-button"
+                part="zoom-button">
+                ${Maximize20({ part: 'zoom-icon' })}
               </div>
             </button>
           `
         : html` ${this.renderImage()} `}
       ${heading
         ? html`
-            <p id="image-caption" class="${c4dPrefix}--image__caption">
+            <p
+              id="image-caption"
+              class="${c4dPrefix}--image__caption"
+              part="caption">
               ${heading}
             </p>
           `

--- a/packages/web-components/tests/snapshots/c4d-image.md
+++ b/packages/web-components/tests/snapshots/c4d-image.md
@@ -7,7 +7,7 @@
 ```
 <slot>
 </slot>
-<picture>
+<picture part="picture">
   <img
     alt=""
     aria-describedby="image-caption long-description"
@@ -20,6 +20,7 @@
 <div
   class="c4d--image__longdescription"
   id="long-description"
+  part="long-description"
 >
   <slot name="long-description">
   </slot>
@@ -34,7 +35,7 @@
 ```
 <slot>
 </slot>
-<picture>
+<picture part="picture">
   <img
     alt=""
     aria-describedby="image-caption long-description"
@@ -47,6 +48,7 @@
 <div
   class="c4d--image__longdescription"
   id="long-description"
+  part="long-description"
 >
   <slot name="long-description">
   </slot>


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-5150](https://jsw.ibm.com/browse/ADCMS-5150)
#11673

### Description

Add shadow parts to image component.

### Changelog

**New**

- Added shadow parts to the image component.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
