### PR TITLE
feat(toggle-tip): add shadow parts

### DIFF
--- a/packages/carbon-web-components/src/components/toggle-tip/toggletip.ts
+++ b/packages/carbon-web-components/src/components/toggle-tip/toggletip.ts
@@ -23,6 +23,13 @@ import styles from './toggletip.scss';
  * Definition tooltip.
  *
  * @element cds-toggletip
+ * @csspart label -  The toggle tip label. Usage `cds-toggletip::part(label)`
+ * @csspart button -  The toggle tip button. Usage `cds-toggletip::part(button)`
+ * @csspart content -  The toggle tip content. Usage `cds-toggletip::part(content)`
+ * @csspart action -  The toggle tip actions. Usage `cds-toggletip::part(action)`
+ * @csspart inner-content -  The inner content Usage `cds-toggletip::part(inner-content)`
+ * @csspart popover-content -  The popover content. Usage `cds-toggletip::part(popover-content)`
+ * @csspart popover-carret -  The popover carret. Usage `cds-toggletip::part(popover-carret)`
  */
 @customElement(`${prefix}-toggletip`)
 class CDSToggletip extends HostListenerMixin(FocusMixin(LitElement)) {
@@ -89,7 +96,7 @@ class CDSToggletip extends HostListenerMixin(FocusMixin(LitElement)) {
 
   protected _renderToggleTipLabel = () => {
     return html`
-      <span class="${prefix}--toggletip-label">
+      <span class="${prefix}--toggletip-label" part="label">
         <slot></slot>
       </span>
     `;
@@ -100,7 +107,8 @@ class CDSToggletip extends HostListenerMixin(FocusMixin(LitElement)) {
       <button
         aria-controls="${this.id}"
         class="${prefix}--toggletip-button"
-        @click=${this._handleClick}>
+        @click=${this._handleClick}
+        part="button">
         ${Information16({ id: 'trigger' })}
       </button>
     `;
@@ -109,31 +117,31 @@ class CDSToggletip extends HostListenerMixin(FocusMixin(LitElement)) {
   protected _renderTooltipContent = () => {
     return this.autoalign
       ? html`
-          <span class="${prefix}--popover-content">
-            <div class="${prefix}--toggletip-content">
+          <span class="${prefix}--popover-content" part="popover-content">
+            <div class="${prefix}--toggletip-content" part="content">
               <slot name="body-text"></slot>
-              <div class="${prefix}--toggletip-actions">
+              <div class="${prefix}--toggletip-actions" part="actions">
                 <slot
                   name="actions"
                   @slotchange="${this._handleActionsSlotChange}"></slot>
               </div>
             </div>
-            <span class="${prefix}--popover-caret"></span>
+            <span class="${prefix}--popover-caret" part="popover-carret"></span>
           </span>
         `
       : html`
-          <span class="${prefix}--popover">
-            <span class="${prefix}--popover-content">
-              <div class="${prefix}--toggletip-content">
+          <span class="${prefix}--popover" part="popover">
+            <span class="${prefix}--popover-content" part="popover-content">
+              <div class="${prefix}--toggletip-content" part="content">
                 <slot name="body-text"></slot>
-                <div class="${prefix}--toggletip-actions">
+                <div class="${prefix}--toggletip-actions" part="actions">
                   <slot
                     name="actions"
                     @slotchange="${this._handleActionsSlotChange}"></slot>
                 </div>
               </div>
             </span>
-            <span class="${prefix}--popover-caret"></span>
+            <span class="${prefix}--popover-caret" part="popover-carret"></span>
           </span>
         `;
   };
@@ -184,7 +192,7 @@ class CDSToggletip extends HostListenerMixin(FocusMixin(LitElement)) {
     });
     return html`
       ${this._renderToggleTipLabel()}
-      <span class="${classes}">
+      <span class="${classes}" part="inner-content">
         ${this._renderInnerContent()}
       </span>
     </span>


### PR DESCRIPTION
### Related Ticket(s)

[Jira](https://jsw.ibm.com/browse/ADCMS-5359)
### Description

All non-slot elements in the shadow DOM should be given a unique "part" name allowing CSS to target and override component default styles.


### Changelog

**New**

- Added shadow - parts to the toggle-tip CWC component 
