### PR TITLE
fix(tabs): avoid setting focus/active to -1

### DIFF
--- a/packages/web-components/src/components/tabs-extended/tabs-extended.ts
+++ b/packages/web-components/src/components/tabs-extended/tabs-extended.ts
@@ -138,8 +138,11 @@ class DDSTabsExtended extends MediaQueryMixin(StableSelectorMixin(LitElement), {
       default:
         break;
     }
-    this._setActiveItem(targetTab);
-    this._setFocus(targetTab);
+
+    if (targetTab !== -1) {
+      this._setActiveItem(targetTab);
+      this._setFocus(targetTab);
+    }
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

Closes #11975 
https://jsw.ibm.com/browse/ADCMS-5840

### Description

tabs-extended's _handleTabListKeyDown method sets `targetTab` to a default value of -1 and then modifies that value for arrow keys and home/end.

Prior to this PR, the component sets the active item and focus to targetTab, even if it's still -1. This PR changes that to only set active/focus if the value has been modified away from -1

### Changelog

**Changed**

- fixes a bug in which tab panels could disappear on keypress
