### PR TITLE
fix(callout-quote): forcing sans-serif font in non latin fonts

### DIFF
--- a/packages/styles/scss/components/callout-quote/index.scss
+++ b/packages/styles/scss/components/callout-quote/index.scss
@@ -26,7 +26,7 @@
     }
 
     &[lang="ar"],
-    &[lang="cn"],
+    &[lang="zh"],
     &[lang="jp"],
     &[lang="ko"] {
       .#{$prefix}--quote__copy {

--- a/packages/styles/scss/components/callout-quote/index.scss
+++ b/packages/styles/scss/components/callout-quote/index.scss
@@ -25,12 +25,12 @@
       }
     }
 
-    &[lang="ar"],
-    &[lang="zh"],
-    &[lang="jp"],
-    &[lang="ko"] {
+    &[lang='ar'],
+    &[lang='zh'],
+    &[lang='jp'],
+    &[lang='ko'] {
       .#{$prefix}--quote__copy {
-         @include carbon--font-family('sans');
+        @include carbon--font-family('sans');
       }
     }
   }

--- a/packages/styles/scss/components/callout-quote/index.scss
+++ b/packages/styles/scss/components/callout-quote/index.scss
@@ -24,6 +24,15 @@
         }
       }
     }
+
+    &[lang="ar"],
+    &[lang="cn"],
+    &[lang="jp"],
+    &[lang="ko"] {
+      .#{$prefix}--quote__copy {
+         @include carbon--font-family('sans');
+      }
+    }
   }
 
   .#{$prefix}--callout-quote .#{$prefix}--callout__container {

--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -23,6 +23,15 @@
       padding-left: $spacing-05;
       max-width: 80%;
     }
+
+    &[lang="ar"],
+    &[lang="cn"],
+    &[lang="jp"],
+    &[lang="ko"] {
+      .#{$prefix}--quote__copy {
+         @include carbon--font-family('sans');
+      }
+    }
   }
 
   .#{$prefix}--quote__container {
@@ -36,7 +45,6 @@
   .#{$prefix}--quote__copy {
     @include carbon--make-col-ready;
     @include carbon--type-style('quotation-01', true);
-    @include carbon--font-family('serif');
 
     word-break: break-word;
     padding: 0 $spacing-07 $carbon--layout-03 $spacing-07;

--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -24,12 +24,12 @@
       max-width: 80%;
     }
 
-    &[lang="ar"],
-    &[lang="zh"],
-    &[lang="jp"],
-    &[lang="ko"] {
+    &[lang='ar'],
+    &[lang='zh'],
+    &[lang='jp'],
+    &[lang='ko'] {
       .#{$prefix}--quote__copy {
-         @include carbon--font-family('sans');
+        @include carbon--font-family('sans');
       }
     }
   }

--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -25,7 +25,7 @@
     }
 
     &[lang="ar"],
