### PR TITLE
fix(button-cta): remove style overrides covered elsewhere

### DIFF
--- a/packages/web-components/src/components/cta/cta.scss
+++ b/packages/web-components/src/components/cta/cta.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2023
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -10,17 +10,6 @@
 @use '../link-with-icon/link-with-icon';
 @use '../feature-card/feature-card'; /* Covers regular card style, too */
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
-
-.#{$c4d-prefix}-ce--cta__icon {
-  flex-shrink: 0;
-}
-
-:host(#{$c4d-prefix}-button-cta) .#{$c4d-prefix}-ce--cta__icon {
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-end: $spacing-05;
-  transform: translateY(-50%);
-}
 
 :host(#{$c4d-prefix}-cta) {
   display: block;


### PR DESCRIPTION
### Related Ticket(s)

Closes #11959

### Description

Fixes an icon alignment issue in the `<c4d-button-cta>` component by removing style overrides that interfered with, or were already covered by extending `c4d-button`.

### Changelog

**Changed**

- Fix button-cta styles to correct icon alignment

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
