### PR TITLE
feat(leadspace): add shadow parts

### DIFF
--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -36,7 +36,6 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * @csspart container - The container. Usage: `c4d-leadspace::part(container)`
  * @csspart gradient - The gradient container. Usage: `c4d-leadspace::part(gradient)`
  * @csspart image-gradient - The image with gradient. Usage: `c4d-leadspace::part(image-gradient)`
- * @csspart gradient-stop - Where the gradient stops. Usage: `c4d-leadspace::part(gradient-stop)`
  * @csspart action - The action. Usage: `c4d-leadspace::part(action)`
  */
 @customElement(`${c4dPrefix}-leadspace`)
@@ -185,7 +184,7 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
                   xmlns:xlink="http://www.w3.org/1999/xlink"
                 >
                   <defs>
-                    <linearGradient id="stops" class="${c4dPrefix}--leadspace__gradient__stops" part="gradient-stop" gradientTransform="${
+                    <linearGradient id="stops" class="${c4dPrefix}--leadspace__gradient__stops" gradientTransform="${
                   type === LEADSPACE_TYPE.CENTERED ? 'rotate(90)' : ''
                 }">
                       ${

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -37,7 +37,6 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * @csspart gradient - The gradient container. Usage: `c4d-leadspace::part(gradient)`
  * @csspart image-gradient - The image with gradient. Usage: `c4d-leadspace::part(image-gradient)`
  * @csspart gradient-stop - Where the gradient stops. Usage: `c4d-leadspace::part(gradient-stop)`
- * @csspart gradient-rect - The gradient. Usage: `c4d-leadspace::part(gradient-rect)`
  * @csspart action - The action. Usage: `c4d-leadspace::part(action)`
  */
 @customElement(`${c4dPrefix}-leadspace`)
@@ -206,7 +205,7 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
                       }
                     </linearGradient>
                   </defs>
-                  <rect class="${c4dPrefix}--leadspace__gradient__rect" part="gradient-rect" width="100" height="100" />
+                  <rect class="${c4dPrefix}--leadspace__gradient__rect" width="100" height="100" />
                 </svg>
               `}
             <div

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,7 +30,15 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * @element c4d-leadspace
  * @slot action The action (CTA) content.
  * @slot image The image content.
+ * @csspart content - The content. Usage: `c4d-leadspace::part(content)`
+ * @csspart content-item - The subheading paragraph. Usage: `c4d-leadspace::part(content-item)`
  * @csspart section - The first DOM node inside the shadow-root. Usage: `c4d-leadspace::part(section)`
+ * @csspart container - The container. Usage: `c4d-leadspace::part(container)`
+ * @csspart gradient - The gradient container. Usage: `c4d-leadspace::part(gradient)`
+ * @csspart image-gradient - The image with gradient. Usage: `c4d-leadspace::part(image-gradient)`
+ * @csspart gradient-stop - Where the gradient stops. Usage: `c4d-leadspace::part(gradient-stop)`
+ * @csspart gradient-rect - The gradient. Usage: `c4d-leadspace::part(gradient-rect)`
+ * @csspart action - The action. Usage: `c4d-leadspace::part(action)`
  */
 @customElement(`${c4dPrefix}-leadspace`)
 class C4DLeadSpace extends StableSelectorMixin(LitElement) {
@@ -81,10 +89,11 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
   protected _renderCopy() {
     const { copy } = this;
     return html`
-      <div class="${c4dPrefix}--leadspace__row">
+      <div class="${c4dPrefix}--leadspace__row" part="content">
         <p
           data-autoid="${c4dPrefix}--leadspace__desc"
-          class="${c4dPrefix}--leadspace__desc">
+          class="${c4dPrefix}--leadspace__desc"
+          part="content-item">
           <slot>${copy}</slot>
         </p>
       </div>
@@ -164,20 +173,20 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
     const { gradientStyleScheme, type, size } = this;
     return html`
       <section class="${this._getTypeClass()}" part="section">
-        <div class="${c4dPrefix}--leadspace__container">
-          <div class="${this._getGradientClass()}">
+        <div class="${c4dPrefix}--leadspace__container" part="container">
+          <div class="${this._getGradientClass()}" part="gradient">
             ${gradientStyleScheme === LEADSPACE_GRADIENT_STYLE_SCHEME.NONE
               ? undefined
               : svg`
                 <svg
