### PR TITLE
feat(pricing-table): add shadow parts

### DIFF
--- a/packages/web-components/src/components/pricing-table/pricing-table-annotation-toggle.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-annotation-toggle.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,6 +18,12 @@ import C4DPricingTableRow from './pricing-table-row';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 const { stablePrefix: c4dPrefix } = settings;
+
+/**
+ * @element c4d-pricing-table-annotation-toggle
+ *
+ * @csspart button - The button. Usage `c4d-pricing-table-annotation-toggle::part(button)`
+ */
 
 @customElement(`${c4dPrefix}-pricing-table-annotation-toggle`)
 class C4DPricingTableAnnotationToggle extends StableSelectorMixin(LitElement) {
@@ -55,6 +61,7 @@ class C4DPricingTableAnnotationToggle extends StableSelectorMixin(LitElement) {
     const { toggled } = this;
     return html`
       <button
+        part="button"
         @click="${this._handleClick}"
         type="button"
         aria-pressed="${toggled}"

--- a/packages/web-components/src/components/pricing-table/pricing-table-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-cell.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,13 @@ import C4DPricingTableCellAnnotation from './pricing-table-cell-annotation';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 const { prefix, stablePrefix: c4dPrefix } = settings;
+
+/**
+ * @element c4d-pricing-table-cell
+ *
+ * @csspart inner-cell - The inner cell. Usage `c4d-pricing-table-cell::part(inner-cell)`
+ * @csspart content-cell - The content cell. Usage `c4d-pricing-table-cell::part(content-cell)`
+ */
 
 @customElement(`${c4dPrefix}-pricing-table-cell`)
 class C4DPricingTableCell extends StableSelectorMixin(
@@ -69,8 +76,8 @@ class C4DPricingTableCell extends StableSelectorMixin(
 
   render() {
     return html`
-      <div class="${prefix}--pricing-table-cell-inner">
-        <div class="${prefix}--pricing-table-cell-content">
+      <div class="${prefix}--pricing-table-cell-inner" part="inner-cell">
+        <div class="${prefix}--pricing-table-cell-content" part="content-cell">
           ${super.render()}
         </div>
         <slot name="toggle"></slot>

--- a/packages/web-components/src/components/pricing-table/pricing-table-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-cell.ts
@@ -23,8 +23,8 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
 /**
  * @element c4d-pricing-table-cell
  *
- * @csspart inner-cell - The inner cell. Usage `c4d-pricing-table-cell::part(inner-cell)`
- * @csspart content-cell - The content cell. Usage `c4d-pricing-table-cell::part(content-cell)`
+ * @csspart container - The cell container. Usage `c4d-pricing-table-cell::part(container)`
+ * @csspart content - The cell content. Usage `c4d-pricing-table-cell::part(content)`
  */
 
 @customElement(`${c4dPrefix}-pricing-table-cell`)

--- a/packages/web-components/src/components/pricing-table/pricing-table-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-cell.ts
@@ -76,8 +76,8 @@ class C4DPricingTableCell extends StableSelectorMixin(
 
   render() {
     return html`
-      <div class="${prefix}--pricing-table-cell-inner" part="inner-cell">
-        <div class="${prefix}--pricing-table-cell-content" part="content-cell">
+      <div class="${prefix}--pricing-table-cell-inner" part="container">
+        <div class="${prefix}--pricing-table-cell-content" part="content">
           ${super.render()}
         </div>
         <slot name="toggle"></slot>

--- a/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
@@ -71,10 +71,10 @@ class C4DPricingTableHeaderCell extends StableSelectorMixin(
           </div>
         `
       : html`
-          <div class="${prefix}--pricing-table-cell-inner" part="inner-cell">
+          <div class="${prefix}--pricing-table-cell-inner" part="content-container">
             <div
               class="${prefix}--pricing-table-cell-content"
-              part="content-cell">
+              part="content">
               ${super.render()}
             </div>
           </div>

--- a/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
@@ -51,7 +51,7 @@ class C4DPricingTableHeaderCell extends StableSelectorMixin(
               <slot name="highlight-label"></slot>
               <slot name="headline"></slot>
               <slot name="caption"></slot>
-              <div class="${tagWrapperSelector}" part="wrapper">
+              <div class="${tagWrapperSelector}" part="tag-wrapper">
                 <slot name="tag"></slot>
               </div>
               <div

--- a/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
@@ -46,7 +46,7 @@ class C4DPricingTableHeaderCell extends StableSelectorMixin(
       ? html`
           <div
             class="${prefix}--pricing-table-header-cell-inner"
-            part="header-cell">
+            part="container">
             <div part="heading">
               <slot name="highlight-label"></slot>
               <slot name="headline"></slot>

--- a/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
@@ -71,10 +71,10 @@ class C4DPricingTableHeaderCell extends StableSelectorMixin(
           </div>
         `
       : html`
-          <div class="${prefix}--pricing-table-cell-inner" part="content-container">
-            <div
-              class="${prefix}--pricing-table-cell-content"
-              part="content">
+          <div
+            class="${prefix}--pricing-table-cell-inner"
+            part="content-container">
+            <div class="${prefix}--pricing-table-cell-content" part="content">
               ${super.render()}
             </div>
           </div>

--- a/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
@@ -56,10 +56,10 @@ class C4DPricingTableHeaderCell extends StableSelectorMixin(
               </div>
               <div
                 class="${prefix}--pricing-table-cell-inner"
-                part="inner-cell">
+                part="content-container">
                 <div
                   class="${prefix}--pricing-table-cell-content"
-                  part="content-cell">
+                  part="content">
                   <slot></slot>
                 </div>
                 <slot name="toggle"></slot>

--- a/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
@@ -47,7 +47,7 @@ class C4DPricingTableHeaderCell extends StableSelectorMixin(
           <div
             class="${prefix}--pricing-table-header-cell-inner"
             part="container">
-            <div part="heading">
+            <div part="heading-container">
               <slot name="highlight-label"></slot>
               <slot name="headline"></slot>
               <slot name="caption"></slot>

--- a/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
@@ -21,11 +21,11 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
 /**
  * @element c4d-pricing-table-header-cell
  *
- * @csspart header-cell - The header cell. Usage `c4d-pricing-table-header-cell::part(header-cell)`
- * @csspart heading - The heading. Usage `c4d-pricing-table-header-cell::part(heading)`
- * @csspart wrapper - The wrapper. Usage `c4d-pricing-table-header-cell::part(wrapper)`
- * @csspart inner-cell - The inner cell. Usage `c4d-pricing-table-header-cell::part(inner-cell)`
- * @csspart content-cell - The content cell. Usage `c4d-pricing-table-header-cell::part(content-cell)`
+ * @csspart container - The cell container. Usage `c4d-pricing-table-header-cell::part(container)`
+ * @csspart heading-container - The heading area container. Usage `c4d-pricing-table-header-cell::part(heading-container)`
+ * @csspart tag-wrapper - A wrapper around the tags. Usage `c4d-pricing-table-header-cell::part(tag-wrapper)`
+ * @csspart content-container - The content area container. Usage `c4d-pricing-table-header-cell::part(content-container)`
+ * @csspart content - The cell content. Usage `c4d-pricing-table-header-cell::part(content)`
  * @csspart cta - The action. Usage `c4d-pricing-table-header-cell::part(cta)`
  */
 

--- a/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table-header-cell.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,6 +18,17 @@ import { carbonElement as customElement } from '../../internal/vendor/@carbon/we
 
 const { prefix, stablePrefix: c4dPrefix } = settings;
 
+/**
+ * @element c4d-pricing-table-header-cell
+ *
+ * @csspart header-cell - The header cell. Usage `c4d-pricing-table-header-cell::part(header-cell)`
+ * @csspart heading - The heading. Usage `c4d-pricing-table-header-cell::part(heading)`
+ * @csspart wrapper - The wrapper. Usage `c4d-pricing-table-header-cell::part(wrapper)`
+ * @csspart inner-cell - The inner cell. Usage `c4d-pricing-table-header-cell::part(inner-cell)`
+ * @csspart content-cell - The content cell. Usage `c4d-pricing-table-header-cell::part(content-cell)`
+ * @csspart cta - The action. Usage `c4d-pricing-table-header-cell::part(cta)`
+ */
+
 @customElement(`${c4dPrefix}-pricing-table-header-cell`)
 class C4DPricingTableHeaderCell extends StableSelectorMixin(
   C4DStructuredListHeaderCell
@@ -33,29 +44,37 @@ class C4DPricingTableHeaderCell extends StableSelectorMixin(
 
     return type === PRICING_TABLE_HEADER_CELL_TYPES.COMPLEX
       ? html`
-          <div class="${prefix}--pricing-table-header-cell-inner">
-            <div>
+          <div
+            class="${prefix}--pricing-table-header-cell-inner"
+            part="header-cell">
+            <div part="heading">
               <slot name="highlight-label"></slot>
               <slot name="headline"></slot>
               <slot name="caption"></slot>
-              <div class="${tagWrapperSelector}">
+              <div class="${tagWrapperSelector}" part="wrapper">
                 <slot name="tag"></slot>
               </div>
-              <div class="${prefix}--pricing-table-cell-inner">
-                <div class="${prefix}--pricing-table-cell-content">
+              <div
+                class="${prefix}--pricing-table-cell-inner"
+                part="inner-cell">
+                <div
+                  class="${prefix}--pricing-table-cell-content"
+                  part="content-cell">
                   <slot></slot>
                 </div>
                 <slot name="toggle"></slot>
               </div>
             </div>
-            <div>
+            <div part="cta">
               <slot name="cta"></slot>
             </div>
           </div>
         `
       : html`
-          <div class="${prefix}--pricing-table-cell-inner">
-            <div class="${prefix}--pricing-table-cell-content">
+          <div class="${prefix}--pricing-table-cell-inner" part="inner-cell">
+            <div
+              class="${prefix}--pricing-table-cell-content"
+              part="content-cell">
               ${super.render()}
             </div>
           </div>

--- a/packages/web-components/src/components/pricing-table/pricing-table.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table.ts
@@ -25,7 +25,10 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
 
 /**
  * @element c4d-pricing-table
- * @csspart section - The list section. Usage `c4d-pricing-table::part(section)`
+ * @csspart container - The table container. Usage `c4d-pricing-table::part(container)`
+ * @csspart sentinel - A sentinel node. Usage `c4d-pricing-table::part(sentinel)`
+ * @csspart start-sentinel - The start sentinel. Usage `c4d-pricing-table::part(start-sentinel)`
+ * @csspart end-sentinel - The end sentinel. Usage `c4d-pricing-table::part(end-sentinel)`
  */
 
 @customElement(`${c4dPrefix}-pricing-table`)

--- a/packages/web-components/src/components/pricing-table/pricing-table.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -22,6 +22,11 @@ import C4DPricingTableHeaderRow from './pricing-table-header-row';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 
 const { prefix, stablePrefix: c4dPrefix } = settings;
+
+/**
+ * @element c4d-pricing-table
+ * @csspart section - The list section. Usage `c4d-pricing-table::part(section)`
+ */
 
 @customElement(`${c4dPrefix}-pricing-table`)
 class C4DPricingTable extends HostListenerMixin(
@@ -175,7 +180,10 @@ class C4DPricingTable extends HostListenerMixin(
     const { sentinelClass } = this.constructor as typeof C4DPricingTable;
 
     return html`
-      <section id="section" class="${`${prefix}--structured-list`}">
+      <section
+        id="section"
+        class="${`${prefix}--structured-list`}"
+        part="section">
         <span class="${sentinelClass}" id="start-sentinel"></span>
         <slot></slot>
         <span class="${sentinelClass}" id="end-sentinel"></span>

--- a/packages/web-components/src/components/pricing-table/pricing-table.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table.ts
@@ -183,7 +183,7 @@ class C4DPricingTable extends HostListenerMixin(
       <section
         id="section"
         class="${`${prefix}--structured-list`}"
-        part="section">
+        part="container">
         <span class="${sentinelClass}" id="start-sentinel"></span>
         <slot></slot>
         <span class="${sentinelClass}" id="end-sentinel"></span>

--- a/packages/web-components/src/components/pricing-table/pricing-table.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table.ts
@@ -187,9 +187,15 @@ class C4DPricingTable extends HostListenerMixin(
         id="section"
         class="${`${prefix}--structured-list`}"
         part="container">
-        <span class="${sentinelClass}" id="start-sentinel" part="sentinel start-sentinel"></span>
+        <span
+          class="${sentinelClass}"
+          id="start-sentinel"
+          part="sentinel start-sentinel"></span>
         <slot></slot>
-        <span class="${sentinelClass}" id="end-sentinel" part="sentinel end-sentinel"></span>
+        <span
+          class="${sentinelClass}"
+          id="end-sentinel"
+          part="sentinel end-sentinel"></span>
       </section>
     `;
   }

--- a/packages/web-components/src/components/pricing-table/pricing-table.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table.ts
@@ -184,9 +184,9 @@ class C4DPricingTable extends HostListenerMixin(
         id="section"
         class="${`${prefix}--structured-list`}"
         part="container">
-        <span class="${sentinelClass}" id="start-sentinel"></span>
+        <span class="${sentinelClass}" id="start-sentinel" part="sentinel start-sentinel"></span>
         <slot></slot>
-        <span class="${sentinelClass}" id="end-sentinel"></span>
+        <span class="${sentinelClass}" id="end-sentinel" part="sentinel end-sentinel"></span>
       </section>
     `;
   }


### PR DESCRIPTION
[ADCMS-5173](https://jsw.ibm.com/browse/ADCMS-5173)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "pricing-table" component.

Changelog

New

Adding the shadow parts for the "pricing-table" component and documentation