### PR TITLE
chore(deps): set react package to private

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@carbon/ibmdotcom-react",
+  "private": true,
   "description": "Carbon for IBM.com React Components",
   "version": "1.61.0",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description

Set React package to `private` to prevent further publishing to NPM.

### Changelog

**Changed**

- `@carbon/ibmdotcom-react` set to private

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
