### PR TITLE
feat(checkbox): add shadow parts

### DIFF
--- a/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
@@ -168,7 +168,10 @@ class CDSCheckboxGroup extends LitElement {
       : `checkbox-group-helper-text-${checkboxGroupInstanceId}`;
 
     const helper = helperText
-      ? html` <div id="${helperId}" class="${prefix}--form__helper-text" part="helper-text">
+      ? html` <div
+          id="${helperId}"
+          class="${prefix}--form__helper-text"
+          part="helper-text">
           ${helperText}
         </div>`
       : null;
@@ -189,19 +192,26 @@ class CDSCheckboxGroup extends LitElement {
         aria-readonly=${readonly}
         ?aria-labelledby=${ariaLabelledBy || legendId}
         ?aria-describedby=${!invalid && !warn && helper ? helperId : undefined}>
-        <legend class="${prefix}--label" id=${legendId || ariaLabelledBy} part="label">
+        <legend
+          class="${prefix}--label"
+          id=${legendId || ariaLabelledBy}
+          part="label">
           ${legendText}
           <slot name="slug" @slotchange="${handleSlotChange}"></slot>
         </legend>
         <slot></slot>
-        <div class="${prefix}--checkbox-group__validation-msg" part="validation-msg">
+        <div
+          class="${prefix}--checkbox-group__validation-msg"
+          part="validation-msg">
           ${!readonly && invalid
             ? html`
                 ${WarningFilled16({
                   class: `${prefix}--checkbox__invalid-icon`,
                   part: `invalid-icon`,
                 })}
-                <div class="${prefix}--form-requirement" part="invalid-text">${invalidText}</div>
+                <div class="${prefix}--form-requirement" part="invalid-text">
+                  ${invalidText}
+                </div>
               `
             : null}
           ${showWarning
@@ -210,7 +220,11 @@ class CDSCheckboxGroup extends LitElement {
                   class: `${prefix}--checkbox__invalid-icon ${prefix}--checkbox__invalid-icon--warning`,
                   part: `invalid-icon invalid-icon--warning`,
                 })}
-                <div class="${prefix}--form-requirement" part="invalid-text invalid-text--warning">${warnText}</div>
+                <div
+                  class="${prefix}--form-requirement"
+                  part="invalid-text invalid-text--warning">
+                  ${warnText}
+                </div>
               `
             : null}
         </div>

--- a/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
@@ -22,8 +22,14 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  *
  * @element cds-checkbox
  * @fires cds-checkbox-changed - The custom event fired after this changebox changes its checked state.
