### PR TITLE
fix(text-cta): prevent order of operations issues

### DIFF
--- a/packages/web-components/src/component-mixins/cta/video.ts
+++ b/packages/web-components/src/component-mixins/cta/video.ts
@@ -132,49 +132,51 @@ const VideoCTAMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
       // Declaring this mixin as it extends `LitElement` seems to cause a TS error
       // @ts-ignore
       super.updated(changedProperties);
-      const { ctaType, videoName, videoDescription, href, videoDuration } =
-        this;
-      const { eventRequestVideoData } = this
-        .constructor as typeof VideoCTAMixinImpl;
-      if (changedProperties.has('ctaType') && ctaType === CTA_TYPE.VIDEO) {
-        if (typeof videoDuration === 'undefined') {
+      customElements.whenDefined(`${ddsPrefix}-text-cta`).then((response) => {
+        const { ctaType, videoName, videoDescription, href, videoDuration } =
+          this;
+        const { eventRequestVideoData } = this
+          .constructor as typeof VideoCTAMixinImpl;
+        if (changedProperties.has('ctaType') && ctaType === CTA_TYPE.VIDEO) {
+          if (typeof videoDuration === 'undefined') {
+            this.dispatchEvent(
+              new CustomEvent(eventRequestVideoData, {
+                bubbles: true,
+                cancelable: true,
+                composed: true,
+                detail: {
+                  href,
+                  videoName,
+                  videoDescription,
+                },
+              })
+            );
+          }
+        }
+
+        if (
+          (changedProperties.has('videoName') &&
+            (videoName === null || videoName === 'null')) ||
+          changedProperties.has('videoDescription')
+        ) {
           this.dispatchEvent(
             new CustomEvent(eventRequestVideoData, {
               bubbles: true,
               cancelable: true,
               composed: true,
               detail: {
-                href,
                 videoName,
                 videoDescription,
+                href,
               },
             })
           );
         }
-      }
 
-      if (
-        (changedProperties.has('videoName') &&
-          (videoName === null || videoName === 'null')) ||
-        changedProperties.has('videoDescription')
-      ) {
-        this.dispatchEvent(
-          new CustomEvent(eventRequestVideoData, {
-            bubbles: true,
-            cancelable: true,
-            composed: true,
-            detail: {
-              videoName,
-              videoDescription,
-              href,
-            },
-          })
-        );
-      }
-
-      if (ctaType === CTA_TYPE.VIDEO && this.offsetWidth > 0) {
-        this._updateVideoThumbnailUrl();
-      }
+        if (ctaType === CTA_TYPE.VIDEO && this.offsetWidth > 0) {
+          this._updateVideoThumbnailUrl();
+        }
+      });
     }
 
     /**

--- a/packages/web-components/src/component-mixins/cta/video.ts
+++ b/packages/web-components/src/component-mixins/cta/video.ts
@@ -133,46 +133,49 @@ const VideoCTAMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
       // @ts-ignore
       super.updated(changedProperties);
       const { ctaType, videoName, videoDescription, href, videoDuration } =
-      this;
-      const { eventRequestVideoData } = this.constructor as typeof VideoCTAMixinImpl;
-      
-      customElements.whenDefined(`${ddsPrefix}-video-cta-container`).then(() => {
-        if (changedProperties.has('ctaType') && ctaType === CTA_TYPE.VIDEO) {
-          if (typeof videoDuration === 'undefined') {
+        this;
+      const { eventRequestVideoData } = this
+        .constructor as typeof VideoCTAMixinImpl;
+
+      customElements
+        .whenDefined(`${ddsPrefix}-video-cta-container`)
+        .then(() => {
+          if (changedProperties.has('ctaType') && ctaType === CTA_TYPE.VIDEO) {
+            if (typeof videoDuration === 'undefined') {
+              this.dispatchEvent(
+                new CustomEvent(eventRequestVideoData, {
+                  bubbles: true,
+                  cancelable: true,
+                  composed: true,
+                  detail: {
+                    href,
+                    videoName,
+                    videoDescription,
+                  },
+                })
+              );
+            }
+          }
+
+          if (
+            (changedProperties.has('videoName') &&
+              (videoName === null || videoName === 'null')) ||
+            changedProperties.has('videoDescription')
+          ) {
             this.dispatchEvent(
               new CustomEvent(eventRequestVideoData, {
                 bubbles: true,
                 cancelable: true,
                 composed: true,
                 detail: {
-                  href,
                   videoName,
                   videoDescription,
+                  href,
                 },
               })
             );
           }
-        }
-
-        if (
-          (changedProperties.has('videoName') &&
-            (videoName === null || videoName === 'null')) ||
-          changedProperties.has('videoDescription')
-        ) {
-          this.dispatchEvent(
-            new CustomEvent(eventRequestVideoData, {
-              bubbles: true,
-              cancelable: true,
-              composed: true,
-              detail: {
-                videoName,
-                videoDescription,
-                href,
-              },
-            })
-          );
-        }
-      });
+        });
       if (ctaType === CTA_TYPE.VIDEO && this.offsetWidth > 0) {
         this._updateVideoThumbnailUrl();
       }

--- a/packages/web-components/src/component-mixins/cta/video.ts
+++ b/packages/web-components/src/component-mixins/cta/video.ts
@@ -132,7 +132,7 @@ const VideoCTAMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
       // Declaring this mixin as it extends `LitElement` seems to cause a TS error
       // @ts-ignore
       super.updated(changedProperties);
-      customElements.whenDefined(`${ddsPrefix}-text-cta`).then((response) => {
+      customElements.whenDefined(`${ddsPrefix}-video-cta-container`).then((response) => {
         const { ctaType, videoName, videoDescription, href, videoDuration } =
           this;
         const { eventRequestVideoData } = this

--- a/packages/web-components/src/component-mixins/cta/video.ts
+++ b/packages/web-components/src/component-mixins/cta/video.ts
@@ -132,11 +132,11 @@ const VideoCTAMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
       // Declaring this mixin as it extends `LitElement` seems to cause a TS error
       // @ts-ignore
       super.updated(changedProperties);
-      customElements.whenDefined(`${ddsPrefix}-video-cta-container`).then((response) => {
-        const { ctaType, videoName, videoDescription, href, videoDuration } =
-          this;
-        const { eventRequestVideoData } = this
-          .constructor as typeof VideoCTAMixinImpl;
+      const { ctaType, videoName, videoDescription, href, videoDuration } =
+      this;
+      const { eventRequestVideoData } = this.constructor as typeof VideoCTAMixinImpl;
+      
+      customElements.whenDefined(`${ddsPrefix}-video-cta-container`).then(() => {
         if (changedProperties.has('ctaType') && ctaType === CTA_TYPE.VIDEO) {
           if (typeof videoDuration === 'undefined') {
             this.dispatchEvent(
@@ -172,11 +172,10 @@ const VideoCTAMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
             })
           );
         }
-
-        if (ctaType === CTA_TYPE.VIDEO && this.offsetWidth > 0) {
-          this._updateVideoThumbnailUrl();
-        }
       });
+      if (ctaType === CTA_TYPE.VIDEO && this.offsetWidth > 0) {
+        this._updateVideoThumbnailUrl();
+      }
     }
 
     /**


### PR DESCRIPTION
### Related Ticket(s)
[Jira](https://jsw.ibm.com/browse/ADCMS-5207)
### Description
An issue where the CTA on cards with videos is not being populated on some pages is being caused  by an order of operation issue where the element is making calls tho an event listener that is not yet defined. 
This PR is to ensure the correct order of execution  

### Changelog

**Changed**
Added `customElements.whenDefined()` to the video mixin  to make sure the event only triggers after all componets needed are loaded.
