### PR TITLE
feat(code-snippet): add shadow parts

### DIFF
--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet-skeleton.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet-skeleton.ts
@@ -16,6 +16,9 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 
 /**
  * Skeleton of code snippet.
+ * @element cds-code-snippet-skeleton
+ * @csspart container - The container. Usage: `cds-code-snippet-skeleton::part(container)`
+ * @csspart item - The item. Usage: `cds-code-snippet-skeleton::part(item)`
  */
 @customElement(`${prefix}-code-snippet-skeleton`)
 class CDSCodeSnippetSkeleton extends LitElement {
@@ -27,10 +30,13 @@ class CDSCodeSnippetSkeleton extends LitElement {
 
   render() {
     return html`
-      <div class="${prefix}--snippet-container">
+      <div class="${prefix}--snippet-container" part="container">
         ${this.type !== CODE_SNIPPET_TYPE.MULTI
-          ? html` <span></span> `
-          : html` <span></span><span></span><span></span> `}
+          ? html` <span part="item"></span> `
+          : html`
+              <span part="item"></span><span part="item"></span
+              ><span part="item"></span>
+            `}
       </div>
     `;
   }

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -62,7 +62,7 @@ const observeResize = (observer: ResizeObserver, elem: Element) => {
  * @csspart oveflow-indicator-right - The right side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator-right)`
  * @csspart copy-button - The copy button. Usage: `cds-code-snippet::part(copy-button)`
  * @csspart show-button - The show more/less button Usage: `cds-code-snippet::part(show-button)`
- * @csspart show-button--text - The show more/less button text. Usage: `cds-code-snippet::part(show-button--text)`
+ * @csspart show-button-text - The show more/less button text. Usage: `cds-code-snippet::part(show-button-text)`
  *
  */
 @customElement(`${prefix}-code-snippet`)

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -384,7 +384,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
       // prettier-ignore
       return html`
         <cds-copy button-class-name="${classes}" @click="${handleCopyClick}"  part="inline-copy">
-          <code slot="icon" part="content content-inline"><slot></slot></code>
+          <code slot="icon" part="content content--inline"><slot></slot></code>
           <span slot="tooltip inline-tooltip" part="tooltip">${tooltipContent}</span>
         </cds-copy>
       `;

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -451,7 +451,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
         ? html`
             <div
               class="${prefix}--snippet__overflow-indicator--right"
-              part="oveflow-indicator--right"></div>
+              part="oveflow-indicator-right"></div>
           `
         : ``}
       ${hideCopyButton

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -433,7 +433,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
         aria-multiline="${type === CODE_SNIPPET_TYPE.MULTI ? true : null}"
         @scroll="${(type === CODE_SNIPPET_TYPE.SINGLE && handleScroll) || null}"
         style=${styleMap(styles)}
-        part="container container-${type}">
+        part="container container--${type}">
         <pre
           @scroll="${(type === CODE_SNIPPET_TYPE.MULTI && handleScroll) ||
           null}"

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -437,7 +437,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
         <pre
           @scroll="${(type === CODE_SNIPPET_TYPE.MULTI && handleScroll) ||
           null}"
-          part="pre pre-${type}"><code part="content content-${type}"><slot></slot></code></pre>
+          part="pre pre--${type}"><code part="content content--${type}"><slot></slot></code></pre>
       </div>
 
       ${hasLeftOverflow

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -58,7 +58,7 @@ const observeResize = (observer: ResizeObserver, elem: Element) => {
  * @csspart pre - The pre element for all types Usage: `cds-code-snippet::part(pre)`
  * @csspart pre--multi - The pre element for the multi line type Usage: `cds-code-snippet::part(pre--multi)`
  * @csspart pre--single - The pre element for the single line type. Usage: `cds-code-snippet::part(pre--single)`
- * @csspart oveflow-indicator--eft - The left side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator--left)`
+ * @csspart oveflow-indicator-left - The left side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator-left)`
  * @csspart oveflow-indicator--right - The right side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator--right)`
  * @csspart copy-button - The copy button. Usage: `cds-code-snippet::part(copy-button)`
  * @csspart show-button - The show more/less button Usage: `cds-code-snippet::part(show-button)`

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -46,6 +46,24 @@ const observeResize = (observer: ResizeObserver, elem: Element) => {
  * Basic code snippet.
  *
  * @element cds-code-snippet
+ * @csspart inline-copy - Copy button fot the inline type. covers the entire element. Usage: `cds-code-snippet::part(inline-copy)`
+ * @csspart content - Code tag content for all types. Usage: `cds-code-snippet::part(content)`
+ * @csspart content-inline - The Code tag content for the inline type. Usage: `cds-code-snippet::part(content-inline)`
+ * @csspart content-multi - The Code tag content for the multi line type. Usage: `cds-code-snippet::part(content-multi)`
+ * @csspart content-single - The Code tag content for the single line type. Usage: `cds-code-snippet::part(content-single)`
+ * @csspart tooltip - The tooltip. Usage: `cds-code-snippet::part(tooltip)`
+ * @csspart container - The container for all types. Usage: `cds-code-snippet::part(container)`
+ * @csspart container-multi - The container for multi line type Usage: `cds-code-snippet::part(container-multi)`
+ * @csspart container-single - The container for single line type. Usage: `cds-code-snippet::part(container-single)`
+ * @csspart pre - The pre element for all types Usage: `cds-code-snippet::part(pre)`
+ * @csspart pre-multi - The pre element for the multi line type Usage: `cds-code-snippet::part(pre-multi)`
+ * @csspart pre-single - The pre element for the single line type. Usage: `cds-code-snippet::part(pre-single)`
+ * @csspart oveflow-indicator-left - The left side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator-left)`
+ * @csspart oveflow-indicator-right - The right side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator-right)`
+ * @csspart copy-button - The copy button. Usage: `cds-code-snippet::part(copy-button)`
+ * @csspart show-button - The show more/less button Usage: `cds-code-snippet::part(show-button)`
+ * @csspart show-button-text - The show more/less button text. Usage: `cds-code-snippet::part(show-button-text)`
+ *
  */
 @customElement(`${prefix}-code-snippet`)
 class CDSCodeSnippet extends FocusMixin(LitElement) {
@@ -365,9 +383,9 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
       // Ensures no extra whitespace text node
       // prettier-ignore
       return html`
-        <cds-copy button-class-name="${classes}" @click="${handleCopyClick}">
-          <code slot="icon"><slot></slot></code>
-          <span slot="tooltip-content">${tooltipContent}</span>
+        <cds-copy button-class-name="${classes}" @click="${handleCopyClick}"  part="inline-copy">
+          <code slot="icon" part="content content-inline"><slot></slot></code>
+          <span slot="tooltip inline-tooltip" part="tooltip">${tooltipContent}</span>
         </cds-copy>
       `;
     }
@@ -414,20 +432,26 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
           : null}"
         aria-multiline="${type === CODE_SNIPPET_TYPE.MULTI ? true : null}"
         @scroll="${(type === CODE_SNIPPET_TYPE.SINGLE && handleScroll) || null}"
