### PR TITLE
feat(breadcrumb): add shadow parts

### DIFF
--- a/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-link.ts
+++ b/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-link.ts
@@ -17,6 +17,7 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * Link in breadcrumb.
  *
  * @element cds-breadcrumb-link
+ * @csspart link - The link wrapper. Usage `cds-breadcrumb-link::part(link)`
  */
 @customElement(`${prefix}-breadcrumb-link`)
 class CDSBreadcrumbLink extends CDSLink {
@@ -24,7 +25,7 @@ class CDSBreadcrumbLink extends CDSLink {
     return html`
       ${this.href
         ? super.render()
-        : html`<span class="${prefix}--link"><slot></slot></span>`}
+        : html`<span class="${prefix}--link" part="link"><slot></slot></span>`}
     `;
   }
   static styles = styles;

--- a/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-overflow-menu.ts
+++ b/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-overflow-menu.ts
@@ -18,12 +18,13 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * Overflow menu in breadcrumb.
  *
  * @element cds-breadcrumb-overflow-menu
+ * @csspart icon - The icon. Usage: `cds-breadcrumb-overflow-menu::part(icon)`
  */
 @customElement(`${prefix}-breadcrumb-overflow-menu`)
 class CDSBreadcrumbOverflowMenu extends CDSOverflowMenu {
   render() {
     return html`
-      <slot name="icon">
+      <slot name="icon" part="icon">
         ${OverflowMenuHorizontal16({
           class: `${prefix}--overflow-menu__icon`,
         })}

--- a/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-overflow-menu.ts
+++ b/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-overflow-menu.ts
@@ -18,13 +18,12 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * Overflow menu in breadcrumb.
  *
  * @element cds-breadcrumb-overflow-menu
- * @csspart icon - The icon. Usage: `cds-breadcrumb-overflow-menu::part(icon)`
  */
 @customElement(`${prefix}-breadcrumb-overflow-menu`)
 class CDSBreadcrumbOverflowMenu extends CDSOverflowMenu {
   render() {
     return html`
-      <slot name="icon" part="icon">
+      <slot name="icon">
         ${OverflowMenuHorizontal16({
           class: `${prefix}--overflow-menu__icon`,
         })}

--- a/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-skeleton.ts
+++ b/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-skeleton.ts
@@ -14,7 +14,7 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 
 const renderItem = () => {
   return html`
-    <div class="${prefix}--breadcrumb-item">
+    <div class="${prefix}--breadcrumb-item" part="item">
       <span class="${prefix}--link">&nbsp;</span>
     </div>
   `;
@@ -27,7 +27,7 @@ const renderItem = () => {
 class CDSBreadcrumbSkeleton extends LitElement {
   render() {
     return html`
-      <div class="${prefix}--breadcrumb ${prefix}--skeleton">
+      <div class="${prefix}--breadcrumb ${prefix}--skeleton" part="skeleton">
         ${renderItem()} ${renderItem()} ${renderItem()}
       </div>
     `;

--- a/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-skeleton.ts
+++ b/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-skeleton.ts
@@ -22,6 +22,9 @@ const renderItem = () => {
 
 /**
  * Skeleton of breadcrumb.
+ * @element cds-breadcrumb-skeleton
+ * @csspart skeleton - The breadcrumb skeleton. Usage: `cds-breadcrumb-skeleton::part(skeleton)`
+ * @csspart item - The items. Usage: `cds-breadcrumb-skeleton::part(item)`
  */
 @customElement(`${prefix}-breadcrumb-skeleton`)
 class CDSBreadcrumbSkeleton extends LitElement {

--- a/packages/carbon-web-components/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/carbon-web-components/src/components/breadcrumb/breadcrumb.ts
@@ -18,6 +18,7 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * Breadcrumb.
  *
  * @element cds-breadcrumb
+ * @csspart list - The list HTML element. Usage: `cds-breadcrumb::part(list)`
  */
 @customElement(`${prefix}-breadcrumb`)
 class CDSBreadcrumb extends LitElement {
@@ -40,7 +41,7 @@ class CDSBreadcrumb extends LitElement {
       [`${prefix}--breadcrumb--no-trailing-slash`]: this.noTrailingSlash,
     });
     return html`
-      <ol class="${classes}">
+      <ol class="${classes}" part="list">
         <slot></slot>
       </ol>
     `;


### PR DESCRIPTION
### Related Ticket(s)

[Jira](https://jsw.ibm.com/browse/ADCMS-5309)

### Description

 we should add CSS Shadow Parts to v2 components to allow light customizations to component internals.

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles.

This PR targets the breadcrumbs component
### Changelog

**New**

Adding shadow parts to the breadcrumbs component 
