### PR TITLE
feat(accordion): add shadow parts

### DIFF
--- a/packages/carbon-web-components/src/components/accordion/accordion-item-skeleton.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion-item-skeleton.ts
@@ -21,13 +21,14 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 class CDSAccordionItemSkeleton extends LitElement {
   render() {
     return html`
-      <span class="${prefix}--accordion__heading">
+      <span class="${prefix}--accordion__heading" part="expando">
         ${ChevronRight16({
           part: 'expando-icon',
           class: `${prefix}--accordion__arrow`,
         })}
         <cds-skeleton-text
-          class="${prefix}--accordion__title"></cds-skeleton-text>
+          class="${prefix}--accordion__title"
+          part="title"></cds-skeleton-text>
       </span>
     `;
   }

--- a/packages/carbon-web-components/src/components/accordion/accordion-item-skeleton.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion-item-skeleton.ts
@@ -16,6 +16,10 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 
 /**
  * Skeleton of accordion item.
+ *
+ * @csspart expando - The element that toggles the accordion open and closed. Usage: `cds-accordion-item-skeleton::part(expando)`
+ * @csspart expando-icon - The icon in the toggle. Usage: `cds-accordion-item-skeleton::part(expando-icon)`
+ * @csspart title - The title text in the toggle. Usage: `cds-accordion-item-skeleton::part(title)`
  */
 @customElement(`${prefix}-accordion-item-skeleton`)
 class CDSAccordionItemSkeleton extends LitElement {

--- a/packages/carbon-web-components/src/components/accordion/accordion-item.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -225,7 +225,7 @@ class CDSAccordionItem extends FocusMixin(LitElement) {
           <slot name="title">${title}</slot>
         </div>
       </button>
-      <div class="${prefix}--accordion__wrapper">
+      <div class="${prefix}--accordion__wrapper" part="content-wrapper">
         <div id="content" part="content" class="${contentClasses}">
           <slot></slot>
         </div>

--- a/packages/carbon-web-components/src/components/accordion/accordion-item.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion-item.ts
@@ -47,10 +47,11 @@ const observeResize = (observer: ResizeObserver, elem: Element) => {
  *   The custom event fired before this accordion item is being toggled upon a user gesture.
  *   Cancellation of this event stops the user-initiated action of toggling this accordion item.
  * @fires cds-accordion-item-toggled - The custom event fired after this accordion item is toggled upon a user gesture.
- * @csspart expando The expando button.
- * @csspart expando-icon The expando icon.
- * @csspart title The title.
- * @csspart content The content.
+ * @csspart expando - The element that toggles the accordion open and closed. Usage: `cds-accordion-item::part(expando)`
+ * @csspart expando-icon - The icon in the toggle. Usage: `cds-accordion-item::part(expando-icon)`
+ * @csspart title - The title text in the toggle. Usage: `cds-accordion-item::part(title)`
+ * @csspart content-wrapper - The element that wraps the content. Usage: `cds-accordion-item::part(content-wrapper)`
+ * @csspart content - The accordion content. Usage: `cds-accordion-item::part(content)`
  */
 @customElement(`${prefix}-accordion-item`)
 class CDSAccordionItem extends FocusMixin(LitElement) {

--- a/packages/carbon-web-components/src/components/accordion/accordion-skeleton.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion-skeleton.ts
@@ -20,6 +20,15 @@ import styles from './accordion.scss';
 
 /**
  * Skeleton of code snippet.
+ *
+ * @csspart item - A skeleton accordion item. Usage: `cds-accordion-skeleton::part(item)`
+ * @csspart item-open - An open skeleton accordion item. Usage: `cds-accordion-skeleton::part(item-open)`
+ * @csspart item-closed - A closed skeleton accordion item. Usage: `cds-accordion-skeleton::part(item-closed)`
+ * @csspart expando - An element that toggles its accordion open and closed. Usage: `cds-accordion-skeleton::part(expando)`
+ * @csspart expando-icon - The icon in a toggle. Usage: `cds-accordion-skeleton::part(expando-icon)`
+ * @csspart title - The title text in a toggle. Usage: `cds-accordion-skeleton::part(title)`
+ * @csspart content - An accordion item's content area. Usage: `cds-accordion-skeleton::part(content)`
+ * @csspart text - The text in an accordion item's content area. Usage: `cds-accordion-skeleton::part(text)`
  */
 @customElement(`${prefix}-accordion-skeleton`)
 class CDSAccordionSkeleton extends LitElement {

--- a/packages/carbon-web-components/src/components/accordion/accordion-skeleton.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion-skeleton.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -91,19 +91,20 @@ class CDSAccordionSkeleton extends LitElement {
     return html`
       ${this.open
         ? html`
-            <li class="${classes}">
-              <span class="${prefix}--accordion__heading">
+            <li class="${classes}" part="item item-open">
+              <span class="${prefix}--accordion__heading" part="expando">
                 ${ChevronRight16({
                   part: 'expando-icon',
                   class: `${prefix}--accordion__arrow`,
                 })}
                 <cds-skeleton-text
-                  class="${prefix}--accordion__title"></cds-skeleton-text>
+                  class="${prefix}--accordion__title"
+                  part="title"></cds-skeleton-text>
               </span>
-              <div class="${prefix}--accordion__content">
-                <cds-skeleton-text width="90%"></cds-skeleton-text>
-                <cds-skeleton-text width="80%"></cds-skeleton-text>
-                <cds-skeleton-text width="85%"></cds-skeleton-text>
+              <div class="${prefix}--accordion__content" part="content">
+                <cds-skeleton-text width="90%" part="text"></cds-skeleton-text>
+                <cds-skeleton-text width="80%" part="text"></cds-skeleton-text>
+                <cds-skeleton-text width="85%" part="text"></cds-skeleton-text>
               </div>
             </li>
           `
@@ -112,7 +113,8 @@ class CDSAccordionSkeleton extends LitElement {
         (_, index) =>
           html`
             <cds-accordion-item-skeleton
-              key=${index}></cds-accordion-item-skeleton>
+              key=${index}
+              part="item item-closed"></cds-accordion-item-skeleton>
           `
       )}
     `;

--- a/packages/carbon-web-components/tests/snapshots/cds-combo-box.md
+++ b/packages/carbon-web-components/tests/snapshots/cds-combo-box.md
@@ -7,31 +7,27 @@
 ```
 <label
   class="cds--label"
+  for="trigger-button"
   hidden=""
+  id="dropdown-label"
   part="title-text"
 >
   <slot name="title-text">
   </slot>
 </label>
-<div
-  class="cds--combo-box cds--dropdown cds--list-box cds--list-box--md"
-  role="listbox"
->
+<div class="cds--combo-box cds--dropdown cds--list-box cds--list-box--md">
   <div
-    aria-controls="menu-body"
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-labelledby="trigger-label"
-    aria-owns="menu-body"
     class="cds--list-box__field"
     part="trigger-button"
   >
     <input
+      aria-activedescendant=""
       aria-autocomplete="list"
       aria-controls="menu-body"
-      aria-label=""
+      aria-expanded="false"
+      aria-haspopup="listbox"
       class="cds--text-input cds--text-input--empty"
-      id="trigger-label"
+      id="trigger-button"
       placeholder=""
       role="combobox"
     >
@@ -41,8 +37,23 @@
     >
     </div>
   </div>
-  <slot name="slug">
+  <slot
+    class="cds--slug--revert"
+    name="slug"
+  >
   </slot>
+  <div
+    aria-labelledby="dropdown-label"
+    class="cds--list-box__menu"
+    hidden=""
+    id="menu-body"
+    part="menu-body"
+    role="listbox"
+    tabindex="-1"
+  >
+    <slot>
+    </slot>
+  </div>
 </div>
 <div
   class="cds--form__helper-text"
@@ -52,13 +63,6 @@
   <slot name="helper-text">
   </slot>
 </div>
-<div
-  aria-live="assertive"
-  aria-relevant="additions text"
-  class="cds--assistive-text"
-  role="status"
->
-</div>
 
 ```
 
@@ -67,7 +71,9 @@
 ```
 <label
   class="cds--label cds--label--disabled"
+  for="trigger-button"
   hidden=""
+  id="dropdown-label"
   part="title-text"
 >
   <slot name="title-text">
@@ -76,24 +82,20 @@
 <div
   class="cds--combo-box cds--dropdown cds--dropdown--invalid cds--list-box cds--list-box--disabled cds--list-box--md"
   data-invalid=""
-  role="listbox"
 >
   <div
-    aria-controls="menu-body"
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-labelledby="trigger-label"
-    aria-owns="menu-body"
     class="cds--list-box__field"
     part="trigger-button"
   >
     <input
+      aria-activedescendant=""
       aria-autocomplete="list"
       aria-controls="menu-body"
-      aria-label=""
+      aria-expanded="false"
+      aria-haspopup="listbox"
       class="cds--text-input"
       disabled=""
-      id="trigger-label"
+      id="trigger-button"
       placeholder=""
       role="combobox"
     >
@@ -103,8 +105,23 @@
     >
     </div>
   </div>
-  <slot name="slug">
+  <slot
+    class="cds--slug--revert"
+    name="slug"
+  >
   </slot>
+  <div
+    aria-labelledby="dropdown-label"
+    class="cds--list-box__menu"
+    hidden=""
+    id="menu-body"
+    part="menu-body"
+    role="listbox"
+    tabindex="-1"
+  >
+    <slot>
+    </slot>
+  </div>
 </div>
 <div
   class="cds--form__helper-text cds--form__helper-text--disabled"
@@ -112,13 +129,6 @@
 >
   <slot name="helper-text">
   </slot>
-</div>
-<div
-  aria-live="assertive"
-  aria-relevant="additions text"
-  class="cds--assistive-text"
-  role="status"
->
 </div>
 
 ```

--- a/packages/carbon-web-components/tests/snapshots/cds-dropdown.md
+++ b/packages/carbon-web-components/tests/snapshots/cds-dropdown.md
@@ -7,25 +7,25 @@
 ```
 <label
   class="cds--label"
+  for="trigger-button"
   hidden=""
+  id="dropdown-label"
   part="title-text"
 >
   <slot name="title-text">
   </slot>
 </label>
-<div
-  class="cds--dropdown cds--list-box cds--list-box--md"
-  role="listbox"
->
+<div class="cds--dropdown cds--list-box cds--list-box--md">
   <div
+    aria-activedescendant=""
     aria-controls="menu-body"
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-labelledby="trigger-label"
-    aria-owns="menu-body"
+    aria-labelledby="dropdown-label"
     class="cds--list-box__field"
+    id="trigger-button"
     part="trigger-button"
-    role="button"
+    role="combobox"
     tabindex="0"
   >
     <span
@@ -39,8 +39,23 @@
     >
     </div>
   </div>
-  <slot name="slug">
+  <slot
+    class="cds--slug--revert"
+    name="slug"
+  >
   </slot>
+  <div
+    aria-labelledby="dropdown-label"
+    class="cds--list-box__menu"
+    hidden=""
+    id="menu-body"
+    part="menu-body"
+    role="listbox"
+    tabindex="-1"
+  >
+    <slot>
+    </slot>
+  </div>
 </div>
 <div
   class="cds--form__helper-text"
@@ -50,13 +65,6 @@
   <slot name="helper-text">
   </slot>
 </div>
-<div
-  aria-live="assertive"
-  aria-relevant="additions text"
-  class="cds--assistive-text"
-  role="status"
->
-</div>
 
 ```
 
@@ -65,25 +73,25 @@
 ```
 <label
   class="cds--label cds--label--disabled"
+  for="trigger-button"
   hidden=""
+  id="dropdown-label"
   part="title-text"
 >
   <slot name="title-text">
   </slot>
 </label>
-<div
-  class="cds--dropdown cds--list-box cds--list-box--disabled cds--list-box--expanded cds--list-box--md"
-  role="listbox"
->
+<div class="cds--dropdown cds--list-box cds--list-box--disabled cds--list-box--expanded cds--list-box--md">
   <div
+    aria-activedescendant="cds-dropdown-item-6"
     aria-controls="menu-body"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="trigger-label"
-    aria-owns="menu-body"
+    aria-labelledby="dropdown-label"
     class="cds--list-box__field"
+    id="trigger-button"
     part="trigger-button"
-    role="button"
+    role="combobox"
     tabindex="0"
   >
     <span
@@ -97,10 +105,13 @@
     >
     </div>
   </div>
-  <slot name="slug">
+  <slot
+    class="cds--slug--revert"
+    name="slug"
+  >
   </slot>
   <div
-    aria-label=""
+    aria-labelledby="dropdown-label"
     class="cds--list-box__menu"
     id="menu-body"
     part="menu-body"
@@ -118,13 +129,6 @@
   <slot name="helper-text">
     helper-text-foo
   </slot>
-</div>
-<div
-  aria-live="assertive"
-  aria-relevant="additions text"
-  class="cds--assistive-text"
-  role="status"
->
 </div>
 
 ```

--- a/packages/carbon-web-components/tests/snapshots/cds-multi-select.md
+++ b/packages/carbon-web-components/tests/snapshots/cds-multi-select.md
@@ -13,19 +13,17 @@
   <slot name="title-text">
   </slot>
 </label>
-<div
-  class="cds--list-box cds--list-box--md cds--multi-select"
-  role="listbox"
->
+<div class="cds--list-box cds--list-box--md cds--multi-select">
   <div
+    aria-activedescendant=""
     aria-controls="menu-body"
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-labelledby="trigger-label"
-    aria-owns="menu-body"
+    aria-labelledby="dropdown-label"
     class="cds--list-box__field"
+    id="trigger-button"
     part="trigger-button"
-    role="button"
+    role="combobox"
     tabindex="0"
   >
     <span
@@ -39,8 +37,23 @@
     >
     </div>
   </div>
-  <slot name="slug">
+  <slot
+    class="cds--slug--revert"
+    name="slug"
+  >
   </slot>
+  <div
+    aria-labelledby="dropdown-label"
+    class="cds--list-box__menu"
+    hidden=""
+    id="menu-body"
+    part="menu-body"
+    role="listbox"
+    tabindex="-1"
+  >
+    <slot>
+    </slot>
+  </div>
 </div>
 <div
   class="cds--form__helper-text"
@@ -49,13 +62,6 @@
 >
   <slot name="helper-text">
   </slot>
-</div>
-<div
-  aria-live="assertive"
-  aria-relevant="additions text"
-  class="cds--assistive-text"
-  role="status"
->
 </div>
 
 ```
@@ -74,17 +80,17 @@
 <div
   class="cds--list-box cds--list-box--disabled cds--list-box--inline cds--list-box--md cds--multi-select cds--multi-select--inline cds--multi-select--invalid"
   data-invalid=""
-  role="listbox"
 >
   <div
+    aria-activedescendant=""
     aria-controls="menu-body"
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-labelledby="trigger-label"
-    aria-owns="menu-body"
+    aria-labelledby="dropdown-label"
     class="cds--list-box__field"
+    id="trigger-button"
     part="trigger-button"
-    role="button"
+    role="combobox"
     tabindex="0"
   >
     <span
@@ -98,8 +104,23 @@
     >
     </div>
   </div>
-  <slot name="slug">
+  <slot
+    class="cds--slug--revert"
+    name="slug"
+  >
   </slot>
+  <div
+    aria-labelledby="dropdown-label"
+    class="cds--list-box__menu"
+    hidden=""
+    id="menu-body"
+    part="menu-body"
+    role="listbox"
+    tabindex="-1"
+  >
+    <slot>
+    </slot>
+  </div>
 </div>
 <div
   class="cds--form__helper-text cds--form__helper-text--disabled"
@@ -107,13 +128,6 @@
 >
   <slot name="helper-text">
   </slot>
-</div>
-<div
-  aria-live="assertive"
-  aria-relevant="additions text"
-  class="cds--assistive-text"
-  role="status"
->
 </div>
 
 ```

--- a/packages/carbon-web-components/tests/snapshots/cds-number-input.md
+++ b/packages/carbon-web-components/tests/snapshots/cds-number-input.md
@@ -25,7 +25,10 @@
       step="1"
       type="number"
     >
-    <slot name="slug">
+    <slot
+      class="cds--slug--revert"
+      name="slug"
+    >
     </slot>
     <div class="cds--number__controls">
       <button

--- a/packages/carbon-web-components/tests/snapshots/data-table.md
+++ b/packages/carbon-web-components/tests/snapshots/data-table.md
@@ -89,9 +89,7 @@
 <button
   class="cds--table-sort"
   part="sort-button"
-  title="
-      Name
-    "
+  title=""
 >
   <span class="cds--table-sort__flex">
     <span


### PR DESCRIPTION
### Related Ticket(s)

Related to https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/11673

### Description

Makes `<cds-accordion>` family of components' shadow tree elements style-able.

### Changelog

**New**

- Adds `part` attributes to `<cds-accordion>` components' shadow root markup.