### PR TITLE
[v1] feat(content-item-horizontal): add shadow parts

### DIFF
--- a/packages/web-components/src/components/content-item-horizontal/content-item-horizontal-media-featured.ts
+++ b/packages/web-components/src/components/content-item-horizontal/content-item-horizontal-media-featured.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -22,21 +22,32 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * media beneath.
  *
  * @element dds-content-item-horizontal-media-featured
+ * @csspart heading-wrapper - The wrapper element around the header. Usage: `dds-content-item-horizontal-media-featured::part(heading-wrapper)`
+ * @csspart row - A wrapper element around a row of content. Usage: `dds-content-item-horizontal-media-featured-media::part(row)`
+ * @csspart row--text - A wrapper element around the textual elements. Usage: `dds-content-item-horizontal-media-featured-media::part(row--text)`
+ * @csspart row--media - A wrapper element around the media. Usage: `dds-content-item-horizontal-media-featured-media::part(row--media)`
+ * @csspart body-wrapper - The wrapper element around the body. Usage: `dds-content-item-horizontal-media-featured::part(body-wrapper)`
  */
 @customElement(`${ddsPrefix}-content-item-horizontal-media-featured`)
 class DDSContentItemHorizontalMediaFeatured extends DDSContentItem {
   render() {
     return html`
-      <div class="${prefix}--content-item-horizontal__row">
-        <div class="${prefix}--content-item-horizontal__col">
+      <div part="row row--text" class="${prefix}--content-item-horizontal__row">
+        <div
+          part="heading-wrapper"
+          class="${prefix}--content-item-horizontal__col">
           <slot name="eyebrow" @slotchange="${this._handleSlotChange}"></slot>
           <slot name="heading"></slot>
         </div>
-        <div class="${prefix}--content-item-horizontal__col">
+        <div
+          part="body-wrapper"
+          class="${prefix}--content-item-horizontal__col">
           ${this._renderBody()} ${this._renderFooter()}
         </div>
       </div>
-      <div class="${prefix}--content-item-horizontal__row">
+      <div
+        part="row row--media"
+        class="${prefix}--content-item-horizontal__row">
         <slot name="media" @slotchange="${this._handleSlotChange}"></slot>
       </div>
     `;

--- a/packages/web-components/src/components/content-item-horizontal/content-item-horizontal-media.ts
+++ b/packages/web-components/src/components/content-item-horizontal/content-item-horizontal-media.ts
@@ -31,7 +31,7 @@ const breakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
  * @csspart row - The wrapper element around the entire shadow root. Usage: `dds-content-item-horizontal-media::part(row)`
  * @csspart row--content - The wrapper element around the entire shadow root. Usage: `dds-content-item-horizontal-media::part(row--content)`
  * @csspart text-column-content-wrapper - The wrapper element around the text column. Usage: `dds-content-item-horizontal-media::part(text-column-content-wrapper)`
- * @csspart media-wrapper - The wrapper element around the media. Usage: `dds-content-item-horizontal-media::part(media)`
+ * @csspart media-wrapper - The wrapper element around the media. Usage: `dds-content-item-horizontal-media::part(media-wrapper)`
  * @csspart footer-wrapper - The wrapper element around the footer. Usage: `dds-content-item-horizontal::part(footer-wrapper)`
  */
 @customElement(`${ddsPrefix}-content-item-horizontal-media`)

--- a/packages/web-components/src/components/content-item-horizontal/content-item-horizontal-media.ts
+++ b/packages/web-components/src/components/content-item-horizontal/content-item-horizontal-media.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -28,6 +28,11 @@ const breakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
  * A component to present content in a horizontal orientation with media.
  *
  * @element dds-content-item-horizontal-media
+ * @csspart row - The wrapper element around the entire shadow root. Usage: `dds-content-item-horizontal-media::part(row)`
+ * @csspart row--content - The wrapper element around the entire shadow root. Usage: `dds-content-item-horizontal-media::part(row--content)`
+ * @csspart text-column-content-wrapper - The wrapper element around the text column. Usage: `dds-content-item-horizontal-media::part(text-column-content-wrapper)`
+ * @csspart media-wrapper - The wrapper element around the media. Usage: `dds-content-item-horizontal-media::part(media)`
+ * @csspart footer-wrapper - The wrapper element around the footer. Usage: `dds-content-item-horizontal::part(footer-wrapper)`
  */
 @customElement(`${ddsPrefix}-content-item-horizontal-media`)
 class DDSContentItemHorizontalMedia extends HostListenerMixin(DDSContentItem) {
@@ -54,7 +59,9 @@ class DDSContentItemHorizontalMedia extends HostListenerMixin(DDSContentItem) {
    */
   protected _renderTextCol(): TemplateResult | string | void {
     return html`
-      <div class="${prefix}--content-item-horizontal__col">
+      <div
+        part="text-column-content-wrapper"
+        class="${prefix}--content-item-horizontal__col">
         <slot name="eyebrow" @slotchange="${this._handleSlotChange}"></slot>
         <slot name="heading"></slot>
         ${this._renderBody()} ${this._renderFooter()}
@@ -71,12 +78,16 @@ class DDSContentItemHorizontalMedia extends HostListenerMixin(DDSContentItem) {
     return alignedRight
       ? html`
           ${this._renderTextCol()}
-          <div class="${prefix}--content-item-horizontal__col">
+          <div
+            part="media-wrapper"
+            class="${prefix}--content-item-horizontal__col">
             <slot name="media" @slotchange="${this._handleSlotChange}"></slot>
           </div>
         `
       : html`
-          <div class="${prefix}--content-item-horizontal__col">
+          <div
+            part="media-wrapper"
+            class="${prefix}--content-item-horizontal__col">
             <slot name="media" @slotchange="${this._handleSlotChange}"></slot>
           </div>
           ${this._renderTextCol()}
@@ -86,6 +97,7 @@ class DDSContentItemHorizontalMedia extends HostListenerMixin(DDSContentItem) {
   render() {
     return html`
       <div
+        part="row row--content"
         class="${prefix}--content-item-horizontal__row ${prefix}--content-item-horizontal-media__align-${this
           .align}">
         ${this._renderContent()}

--- a/packages/web-components/src/components/content-item-horizontal/content-item-horizontal.ts
+++ b/packages/web-components/src/components/content-item-horizontal/content-item-horizontal.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,6 +21,11 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * A component to present a content in a horizontal orientation.
  *
  * @element dds-content-item-horizontal
+ * @csspart heading-wrapper - The wrapper element around the header. Usage: `dds-content-item-horizontal::part(heading-wrapper)`
+ * @csspart content-wrapper - The wrapper element around the content. Usage: `dds-content-item-horizontal::part(content-wrapper)`
+ * @csspart body-wrapper - The wrapper element around the body. Usage: `dds-content-item-horizontal::part(body-wrapper)`
+ * @csspart footer-wrapper - The wrapper element around the footer. Usage: `dds-content-item-horizontal::part(footer-wrapper)`
+ * @csspart thumbnail-wrapper - The wrapper element around the thumbnail. Usage: `dds-content-item-horizontal::part(thumbnail-wrapper)`
  */
 @customElement(`${ddsPrefix}-content-item-horizontal`)
 class DDSContentItemHorizontal extends DDSContentItem {
@@ -42,26 +47,38 @@ class DDSContentItemHorizontal extends DDSContentItem {
     return html`
       ${!this.thumbnail
         ? html`
-            <div class="${prefix}--content-item-horizontal__heading-wrapper">
+            <div
+              part="heading-wrapper"
+              class="${prefix}--content-item-horizontal__heading-wrapper">
               <slot
                 name="eyebrow"
                 @slotchange="${this._handleSlotChange}"></slot>
               <slot name="heading"></slot>
             </div>
-            <div class="${prefix}--content-item-horizontal__content-wrapper">
+            <div
+              part="content-wrapper"
+              class="${prefix}--content-item-horizontal__content-wrapper">
               ${this._renderBody()}${this._renderFooter()}${this._renderMedia()}
             </div>
           `
         : html`
-            <div class="${prefix}--content-item-horizontal__body-wrapper">
-              <div class="${prefix}--content-item-horizontal__heading-wrapper">
+            <div
+              part="body-wrapper"
+              class="${prefix}--content-item-horizontal__body-wrapper">
+              <div
+                part="heading-wrapper"
+                class="${prefix}--content-item-horizontal__heading-wrapper">
                 <slot name="heading"></slot>
               </div>
-              <div class="${prefix}--content-item-horizontal__content-wrapper">
+              <div
+                part="content-wrapper"
+                class="${prefix}--content-item-horizontal__content-wrapper">
                 ${this._renderBody()}${this._renderFooter()}
               </div>
             </div>
-            <div class="${prefix}--content-item-horizontal__col--2">
+            <div
+              part="thumbnail-wrapper"
+              class="${prefix}--content-item-horizontal__col--2">
               <slot name="thumbnail" @slotchange="${this._handleSlotChange}">
               </slot>
             </div>

--- a/packages/web-components/src/components/content-item/content-item.ts
+++ b/packages/web-components/src/components/content-item/content-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,6 +31,8 @@ const slotExistencePropertyNames = {
  * @slot media - The media content.
  * @slot heading - The heading content.
  * @slot footer - The footer (CTA) content.
+ * @csspart wrapper - The wrapper element around the entire shadow root. Usage: `dds-content-item::part(wrapper)`
+ * @csspart footer-wrapper - The wrapper element around the footer. Usage: `dds-content-item::part(footer-wrapper)`
  */
 @customElement(`${ddsPrefix}-content-item`)
 class DDSContentItem extends StableSelectorMixin(LitElement) {
@@ -88,7 +90,10 @@ class DDSContentItem extends StableSelectorMixin(LitElement) {
   protected _renderFooter(): TemplateResult | string | void {
     const { _hasFooter: hasFooter } = this;
     return html`
-      <div ?hidden="${!hasFooter}" class="${prefix}--content-item__cta">
+      <div
+        part="footer-wrapper"
+        ?hidden="${!hasFooter}"
+        class="${prefix}--content-item__cta">
         <slot name="footer" @slotchange="${this._handleSlotChange}"></slot>
       </div>
     `;
@@ -97,7 +102,7 @@ class DDSContentItem extends StableSelectorMixin(LitElement) {
   render() {
     return html`
       <slot name="heading"></slot>
-      <div>
+      <div part="wrapper">
         <slot name="media"></slot>
       </div>
       ${this._renderBody()}${this._renderFooter()}

--- a/packages/web-components/tests/snapshots/dds-content-item-horizontal.md
+++ b/packages/web-components/tests/snapshots/dds-content-item-horizontal.md
@@ -5,18 +5,25 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-item-horizontal__heading-wrapper">
+<div
+  class="bx--content-item-horizontal__heading-wrapper"
+  part="heading-wrapper"
+>
   <slot name="eyebrow">
   </slot>
   <slot name="heading">
   </slot>
 </div>
-<div class="bx--content-item-horizontal__content-wrapper">
+<div
+  class="bx--content-item-horizontal__content-wrapper"
+  part="content-wrapper"
+>
   <slot>
   </slot>
   <div
     class="bx--content-item__cta"
     hidden=""
+    part="footer-wrapper"
   >
     <slot name="footer">
     </slot>
@@ -30,18 +37,25 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-item-horizontal__heading-wrapper">
+<div
+  class="bx--content-item-horizontal__heading-wrapper"
+  part="heading-wrapper"
+>
   <slot name="eyebrow">
   </slot>
   <slot name="heading">
   </slot>
 </div>
-<div class="bx--content-item-horizontal__content-wrapper">
+<div
+  class="bx--content-item-horizontal__content-wrapper"
+  part="content-wrapper"
+>
   <slot>
   </slot>
   <div
     class="bx--content-item__cta"
     hidden=""
+    part="footer-wrapper"
   >
     <slot name="footer">
     </slot>
@@ -57,8 +71,14 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-item-horizontal-media__align-right bx--content-item-horizontal__row">
-  <div class="bx--content-item-horizontal__col">
+<div
+  class="bx--content-item-horizontal-media__align-right bx--content-item-horizontal__row"
+  part="row row--content"
+>
+  <div
+    class="bx--content-item-horizontal__col"
+    part="text-column-content-wrapper"
+  >
     <slot name="eyebrow">
     </slot>
     <slot name="heading">
@@ -68,12 +88,16 @@
     <div
       class="bx--content-item__cta"
       hidden=""
+      part="footer-wrapper"
     >
       <slot name="footer">
       </slot>
     </div>
   </div>
-  <div class="bx--content-item-horizontal__col">
+  <div
+    class="bx--content-item-horizontal__col"
+    part="media-wrapper"
+  >
     <slot name="media">
     </slot>
   </div>
@@ -84,8 +108,14 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-item-horizontal-media__align-right bx--content-item-horizontal__row">
-  <div class="bx--content-item-horizontal__col">
+<div
+  class="bx--content-item-horizontal-media__align-right bx--content-item-horizontal__row"
+  part="row row--content"
+>
+  <div
+    class="bx--content-item-horizontal__col"
+    part="text-column-content-wrapper"
+  >
     <slot name="eyebrow">
     </slot>
     <slot name="heading">
@@ -95,12 +125,16 @@
     <div
       class="bx--content-item__cta"
       hidden=""
+      part="footer-wrapper"
     >
       <slot name="footer">
       </slot>
     </div>
   </div>
-  <div class="bx--content-item-horizontal__col">
+  <div
+    class="bx--content-item-horizontal__col"
+    part="media-wrapper"
+  >
     <slot name="media">
     </slot>
   </div>
@@ -113,26 +147,39 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-item-horizontal__row">
-  <div class="bx--content-item-horizontal__col">
+<div
+  class="bx--content-item-horizontal__row"
+  part="row row--text"
+>
+  <div
+    class="bx--content-item-horizontal__col"
+    part="heading-wrapper"
+  >
     <slot name="eyebrow">
     </slot>
     <slot name="heading">
     </slot>
   </div>
-  <div class="bx--content-item-horizontal__col">
+  <div
+    class="bx--content-item-horizontal__col"
+    part="body-wrapper"
+  >
     <slot>
     </slot>
     <div
       class="bx--content-item__cta"
       hidden=""
+      part="footer-wrapper"
     >
       <slot name="footer">
       </slot>
     </div>
   </div>
 </div>
-<div class="bx--content-item-horizontal__row">
+<div
+  class="bx--content-item-horizontal__row"
+  part="row row--media"
+>
   <slot name="media">
   </slot>
 </div>
@@ -142,26 +189,39 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-item-horizontal__row">
-  <div class="bx--content-item-horizontal__col">
+<div
+  class="bx--content-item-horizontal__row"
+  part="row row--text"
+>
+  <div
+    class="bx--content-item-horizontal__col"
+    part="heading-wrapper"
+  >
     <slot name="eyebrow">
     </slot>
     <slot name="heading">
     </slot>
   </div>
-  <div class="bx--content-item-horizontal__col">
+  <div
+    class="bx--content-item-horizontal__col"
+    part="body-wrapper"
+  >
     <slot>
     </slot>
     <div
       class="bx--content-item__cta"
       hidden=""
+      part="footer-wrapper"
     >
       <slot name="footer">
       </slot>
     </div>
   </div>
 </div>
-<div class="bx--content-item-horizontal__row">
+<div
+  class="bx--content-item-horizontal__row"
+  part="row row--media"
+>
   <slot name="media">
   </slot>
 </div>
@@ -173,24 +233,37 @@
 ####   `should render with minimum attributes`
 
 ```
-<div class="bx--content-item-horizontal__body-wrapper">
-  <div class="bx--content-item-horizontal__heading-wrapper">
+<div
+  class="bx--content-item-horizontal__body-wrapper"
+  part="body-wrapper"
+>
+  <div
+    class="bx--content-item-horizontal__heading-wrapper"
+    part="heading-wrapper"
+  >
     <slot name="heading">
     </slot>
   </div>
-  <div class="bx--content-item-horizontal__content-wrapper">
+  <div
+    class="bx--content-item-horizontal__content-wrapper"
+    part="content-wrapper"
+  >
     <slot>
     </slot>
     <div
       class="bx--content-item__cta"
       hidden=""
+      part="footer-wrapper"
     >
       <slot name="footer">
       </slot>
     </div>
   </div>
 </div>
-<div class="bx--content-item-horizontal__col--2">
+<div
+  class="bx--content-item-horizontal__col--2"
+  part="thumbnail-wrapper"
+>
   <slot name="thumbnail">
   </slot>
 </div>
@@ -200,24 +273,37 @@
 ####   `should render with various attributes`
 
 ```
-<div class="bx--content-item-horizontal__body-wrapper">
-  <div class="bx--content-item-horizontal__heading-wrapper">
+<div
+  class="bx--content-item-horizontal__body-wrapper"
+  part="body-wrapper"
+>
+  <div
+    class="bx--content-item-horizontal__heading-wrapper"
+    part="heading-wrapper"
+  >
     <slot name="heading">
     </slot>
   </div>
-  <div class="bx--content-item-horizontal__content-wrapper">
+  <div
+    class="bx--content-item-horizontal__content-wrapper"
+    part="content-wrapper"
+  >
     <slot>
     </slot>
     <div
       class="bx--content-item__cta"
       hidden=""
+      part="footer-wrapper"
     >
       <slot name="footer">
       </slot>
     </div>
   </div>
 </div>
-<div class="bx--content-item-horizontal__col--2">
+<div
+  class="bx--content-item-horizontal__col--2"
+  part="thumbnail-wrapper"
+>
   <slot name="thumbnail">
   </slot>
 </div>

--- a/packages/web-components/tests/snapshots/dds-content-item.md
+++ b/packages/web-components/tests/snapshots/dds-content-item.md
@@ -7,7 +7,7 @@
 ```
 <slot name="heading">
 </slot>
-<div>
+<div part="wrapper">
   <slot name="media">
   </slot>
 </div>
@@ -16,6 +16,7 @@
 <div
   class="bx--content-item__cta"
   hidden=""
+  part="footer-wrapper"
 >
   <slot name="footer">
   </slot>
@@ -28,13 +29,16 @@
 ```
 <slot name="heading">
 </slot>
-<div>
+<div part="wrapper">
   <slot name="media">
   </slot>
 </div>
 <slot>
 </slot>
-<div class="bx--content-item__cta">
+<div
+  class="bx--content-item__cta"
+  part="footer-wrapper"
+>
   <slot name="footer">
   </slot>
 </div>

--- a/packages/web-components/tests/snapshots/dds-pictogram-item.md
+++ b/packages/web-components/tests/snapshots/dds-pictogram-item.md
@@ -15,7 +15,7 @@
     <div class="bx--content-item">
       <slot name="heading">
       </slot>
-      <div>
+      <div part="wrapper">
         <slot name="media">
         </slot>
       </div>
@@ -24,6 +24,7 @@
       <div
         class="bx--content-item__cta"
         hidden=""
+        part="footer-wrapper"
       >
         <slot name="footer">
         </slot>


### PR DESCRIPTION
### Related Ticket(s)

[Jira ticket](https://jsw.ibm.com/browse/ADCMS-6329)

### Description

Adds shadow parts to the `<dds-content-item-horizontal>` family of components in order to allow for slight design adjustments in AEM.

### Changelog

**New**

- Added shadow parts for `<dds-content-item-horizontal>` family of components.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