-                  class="${c4dPrefix}--leadspace__gradient"
+                  class="${c4dPrefix}--leadspace__gradient" part="image-gradient"
                   viewBox="0 0 100 100"
                   preserveAspectRatio="none"
                   xmlns="http://www.w3.org/2000/svg"
                   xmlns:xlink="http://www.w3.org/1999/xlink"
                 >
                   <defs>
-                    <linearGradient id="stops" class="${c4dPrefix}--leadspace__gradient__stops" gradientTransform="${
+                    <linearGradient id="stops" class="${c4dPrefix}--leadspace__gradient__stops" part="gradient-stop" gradientTransform="${
                   type === LEADSPACE_TYPE.CENTERED ? 'rotate(90)' : ''
                 }">
                       ${
@@ -197,11 +206,13 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
                       }
                     </linearGradient>
                   </defs>
-                  <rect class="${c4dPrefix}--leadspace__gradient__rect" width="100" height="100" />
+                  <rect class="${c4dPrefix}--leadspace__gradient__rect" part="gradient-rect" width="100" height="100" />
                 </svg>
               `}
-            <div class="${c4dPrefix}--leadspace--content__container">
-              <div class="${c4dPrefix}--leadspace__row">
+            <div
+              class="${c4dPrefix}--leadspace--content__container"
+              part="container">
+              <div class="${c4dPrefix}--leadspace__row" part="content">
                 <slot
                   name="navigation"
                   @slotchange="${this._handleSlotChange}"></slot>
@@ -209,9 +220,13 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
               </div>
               ${size !== LEADSPACE_SIZE.SHORT
                 ? html`
-                    <div class="${c4dPrefix}--leadspace__content">
+                    <div
+                      class="${c4dPrefix}--leadspace__content"
+                      part="content">
                       ${this._renderCopy()}
-                      <div class="${c4dPrefix}--leadspace__action">
+                      <div
+                        class="${c4dPrefix}--leadspace__action"
+                        part="action">
                         <slot name="action"></slot>
                       </div>
                     </div>

--- a/packages/web-components/src/components/leadspace/leadspace.ts
+++ b/packages/web-components/src/components/leadspace/leadspace.ts
@@ -32,10 +32,15 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * @slot image The image content.
  * @csspart content - The content. Usage: `c4d-leadspace::part(content)`
  * @csspart content-item - The subheading paragraph. Usage: `c4d-leadspace::part(content-item)`
+ * @csspart row - Row wrappers. Usage: `c4d-leadspace::part(row)`
+ * @csspart row--description - Row wrapper for the description. Usage: `c4d-leadspace::part(row--description)`
+ * @csspart row--content - Row wrapper for the navigation and heading. Usage: `c4d-leadspace::part(row--content)`
+ * @csspart description - The description. Usage`c4d-leadspace::part(description)`
  * @csspart section - The first DOM node inside the shadow-root. Usage: `c4d-leadspace::part(section)`
- * @csspart container - The container. Usage: `c4d-leadspace::part(container)`
- * @csspart gradient - The gradient container. Usage: `c4d-leadspace::part(gradient)`
- * @csspart image-gradient - The image with gradient. Usage: `c4d-leadspace::part(image-gradient)`
+ * @csspart container - The container around the whole leadspace. Usage: `c4d-leadspace::part(container)`
+ * @csspart content-container - The container around just the content of the leadspace. Usage: `c4d-leadspace::part(content-container)`
+ * @csspart overlay - The leadspace overlay wrapping all contents and optional gradient. Usage: `c4d-leadspace::part(overlay)`
+ * @csspart gradient - The SVG gradient. Usage: `c4d-leadspace::part(gradient)`
  * @csspart action - The action. Usage: `c4d-leadspace::part(action)`
  */
 @customElement(`${c4dPrefix}-leadspace`)
