### PR TITLE
fix(toast-notification): remove divs duplicated on lines 36 and 47

### DIFF
--- a/packages/carbon-web-components/src/components/notification/toast-notification.ts
+++ b/packages/carbon-web-components/src/components/notification/toast-notification.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -55,13 +55,8 @@ class CDSToastNotification extends CDSInlineNotification {
   caption = '';
 
   render() {
-    const { _type: type } = this;
     return html`
-      ${this._renderIcon()}
-      <div class="${prefix}--${type}-notification__details">
-        ${this._renderText()}
-      </div>
-      ${this._renderButton()}
+      ${this._renderIcon()} ${this._renderText()} ${this._renderButton()}
     `;
   }
 


### PR DESCRIPTION
### Description

This PR removes the duplicate `div` with `class="${prefix}--${type}-notification__details"` that wraps the notification content. The duplication results in the class being applied twice, causing the style `margin-inline-end: 1rem;` to be applied twice.

![image](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/assets/7409239/8b5e2b6a-4797-46fc-8025-8f98b70fec37)

### Changelog

**Removed**

- Duplicate div wrapping notification content
