### PR TITLE
feat(card): add subcomponents shadow parts

### DIFF
--- a/packages/styles/scss/components/image/_image.scss
+++ b/packages/styles/scss/components/image/_image.scss
@@ -48,18 +48,7 @@
 
   :host(#{$c4d-prefix}-image)[card-group-item],
   :host(#{$c4d-prefix}-image) {
-    @include ratio-base(4, 3, true);
-
     overflow: hidden;
-    block-size: 0;
-
-    padding-block-start: 75%;
-
-    .#{$c4d-prefix}--image__img {
-      position: absolute;
-      block-size: 100%;
-      inset-block-start: 0;
-    }
   }
 
   .#{$c4d-prefix}--image__longdescription {

--- a/packages/web-components/src/components/card/card-footer.ts
+++ b/packages/web-components/src/components/card/card-footer.ts
@@ -21,6 +21,7 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * Card footer.
  *
  * @element c4d-card-footer
+ * @csspart copy - The Copy. Usage: `c4d-card-footer::part(copy)`
  */
 @customElement(`${c4dPrefix}-card-footer`)
 class C4DCardFooter extends C4DLinkWithIcon {
@@ -65,7 +66,10 @@ class C4DCardFooter extends C4DLinkWithIcon {
   _renderContent() {
     const { _hasCopy: hasCopy } = this;
     return html`
-      <span ?hidden="${!hasCopy}" class="${prefix}--card__cta__copy">
+      <span
+        ?hidden="${!hasCopy}"
+        class="${prefix}--card__cta__copy"
+        part="copy">
         <slot @slotchange="${this._handleSlotChange}"></slot>
       </span>
     `;

--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -43,6 +43,7 @@ const slotExistencePropertyNames = {
  * @slot heading - The heading content.
  * @slot image - The image content.
  * @slot footer - The footer content.
+ * @csspart caption - The Caption (default heading). Usage: `c4d-card::part(caption)`
  * @csspart copy - The Copy. Usage: `c4d-card::part(copy)`
  * @csspart container - The Inner content container. Usage: `c4d-card::part(container)`
  * @csspart video-thumbnail - The video thumbnail. Usage: `c4d-card::part(video-thumbnail)`
@@ -116,7 +117,7 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
     );
     return html`
       <slot name="heading"></slot
-      ><c4d-card-heading>${caption}</c4d-card-heading>
+      ><c4d-card-heading part="caption">${caption}</c4d-card-heading>
     `;
   }
 

--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -44,6 +44,7 @@ const slotExistencePropertyNames = {
  * @slot image - The image content.
  * @slot footer - The footer content.
  * @csspart copy - The Copy. Usage: `c4d-card::part(copy)`
+ * @csspart container - The Inner content container. Usage: `c4d-card::part(container)`
  * @csspart video-thumbnail - The video thumbnail. Usage: `c4d-card::part(video-thumbnail)`
  * @csspart disabled-link - . Disabled link. Usage: `c4d-card::part(disabled-link)`
  * @csspart wrapper - The component wrapper. Usage: `c4d-card::part(wrapper)`
@@ -406,7 +407,7 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
   render() {
     return this._hasPictogram
       ? html`
-          <div>
+          <div part="container">
             ${this._renderInner()}
             <a
               class="${`${prefix}--card__link`}"
@@ -418,7 +419,7 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
             >
           </div>
         `
-      : html` <div>${this._renderInner()}</div> `;
+      : html` <div part="container">${this._renderInner()}</div> `;
   }
 
   static get stableSelector() {

--- a/packages/web-components/tests/snapshots/c4d-card-footer.md
+++ b/packages/web-components/tests/snapshots/c4d-card-footer.md
@@ -15,6 +15,7 @@
   <span
     class="cds--card__cta__copy"
     hidden=""
+    part="copy"
   >
     <slot>
     </slot>
@@ -41,6 +42,7 @@
   <span
     class="cds--card__cta__copy"
     hidden=""
+    part="copy"
   >
     <slot>
     </slot>

--- a/packages/web-components/tests/snapshots/c4d-card-in-card.md
+++ b/packages/web-components/tests/snapshots/c4d-card-in-card.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--card cds--card-in-card cds--tile">
+<div
+  class="cds--card cds--card-in-card cds--tile"
+  part="container"
+>
   <slot name="image">
   </slot>
   <div
@@ -44,7 +47,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--card cds--card--link cds--card-in-card cds--tile cds--tile--clickable">
+<div
+  class="cds--card cds--card--link cds--card-in-card cds--tile cds--tile--clickable"
+  part="container"
+>
   <slot name="image">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/c4d-card.md
+++ b/packages/web-components/tests/snapshots/c4d-card.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--card cds--tile">
+<div
+  class="cds--card cds--tile"
+  part="container"
+>
   <slot name="image">
   </slot>
   <div
@@ -44,7 +47,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--card cds--tile">
+<div
+  class="cds--card cds--tile"
+  part="container"
+>
   <slot name="image">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/c4d-feature-card.md
+++ b/packages/web-components/tests/snapshots/c4d-feature-card.md
@@ -5,7 +5,10 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="cds--card cds--feature-card__card cds--tile">
+<div
+  class="cds--card cds--feature-card__card cds--tile"
+  part="container"
+>
   <slot name="image">
   </slot>
   <div
@@ -44,7 +47,10 @@
 ####   `should render with various attributes`
 
 ```
-<div class="cds--card cds--card--link cds--feature-card__card cds--tile cds--tile--clickable">
+<div
+  class="cds--card cds--card--link cds--feature-card__card cds--tile cds--tile--clickable"
+  part="container"
+>
   <slot name="image">
   </slot>
   <div

--- a/packages/web-components/tests/snapshots/c4d-filter-panel-composite.md
+++ b/packages/web-components/tests/snapshots/c4d-filter-panel-composite.md
@@ -7,19 +7,14 @@
 ```
 <slot name="heading">
 </slot>
-<cds-button
-  kind="tertiary"
-  part="button"
->
-</cds-button>
-<c4d-filter-panel-modal
-  data-autoid="c4d-filter-panel-modal"
+<c4d-filter-panel
+  data-autoid="c4d-filter-panel"
   heading=""
-  part="panel-modal"
+  part="filter-panel"
 >
   <slot>
   </slot>
-</c4d-filter-panel-modal>
+</c4d-filter-panel>
 
 ```
 

--- a/packages/web-components/tests/snapshots/c4d-masthead-profile.md
+++ b/packages/web-components/tests/snapshots/c4d-masthead-profile.md
@@ -10,7 +10,7 @@
   aria-label="User profile"
   class="cds--header__menu-item cds--header__menu-title"
   href="javascript:void 0"
-  part="masthead-profile-link"
+  part="profile-link"
   role="button"
   tabindex="0"
 >
@@ -30,7 +30,7 @@
   aria-label="User profile"
   class="cds--header__menu-item cds--header__menu-title"
   href="javascript:void 0"
-  part="masthead-profile-link"
+  part="profile-link"
   role="button"
   tabindex="0"
 >


### PR DESCRIPTION
### Related Ticket(s)
[JIRA](https://jsw.ibm.com/browse/ADCMS-6137)

### Description

Adding shadow parts to the sub components of `card`

### Changelog

**New**

- `part` attribute to HTML tags under the `card` component
 