### PR TITLE
fix(build): fix exports subpaths

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -17,8 +17,8 @@
       "node": "./lib/globals/*",
       "default": "./es/globals/*"
     },
-    "./es/": "./es/*",
-    "./lib/": "./lib/*",
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
     "./custom-elements.json": "./custom-elements.json",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
### Related Ticket(s)

Closes #11933 

### Description

Fixes issues with the export sub-paths in @carbon/ibmdotcom-web-components

### Changelog

**Changed**

- Fixes export sub-paths.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