-    &[lang="cn"],
+    &[lang="zh"],
     &[lang="jp"],
     &[lang="ko"] {
       .#{$prefix}--quote__copy {

--- a/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
+++ b/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
@@ -64,7 +64,8 @@ export default {
       CalloutQuote: () => ({
         copy: textNullable(
           'Quote (copy):',
-          '経営幹部の71％は、メインフレーム・ベースのアプリケーションこそビジネス戦略の中心であると述べています。'
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus est purus, posuere at est vitae, ' +
+            'ornare rhoncus sem. Suspendisse vitae tellus fermentum, hendrerit augue eu, placerat magna.'
         ),
         quoteMark: select(
           'Quote Mark (markType):',

--- a/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
+++ b/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
@@ -64,8 +64,7 @@ export default {
       CalloutQuote: () => ({
         copy: textNullable(
           'Quote (copy):',
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus est purus, posuere at est vitae, ' +
-            'ornare rhoncus sem. Suspendisse vitae tellus fermentum, hendrerit augue eu, placerat magna.'
+          '経営幹部の71％は、メインフレーム・ベースのアプリケーションこそビジネス戦略の中心であると述べています。'
         ),
         quoteMark: select(
           'Quote Mark (markType):',

--- a/packages/web-components/src/components/carousel/__tests__/carousel.test.ts
+++ b/packages/web-components/src/components/carousel/__tests__/carousel.test.ts
@@ -37,7 +37,7 @@ describe('dds-carousel', function () {
       const origResult = origComputedStyle.call(window, elem);
       return {
         getPropertyValue(name) {
-          return name !== '--dds-carousel-page-size'
+          return name !== '--dds--carousel--page-size'
             ? origResult.getPropertyValue(name)
             : pageSize;
         },

--- a/packages/web-components/src/components/quote/quote.ts
+++ b/packages/web-components/src/components/quote/quote.ts
@@ -14,6 +14,7 @@ import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import { QUOTE_TYPES, QUOTE_COLOR_SCHEMES } from './defs';
 import '../horizontal-rule/horizontal-rule';
 import { carbonElement as customElement } from '../../internal/vendor/@carbon/web-components/globals/decorators/carbon-element';
+import { LocaleAPI } from '../../internal/vendor/@carbon/ibmdotcom-services/services/Locale/';
 
 export { QUOTE_TYPES, QUOTE_COLOR_SCHEMES };
 
@@ -58,6 +59,9 @@ class DDSQuote extends StableSelectorMixin(LitElement) {
   @property({ reflect: true, attribute: 'color-scheme' })
   colorScheme = QUOTE_COLOR_SCHEMES.REGULAR;
 
+  @property({ reflect: true, attribute: 'lang' })
+  lc;
+
   /**
    * `true` if there is source heading.
    */
@@ -77,6 +81,13 @@ class DDSQuote extends StableSelectorMixin(LitElement) {
    * `true` if there is cta.
    */
   protected _hasFooter = false;
+
+  connectedCallback() {
+    super.connectedCallback();
+    LocaleAPI.getLang().then(({ lc }) => {
+      this.lc = lc;
+    });
+  }
 
   /**
    * Handles `slotchange` event.

--- a/packages/web-components/src/components/quote/quote.ts
+++ b/packages/web-components/src/components/quote/quote.ts
@@ -104,51 +104,69 @@ class DDSQuote extends StableSelectorMixin(LitElement) {
   }
 
   protected _renderQuote() {
-    const isLTR = getComputedStyle(this).direction.toLowerCase() === "ltr";
+    const isLTR = getComputedStyle(this).direction.toLowerCase() === 'ltr';
     switch (this.markType) {
       case QUOTE_TYPES.SINGLE_CURVED:
         return html`
-          <span class="${prefix}--quote__mark">${isLTR ? "‘" : "’"}</span>
+          <span class="${prefix}--quote__mark">${isLTR ? '‘' : '’'}</span>
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "‘" : "’"}</span>
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing"
+              >${!isLTR ? '‘' : '’'}</span
+            >
           </blockquote>
         `;
       case QUOTE_TYPES.DOUBLE_ANGLE:
         return html`
-          <span class="${prefix}--quote__mark">${isLTR ? "«" : "»"}</span>
+          <span class="${prefix}--quote__mark">${isLTR ? '«' : '»'}</span>
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "«" : "»"}</span>
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing"
+              >${!isLTR ? '«' : '»'}</span
+            >
           </blockquote>
         `;
       case QUOTE_TYPES.SINGLE_ANGLE:
         return html`
-          <span class="${prefix}--quote__mark">${isLTR ? "‹" : "›"}</span>
+          <span class="${prefix}--quote__mark">${isLTR ? '‹' : '›'}</span>
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "‹" : "›"}</span>
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing"
+              >${!isLTR ? '‹' : '›'}</span
+            >
           </blockquote>
         `;
       case QUOTE_TYPES.LOW_HIGH_REVERSED_DOUBLE_CURVED:
         return html`
-          <span class="${prefix}--quote__mark">${isLTR ? "„" : "“"}</span>
+          <span class="${prefix}--quote__mark">${isLTR ? '„' : '“'}</span>
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "„" : "“"}</span>
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing"
+              >${!isLTR ? '„' : '“'}</span
+            >
           </blockquote>
         `;
       case QUOTE_TYPES.CORNER_BRACKET:
         return html`
           <span
             class="${prefix}--quote__mark ${prefix}--quote__mark-corner-bracket"
-            >${isLTR ? "「" : "」"}</span
+            >${isLTR ? '「' : '」'}</span
           >
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "「" : "」"}</span>
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing"
+              >${!isLTR ? '「' : '」'}</span
+            >
           </blockquote>
         `;
       default:
         return html`
-          <span class="${prefix}--quote__mark">${isLTR ? "“" : "”"}</span>
+          <span class="${prefix}--quote__mark">${isLTR ? '“' : '”'}</span>
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "“" : "”"}</span>
+            <slot></slot
+            ><span class="${prefix}--quote__mark-closing"
+              >${!isLTR ? '“' : '”'}</span
+            >
           </blockquote>
         `;
     }

--- a/packages/web-components/src/components/quote/quote.ts
+++ b/packages/web-components/src/components/quote/quote.ts
@@ -104,50 +104,51 @@ class DDSQuote extends StableSelectorMixin(LitElement) {
   }
 
   protected _renderQuote() {
+    const isLTR = getComputedStyle(this).direction.toLowerCase() === "ltr";
     switch (this.markType) {
       case QUOTE_TYPES.SINGLE_CURVED:
         return html`
-          <span class="${prefix}--quote__mark">‘</span>
+          <span class="${prefix}--quote__mark">${isLTR ? "‘" : "’"}</span>
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">’</span>
+            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "‘" : "’"}</span>
           </blockquote>
         `;
       case QUOTE_TYPES.DOUBLE_ANGLE:
         return html`
-          <span class="${prefix}--quote__mark">«</span>
+          <span class="${prefix}--quote__mark">${isLTR ? "«" : "»"}</span>
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">»</span>
+            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "«" : "»"}</span>
           </blockquote>
         `;
       case QUOTE_TYPES.SINGLE_ANGLE:
         return html`
-          <span class="${prefix}--quote__mark">‹</span>
+          <span class="${prefix}--quote__mark">${isLTR ? "‹" : "›"}</span>
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">›</span>
+            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "‹" : "›"}</span>
           </blockquote>
         `;
       case QUOTE_TYPES.LOW_HIGH_REVERSED_DOUBLE_CURVED:
         return html`
-          <span class="${prefix}--quote__mark">„</span>
+          <span class="${prefix}--quote__mark">${isLTR ? "„" : "“"}</span>
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">“</span>
+            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "„" : "“"}</span>
           </blockquote>
         `;
       case QUOTE_TYPES.CORNER_BRACKET:
         return html`
           <span
             class="${prefix}--quote__mark ${prefix}--quote__mark-corner-bracket"
-            >「</span
+            >${isLTR ? "「" : "」"}</span
           >
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">」</span>
+            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "「" : "」"}</span>
           </blockquote>
         `;
       default:
         return html`
-          <span class="${prefix}--quote__mark">“</span>
+          <span class="${prefix}--quote__mark">${isLTR ? "“" : "”"}</span>
           <blockquote class="${prefix}--quote__copy">
-            <slot></slot><span class="${prefix}--quote__mark-closing">”</span>
+            <slot></slot><span class="${prefix}--quote__mark-closing">${!isLTR ? "“" : "”"}</span>
           </blockquote>
         `;
     }

--- a/packages/web-components/tests/karma.conf.js
+++ b/packages/web-components/tests/karma.conf.js
@@ -207,7 +207,7 @@ module.exports = function setupKarma(config) {
       },
       ChromeCustom: {
         base: 'ChromeHeadless',
-        flags: ['--window-size=1920,1080']
+        flags: ['--window-size=1920,1080'],
       },
     },
 

--- a/packages/web-components/tests/karma.conf.js
+++ b/packages/web-components/tests/karma.conf.js
@@ -53,7 +53,7 @@ module.exports = function setupKarma(config) {
   config.set({
     basePath: '..',
 
-    browsers: (browsers.length > 0 ? browsers : ['ChromeHeadless']).map(
+    browsers: (browsers.length > 0 ? browsers : ['ChromeCustom']).map(
       normalizeBrowser
     ),
 
@@ -204,6 +204,10 @@ module.exports = function setupKarma(config) {
       Chrome_Travis: {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox'],
+      },
+      ChromeCustom: {
+        base: 'ChromeHeadless',
+        flags: ['--window-size=1920,1080']
       },
     },
 

--- a/packages/web-components/tests/snapshots/dds-filter-panel-composite.md
+++ b/packages/web-components/tests/snapshots/dds-filter-panel-composite.md
@@ -7,17 +7,13 @@
 ```
 <slot name="heading">
 </slot>
-<button class="bx--filter-button">
-  <div class="bx--filter__modal__button">
-  </div>
-</button>
-<dds-filter-panel-modal
-  data-autoid="dds-filter-panel-modal"
+<dds-filter-panel
+  data-autoid="dds-filter-panel"
   heading=""
 >
   <slot>
   </slot>
-</dds-filter-panel-modal>
+</dds-filter-panel>
 
 ```
 
@@ -26,17 +22,13 @@
 ```
 <slot name="heading">
 </slot>
-<button class="bx--filter-button">
-  <div class="bx--filter__modal__button">
-  </div>
-</button>
-<dds-filter-panel-modal
-  data-autoid="dds-filter-panel-modal"
+<dds-filter-panel
+  data-autoid="dds-filter-panel"
   heading=""
 >
   <slot>
   </slot>
-</dds-filter-panel-modal>
+</dds-filter-panel>
 
 ```
 

--- a/packages/web-components/tests/snapshots/dds-table-of-contents.md
+++ b/packages/web-components/tests/snapshots/dds-table-of-contents.md
@@ -9,7 +9,6 @@
   <div
     class="bx--tableofcontents__sidebar"
     part="table"
-    style="transition: none; top: 0px;"
   >
     <div
       class="bx--tableofcontents__desktop__children"
@@ -24,7 +23,7 @@
     </div>
     <div
       class="dds-ce--table-of-contents__items-container"
-      style="position: sticky; top: 0"
+      style="position: sticky; top: 0px; transition: none;"
     >
       <div class="bx--tableofcontents__desktop-container">
         <div
@@ -67,7 +66,6 @@
   <div
     class="bx--tableofcontents__sidebar"
     part="table"
-    style="transition: none; top: 0px;"
   >
     <div class="bx--tableofcontents__desktop__children">
       <slot name="heading">
@@ -79,7 +77,7 @@
     </div>
     <div
       class="dds-ce--table-of-contents__items-container"
-      style="position: sticky; top: 0"
+      style="position: sticky; top: 0px; transition: none;"
     >
       <div class="bx--tableofcontents__desktop-container">
         <div
@@ -122,13 +120,12 @@
   <div
     class="bx--tableofcontents__sidebar"
     part="table"
-    style="transition: none; top: 0px;"
   >
     <div class="bx--tableofcontents__mobile-top">
     </div>
     <div
       class="dds-ce--table-of-contents__items-container"
-      style="position: sticky; top: 0"
+      style="position: sticky; top: 0px; transition: none;"
     >
       <div class="bx--tableofcontents__desktop-container">
         <div

--- a/packages/web-components/tests/snapshots/dds-tabs-extended-media.md
+++ b/packages/web-components/tests/snapshots/dds-tabs-extended-media.md
@@ -11,10 +11,17 @@
     </slot>
   </div>
   <div class="bx--tabs-extended">
-    <ul class="bx--accordion">
+    <div class="bx--tabs">
+      <ul
+        class="bx--tabs__nav bx--tabs__nav--hidden"
+        role="tablist"
+      >
+      </ul>
+    </div>
+    <div class="bx--tab-content">
       <slot>
       </slot>
-    </ul>
+    </div>
   </div>
 </div>
 
@@ -29,10 +36,17 @@
     </slot>
   </div>
   <div class="bx--tabs-extended">
-    <ul class="bx--accordion">
+    <div class="bx--tabs">
+      <ul
+        class="bx--tabs__nav bx--tabs__nav--hidden"
+        role="tablist"
+      >
+      </ul>
+    </div>
+    <div class="bx--tab-content">
       <slot>
       </slot>
-    </ul>
+    </div>
   </div>
 </div>
 

--- a/packages/web-components/tests/snapshots/dds-tabs-extended.md
+++ b/packages/web-components/tests/snapshots/dds-tabs-extended.md
@@ -6,10 +6,17 @@
 
 ```
 <div class="bx--tabs-extended bx--tabs-extended--horizontal">
-  <ul class="bx--accordion">
+  <div class="bx--tabs">
+    <ul
+      class="bx--tabs__nav bx--tabs__nav--hidden"
+      role="tablist"
+    >
+    </ul>
+  </div>
+  <div class="bx--tab-content">
     <slot>
     </slot>
-  </ul>
+  </div>
 </div>
 
 ```
@@ -18,10 +25,17 @@
 
 ```
 <div class="bx--tabs-extended bx--tabs-extended--horizontal">
-  <ul class="bx--accordion">
+  <div class="bx--tabs">
+    <ul
+      class="bx--tabs__nav bx--tabs__nav--hidden"
+      role="tablist"
+    >
+    </ul>
+  </div>
+  <div class="bx--tab-content">
     <slot>
     </slot>
-  </ul>
+  </div>
 </div>
 
 ```


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6085](https://jsw.ibm.com/browse/ADCMS-6085)

### Description

When using the callout-quote component, the shadowroot styles render the blockquote element in a serif font. (e.g. [mainframe application modernization](https://www.ibm.com/mainframe-application-modernization))

In non-latin fonts, however, there isn't a serif version of those typefaces, leading to the components rendering non-plex characters. (e.g. [MAM in Japanese](https://www.ibm.com/jp-ja/mainframe-application-modernization))

With this fixed applied:
![image](https://github.com/user-attachments/assets/802cf250-30f5-4996-9e51-15524a7e459e)

