### PR TITLE
feat(copy): add shadow parts

### DIFF
--- a/packages/carbon-web-components/src/components/copy/copy.ts
+++ b/packages/carbon-web-components/src/components/copy/copy.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/carbon-web-components/src/components/copy/copy.ts
+++ b/packages/carbon-web-components/src/components/copy/copy.ts
@@ -17,6 +17,8 @@ import CDSIconButton from '../icon-button/icon-button';
  * Copy.
  *
  * @element cds-copy
+ *
+ * @csspart content - The content. Usage `cds-copy::part(content)`
  */
 @customElement(`${prefix}-copy`)
 class CDSCopy extends CDSIconButton {
@@ -81,7 +83,7 @@ class CDSCopy extends CDSIconButton {
   // eslint-disable-next-line class-methods-use-this
   protected _renderTooltipContent() {
     return html`
-      <cds-tooltip-content>
+      <cds-tooltip-content part="content">
         ${this._showFeedback
           ? this.feedback
           : html`<slot name="tooltip-content"></slot>`}

--- a/packages/carbon-web-components/src/components/copy/copy.ts
+++ b/packages/carbon-web-components/src/components/copy/copy.ts
@@ -18,7 +18,7 @@ import CDSIconButton from '../icon-button/icon-button';
  *
  * @element cds-copy
  *
- * @csspart content - The content. Usage `cds-copy::part(content)`
+ * @csspart tooltip-content - The content. Usage `cds-copy::part(tooltip-content)`
  */
 @customElement(`${prefix}-copy`)
 class CDSCopy extends CDSIconButton {

--- a/packages/carbon-web-components/src/components/copy/copy.ts
+++ b/packages/carbon-web-components/src/components/copy/copy.ts
@@ -83,7 +83,7 @@ class CDSCopy extends CDSIconButton {
   // eslint-disable-next-line class-methods-use-this
   protected _renderTooltipContent() {
     return html`
-      <cds-tooltip-content part="content">
+      <cds-tooltip-content part="tooltip-content">
         ${this._showFeedback
           ? this.feedback
           : html`<slot name="tooltip-content"></slot>`}


### PR DESCRIPTION
[ADCMS-5316](https://jsw.ibm.com/browse/ADCMS-5316)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "copy" component.

Changelog

New

Adding the shadow parts for the "copy" component and documentation.