### PR TITLE
fix(package): remove unneeded wicg-inert package - v1

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -104,7 +104,6 @@
     "redux": "^4.0.0",
     "redux-logger": "^3.0.0",
     "redux-thunk": "^2.3.0",
-    "wicg-inert": "^3.1.2",
     "window-or-global": "^1.0.1"
   },
   "optionalDependencies": {

--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,6 @@
 import { html, property, state, query, LitElement } from 'lit-element';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
-import 'wicg-inert';
 import settings from 'carbon-components/es/globals/js/settings.js';
 import { slow01 } from '@carbon/motion';
 import ifNonNull from '../../internal/vendor/@carbon/web-components/globals/directives/if-non-null.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2596,7 +2596,6 @@ __metadata:
     url-loader: "npm:^4.1.1"
     web-component-analyzer: "npm:1.2.0-next.0"
     webpack: "npm:^4.46.0"
-    wicg-inert: "npm:^3.1.2"
     window-or-global: "npm:^1.0.1"
   dependenciesMeta:
     "@carbon/icons-react":
@@ -35624,7 +35623,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wicg-inert@npm:^3.1.1, wicg-inert@npm:^3.1.2":
+"wicg-inert@npm:^3.1.1":
   version: 3.1.2
   resolution: "wicg-inert@npm:3.1.2"
   checksum: a726f5ca2d3535dba9a638ff60b720d9f81857cb9b51bcaf9c2a71ee50d784ff3be6c5d9f0acc35edd8fee92bb3587c0a9daabb70baa725a106d149ae0fd8584


### PR DESCRIPTION
### Related Ticket(s)

Closes #11907

### Description

The `wicg-inert` package poses a security vulnerability. As the `inert` attribute seems to be [supported by all browsers](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert#browser_compatibility), this polyfill package is no longer needed.

### Changelog

**Removed**

- remove `wicg-inert` package

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
