### PR TITLE
fix(content-group-heading): render h3 tag to light DOM

### DIFF
--- a/packages/web-components/src/components/content-group/__stories__/content-group.stories.ts
+++ b/packages/web-components/src/components/content-group/__stories__/content-group.stories.ts
@@ -13,6 +13,8 @@ import '../../cta/text-cta';
 import '../../image/index';
 import { html } from 'lit-element';
 import { boolean, optionsKnob } from '@storybook/addon-knobs';
+import { addons } from '@storybook/addons';
+import { FORCE_REMOUNT } from '@storybook/core-events';
 import imgLg16x9 from '../../../../../storybook-images/assets/720/fpo--16x9--720x405--004.jpg';
 import imgMd16x9 from '../../../../../storybook-images/assets/480/fpo--16x9--480x270--004.jpg';
 import imgSm16x9 from '../../../../../storybook-images/assets/320/fpo--16x9--320x180--004.jpg';
@@ -54,18 +56,22 @@ export const Default = (args) => {
                 slot="media"
                 alt="Image alt text"
                 default-src="${imgLg16x9}"
-                heading="Image caption text">
+                heading="Image caption text"
+              >
                 <dds-image-item
                   media="(min-width: 672px)"
-                  srcset="${imgLg16x9}">
+                  srcset="${imgLg16x9}"
+                >
                 </dds-image-item>
                 <dds-image-item
                   media="(min-width: 400px)"
-                  srcset="${imgMd16x9}">
+                  srcset="${imgMd16x9}"
+                >
                 </dds-image-item>
                 <dds-image-item
                   media="(min-width: 320px)"
-                  srcset="${imgSm16x9}">
+                  srcset="${imgSm16x9}"
+                >
                 </dds-image-item>
               </dds-image>
               <dds-content-item-copy
@@ -78,7 +84,8 @@ export const Default = (args) => {
               <dds-text-cta
                 slot="footer"
                 cta-type="local"
-                href="https://www.example.com">
+                href="https://www.example.com"
+              >
                 Read more about NLP
               </dds-text-cta>
             </dds-content-item>
@@ -92,7 +99,8 @@ export const Default = (args) => {
               >
               <dds-video-player-container
                 slot="media"
-                video-id="0_ibuqxqbe"></dds-video-player-container>
+                video-id="0_ibuqxqbe"
+              ></dds-video-player-container>
               <dds-content-item-copy
                 >This area of NLP takes "real world" text and applies a symbolic
                 system for a machine to interpret its meaning, using formal
@@ -103,7 +111,8 @@ export const Default = (args) => {
               <dds-text-cta
                 slot="footer"
                 cta-type="local"
-                href="https://www.example.com">
+                href="https://www.example.com"
+              >
                 Read more about NLP
               </dds-text-cta>
             </dds-content-item>
@@ -114,7 +123,8 @@ export const Default = (args) => {
             <dds-card-link-cta
               slot="footer"
               cta-type="local"
-              href="https://www.example.com">
+              href="https://www.example.com"
+            >
               <dds-card-link-heading
                 >Learn more about natual language
                 processing</dds-card-link-heading
@@ -127,18 +137,36 @@ export const Default = (args) => {
   `;
 };
 
+let currentHeadingText = null;
+
 export default {
   title: 'Components/Content group',
   decorators: [
-    (story) => html`
-      <div class="bx--grid">
-        <div class="bx--row">
-          <div class="bx--col-lg-12 bx--no-gutter">
-            <dds-video-cta-container> ${story()} </dds-video-cta-container>
+    (story, context) => {
+      const { args, id: storyId } = context;
+
+      // Due to the way that `<dds-content-group-heading>` is implemented, we
+      // need to force a remount of the component every time the heading text
+      // changes. We track the value of the current heading text in an in scope
+      // variable and when we detect a change, we trigger a remount.
+      if (
+        currentHeadingText !== null &&
+        currentHeadingText !== args.ContentGroup.heading
+      ) {
+        addons.getChannel().emit(FORCE_REMOUNT, { storyId });
+      }
+      currentHeadingText = args.ContentGroup.heading;
+
+      return html`
+        <div class="bx--grid">
+          <div class="bx--row">
+            <div class="bx--col-lg-12 bx--no-gutter">
+              <dds-video-cta-container> ${story()} </dds-video-cta-container>
+            </div>
           </div>
         </div>
-      </div>
-    `,
+      `;
+    },
   ],
   parameters: {
     ...readme.parameters,

--- a/packages/web-components/src/components/content-group/__stories__/content-group.stories.ts
+++ b/packages/web-components/src/components/content-group/__stories__/content-group.stories.ts
@@ -58,22 +58,18 @@ export const Default = (args) => {
                 slot="media"
                 alt="Image alt text"
                 default-src="${imgLg16x9}"
-                heading="Image caption text"
-              >
+                heading="Image caption text">
                 <dds-image-item
                   media="(min-width: 672px)"
-                  srcset="${imgLg16x9}"
-                >
+                  srcset="${imgLg16x9}">
                 </dds-image-item>
                 <dds-image-item
                   media="(min-width: 400px)"
-                  srcset="${imgMd16x9}"
-                >
+                  srcset="${imgMd16x9}">
                 </dds-image-item>
                 <dds-image-item
                   media="(min-width: 320px)"
-                  srcset="${imgSm16x9}"
-                >
+                  srcset="${imgSm16x9}">
                 </dds-image-item>
               </dds-image>
               <dds-content-item-copy
@@ -86,8 +82,7 @@ export const Default = (args) => {
               <dds-text-cta
                 slot="footer"
                 cta-type="local"
-                href="https://www.example.com"
-              >
+                href="https://www.example.com">
                 Read more about NLP
               </dds-text-cta>
             </dds-content-item>
@@ -101,8 +96,7 @@ export const Default = (args) => {
               >
               <dds-video-player-container
                 slot="media"
-                video-id="0_ibuqxqbe"
-              ></dds-video-player-container>
+                video-id="0_ibuqxqbe"></dds-video-player-container>
               <dds-content-item-copy
                 >This area of NLP takes "real world" text and applies a symbolic
                 system for a machine to interpret its meaning, using formal
@@ -113,8 +107,7 @@ export const Default = (args) => {
               <dds-text-cta
                 slot="footer"
                 cta-type="local"
-                href="https://www.example.com"
-              >
+                href="https://www.example.com">
                 Read more about NLP
               </dds-text-cta>
             </dds-content-item>
@@ -125,8 +118,7 @@ export const Default = (args) => {
             <dds-card-link-cta
               slot="footer"
               cta-type="local"
-              href="https://www.example.com"
-            >
+              href="https://www.example.com">
               <dds-card-link-heading
                 >Learn more about natual language
                 processing</dds-card-link-heading

--- a/packages/web-components/src/components/content-group/__stories__/content-group.stories.ts
+++ b/packages/web-components/src/components/content-group/__stories__/content-group.stories.ts
@@ -26,7 +26,9 @@ export const Default = (args) => {
     args?.ContentGroup ?? {};
   return html`
     <dds-content-group>
-      <dds-content-group-heading>${heading}</dds-content-group-heading>
+      <dds-content-group-heading
+        ><a name="thing"></a>${heading}</dds-content-group-heading
+      >
       ${showCopy
         ? html` <dds-content-group-copy>${copy}</dds-content-group-copy> `
         : ''}

--- a/packages/web-components/src/components/content-group/content-group-heading.ts
+++ b/packages/web-components/src/components/content-group/content-group-heading.ts
@@ -8,6 +8,7 @@
  */
 
 import { html, property, LitElement } from 'lit-element';
+import { render } from 'lit-html';
 import ddsSettings from '../../internal/vendor/@carbon/ibmdotcom-utilities/utilities/settings/settings';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './content-group.scss';
@@ -28,12 +29,22 @@ class DDSContentGroupHeading extends StableSelectorMixin(LitElement) {
   @property({ reflect: true })
   slot = 'heading';
 
-  connectedCallback() {
-    super.connectedCallback();
+  /**
+   * Render the heading tag into the light DOM of this component.
+   */
+  protected _renderHeading() {
+    const template = document.createElement('template');
+    template.innerHTML = `<h3>${this.innerHTML.trim()}</h3>`;
+    const heading = template.content.firstChild;
+    render(html`${heading}`, this);
+  }
+
+  firstUpdated() {
+    this._renderHeading();
   }
 
   render() {
-    return html` <h3><slot></slot></h3>`;
+    return html`<slot></slot>`;
   }
 
   static get stableSelector() {

--- a/packages/web-components/src/components/content-group/content-group.scss
+++ b/packages/web-components/src/components/content-group/content-group.scss
@@ -21,13 +21,3 @@
 :host(#{$dds-prefix}-content-group-copy) {
   @include carbon--type-style('body-long-02');
 }
-
-:host(#{$dds-prefix}-content-group-heading) {
-  @include carbon--type-style('expressive-heading-04', true);
-
-  h3 {
-    font: inherit;
-    letter-spacing: inherit;
-    line-height: inherit;
-  }
-}


### PR DESCRIPTION
### Related Ticket(s)

[Jira ticket](https://jsw.ibm.com/browse/ADCMS-5810)

### Description

Adjusts the `<dds-content-group-heading>` component to render its heading to the light DOM, and then reflect it back via default slot. This allows arbitrary HTML to be slotted, as we had before, but to also enforce an `<h3>` to the light DOM to fix the SEO issues.

### Changelog

**Changed**

- content-group-heading component will now wrap the slotted markup in and `<h3>` and write the result to the light DOM for SEO purposes

### Testing Instructions

* Visit the Content Group stories. Pay particular attention to the `<dds-content-group-heading>` component.
* Check against the current v1 Storybook
* There should be no visual regressions
* Inspect the source of the `<dds-content-group-heading>` component. 
* An `<h3>` tag should be present in the light DOM, wrapping any markup that was slotted.
* Also try adjusting the Heading knob in Storybook. The changes should be reflected in the Story.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
