### PR TITLE
fix(custom-element): ensure all cwc components use carbonElement

### DIFF
--- a/packages/carbon-web-components/src/components/chat-button/chat-button.ts
+++ b/packages/carbon-web-components/src/components/chat-button/chat-button.ts
@@ -8,8 +8,9 @@
  */
 
 import { html, LitElement } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import '../button/button';
 import { CHAT_BUTTON_SIZE, CHAT_BUTTON_KIND } from './defs';
 import styles from './chat-button.scss';

--- a/packages/carbon-web-components/src/components/copy-button/copy-button.ts
+++ b/packages/carbon-web-components/src/components/copy-button/copy-button.ts
@@ -1,15 +1,16 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
 import Copy16 from '@carbon/icons/lib/copy/16';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import FocusMixin from '../../globals/mixins/focus';
 import styles from './copy-button.scss';

--- a/packages/carbon-web-components/src/components/copy/copy.ts
+++ b/packages/carbon-web-components/src/components/copy/copy.ts
@@ -1,17 +1,18 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import styles from '../copy-button/copy-button.scss';
 import CDSIconButton from '../icon-button/icon-button';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 
 /**
  * Copy.

--- a/packages/carbon-web-components/src/components/data-table/table-skeleton.ts
+++ b/packages/carbon-web-components/src/components/data-table/table-skeleton.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,8 @@
 
 import { classMap } from 'lit/directives/class-map.js';
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import styles from './data-table.scss';
 

--- a/packages/carbon-web-components/src/components/file-uploader/demo-file-uploader.ts
+++ b/packages/carbon-web-components/src/components/file-uploader/demo-file-uploader.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 
 import { delay } from 'bluebird';
 import { prefix } from '../../globals/settings';

--- a/packages/carbon-web-components/src/components/file-uploader/file-uploader-button.ts
+++ b/packages/carbon-web-components/src/components/file-uploader/file-uploader-button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,8 @@
 
 import { classMap } from 'lit/directives/class-map.js';
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import HostListenerMixin from '../../globals/mixins/host-listener';
 import ifNonEmpty from '../../globals/directives/if-non-empty';

--- a/packages/carbon-web-components/src/components/form-group/form-group.ts
+++ b/packages/carbon-web-components/src/components/form-group/form-group.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import styles from './form-group.scss';
 

--- a/packages/carbon-web-components/src/components/icon-button/icon-button.ts
+++ b/packages/carbon-web-components/src/components/icon-button/icon-button.ts
@@ -8,7 +8,8 @@
  */
 
 import { html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import '../tooltip/index';
 import '../button/index';

--- a/packages/carbon-web-components/src/components/layer/layer.ts
+++ b/packages/carbon-web-components/src/components/layer/layer.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import styles from './layer.scss';
 

--- a/packages/carbon-web-components/src/components/notification/actionable-notification.ts
+++ b/packages/carbon-web-components/src/components/notification/actionable-notification.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,8 +13,9 @@ import InformationSquareFilled20 from '@carbon/icons/lib/information--square--fi
 import WarningFilled20 from '@carbon/icons/lib/warning--filled/20';
 import WarningAltFilled20 from '@carbon/icons/lib/warning--alt--filled/20';
 import { html, svg } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { NOTIFICATION_TYPE, NOTIFICATION_KIND } from './defs';
 import CDSInlineNotification from './inline-notification';
 import styles from './actionable-notification.scss';

--- a/packages/carbon-web-components/src/components/popover/popover-content.ts
+++ b/packages/carbon-web-components/src/components/popover/popover-content.ts
@@ -8,7 +8,8 @@
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import styles from './popover.scss';
 

--- a/packages/carbon-web-components/src/components/popover/popover.ts
+++ b/packages/carbon-web-components/src/components/popover/popover.ts
@@ -9,7 +9,8 @@
 
 import { classMap } from 'lit/directives/class-map.js';
 import { LitElement, html } from 'lit';
-import { property, customElement, query } from 'lit/decorators.js';
+import { property, query } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import styles from './popover.scss';
 import CDSPopoverContent from './popover-content';

--- a/packages/carbon-web-components/src/components/progress-bar/progress-bar.ts
+++ b/packages/carbon-web-components/src/components/progress-bar/progress-bar.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { classMap } from 'lit/directives/class-map.js';
 import ErrorFilled16 from '@carbon/icons/lib/error--filled/16';
 import CheckmarkFilled16 from '@carbon/icons/lib/checkmark--filled/16';

--- a/packages/carbon-web-components/src/components/select/select-skeleton.ts
+++ b/packages/carbon-web-components/src/components/select/select-skeleton.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import styles from './select.scss';
 

--- a/packages/carbon-web-components/src/components/stack/stack.ts
+++ b/packages/carbon-web-components/src/components/stack/stack.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement, html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import styles from './stack.scss';
 import { STACK_ORIENTATION, SPACING_STEPS } from './defs';

--- a/packages/carbon-web-components/src/components/text-input/text-input-skeleton.ts
+++ b/packages/carbon-web-components/src/components/text-input/text-input-skeleton.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import styles from './text-input.scss';
 

--- a/packages/carbon-web-components/src/components/text-input/text-input.ts
+++ b/packages/carbon-web-components/src/components/text-input/text-input.ts
@@ -8,7 +8,8 @@
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement, query } from 'lit/decorators.js';
+import { property, query } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { classMap } from 'lit/directives/class-map.js';
 import { prefix } from '../../globals/settings';
 import View16 from '@carbon/icons/lib/view/16';

--- a/packages/carbon-web-components/src/components/toggle-tip/toggletip.ts
+++ b/packages/carbon-web-components/src/components/toggle-tip/toggletip.ts
@@ -9,7 +9,8 @@
 
 import { classMap } from 'lit/directives/class-map.js';
 import { html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import Information16 from '@carbon/icons/lib/information/16';
 import { prefix } from '../../globals/settings';
 import HostListener from '../../globals/decorators/host-listener';

--- a/packages/carbon-web-components/src/components/ui-shell/header-global-action.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/header-global-action.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement } from 'lit';
-import { property, customElement, query } from 'lit/decorators.js';
+import { property, query } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { BUTTON_TOOLTIP_POSITION } from '../button/button';
 import CDSButton from '../button/button';
 import HostListener from '../../globals/decorators/host-listener';

--- a/packages/carbon-web-components/src/components/ui-shell/header-panel.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/header-panel.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import styles from './header.scss';
 import { prefix } from '../../globals/settings';
 

--- a/packages/carbon-web-components/src/components/ui-shell/header-side-nav-items.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/header-side-nav-items.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import styles from './side-nav.scss';
 

--- a/packages/carbon-web-components/src/components/ui-shell/switcher-item.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/switcher-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,8 @@
 
 import { classMap } from 'lit/directives/class-map.js';
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { prefix } from '../../globals/settings';
 import FocusMixin from '../../globals/mixins/focus';
 import styles from './header.scss';

--- a/packages/carbon-web-components/src/components/ui-shell/switcher.ts
+++ b/packages/carbon-web-components/src/components/ui-shell/switcher.ts
@@ -1,14 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import styles from './header.scss';
 import { prefix } from '../../globals/settings';
 


### PR DESCRIPTION
### Related Ticket(s)

Closes # {{Provide issue number link(s) to the related ticket(s) that this pull request addresses}}

### Description

Ensure all CWC are using the `carbonElement` decorator to prevent clashing when user is trying to import the same component from different locations

### Changelog

**Changed**

- ensure all CWC are importing and using the `carbonElement` decorator

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
