### PR TITLE
feat(sticky-header): allow mixed prefixes with warning

### DIFF
--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -76,12 +76,15 @@ class StickyHeader {
     const received = component.tagName.toLowerCase();
     if (received !== expected) {
       // TODO: don't check for v1/v2 compatibility after v1 EOL.
-      if (received.split('-').splice(1).join('-') !== expected.split('-').splice(1).join('-')) {
+      if (
+        received.split('-').splice(1).join('-') !==
+        expected.split('-').splice(1).join('-')
+      ) {
         throw new TypeError(`${expected} expected, ${received} provided`);
       } else {
         const message = [
           `Mixed prefixes detected.\n`,
-          `expected ${expected}, found ${received}.`
+          `expected ${expected}, found ${received}.`,
         ];
         console.warn(message.join(''));
         return true;

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -108,11 +108,9 @@ class StickyHeader {
     const elementPrefix = element.tagName.toLowerCase().split('-')[0];
     if (elementPrefix === ddsPrefix) {
       v1Func.bind(this)();
-    }
-    else if (elementPrefix === c4dPrefix) {
+    } else if (elementPrefix === c4dPrefix) {
       v2Func.bind(this)();
-    }
-    else {
+    } else {
       throw new Error(`
         Could not find sub-elements for ${element.tagName.toLowerCase()}.
       `);
@@ -125,9 +123,8 @@ class StickyHeader {
   _updateLeadspaceRefsV1() {
     const { leadspaceSearch } = this._elements;
 
-    this._elements.leadspaceSearchBar = leadspaceSearch.shadowRoot.querySelector(
-      `.${prefix}--search-container`
-    );
+    this._elements.leadspaceSearchBar =
+      leadspaceSearch.shadowRoot.querySelector(`.${prefix}--search-container`);
     this._elements.leadspaceSearchInput = leadspaceSearch.querySelector(
       `${ddsPrefix}-search-with-typeahead`
     );
@@ -139,9 +136,10 @@ class StickyHeader {
   _updateLeadspaceRefsV2() {
     const { leadspaceSearch } = this._elements;
 
-    this._elements.leadspaceSearchBar = leadspaceSearch.shadowRoot.querySelector(
-      `.${prefixV2}--search-container`
-    );
+    this._elements.leadspaceSearchBar =
+      leadspaceSearch.shadowRoot.querySelector(
+        `.${prefixV2}--search-container`
+      );
     this._elements.leadspaceSearchInput = leadspaceSearch.querySelector(
       `${c4dPrefix}-search-with-typeahead`
     );
@@ -248,8 +246,10 @@ class StickyHeader {
         this._updateLeadspaceRefsV2
       );
       this._state.leadspaceSearchThreshold =
-        parseInt(window.getComputedStyle(this._elements.leadspaceSearchBar).paddingBottom) -
-        16;
+        parseInt(
+          window.getComputedStyle(this._elements.leadspaceSearchBar)
+            .paddingBottom
+        ) - 16;
       this._manageStickyElements();
     }
   }

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -13,6 +13,9 @@ import settings from 'carbon-components/es/globals/js/settings';
 const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;
 
+const c4dPrefix = 'c4d';
+const prefixV2 = 'cds';
+
 const gridBreakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
 
 class StickyHeader {
@@ -95,10 +98,85 @@ class StickyHeader {
   }
 
   /**
-   * Stores references to TOC sub-elements that are relevant to current viewport
-   * dimensions.
+   * Helper method to query for either C4IBM v1.x or v2.x sub-elements;
+   *
+   * @param {*} element The C4IBM element.
+   * @param {*} v1Func The querying function to run if using a C4IBM v1.x element.
+   * @param {*} v2Func The querying function to run if using a C4IBM v2.x element.
    */
-  _updateTableOfContentsRefs() {
+  _updateRefsV1orV2(element, v1Func, v2Func) {
+    const elementPrefix = element.tagName.toLowerCase().split('-')[0];
+    if (elementPrefix === ddsPrefix) {
+      v1Func.bind(this)();
+    }
+    else if (elementPrefix === c4dPrefix) {
+      v2Func.bind(this)();
+    }
+    else {
+      throw new Error(`
+        Could not find sub-elements for ${element.tagName.toLowerCase()}.
+      `);
+    }
+  }
+
+  /**
+   * Temporary method to find v1 leadspace sub-elements.
+   */
+  _updateLeadspaceRefsV1() {
+    const { leadspaceSearch } = this._elements;
+
+    this._elements.leadspaceSearchBar = leadspaceSearch.shadowRoot.querySelector(
+      `.${prefix}--search-container`
+    );
+    this._elements.leadspaceSearchInput = leadspaceSearch.querySelector(
+      `${ddsPrefix}-search-with-typeahead`
+    );
+  }
+
+  /**
+   * Temporary method to find v2 leadspace sub-elements.
+   */
+  _updateLeadspaceRefsV2() {
+    const { leadspaceSearch } = this._elements;
+
+    this._elements.leadspaceSearchBar = leadspaceSearch.shadowRoot.querySelector(
+      `.${prefixV2}--search-container`
+    );
+    this._elements.leadspaceSearchInput = leadspaceSearch.querySelector(
+      `${c4dPrefix}-search-with-typeahead`
+    );
+  }
+
+  /**
+   * Temporary method to find v1 masthead sub-elements.
+   */
+  _updateMastheadRefsV1() {
+    const { masthead } = this._elements;
+    this._elements.mastheadL0 = masthead.shadowRoot.querySelector(
+      `.${prefix}--masthead__l0`
+    );
+    this._elements.mastheadL1 = masthead.querySelector(
+      `${ddsPrefix}-masthead-l1`
+    );
+  }
+
+  /**
+   * Temporary method to find v2 masthead sub-elements.
+   */
+  _updateMastheadRefsV2() {
+    const { masthead } = this._elements;
+    this._elements.mastheadL0 = masthead.shadowRoot.querySelector(
+      `.${prefix}--masthead__l0`
+    );
+    this._elements.mastheadL1 = masthead.querySelector(
+      `${c4dPrefix}-masthead-l1`
+    );
+  }
+
+  /**
+   * Temporary method to find v1 table of contents sub-elements.
+   */
+  _updateTableOfContentsRefsV1() {
     const { tableOfContents: toc } = this._elements;
     const tocRoot = toc.shadowRoot;
     const selectors = {
@@ -120,6 +198,32 @@ class StickyHeader {
     );
   }
 
+  /**
+   * Temporary method to find v2 table of contents sub-elements.
+   */
+  _updateTableOfContentsRefsV2() {
+    const { tableOfContents: toc } = this._elements;
+    const tocRoot = toc.shadowRoot;
+    this._elements.tableOfContentsInnerBar = tocRoot.querySelector(
+      window.innerWidth >= gridBreakpoint && toc?.layout !== 'horizontal'
+        ? `.${c4dPrefix}-ce--table-of-contents__items-container`
+        : `.${prefixV2}--tableofcontents__navbar`
+    );
+  }
+
+  /**
+   * Stores references to TOC sub-elements that are relevant to current viewport
+   * dimensions.
+   */
+  _updateTableOfContentsRefs() {
+    const { tableOfContents: toc } = this._elements;
+    this._updateRefsV1orV2(
+      toc,
+      this._updateTableOfContentsRefsV1,
+      this._updateTableOfContentsRefsV2
+    );
+  }
+
   set banner(component) {
     if (this._validateComponent(component, `${ddsPrefix}-universal-banner`)) {
       this._elements.banner = component;
@@ -138,15 +242,13 @@ class StickyHeader {
       this._validateComponent(component, `${ddsPrefix}-leadspace-with-search`)
     ) {
       this._elements.leadspaceSearch = component;
-      const leadspaceSearchBar = component.shadowRoot.querySelector(
-        `.${prefix}--search-container`
-      );
-      this._elements.leadspaceSearchBar = leadspaceSearchBar;
-      this._elements.leadspaceSearchInput = component.querySelector(
-        `${ddsPrefix}-search-with-typeahead`
+      this._updateRefsV1orV2(
+        component,
+        this._updateLeadspaceRefsV1,
+        this._updateLeadspaceRefsV2
       );
       this._state.leadspaceSearchThreshold =
-        parseInt(window.getComputedStyle(leadspaceSearchBar).paddingBottom) -
+        parseInt(window.getComputedStyle(this._elements.leadspaceSearchBar).paddingBottom) -
         16;
       this._manageStickyElements();
     }
@@ -162,14 +264,13 @@ class StickyHeader {
   set masthead(component) {
     if (this._validateComponent(component, `${ddsPrefix}-masthead`)) {
       this._elements.masthead = component;
-      if (this._elements.banner)
+      if (this._elements.banner) {
         this._elements.masthead.setAttribute('with-banner', '');
-
-      this._elements.mastheadL0 = component.shadowRoot.querySelector(
-        `.${prefix}--masthead__l0`
-      );
-      this._elements.mastheadL1 = component.querySelector(
-        `${ddsPrefix}-masthead-l1`
+      }
+      this._updateRefsV1orV2(
+        component,
+        this._updateMastheadRefsV1,
+        this._updateMastheadRefsV2
       );
       this._manageStickyElements();
     }

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -75,7 +75,17 @@ class StickyHeader {
   _validateComponent(component, expected) {
     const received = component.tagName.toLowerCase();
     if (received !== expected) {
-      throw new TypeError(`${expected} expected, ${received} provided`);
+      // TODO: don't check for v1/v2 compatibility after v1 EOL.
+      if (received.split('-').splice(1).join('-') !== expected.split('-').splice(1).join('-')) {
+        throw new TypeError(`${expected} expected, ${received} provided`);
+      } else {
+        const message = [
+          `Mixed prefixes detected.\n`,
+          `expected ${expected}, found ${received}.`
+        ];
+        console.warn(message.join(''));
+        return true;
+      }
     } else {
       return true;
     }

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -14,7 +14,7 @@ const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;
 
 const c4dPrefix = 'c4d';
-const prefixV2 = 'cds';
+const cdsPrefix = 'cds';
 
 const gridBreakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
 
@@ -138,7 +138,7 @@ class StickyHeader {
 
     this._elements.leadspaceSearchBar =
       leadspaceSearch.shadowRoot.querySelector(
-        `.${prefixV2}--search-container`
+        `.${cdsPrefix}--search-container`
       );
     this._elements.leadspaceSearchInput = leadspaceSearch.querySelector(
       `${c4dPrefix}-search-with-typeahead`
@@ -164,7 +164,7 @@ class StickyHeader {
   _updateMastheadRefsV2() {
     const { masthead } = this._elements;
     this._elements.mastheadL0 = masthead.shadowRoot.querySelector(
-      `.${prefixV2}--masthead__l0`
+      `.${cdsPrefix}--masthead__l0`
     );
     this._elements.mastheadL1 = masthead.querySelector(
       `${c4dPrefix}-masthead-l1`
@@ -205,7 +205,7 @@ class StickyHeader {
     this._elements.tableOfContentsInnerBar = tocRoot.querySelector(
       window.innerWidth >= gridBreakpoint && toc?.layout !== 'horizontal'
         ? `.${c4dPrefix}-ce--table-of-contents__items-container`
-        : `.${prefixV2}--tableofcontents__navbar`
+        : `.${cdsPrefix}--tableofcontents__navbar`
     );
   }
 

--- a/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
+++ b/packages/utilities/src/utilities/StickyHeader/StickyHeader.js
@@ -166,7 +166,7 @@ class StickyHeader {
   _updateMastheadRefsV2() {
     const { masthead } = this._elements;
     this._elements.mastheadL0 = masthead.shadowRoot.querySelector(
-      `.${prefix}--masthead__l0`
+      `.${prefixV2}--masthead__l0`
     );
     this._elements.mastheadL1 = masthead.querySelector(
       `${c4dPrefix}-masthead-l1`


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-5224](https://jsw.ibm.com/browse/ADCMS-5224)

### Description

The StickyHeader utility validates all components it tracks, prior to this PR is expects the provided element's `tagName` to match `${ddsPrefix}-component-name`. This works when all components are using the same prefix, but as we work on upgrading from v1 to v2 we'll need to mix-and-match prefixes. This PR will allow the StickyHeader to continue working despite the prefix differences

### Changelog

**Changed**

- allows StickyHeader to validate (with a warning) components that have unexpected prefixes.