### PR TITLE
fix(tabs-extended): adjustments to force Safari to soft hyphenate better for tab names

### DIFF
--- a/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
+++ b/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
@@ -97,6 +97,7 @@
 
         div {
           align-self: flex-start;
+          width: 100%;
         }
 
         /* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix */

--- a/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
+++ b/packages/web-components/src/components/tabs-extended/__stories__/tabs-extended.stories.ts
@@ -67,7 +67,7 @@ export const Default = (args) => {
       <dds-tab label="Third tab">
         <p>Content for third tab goes here.</p>
       </dds-tab>
-      <dds-tab label="Fourth tab">
+      <dds-tab label="Ihre anwendungsübergreifend Konnektivität">
         <p>Content for fourth tab goes here.</p>
       </dds-tab>
       <dds-tab label="Fifth tab" disabled>

--- a/packages/web-components/tests/snapshots/dds-table-of-contents.md
+++ b/packages/web-components/tests/snapshots/dds-table-of-contents.md
@@ -9,7 +9,7 @@
   <div
     class="bx--tableofcontents__sidebar"
     part="table"
-    style="transition: none 0s ease 0s; top: 0px;"
+    style="transition: none; top: 0px;"
   >
     <div
       class="bx--tableofcontents__desktop__children"
@@ -67,7 +67,7 @@
   <div
     class="bx--tableofcontents__sidebar"
     part="table"
-    style="transition: none 0s ease 0s; top: 0px;"
+    style="transition: none; top: 0px;"
   >
     <div class="bx--tableofcontents__desktop__children">
       <slot name="heading">
@@ -122,7 +122,7 @@
   <div
     class="bx--tableofcontents__sidebar"
     part="table"
-    style="transition: none 0s ease 0s; top: 0px;"
+    style="transition: none; top: 0px;"
   >
     <div class="bx--tableofcontents__mobile-top">
     </div>


### PR DESCRIPTION
### Related Ticket(s)

Closes #11965

### Description

With certain content in tab names, Safari does not soft hyphenate how we would want it to, leading to text overflowing the container. This adds a width the the wrapping <div> of the <p> where the tab title sits.This will cause Safari to soft hyphenate better, and avoid overflowing the container.

### Changelog

**Changed**

- Fix text overflow issue in the tab title on Safari

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