- * @csspart input The checkbox.
- * @csspart label The label.
+ * @csspart input - The checkbox. Usage: `cds-checkbox::part(input)`
+ * @csspart label - The label. Usage: `cds-checkbox::part(label)`
+ * @csspart helper-text - The helper text. Usage: `cds-checkbox::part(helper-text)`
+ * @csspart validation-msg - The validation message. Usage: `cds-checkbox::part(validation-msg)`
+ * @csspart invalid-icon - Icon for invalid input. Usage: `cds-checkbox::part(invalid-icon)`
+ * @csspart invalid-text - Text for invalid input. Usage: `cds-checkbox::part(invalid-text)`
+ * @csspart invalid-icon--warning - Icon for warnings. Usage: `cds-checkbox::part(invalid-icon--warning)`
+ * @csspart invalid-text--warning - Text For Warings. Usage: `cds-checkbox::part(invalid-text--warning)`
  */
 @customElement(`${prefix}-checkbox-group`)
 class CDSCheckboxGroup extends LitElement {
@@ -162,7 +168,7 @@ class CDSCheckboxGroup extends LitElement {
       : `checkbox-group-helper-text-${checkboxGroupInstanceId}`;
 
     const helper = helperText
-      ? html` <div id="${helperId}" class="${prefix}--form__helper-text">
+      ? html` <div id="${helperId}" class="${prefix}--form__helper-text" part="helper-text">
           ${helperText}
         </div>`
       : null;
@@ -183,26 +189,28 @@ class CDSCheckboxGroup extends LitElement {
         aria-readonly=${readonly}
         ?aria-labelledby=${ariaLabelledBy || legendId}
         ?aria-describedby=${!invalid && !warn && helper ? helperId : undefined}>
-        <legend class="${prefix}--label" id=${legendId || ariaLabelledBy}>
+        <legend class="${prefix}--label" id=${legendId || ariaLabelledBy} part="label">
           ${legendText}
           <slot name="slug" @slotchange="${handleSlotChange}"></slot>
         </legend>
         <slot></slot>
-        <div class="${prefix}--checkbox-group__validation-msg">
+        <div class="${prefix}--checkbox-group__validation-msg" part="validation-msg">
           ${!readonly && invalid
             ? html`
                 ${WarningFilled16({
                   class: `${prefix}--checkbox__invalid-icon`,
+                  part: `invalid-icon`,
                 })}
-                <div class="${prefix}--form-requirement">${invalidText}</div>
+                <div class="${prefix}--form-requirement" part="invalid-text">${invalidText}</div>
               `
             : null}
           ${showWarning
             ? html`
                 ${WarningAltFilled16({
                   class: `${prefix}--checkbox__invalid-icon ${prefix}--checkbox__invalid-icon--warning`,
+                  part: `invalid-icon invalid-icon--warning`,
                 })}
-                <div class="${prefix}--form-requirement">${warnText}</div>
+                <div class="${prefix}--form-requirement" part="invalid-text invalid-text--warning">${warnText}</div>
               `
             : null}
         </div>

--- a/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-group.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,18 +18,18 @@ import styles from './checkbox.scss';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 
 /**
- * Check box.
+ * Check box group.
  *
- * @element cds-checkbox
- * @fires cds-checkbox-changed - The custom event fired after this changebox changes its checked state.
- * @csspart input - The checkbox. Usage: `cds-checkbox::part(input)`
- * @csspart label - The label. Usage: `cds-checkbox::part(label)`
- * @csspart helper-text - The helper text. Usage: `cds-checkbox::part(helper-text)`
- * @csspart validation-msg - The validation message. Usage: `cds-checkbox::part(validation-msg)`
- * @csspart invalid-icon - Icon for invalid input. Usage: `cds-checkbox::part(invalid-icon)`
- * @csspart invalid-text - Text for invalid input. Usage: `cds-checkbox::part(invalid-text)`
- * @csspart invalid-icon--warning - Icon for warnings. Usage: `cds-checkbox::part(invalid-icon--warning)`
- * @csspart invalid-text--warning - Text For Warings. Usage: `cds-checkbox::part(invalid-text--warning)`
+ * @element cds-checkbox-group
+ * @csspart fieldset - The fieldset element wrapping the group. Usage: `cds-checkbox-group::part(input)`
+ * @csspart input - The checkbox. Usage: `cds-checkbox-group::part(input)`
+ * @csspart label - The label. Usage: `cds-checkbox-group::part(label)`
+ * @csspart helper-text - The helper text. Usage: `cds-checkbox-group::part(helper-text)`
+ * @csspart validation-msg - The validation message. Usage: `cds-checkbox-group::part(validation-msg)`
+ * @csspart invalid-icon - Icon for invalid input. Usage: `cds-checkbox-group::part(invalid-icon)`
+ * @csspart invalid-text - Text for invalid input. Usage: `cds-checkbox-group::part(invalid-text)`
+ * @csspart invalid-icon--warning - Icon for warnings. Usage: `cds-checkbox-group::part(invalid-icon--warning)`
+ * @csspart invalid-text--warning - Text for warnings. Usage: `cds-checkbox-group::part(invalid-text--warning)`
  */
 @customElement(`${prefix}-checkbox-group`)
 class CDSCheckboxGroup extends LitElement {
@@ -186,6 +186,7 @@ class CDSCheckboxGroup extends LitElement {
 
     return html`
       <fieldset
+        part="fieldset"
         class="${fieldsetClasses}"
         ?data-invalid=${invalid}
         ?disabled=${disabled}

--- a/packages/carbon-web-components/src/components/checkbox/checkbox-skeleton.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-skeleton.ts
@@ -14,7 +14,7 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 
 /**
  * Skeleton of number input.
- * @element cds-checkbox-skeleton 
+ * @element cds-checkbox-skeleton
  * @csspart label - The label. Usage: `cds-checkbox-skeleton::part(label)`
  * @csspart label-text - The tex. Usage: `cds-checkbox-skeleton::part(label-text)`
  */
@@ -23,8 +23,10 @@ class CDSCheckboxSkeleton extends LitElement {
   render() {
     return html`
       <label class="${prefix}--checkbox-label" for="checkbox" part="label">
-        <span class="${prefix}--checkbox-label-text ${prefix}--skeleton"
-          part="label-text"><slot></slot
+        <span
+          class="${prefix}--checkbox-label-text ${prefix}--skeleton"
+          part="label-text"
+          ><slot></slot
         ></span>
       </label>
     `;

--- a/packages/carbon-web-components/src/components/checkbox/checkbox-skeleton.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-skeleton.ts
@@ -14,6 +14,9 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 
 /**
  * Skeleton of number input.
+ * @element cds-checkbox-skeleton 
+ * @csspart label - The label. Usage: `cds-checkbox-skeleton::part(label)`
+ * @csspart label-text - The tex. Usage: `cds-checkbox-skeleton::part(label-text)`
  */
 @customElement(`${prefix}-checkbox-skeleton`)
 class CDSCheckboxSkeleton extends LitElement {
@@ -21,7 +24,7 @@ class CDSCheckboxSkeleton extends LitElement {
     return html`
       <label class="${prefix}--checkbox-label" for="checkbox" part="label">
         <span class="${prefix}--checkbox-label-text ${prefix}--skeleton"
-          ><slot></slot
+          part="label-text"><slot></slot
         ></span>
       </label>
     `;

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -23,15 +23,16 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * Check box.
  *
  * @element cds-checkbox
- * @fires cds-checkbox-changed - The custom event fired after this changebox changes its checked state.
+ * @fires cds-checkbox-changed - The custom event fired after this checkbox changes its checked state.
  * @csspart input - The checkbox. Usage: `cds-checkbox::part(input)`
  * @csspart label - The label. Usage: `cds-checkbox::part(label)`
+ * @csspart label-text - The label text. Usage: `cds-checkbox::part(label-text)`
  * @csspart helper-text - The helper text. Usage: `cds-checkbox::part(helper-text)`
  * @csspart validation-msg - The validation message. Usage: `cds-checkbox::part(validation-msg)`
  * @csspart invalid-icon - Icon for invalid input. Usage: `cds-checkbox::part(invalid-icon)`
  * @csspart invalid-text - Text for invalid input. Usage: `cds-checkbox::part(invalid-text)`
  * @csspart invalid-icon--warning - Icon for warnings. Usage: `cds-checkbox::part(invalid-icon--warning)`
- * @csspart invalid-text--warning - Text For Warings. Usage: `cds-checkbox::part(invalid-text--warning)`
+ * @csspart invalid-text--warning - Text for warnings. Usage: `cds-checkbox::part(invalid-text--warning)`
  */
 @customElement(`${prefix}-checkbox`)
 class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
@@ -262,7 +263,7 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
         part="label"
         class="${labelClasses}"
         title="${ifDefined(title)}">
-        <span class="${labelTextClasses}"
+        <span part="label-text" class="${labelTextClasses}"
           >${labelText ? labelText : html`<slot></slot>`}</span
         >
       </label>

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.ts
@@ -230,7 +230,9 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
     const showHelper = !invalid && !warn;
 
     const helper = helperText
-      ? html` <div class="${prefix}--form__helper-text" part="helper-text">${helperText}</div>`
+      ? html` <div class="${prefix}--form__helper-text" part="helper-text">
+          ${helperText}
+        </div>`
       : null;
 
     const labelClasses = classMap({
@@ -272,7 +274,9 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
                 class: `${prefix}--checkbox__invalid-icon`,
                 part: `invalid-icon`,
               })}
-              <div class="${prefix}--form-requirement" part="invalid-text">${invalidText}</div>
+              <div class="${prefix}--form-requirement" part="invalid-text">
+                ${invalidText}
+              </div>
             `
           : null}
         ${showWarning
@@ -281,7 +285,9 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
                 class: `${prefix}--checkbox__invalid-icon ${prefix}--checkbox__invalid-icon--warning`,
                 part: `invalid-icon invalid-icon--waring`,
               })}
-              <div class="${prefix}--form-requirement" part="warning-text">${warnText}</div>
+              <div class="${prefix}--form-requirement" part="warning-text">
+                ${warnText}
+              </div>
             `
           : null}
       </div>

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.ts
@@ -24,8 +24,14 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  *
  * @element cds-checkbox
  * @fires cds-checkbox-changed - The custom event fired after this changebox changes its checked state.
- * @csspart input The checkbox.
- * @csspart label The label.
+ * @csspart input - The checkbox. Usage: `cds-checkbox::part(input)`
+ * @csspart label - The label. Usage: `cds-checkbox::part(label)`
+ * @csspart helper-text - The helper text. Usage: `cds-checkbox::part(helper-text)`
+ * @csspart validation-msg - The validation message. Usage: `cds-checkbox::part(validation-msg)`
+ * @csspart invalid-icon - Icon for invalid input. Usage: `cds-checkbox::part(invalid-icon)`
+ * @csspart invalid-text - Text for invalid input. Usage: `cds-checkbox::part(invalid-text)`
+ * @csspart invalid-icon--warning - Icon for warnings. Usage: `cds-checkbox::part(invalid-icon--warning)`
+ * @csspart invalid-text--warning - Text For Warings. Usage: `cds-checkbox::part(invalid-text--warning)`
  */
 @customElement(`${prefix}-checkbox`)
 class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
@@ -224,7 +230,7 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
     const showHelper = !invalid && !warn;
 
     const helper = helperText
-      ? html` <div class="${prefix}--form__helper-text">${helperText}</div>`
+      ? html` <div class="${prefix}--form__helper-text" part="helper-text">${helperText}</div>`
       : null;
 
     const labelClasses = classMap({
@@ -259,21 +265,23 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
         >
       </label>
       <slot name="slug" @slotchange="${this._handleSlotChange}"></slot>
-      <div class="${prefix}--checkbox__validation-msg">
+      <div class="${prefix}--checkbox__validation-msg" part="validation-msg">
         ${!readonly && invalid
           ? html`
               ${WarningFilled16({
                 class: `${prefix}--checkbox__invalid-icon`,
+                part: `invalid-icon`,
               })}
-              <div class="${prefix}--form-requirement">${invalidText}</div>
+              <div class="${prefix}--form-requirement" part="invalid-text">${invalidText}</div>
             `
           : null}
         ${showWarning
           ? html`
               ${WarningAltFilled16({
                 class: `${prefix}--checkbox__invalid-icon ${prefix}--checkbox__invalid-icon--warning`,
+                part: `invalid-icon invalid-icon--waring`,
               })}
-              <div class="${prefix}--form-requirement">${warnText}</div>
+              <div class="${prefix}--form-requirement" part="warning-text">${warnText}</div>
             `
           : null}
       </div>


### PR DESCRIPTION
### Related Ticket(s)

[Jira](https://jsw.ibm.com/browse/ADCMS-5312)

### Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles.

### Changelog

adding shadow parts to the checkbox component
