### PR TITLE
fix(card): arrow direction on RTL

### DIFF
--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { TemplateResult, html, LitElement} from 'lit';
+import { TemplateResult, html, LitElement } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import ArrowRight20 from '@carbon/web-components/es/icons/arrow--right/20.js';
@@ -224,20 +224,21 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
 
   /**
    * @returns The CTA arrow.
-   * 
+   *
    */
-  protected _renderArrow(){
-    const isLTR = window.getComputedStyle(this).direction.toUpperCase() === 'LTR';
+  protected _renderArrow() {
+    const isLTR =
+      window.getComputedStyle(this).direction.toUpperCase() === 'LTR';
     return html`
-            <a
-              class="${`${prefix}--card__link`}"
-              part="link"
-              href="${ifDefined(this.href)}"
-              aria-label="${this.querySelector(`${c4dPrefix}-card-heading`)
-                ?.textContent || ''}"
-              >${isLTR ? ArrowRight20() : ArrowLeft20()}</a
-            >
-    `
+      <a
+        class="${`${prefix}--card__link`}"
+        part="link"
+        href="${ifDefined(this.href)}"
+        aria-label="${this.querySelector(`${c4dPrefix}-card-heading`)
+          ?.textContent || ''}"
+        >${isLTR ? ArrowRight20() : ArrowLeft20()}</a
+      >
+    `;
   }
   /**
    * The color scheme.
@@ -429,8 +430,7 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
     return this._hasPictogram
       ? html`
           <div part="container">
-            ${this._renderInner()}
-            ${this._renderArrow()}
+            ${this._renderInner()} ${this._renderArrow()}
           </div>
         `
       : html` <div part="container">${this._renderInner()}</div> `;

--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -7,10 +7,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { TemplateResult, html, LitElement } from 'lit';
+import { TemplateResult, html, LitElement} from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import ArrowRight20 from '@carbon/web-components/es/icons/arrow--right/20.js';
+import ArrowLeft20 from '@carbon/web-components/es/icons/arrow--left/20.js';
 import CDSLink from '@carbon/web-components/es/components/link/link.js';
 import markdownToHtml from '@carbon/ibmdotcom-utilities/es/utilities/markdownToHtml/markdownToHtml.js';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
@@ -222,6 +223,23 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
   }
 
   /**
+   * @returns The CTA arrow.
+   * 
+   */
+  protected _renderArrow(){
+    const isLTR = window.getComputedStyle(this).direction.toUpperCase() === 'LTR';
+    return html`
+            <a
+              class="${`${prefix}--card__link`}"
+              part="link"
+              href="${ifDefined(this.href)}"
+              aria-label="${this.querySelector(`${c4dPrefix}-card-heading`)
+                ?.textContent || ''}"
+              >${isLTR ? ArrowRight20() : ArrowLeft20()}</a
+            >
+    `
+  }
+  /**
    * The color scheme.
    * A typical use case of using another color scheme of card is having a "CTA" purpose of card at the last in card group.
    *
@@ -406,19 +424,13 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
       this._handleVideoTitleUpdate
     );
   }
+
   render() {
     return this._hasPictogram
       ? html`
           <div part="container">
             ${this._renderInner()}
-            <a
-              class="${`${prefix}--card__link`}"
-              part="link"
-              href="${ifDefined(this.href)}"
-              aria-label="${this.querySelector(`${c4dPrefix}-card-heading`)
-                ?.textContent || ''}"
-              >${ArrowRight20()}</a
-            >
+            ${this._renderArrow()}
           </div>
         `
       : html` <div part="container">${this._renderInner()}</div> `;


### PR DESCRIPTION
### Related Ticket(s)

Closes # [ADCMS-6396](https://jsw.ibm.com/browse/ADCMS-6396)

### Description
Link icons are directing to right instead of left for card-group-pictogram in RTL pages as well as story book of v2

### Changelog

**Changed**

- Use the correct arrow icon for pictogram card in RTL