-        style=${styleMap(styles)}>
+        style=${styleMap(styles)}
+        part="container container-${type}">
         <pre
           @scroll="${(type === CODE_SNIPPET_TYPE.MULTI && handleScroll) ||
-          null}"><code><slot></slot></code></pre>
+          null}"
+          part="pre pre-${type}"><code part="content content-${type}"><slot></slot></code></pre>
       </div>
 
       ${hasLeftOverflow
         ? html`
-            <div class="${prefix}--snippet__overflow-indicator--left"></div>
+            <div
+              class="${prefix}--snippet__overflow-indicator--left"
+              part="oveflow-indicator-left"></div>
           `
         : ``}
       ${hasRightOverflow && type !== CODE_SNIPPET_TYPE.MULTI
         ? html`
-            <div class="${prefix}--snippet__overflow-indicator--right"></div>
+            <div
+              class="${prefix}--snippet__overflow-indicator--right"
+              part="oveflow-indicator-right"></div>
           `
         : ``}
       ${hideCopyButton
@@ -438,7 +462,8 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
               button-class-name=${disabledCopyButtonClasses}
               feedback=${feedback}
               feedback-timeout=${feedbackTimeout}
-              @click="${handleCopyClick}">
+              @click="${handleCopyClick}"
+              part="copy-button">
               ${tooltipContent}
             </cds-copy-button>
           `}
@@ -449,8 +474,11 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
               size="sm"
               button-class-name=${expandButtonClass}
               ?disabled=${disabled}
-              @click=${() => this._handleClickExpanded()}>
-              <span class="${prefix}--snippet-btn--text">
+              @click=${() => this._handleClickExpanded()}
+              part="show-button">
+              <span
+                class="${prefix}--snippet-btn--text"
+                part="show-button-text">
                 ${expandCodeBtnText}
               </span>
               ${ChevronDown16({

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -385,7 +385,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
       return html`
         <cds-copy button-class-name="${classes}" @click="${handleCopyClick}"  part="inline-copy">
           <code slot="icon" part="content content--inline"><slot></slot></code>
-          <span slot="tooltip inline-tooltip" part="tooltip">${tooltipContent}</span>
+          <span slot="tooltip-content" part="tooltip tooltip--inline">${tooltipContent}</span>
         </cds-copy>
       `;
     }

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -48,21 +48,21 @@ const observeResize = (observer: ResizeObserver, elem: Element) => {
  * @element cds-code-snippet
  * @csspart inline-copy - Copy button fot the inline type. covers the entire element. Usage: `cds-code-snippet::part(inline-copy)`
  * @csspart content - Code tag content for all types. Usage: `cds-code-snippet::part(content)`
- * @csspart content-inline - The Code tag content for the inline type. Usage: `cds-code-snippet::part(content-inline)`
- * @csspart content-multi - The Code tag content for the multi line type. Usage: `cds-code-snippet::part(content-multi)`
- * @csspart content-single - The Code tag content for the single line type. Usage: `cds-code-snippet::part(content-single)`
+ * @csspart content--inline - The Code tag content for the inline type. Usage: `cds-code-snippet::part(content--inline)`
+ * @csspart content--multi - The Code tag content for the multi line type. Usage: `cds-code-snippet::part(content--multi)`
+ * @csspart content--single - The Code tag content for the single line type. Usage: `cds-code-snippet::part(content--single)`
  * @csspart tooltip - The tooltip. Usage: `cds-code-snippet::part(tooltip)`
  * @csspart container - The container for all types. Usage: `cds-code-snippet::part(container)`
- * @csspart container-multi - The container for multi line type Usage: `cds-code-snippet::part(container-multi)`
- * @csspart container-single - The container for single line type. Usage: `cds-code-snippet::part(container-single)`
+ * @csspart container--multi - The container for multi line type Usage: `cds-code-snippet::part(container--multi)`
+ * @csspart container--single - The container for single line type. Usage: `cds-code-snippet::part(container--single)`
  * @csspart pre - The pre element for all types Usage: `cds-code-snippet::part(pre)`
- * @csspart pre-multi - The pre element for the multi line type Usage: `cds-code-snippet::part(pre-multi)`
- * @csspart pre-single - The pre element for the single line type. Usage: `cds-code-snippet::part(pre-single)`
- * @csspart oveflow-indicator-left - The left side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator-left)`
- * @csspart oveflow-indicator-right - The right side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator-right)`
+ * @csspart pre--multi - The pre element for the multi line type Usage: `cds-code-snippet::part(pre--multi)`
+ * @csspart pre--single - The pre element for the single line type. Usage: `cds-code-snippet::part(pre--single)`
+ * @csspart oveflow-indicator--eft - The left side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator--left)`
+ * @csspart oveflow-indicator--right - The right side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator--right)`
  * @csspart copy-button - The copy button. Usage: `cds-code-snippet::part(copy-button)`
  * @csspart show-button - The show more/less button Usage: `cds-code-snippet::part(show-button)`
- * @csspart show-button-text - The show more/less button text. Usage: `cds-code-snippet::part(show-button-text)`
+ * @csspart show-button--text - The show more/less button text. Usage: `cds-code-snippet::part(show-button--text)`
  *
  */
 @customElement(`${prefix}-code-snippet`)
@@ -451,7 +451,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
         ? html`
             <div
               class="${prefix}--snippet__overflow-indicator--right"
