### PR TITLE
chore(ibm-common): add mandatory IBM instrumentation tags (v2)

### DIFF
--- a/packages/web-components/.storybook/manager-head.html
+++ b/packages/web-components/.storybook/manager-head.html
@@ -29,12 +29,44 @@ LICENSE file in the root directory of this source tree.
 </script>
 
 <footer>
-  <c4d-footer-container disable-locale-button="true" size="micro" />
+  <dds-footer-container
+    key="footer"
+    disable-locale-button="true"
+    size="micro" />,
 </footer>
 
 <script
+  key="8"
   type="module"
-  src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/latest/footer.min.js"></script>
+  src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/footer.min.js" />
+
+<!-- Tealium/GA Set up -->
+<script type="text/javascript">
+  window._ibmAnalytics = {
+    settings: {
+      name: 'CarbonDotcomWebComponentsStorybook',
+      isSpa: true,
+      tealiumProfileName: 'ibm-web-app',
+    },
+    onLoad: [['ibmStats.pageview', []]],
+  };
+  digitalData = {
+    page: {
+      pageInfo: {
+        ibm: {
+          siteId: 'IBM_' + _ibmAnalytics.settings.name,
+        },
+      },
+      category: {
+        primaryCategory: 'PC100',
+      },
+    },
+  };
+</script>
+<script
+  src="//1.www.s81c.com/common/stats/ibm-common.js"
+  type="text/javascript"
+  async="async"></script>
 
 <!-- Minimum setting to use IBM Plex font -->
 <style type="text/css">

--- a/packages/web-components/.storybook/manager-head.html
+++ b/packages/web-components/.storybook/manager-head.html
@@ -70,6 +70,25 @@ LICENSE file in the root directory of this source tree.
 
 <!-- Minimum setting to use IBM Plex font -->
 <style type="text/css">
+  /* This style is required because of the compliance footer */
+  #root > div {
+    height: calc(100vh - 48px);
+  }
+
+  /* This style is required because of the compliance footer in smaller screens */
+  @media (max-width: 671px) {
+    nav[class^='css-'] {
+      height: 281px;
+    }
+  }
+
+  footer {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    z-index: 99999;
+  }
+
   @font-face {
     font-weight: 400;
     font-family: 'IBM Plex Sans';

--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -497,9 +497,6 @@
   }
 </script>
 
-<!-- IBM Tag Management and Site Analytics -->
-<script src="//1.www.s81c.com/common/stats/ibm-common.js" defer></script>
-
 <style>
   @media only percy {
     [data-autoid='cds--privacy-cp'] {

--- a/packages/web-components/.storybook/react/manager-head.html
+++ b/packages/web-components/.storybook/react/manager-head.html
@@ -19,6 +19,46 @@
   document.title = 'Carbon for IBM.com Web Components with React';
 </script>
 
+<footer>
+  <dds-footer-container
+    key="footer"
+    disable-locale-button="true"
+    size="micro" />,
+</footer>
+
+<script
+  key="8"
+  type="module"
+  src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/footer.min.js" />
+
+<!-- Tealium/GA Set up -->
+<script type="text/javascript">
+  window._ibmAnalytics = {
+    settings: {
+      name: 'CarbonDotcomWebComponentsStorybook',
+      isSpa: true,
+      tealiumProfileName: 'ibm-web-app',
+    },
+    onLoad: [['ibmStats.pageview', []]],
+  };
+  digitalData = {
+    page: {
+      pageInfo: {
+        ibm: {
+          siteId: 'IBM_' + _ibmAnalytics.settings.name,
+        },
+      },
+      category: {
+        primaryCategory: 'PC100',
+      },
+    },
+  };
+</script>
+<script
+  src="//1.www.s81c.com/common/stats/ibm-common.js"
+  type="text/javascript"
+  async="async"></script>
+
 <!-- Minimum setting to use IBM Plex font -->
 <style type="text/css">
   @font-face {

--- a/packages/web-components/.storybook/react/manager-head.html
+++ b/packages/web-components/.storybook/react/manager-head.html
@@ -61,6 +61,25 @@
 
 <!-- Minimum setting to use IBM Plex font -->
 <style type="text/css">
+  /* This style is required because of the compliance footer */
+  #root > div {
+    height: calc(100vh - 48px);
+  }
+
+  /* This style is required because of the compliance footer in smaller screens */
+  @media (max-width: 671px) {
+    nav[class^='css-'] {
+      height: 281px;
+    }
+  }
+
+  footer {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    z-index: 99999;
+  }
+
   @font-face {
     font-weight: 400;
     font-family: 'IBM Plex Sans';

--- a/packages/web-components/.storybook/react/preview-head.html
+++ b/packages/web-components/.storybook/react/preview-head.html
@@ -497,9 +497,6 @@
   }
 </script>
 
-<!-- IBM Tag Management and Site Analytics -->
-<script src="//1.www.s81c.com/common/stats/ibm-common.js" defer></script>
-
 <style>
   @media only percy {
     [data-autoid='cds--privacy-cp'] {


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Adding mandatory intrumentation tags for Carbon for IBM.com web components storybook

### Changelog

**Changed**

- Added `ibm-common.js` and IBM footer to storybooks
