### PR TITLE
feat(ai-skeleton): add shadow parts

### DIFF
--- a/packages/carbon-web-components/src/components/ai-skeleton/ai-skeleton-icon.ts
+++ b/packages/carbon-web-components/src/components/ai-skeleton/ai-skeleton-icon.ts
@@ -18,6 +18,7 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * AI skeleton icon.
  *
  * @element cds-ai-skeleton-icon
+ * @csspart icon - The icon. Usage `cds-ai-skeleton-icon::part(icon)`
  */
 @customElement(`${prefix}-ai-skeleton-icon`)
 class CDSAISkeletonIcon extends LitElement {
@@ -30,6 +31,7 @@ class CDSAISkeletonIcon extends LitElement {
   render() {
     return html`<cds-skeleton-icon
       class="${prefix}--skeleton__icon--ai"
+      part="icon"
       style="${this.customStyles}"></cds-skeleton-icon>`;
   }
 

--- a/packages/carbon-web-components/src/components/ai-skeleton/ai-skeleton-placeholder.ts
+++ b/packages/carbon-web-components/src/components/ai-skeleton/ai-skeleton-placeholder.ts
@@ -17,12 +17,14 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * AI skeleton placeholder.
  *
  * @element cds-ai-skeleton-placeholder
+ * @csspart placeholder - The placeholder. Usage `cds-ai-skeleton-placeholder::part(placeholder)`
  */
 @customElement(`${prefix}-ai-skeleton-placeholder`)
 class CDSAISkeletonPlaceholder extends LitElement {
   render() {
     return html`<cds-skeleton-placeholder
-      optional-classes="${prefix}--skeleton__placeholder--ai"></cds-skeleton-placeholder>`;
+      optional-classes="${prefix}--skeleton__placeholder--ai"
+      part="placeholder"></cds-skeleton-placeholder>`;
   }
 
   static styles = styles;

--- a/packages/carbon-web-components/src/components/ai-skeleton/ai-skeleton-text.ts
+++ b/packages/carbon-web-components/src/components/ai-skeleton/ai-skeleton-text.ts
@@ -18,6 +18,7 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * AI skeleton text.
  *
  * @element cds-ai-skeleton-text
+ * @csspart text - The text. Usage `cds-ai-skeleton-text::part(text)`
  */
 @customElement(`${prefix}-ai-skeleton-text`)
 class CDSAISkeletonText extends LitElement {
@@ -52,7 +53,8 @@ class CDSAISkeletonText extends LitElement {
       width="${width}"
       linecount="${lineCount}"
       ?paragraph="${paragraph}"
-      optional-classes="${prefix}--skeleton__text--ai"></cds-skeleton-text>`;
+      optional-classes="${prefix}--skeleton__text--ai"
+      part="text"></cds-skeleton-text>`;
   }
 
   static styles = styles;


### PR DESCRIPTION
[ADCMS-5308](https://jsw.ibm.com/browse/ADCMS-5308)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "ai-skeleton" component.

Changelog

New

Adding the shadow parts for the "ai-skeleton" component and documentation.