-              part="oveflow-indicator-right"></div>
+              part="oveflow-indicator--right"></div>
           `
         : ``}
       ${hideCopyButton
@@ -478,7 +478,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
               part="show-button">
               <span
                 class="${prefix}--snippet-btn--text"
-                part="show-button-text">
+                part="show-button--text">
                 ${expandCodeBtnText}
               </span>
               ${ChevronDown16({

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -478,7 +478,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
               part="show-button">
               <span
                 class="${prefix}--snippet-btn--text"
-                part="show-button--text">
+                part="show-button-text">
                 ${expandCodeBtnText}
               </span>
               ${ChevronDown16({

--- a/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/carbon-web-components/src/components/code-snippet/code-snippet.ts
@@ -59,7 +59,7 @@ const observeResize = (observer: ResizeObserver, elem: Element) => {
  * @csspart pre--multi - The pre element for the multi line type Usage: `cds-code-snippet::part(pre--multi)`
  * @csspart pre--single - The pre element for the single line type. Usage: `cds-code-snippet::part(pre--single)`
  * @csspart oveflow-indicator-left - The left side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator-left)`
- * @csspart oveflow-indicator--right - The right side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator--right)`
+ * @csspart oveflow-indicator-right - The right side overflow indicator. Usage: `cds-code-snippet::part(oveflow-indicator-right)`
  * @csspart copy-button - The copy button. Usage: `cds-code-snippet::part(copy-button)`
  * @csspart show-button - The show more/less button Usage: `cds-code-snippet::part(show-button)`
  * @csspart show-button--text - The show more/less button text. Usage: `cds-code-snippet::part(show-button--text)`


### PR DESCRIPTION
### Related Ticket(s)

[Jira](https://jsw.ibm.com/browse/ADCMS-5313)

## Description

We should add CSS Shadow Parts to v2 components to allow light customizations to component internals.

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles.

### Changelog

**New**

Adding shadow parts to the code snippet component.
