### PR TITLE
feat(textarea): add shadow parts

### DIFF
--- a/packages/carbon-web-components/src/components/textarea/textarea-skeleton.ts
+++ b/packages/carbon-web-components/src/components/textarea/textarea-skeleton.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,13 +14,20 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 
 /**
  * Skeleton of text area.
+ *
+ * @element cds-textarea-skeleton
+ *
+ * @csspart label - The label. Usage `cds-textarea-skeleton::part(label)`
+ * @csspart textarea - The textarea. Usage `cds-textarea-skeleton::part(textarea)`
  */
 @customElement(`${prefix}-textarea-skeleton`)
 class CDSTextareaSkeleton extends LitElement {
   render() {
     return html`
-      <span class="${prefix}--label ${prefix}--skeleton"></span>
-      <div class="${prefix}--skeleton ${prefix}--text-area"></div>
+      <span class="${prefix}--label ${prefix}--skeleton" part="label"></span>
+      <div
+        class="${prefix}--skeleton ${prefix}--text-area"
+        part="textarea"></div>
     `;
   }
 

--- a/packages/carbon-web-components/src/components/textarea/textarea.ts
+++ b/packages/carbon-web-components/src/components/textarea/textarea.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -26,6 +26,14 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  * @slot helper-text - The helper text.
  * @slot label-text - The label text.
  * @slot validity-message - The validity message. If present and non-empty, this input shows the UI of its invalid state.
+ *
+ * @csspart label - The label. Usage `cds-textarea::part(label)`
+ * @csspart label-wrapper - The label wrapper. Usage `cds-textarea::part(label-wrapper)`
+ * @csspart label-input - The label input. Usage `cds-textarea::part(label-input)`
+ * @csspart wrapper - The wrapper. Usage `cds-textarea::part(wrapper)`
+ * @csspart textarea - The textarea. Usage `cds-textarea::part(textarea)`
+ * @csspart helper-text - The helper text. Usage `cds-textarea::part(helper-text)`
+ * @csspart form-requirement - The form requirement. Usage `cds-textarea::part(form-requirement)`
  */
 @customElement(`${prefix}-textarea`)
 class CDSTextarea extends CDSTextInput {
@@ -114,7 +122,7 @@ class CDSTextarea extends CDSTextInput {
 
     const counter =
       enableCounter && maxCount
-        ? html` <label class="${labelClasses}">
+        ? html` <label class="${labelClasses}" part="label">
             <slot name="label-text">${textCount}/${maxCount}</slot>
           </label>`
         : null;
@@ -129,22 +137,26 @@ class CDSTextarea extends CDSTextInput {
     };
 
     return html`
-      <div class="${prefix}--text-area__label-wrapper">
+      <div class="${prefix}--text-area__label-wrapper" part="label-wrapper">
         ${this.hideLabel
           ? html``
           : html`
-              <label class="${labelClasses}" for="input">
+              <label class="${labelClasses}" for="input" part="label-input">
                 <slot name="label-text"> ${this.label} </slot>
               </label>
             `}
         ${counter}
       </div>
-      <div class="${textareaWrapperClasses}" ?data-invalid="${this.invalid}">
+      <div
+        class="${textareaWrapperClasses}"
+        ?data-invalid="${this.invalid}"
+        part="wrapper">
         ${icon()}
         <textarea
           autocomplete="${this.autocomplete}"
           ?autofocus="${this.autofocus}"
           class="${textareaClasses}"
+          part="textarea"
           cols="${ifDefined(this.cols)}"
           ?data-invalid="${this.invalid}"
           ?disabled="${this.disabled}"
@@ -160,11 +172,15 @@ class CDSTextarea extends CDSTextInput {
           @input="${this._handleInput}"></textarea>
         <slot name="slug" @slotchange="${this._handleSlotChange}"></slot>
       </div>
-      <div class="${helperTextClasses}" ?hidden="${this.invalid || this.warn}">
+      <div
+        class="${helperTextClasses}"
+        ?hidden="${this.invalid || this.warn}"
+        part="helper-text">
         <slot name="helper-text"> ${this.helperText} </slot>
       </div>
       <div
         class="${prefix}--form-requirement"
+        part="form-requirement"
         ?hidden="${!this.invalid && !this.warn}">
         <slot name="${this.invalid ? 'invalid-text' : 'warn-text'}">
           ${this.invalid ? this.invalidText : this.warnText}


### PR DESCRIPTION
[ADCMS-5356](https://jsw.ibm.com/browse/ADCMS-5356)

Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles. This is for the "textarea" component.

Changelog

New

Adding the shadow parts for the "textarea" component and documentation.