### PR TITLE
fix(code-snippet): improve copy button overlay presentation

### DIFF
--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.scss
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.scss
@@ -100,6 +100,7 @@ $css--plex: true !default;
   .#{$prefix}--snippet-container {
     display: flex;
     align-items: start;
+    order: initial;
     overflow: hidden;
     position: relative;
     height: auto;

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.scss
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.scss
@@ -93,12 +93,17 @@ $css--plex: true !default;
     }
   }
 
+  .#{$prefix}--snippet-button {
+    z-index: 1;
+  }
+
   .#{$prefix}--snippet-container {
     display: block;
     overflow: hidden;
     position: relative;
     height: auto;
     padding-bottom: 0;
+    padding-right: $carbon--spacing-07;
     max-height: rem(238px);
     min-height: rem(56px);
     transition: max-height $duration--moderate-01 motion(standard, productive);

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.scss
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.scss
@@ -103,7 +103,7 @@ $css--plex: true !default;
     position: relative;
     height: auto;
     padding-bottom: 0;
-    padding-right: $carbon--spacing-07;
+    padding-right: $carbon--spacing-06;
     max-height: rem(238px);
     min-height: rem(56px);
     transition: max-height $duration--moderate-01 motion(standard, productive);

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.scss
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.scss
@@ -98,7 +98,8 @@ $css--plex: true !default;
   }
 
   .#{$prefix}--snippet-container {
-    display: block;
+    display: flex;
+    align-items: start;
     overflow: hidden;
     position: relative;
     height: auto;
@@ -127,11 +128,17 @@ $css--plex: true !default;
 
   .#{$prefix}-ce--snippet-container--expanded {
     max-height: rem(1500px);
+    overflow: auto;
     transition: max-height $duration--moderate-01 motion(standard, productive);
 
     pre {
       overflow-x: auto;
     }
+  }
+
+  .#{$prefix}--snippet__overflow-indicator--right {
+    right: 0;
+    width: $carbon--spacing-10;
   }
 }
 

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.scss
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.scss
@@ -103,7 +103,7 @@ $css--plex: true !default;
     position: relative;
     height: auto;
     padding-bottom: 0;
-    padding-right: $carbon--spacing-06;
+    padding-right: $carbon--spacing-08;
     max-height: rem(238px);
     min-height: rem(56px);
     transition: max-height $duration--moderate-01 motion(standard, productive);

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -319,11 +319,7 @@ class BXCodeSnippet extends FocusMixin(LitElement) {
         showFeedback: showCopyButtonFeedback,
         handleClickButton: handleClickCopyButton,
         className: `${prefix}--snippet ${prefix}--snippet--inline`,
-        children: html`
-          <code aria-label="${codeAssistiveText}">
-            <slot @slotchange="${handleSlotChange}"></slot>
-          </code>
-        `,
+        children: html`<code aria-label="${codeAssistiveText}"><slot @slotchange="${handleSlotChange}"></slot></code>`,
       })}
     `;
   }

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -34,6 +34,7 @@ class BXCodeSnippet extends FocusMixin(LitElement) {
   /**
    * `true` to expand multi-line variant of code snippet.
    */
+  @state()
   private _expanded = false;
 
   /**
@@ -104,7 +105,6 @@ class BXCodeSnippet extends FocusMixin(LitElement) {
    */
   private _handleClickExpando() {
     this._expanded = !this._expanded;
-    this.requestUpdate();
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

Closes #11872

### Description

The `<bx-code-snippet>` copy button is positioned absolutely, creating scenarios where it can overlay text in the component body. Giving it a greater `z-index` value allows it to sit atop the text rather than gets mashed into the text.

### Changelog

**Changed**

- Prevents `<bx-code-snippet>` copy button from obscuring component text and becoming difficult to identify in certain scenarios.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
