### PR TITLE
feat(chat-button): add shadow parts

### DIFF
--- a/packages/carbon-web-components/src/components/chat-button/chat-button-skeleton.ts
+++ b/packages/carbon-web-components/src/components/chat-button/chat-button-skeleton.ts
@@ -20,6 +20,7 @@ export { CHAT_BUTTON_SIZE };
  * Chat button skeleton.
  *
  * @element cds-chat-button-skeleton
+ * @csspart skeleton - The button skeleton. Usage `cds-chat-button-skeleton::part(skeleton)`
  */
 @customElement(`${prefix}-chat-button-skeleton`)
 class CDSChatButtonSkeleton extends LitElement {
@@ -37,7 +38,7 @@ class CDSChatButtonSkeleton extends LitElement {
       [`${prefix}--layout--size-${this.size}`]: this.size,
     });
 
-    return html` <div class="${skeletonClasses}"></div> `;
+    return html` <div class="${skeletonClasses}" part="skeleton"></div> `;
   }
 
   static styles = styles;

--- a/packages/carbon-web-components/src/components/chat-button/chat-button.ts
+++ b/packages/carbon-web-components/src/components/chat-button/chat-button.ts
@@ -19,6 +19,8 @@ export { CHAT_BUTTON_SIZE, CHAT_BUTTON_KIND };
 /**
  * Icon Button
  *
+ * @element cds-chat-button
+ * @csspart button - The button. Usage `cds-chat-button::part(button)`
  */
 @customElement(`${prefix}-chat-button`)
 class CDSChatButton extends LitElement {
@@ -95,6 +97,7 @@ class CDSChatButton extends LitElement {
 
     return html`
       <cds-button
+        part="button"
         button-class-name="${classes}"
         size="${this.size}"
         kind="${this.kind}"


### PR DESCRIPTION
[ADCMS-5311](https://jsw.ibm.com/browse/ADCMS-5311)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "chat-button" component.

Changelog

New

Adding the shadow parts for the "chat-button" component and documentation.