### PR TITLE
feat(tabs): add shadow parts

### DIFF
--- a/packages/carbon-web-components/src/components/tabs/tab-skeleton.ts
+++ b/packages/carbon-web-components/src/components/tabs/tab-skeleton.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,11 +14,16 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 
 /**
  * Skeleton of tab.
+ * @element cds-tab-skeleton
+ *
+ * @csspart nav-link - The tabs navigation links. Usage `cds-tab-skeleton::part(nav-link)`
  */
 @customElement(`${prefix}-tab-skeleton`)
 export default class CDSTabSkeleton extends LitElement {
   render() {
-    return html` <div class="${prefix}--tabs__nav-link"></div> `;
+    return html`
+      <div class="${prefix}--tabs__nav-link" part="nav-link"></div>
+    `;
   }
 
   static styles = styles;

--- a/packages/carbon-web-components/src/components/tabs/tab.ts
+++ b/packages/carbon-web-components/src/components/tabs/tab.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,8 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * Basic tab.
  *
  * @element cds-tab
+ *
+ * @csspart nav-link - The tabs navigation links. Usage `cds-tab::part(nav-link)`
  */
 @customElement(`${prefix}-tab`)
 export default class CDSTab extends CDSContentSwitcherItem {
@@ -70,6 +72,7 @@ export default class CDSTab extends CDSContentSwitcherItem {
     return html`
       <a
         class="${prefix}--tabs__nav-link"
+        part="nav-link"
         role="tab"
         aria-label="${tabTitle}"
         tabindex="${selected ? 0 : -1}"

--- a/packages/carbon-web-components/src/components/tabs/tabs-skeleton.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs-skeleton.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,15 +14,20 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 
 /**
  * Skeleton of tabs.
+ * @element cds-tabs-skeleton
+ *
+ * @csspart trigger - The tabs skeleton trigger. Usage `cds-tabs-skeleton::part(trigger)`
+ * @csspart trigger-text - The tabs skeleton trigger text. Usage `cds-tabs-skeleton::part(trigger-text)`
+ * @csspart nav - The tabs skeleton navigation. Usage `cds-tabs-skeleton::part(nav)`
  */
 @customElement(`${prefix}-tabs-skeleton`)
 export default class CDSTabsSkeleton extends LitElement {
   render() {
     return html`
-      <div class="${prefix}--tabs-trigger">
-        <span class="${prefix}--tabs-trigger-text"></span>
+      <div class="${prefix}--tabs-trigger" part="trigger">
+        <span class="${prefix}--tabs-trigger-text" part="trigger-text"></span>
       </div>
-      <ul class="${prefix}--tabs__nav">
+      <ul class="${prefix}--tabs__nav" part="nav">
         <slot></slot>
       </ul>
     `;

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -34,6 +34,16 @@ export { NAVIGATION_DIRECTION, TABS_KEYBOARD_ACTION, TABS_TYPE };
  *   The custom event fired before a tab is selected upon a user gesture.
  *   Cancellation of this event stops changing the user-initiated selection.
  * @fires cds-tabs-selected - The custom event fired after a a tab is selected upon a user gesture.
+ *
+ * @csspart prev-button - The previous button when tab list is wider than container. Usage `cds-tabs::part(prev-button)`
+ * @csspart next-button - The next button when tab list is wider than container. Usage `cds-tabs::part(next-button)`
+ * @csspart container - The tabs navigation container. Usage `cds-tabs::part(container)`
+ * @csspart content - The tabs navigation content. Usage `cds-tabs::part(content)`
+ * @csspart nav - The tabs navigation. Usage `cds-tabs::part(nav)`
+ * @csspart tablist - The tabs list. Usage `cds-tabs::part(tablist)`
+ * @csspart sub-content-left - The left content. Usage `cds-tabs::part(sub-content-left)`
+ * @csspart sub-content-right - The right content. Usage `cds-tabs::part(sub-content-right)`
+ * @csspart assistive-text - The assistive text. Usage `cds-tabs::part(assistive-text)`
  */
 @customElement(`${prefix}-tabs`)
 export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
@@ -477,13 +487,21 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
 
     return html`
       ${this.renderPreviousButton()}
-      <div class="${prefix}--tabs-nav-content-container">
-        <div class="${prefix}--tabs-nav-content">
-          <div class="${prefix}--tabs-nav">
-            <div id="tablist" role="tablist" class="${prefix}--tab--list">
-              <div class="${prefix}--sub-content-left"></div>
+      <div class="${prefix}--tabs-nav-content-container" part="container">
+        <div class="${prefix}--tabs-nav-content" part="content">
+          <div class="${prefix}--tabs-nav" part="nav">
+            <div
+              id="tablist"
+              role="tablist"
+              class="${prefix}--tab--list"
+              part="tablist">
+              <div
+                class="${prefix}--sub-content-left"
+                part="sub-content-left"></div>
               <slot @slotchange=${handleSlotchange}></slot>
-              <div class="${prefix}--sub-content-right"></div>
+              <div
+                class="${prefix}--sub-content-right"
+                part="sub-content-right"></div>
             </div>
           </div>
         </div>
@@ -491,6 +509,7 @@ export default class CDSTabs extends HostListenerMixin(CDSContentSwitcher) {
       ${this.renderNextButton()}
       <div
         class="${prefix}--assistive-text"
+        part="assistive-text"
         role="status"
         aria-live="assertive"
         aria-relevant="additions text">


### PR DESCRIPTION
[ADCMS-5352](https://jsw.ibm.com/browse/ADCMS-5352)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "tabs" component.

Changelog

New

Adding the shadow parts for the "tabs" component and documentation.