@@ -87,11 +92,11 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
   protected _renderCopy() {
     const { copy } = this;
     return html`
-      <div class="${c4dPrefix}--leadspace__row" part="content">
+      <div class="${c4dPrefix}--leadspace__row" part="row row--description">
         <p
           data-autoid="${c4dPrefix}--leadspace__desc"
           class="${c4dPrefix}--leadspace__desc"
-          part="content-item">
+          part="description">
           <slot>${copy}</slot>
         </p>
       </div>
@@ -172,12 +177,12 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
     return html`
       <section class="${this._getTypeClass()}" part="section">
         <div class="${c4dPrefix}--leadspace__container" part="container">
-          <div class="${this._getGradientClass()}" part="gradient">
+          <div class="${this._getGradientClass()}" part="overlay">
             ${gradientStyleScheme === LEADSPACE_GRADIENT_STYLE_SCHEME.NONE
               ? undefined
               : svg`
                 <svg
-                  class="${c4dPrefix}--leadspace__gradient" part="image-gradient"
+                  class="${c4dPrefix}--leadspace__gradient" part="gradient"
                   viewBox="0 0 100 100"
                   preserveAspectRatio="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -209,8 +214,8 @@ class C4DLeadSpace extends StableSelectorMixin(LitElement) {
               `}
             <div
               class="${c4dPrefix}--leadspace--content__container"
-              part="container">
-              <div class="${c4dPrefix}--leadspace__row" part="content">
+              part="content-container">
+              <div class="${c4dPrefix}--leadspace__row" part="row row--content">
                 <slot
                   name="navigation"
                   @slotchange="${this._handleSlotChange}"></slot>

--- a/packages/web-components/tests/snapshots/c4d-leadspace.md
+++ b/packages/web-components/tests/snapshots/c4d-leadspace.md
@@ -9,26 +9,48 @@
   class="c4d--leadspace__section"
   part="section"
 >
-  <div class="c4d--leadspace__container">
-    <div class="c4d--leadspace__overlay">
-      <div class="c4d--leadspace--content__container">
-        <div class="c4d--leadspace__row">
+  <div
+    class="c4d--leadspace__container"
+    part="container"
+  >
+    <div
+      class="c4d--leadspace__overlay"
+      part="overlay"
+    >
+      <div
+        class="c4d--leadspace--content__container"
+        part="content-container"
+      >
+        <div
+          class="c4d--leadspace__row"
+          part="row row--content"
+        >
           <slot name="navigation">
           </slot>
           <slot name="heading">
           </slot>
         </div>
-        <div class="c4d--leadspace__content">
-          <div class="c4d--leadspace__row">
+        <div
+          class="c4d--leadspace__content"
+          part="content"
+        >
+          <div
+            class="c4d--leadspace__row"
+            part="row row--description"
+          >
             <p
               class="c4d--leadspace__desc"
               data-autoid="c4d--leadspace__desc"
+              part="description"
             >
               <slot>
               </slot>
             </p>
           </div>
-          <div class="c4d--leadspace__action">
+          <div
+            class="c4d--leadspace__action"
+            part="action"
+          >
             <slot name="action">
             </slot>
           </div>
@@ -49,26 +71,48 @@
   class="c4d--leadspace__section"
   part="section"
 >
-  <div class="c4d--leadspace__container">
-    <div class="c4d--leadspace__overlay">
-      <div class="c4d--leadspace--content__container">
-        <div class="c4d--leadspace__row">
+  <div
+    class="c4d--leadspace__container"
+    part="container"
+  >
+    <div
+      class="c4d--leadspace__overlay"
+      part="overlay"
+    >
+      <div
+        class="c4d--leadspace--content__container"
+        part="content-container"
+      >
+        <div
+          class="c4d--leadspace__row"
+          part="row row--content"
+        >
           <slot name="navigation">
           </slot>
           <slot name="heading">
           </slot>
         </div>
-        <div class="c4d--leadspace__content">
-          <div class="c4d--leadspace__row">
+        <div
+          class="c4d--leadspace__content"
+          part="content"
+        >
+          <div
+            class="c4d--leadspace__row"
+            part="row row--description"
+          >
             <p
               class="c4d--leadspace__desc"
               data-autoid="c4d--leadspace__desc"
+              part="description"
             >
               <slot>
               </slot>
             </p>
           </div>
-          <div class="c4d--leadspace__action">
+          <div
+            class="c4d--leadspace__action"
+            part="action"
+          >
             <slot name="action">
             </slot>
           </div>
@@ -91,26 +135,48 @@
   class="c4d--leadspace__section"
   part="section"
 >
-  <div class="c4d--leadspace__container">
-    <div class="c4d--leadspace__overlay">
-      <div class="c4d--leadspace--content__container">
-        <div class="c4d--leadspace__row">
+  <div
+    class="c4d--leadspace__container"
+    part="container"
+  >
+    <div
+      class="c4d--leadspace__overlay"
+      part="overlay"
+    >
+      <div
+        class="c4d--leadspace--content__container"
+        part="content-container"
+      >
+        <div
+          class="c4d--leadspace__row"
+          part="row row--content"
+        >
           <slot name="navigation">
           </slot>
           <slot name="heading">
           </slot>
         </div>
-        <div class="c4d--leadspace__content">
-          <div class="c4d--leadspace__row">
+        <div
+          class="c4d--leadspace__content"
+          part="content"
+        >
+          <div
+            class="c4d--leadspace__row"
+            part="row row--description"
+          >
             <p
               class="c4d--leadspace__desc"
               data-autoid="c4d--leadspace__desc"
+              part="description"
             >
               <slot>
               </slot>
             </p>
           </div>
-          <div class="c4d--leadspace__action">
+          <div
+            class="c4d--leadspace__action"
+            part="action"
+          >
             <slot name="action">
             </slot>
           </div>
@@ -131,26 +197,48 @@
   class="c4d--leadspace__section"
   part="section"
 >
-  <div class="c4d--leadspace__container">
-    <div class="c4d--leadspace--gradient c4d--leadspace__overlay">
-      <div class="c4d--leadspace--content__container">
-        <div class="c4d--leadspace__row">
+  <div
+    class="c4d--leadspace__container"
+    part="container"
+  >
+    <div
+      class="c4d--leadspace--gradient c4d--leadspace__overlay"
+      part="overlay"
+    >
+      <div
+        class="c4d--leadspace--content__container"
+        part="content-container"
+      >
+        <div
+          class="c4d--leadspace__row"
+          part="row row--content"
+        >
           <slot name="navigation">
           </slot>
           <slot name="heading">
           </slot>
         </div>
-        <div class="c4d--leadspace__content">
-          <div class="c4d--leadspace__row">
+        <div
+          class="c4d--leadspace__content"
+          part="content"
+        >
+          <div
+            class="c4d--leadspace__row"
+            part="row row--description"
+          >
             <p
               class="c4d--leadspace__desc"
               data-autoid="c4d--leadspace__desc"
+              part="description"
             >
               <slot>
               </slot>
             </p>
           </div>
-          <div class="c4d--leadspace__action">
+          <div
+            class="c4d--leadspace__action"
+            part="action"
+          >
             <slot name="action">
             </slot>
           </div>
@@ -173,26 +261,48 @@
   class="c4d--leadspace__section"
   part="section"
 >
-  <div class="c4d--leadspace__container">
-    <div class="c4d--leadspace__overlay">
-      <div class="c4d--leadspace--content__container">
-        <div class="c4d--leadspace__row">
+  <div
+    class="c4d--leadspace__container"
+    part="container"
+  >
+    <div
+      class="c4d--leadspace__overlay"
+      part="overlay"
+    >
+      <div
+        class="c4d--leadspace--content__container"
+        part="content-container"
+      >
+        <div
+          class="c4d--leadspace__row"
+          part="row row--content"
+        >
           <slot name="navigation">
           </slot>
           <slot name="heading">
           </slot>
         </div>
-        <div class="c4d--leadspace__content">
-          <div class="c4d--leadspace__row">
+        <div
+          class="c4d--leadspace__content"
+          part="content"
+        >
+          <div
+            class="c4d--leadspace__row"
+            part="row row--description"
+          >
             <p
               class="c4d--leadspace__desc"
               data-autoid="c4d--leadspace__desc"
+              part="description"
             >
               <slot>
               </slot>
             </p>
           </div>
-          <div class="c4d--leadspace__action">
+          <div
+            class="c4d--leadspace__action"
+            part="action"
+          >
             <slot name="action">
             </slot>
           </div>
@@ -213,26 +323,48 @@
   class="c4d--leadspace__section"
   part="section"
 >
-  <div class="c4d--leadspace__container">
-    <div class="c4d--leadspace__overlay">
-      <div class="c4d--leadspace--content__container">
-        <div class="c4d--leadspace__row">
+  <div
+    class="c4d--leadspace__container"
+    part="container"
+  >
+    <div
+      class="c4d--leadspace__overlay"
+      part="overlay"
+    >
+      <div
+        class="c4d--leadspace--content__container"
+        part="content-container"
+      >
+        <div
+          class="c4d--leadspace__row"
+          part="row row--content"
+        >
           <slot name="navigation">
           </slot>
           <slot name="heading">
           </slot>
         </div>
-        <div class="c4d--leadspace__content">
-          <div class="c4d--leadspace__row">
+        <div
+          class="c4d--leadspace__content"
+          part="content"
+        >
+          <div
+            class="c4d--leadspace__row"
+            part="row row--description"
+          >
             <p
               class="c4d--leadspace__desc"
               data-autoid="c4d--leadspace__desc"
+              part="description"
             >
               <slot>
               </slot>
             </p>
           </div>
-          <div class="c4d--leadspace__action">
+          <div
+            class="c4d--leadspace__action"
+            part="action"
+          >
             <slot name="action">
             </slot>
           </div>
@@ -255,26 +387,48 @@
   class="c4d--leadspace__section"
   part="section"
 >
-  <div class="c4d--leadspace__container">
-    <div class="c4d--leadspace__overlay">
-      <div class="c4d--leadspace--content__container">
-        <div class="c4d--leadspace__row">
+  <div
+    class="c4d--leadspace__container"
+    part="container"
+  >
+    <div
+      class="c4d--leadspace__overlay"
+      part="overlay"
+    >
+      <div
+        class="c4d--leadspace--content__container"
+        part="content-container"
+      >
+        <div
+          class="c4d--leadspace__row"
+          part="row row--content"
+        >
           <slot name="navigation">
           </slot>
           <slot name="heading">
           </slot>
         </div>
-        <div class="c4d--leadspace__content">
-          <div class="c4d--leadspace__row">
+        <div
+          class="c4d--leadspace__content"
+          part="content"
+        >
+          <div
+            class="c4d--leadspace__row"
+            part="row row--description"
+          >
             <p
               class="c4d--leadspace__desc"
               data-autoid="c4d--leadspace__desc"
+              part="description"
             >
               <slot>
               </slot>
             </p>
           </div>
-          <div class="c4d--leadspace__action">
+          <div
+            class="c4d--leadspace__action"
+            part="action"
+          >
             <slot name="action">
             </slot>
           </div>
@@ -295,26 +449,48 @@
   class="c4d--leadspace__section"
   part="section"
 >
-  <div class="c4d--leadspace__container">
-    <div class="c4d--leadspace--gradient c4d--leadspace__overlay">
-      <div class="c4d--leadspace--content__container">
-        <div class="c4d--leadspace__row">
+  <div
+    class="c4d--leadspace__container"
+    part="container"
+  >
+    <div
+      class="c4d--leadspace--gradient c4d--leadspace__overlay"
+      part="overlay"
+    >
+      <div
+        class="c4d--leadspace--content__container"
+        part="content-container"
+      >
+        <div
+          class="c4d--leadspace__row"
+          part="row row--content"
+        >
           <slot name="navigation">
           </slot>
           <slot name="heading">
           </slot>
         </div>
-        <div class="c4d--leadspace__content">
-          <div class="c4d--leadspace__row">
+        <div
+          class="c4d--leadspace__content"
+          part="content"
+        >
+          <div
+            class="c4d--leadspace__row"
+            part="row row--description"
+          >
             <p
               class="c4d--leadspace__desc"
               data-autoid="c4d--leadspace__desc"
+              part="description"
             >
               <slot>
               </slot>
             </p>
           </div>
-          <div class="c4d--leadspace__action">
+          <div
+            class="c4d--leadspace__action"
+            part="action"
+          >
             <slot name="action">
             </slot>
           </div>


### PR DESCRIPTION
[ADCMS-5161](https://jsw.ibm.com/browse/ADCMS-5161)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "leadspace" component.

Changelog

New

Adding the shadow parts for the "leadspace" component and documentation