### PR TITLE
fix(fonts): set font path for plex fonts cdn

### DIFF
--- a/packages/web-components/src/globals/scss/plex.scss
+++ b/packages/web-components/src/globals/scss/plex.scss
@@ -1,9 +1,13 @@
 //
-// Copyright IBM Corp. 2021
+// Copyright IBM Corp. 2021, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
+
+@use '@carbon/styles/scss/config' with (
+  $font-path: 'https://1.www.s81c.com/common/carbon/plex/fonts'
+);
 
 @use '@carbon/styles/scss/fonts' as *;
 @use '@carbon/styles/scss/reset' as *;

--- a/packages/web-components/src/globals/scss/plex.scss
+++ b/packages/web-components/src/globals/scss/plex.scss
@@ -6,7 +6,7 @@
 //
 
 @use '@carbon/styles/scss/config' with (
-  $font-path: 'https://1.www.s81c.com/common/carbon/plex/fonts'
+  $use-akamai-cdn: true
 );
 
 @use '@carbon/styles/scss/fonts' as *;


### PR DESCRIPTION
### Related Ticket(s)

Closes # {{Provide issue number link(s) to the related ticket(s) that this pull request addresses}}

### Description

the plex font paths are defaulting to `~ibm/plex` which ends up 404ing when we use the font CDNs. This PR sets `use-akamai-cdn` flag to true in the carbon font configs.

### Changelog

**New**

- set `use-akamai-cd` flag for plex fonts


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
