### PR TITLE
fix(card): component renders multiple headings

### DIFF
--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -108,8 +108,9 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
       )
     );
     return html`
-      <slot name="heading"></slot
-      ><c4d-card-heading>${caption}</c4d-card-heading>
+      <slot name="heading"
+        ><c4d-card-heading>${caption}</c4d-card-heading></slot
+      >
     `;
   }
 


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6175](https://jsw.ibm.com/browse/ADCMS-6175)

### Description

C4DCard and C4DCardCTA both have a `_renderHeading()` method that returns the following:

```
<slot name="heading"></slot>
<c4d-card-heading>${caption}</c4d-card-heading>
```

If these components are authored with a <c4d-card-heading> element within them, it's automatically assigned to slot="heading". This leads to cards with multiple headings, each with their own minimum of 64px of margin-bottom.

![image](https://github.com/user-attachments/assets/ea5fcfb7-230f-4593-a194-3ef84bcfade1)


**Changed**

![image](https://github.com/user-attachments/assets/52a1c050-2a1d-44ea-91a3-a566b8962b51)

