### PR TITLE
Fix for bundling code with references to @carbon/ibmdotcom-services-store

### DIFF
--- a/packages/web-components/gulp-tasks/clean.js
+++ b/packages/web-components/gulp-tasks/clean.js
@@ -25,6 +25,7 @@ function _clean() {
     del(config.cjsDestDir),
     del(config.jsDestDir),
     del(config.sassDestDir),
+    del(config.vendorSrcDirBase),
     del('custom-elements.json'),
     del('storybook-static'),
   ]);

--- a/packages/web-components/gulp-tasks/config.js
+++ b/packages/web-components/gulp-tasks/config.js
@@ -86,6 +86,10 @@ module.exports = {
     ),
     'es'
   ),
+  servicesStoreVendorSrcDir: path.resolve(
+    __dirname,
+    '../src/internal/vendor/@carbon/ibmdotcom-services-store'
+  ),
   servicesStoreVendorESDstDir: path.resolve(
     __dirname,
     '../es/internal/vendor/@carbon/ibmdotcom-services-store'

--- a/packages/web-components/gulp-tasks/vendor.js
+++ b/packages/web-components/gulp-tasks/vendor.js
@@ -17,6 +17,7 @@ const {
   servicesVendorESDstDir,
   servicesStoreCJSSrcDir,
   servicesStoreESSrcDir,
+  servicesStoreVendorSrcDir,
   servicesStoreVendorCJSDstDir,
   servicesStoreVendorESDstDir,
   utilitiesCJSSrcDir,
@@ -40,6 +41,14 @@ const servicesVendorCJSDst = () =>
   gulp
     .src([`${servicesCJSSrcDir}/**/*`, '!**/*-{test,story}.js'])
     .pipe(gulp.dest(servicesVendorCJSDstDir));
+
+/**
+ * Generates `src/internal/vendor` contents.
+ */
+const servicesStoreVendorSrc = () =>
+  gulp
+    .src([`${servicesStoreESSrcDir}/**/*`, '!**/*-{test,story}.js'])
+    .pipe(gulp.dest(servicesStoreVendorSrcDir));
 
 /**
  * Generate `es/internal/vendor` contents.
@@ -84,7 +93,11 @@ gulp.task(
 );
 gulp.task(
   'vendor:services-store',
-  gulp.parallel(servicesStoreVendorCJSDst, servicesStoreVendorESDst)
+  gulp.parallel(
+    servicesStoreVendorSrc,
+    servicesStoreVendorCJSDst,
+    servicesStoreVendorESDst
+  )
 );
 gulp.task(
   'vendor',

--- a/packages/web-components/src/components/cta/video-cta-composite.ts
+++ b/packages/web-components/src/components/cta/video-cta-composite.ts
@@ -15,7 +15,7 @@ import HostListener from '@carbon/web-components/es/globals/decorators/host-list
 import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import ModalRenderMixin from '../../globals/mixins/modal-render';
-import { MediaData } from '@carbon/ibmdotcom-services-store/es/types/kalturaPlayerAPI';
+import { MediaData } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/kalturaPlayerAPI';
 import Handle from '../../globals/internal/handle';
 import C4DLightboxVideoPlayerComposite from '../lightbox-media-viewer/lightbox-video-player-composite';
 // Above import is interface-only ref and thus code won't be brought into the build

--- a/packages/web-components/src/components/cta/video-cta-container.ts
+++ b/packages/web-components/src/components/cta/video-cta-container.ts
@@ -12,10 +12,10 @@ import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings
 import {
   MediaData,
   MediaPlayerAPIState,
-} from '@carbon/ibmdotcom-services-store/es/types/kalturaPlayerAPI';
-import store from '@carbon/ibmdotcom-services-store/es/store.js';
-import { loadMediaData } from '@carbon/ibmdotcom-services-store/es/actions/kalturaPlayerAPI.js';
-import { MediaPlayerAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/kalturaPlayerAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/kalturaPlayerAPI';
+import store from '../../internal/vendor/@carbon/ibmdotcom-services-store/store.js';
+import { loadMediaData } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/kalturaPlayerAPI.js';
+import { MediaPlayerAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/kalturaPlayerAPI';
 import {
   C4DVideoPlayerContainerMixin,
   mapStateToProps,

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -37,7 +37,7 @@ import {
   tocContent,
   contentLeadspaceSearch,
 } from './data/content';
-import { UNAUTHENTICATED_STATUS } from '@carbon/ibmdotcom-services-store/es/types/profileAPI';
+import { UNAUTHENTICATED_STATUS } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI';
 import { TOC_TYPES } from '../../table-of-contents/defs';
 
 // eslint-disable-next-line sort-imports

--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell-composite.ts
@@ -12,7 +12,7 @@ import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import { globalInit } from '@carbon/ibmdotcom-services/es/services/global/global.js';
-import { LocaleList } from '@carbon/ibmdotcom-services-store/es/types/localeAPI';
+import { LocaleList } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/localeAPI';
 import {
   BasicLink,
   BasicLinkSet,
@@ -20,8 +20,8 @@ import {
   L0MenuItem,
   MastheadProfileItem,
   Translation,
-} from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
-import { UNAUTHENTICATED_STATUS } from '@carbon/ibmdotcom-services-store/es/types/profileAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
+import { UNAUTHENTICATED_STATUS } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI';
 import { FOOTER_SIZE } from '../footer/footer';
 import '../footer/footer-composite';
 import './dotcom-shell';

--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell-container.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell-container.ts
@@ -10,11 +10,11 @@
 import { ActionCreatorsMapObject, Dispatch, Store } from 'redux';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import ConnectMixin from '../../globals/mixins/connect';
-import store from '@carbon/ibmdotcom-services-store/es/store.js';
-import { LocaleAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/localeAPI';
-import { TranslateAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/translateAPI';
-import { ProfileAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/profileAPI';
-import { SearchAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/searchAPI';
+import store from '../../internal/vendor/@carbon/ibmdotcom-services-store/store.js';
+import { LocaleAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/localeAPI';
+import { TranslateAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/translateAPI';
+import { ProfileAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/profileAPI';
+import { SearchAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/searchAPI';
 import {
   FooterContainerActions,
   FooterContainerState,

--- a/packages/web-components/src/components/footer/__stories__/adjunct-links.ts
+++ b/packages/web-components/src/components/footer/__stories__/adjunct-links.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { BasicLink } from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+import { BasicLink } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 
 const adjunctLinks: BasicLink[] = [
   {

--- a/packages/web-components/src/components/footer/__stories__/legal-links.ts
+++ b/packages/web-components/src/components/footer/__stories__/legal-links.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { BasicLink } from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+import { BasicLink } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 
 const legalLinks: BasicLink[] = [
   {

--- a/packages/web-components/src/components/footer/__stories__/links.ts
+++ b/packages/web-components/src/components/footer/__stories__/links.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { BasicLinkSet } from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+import { BasicLinkSet } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 
 /**
  * Footer links.

--- a/packages/web-components/src/components/footer/__tests__/footer-composite.test.ts
+++ b/packages/web-components/src/components/footer/__tests__/footer-composite.test.ts
@@ -9,11 +9,11 @@
 
 import { render } from 'lit/html.js';
 import { forEach } from '../../../globals/internal/collection-helpers';
-import { LocaleList } from '@carbon/ibmdotcom-services-store/es/types/localeAPI';
+import { LocaleList } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/localeAPI';
 import {
   BasicLink,
   BasicLinkSet,
-} from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+} from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 import '../footer-composite';
 import { Default } from '../__stories__/footer.stories';
 

--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -21,12 +21,12 @@ import MediaQueryMixin, {
 import HybridRenderMixin from '../../globals/mixins/hybrid-render';
 import ModalRenderMixin from '../../globals/mixins/modal-render';
 import { globalInit } from '@carbon/ibmdotcom-services/es/services/global/global.js';
-import { LocaleList } from '@carbon/ibmdotcom-services-store/es/types/localeAPI';
+import { LocaleList } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/localeAPI';
 import {
   BasicLink,
   BasicLinkSet,
   Translation,
-} from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 import { FOOTER_SIZE } from './footer';
 import { DROPDOWN_SIZE } from './combo-box';
 // Above import is interface-only ref and thus code won't be brought into the build

--- a/packages/web-components/src/components/footer/footer-container.ts
+++ b/packages/web-components/src/components/footer/footer-container.ts
@@ -16,25 +16,25 @@ import {
 } from 'redux';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import ConnectMixin from '../../globals/mixins/connect';
-import store from '@carbon/ibmdotcom-services-store/es/store.js';
-import { LocaleAPIState } from '@carbon/ibmdotcom-services-store/es/types/localeAPI';
+import store from '../../internal/vendor/@carbon/ibmdotcom-services-store/store.js';
+import { LocaleAPIState } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/localeAPI';
 import {
   BasicLink,
   BasicLinkSet,
   TranslateAPIState,
-} from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 import {
   loadLanguage,
   setLanguage,
   loadLocaleList,
   setLocaleList,
-} from '@carbon/ibmdotcom-services-store/es/actions/localeAPI.js';
-import { LocaleAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/localeAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/localeAPI.js';
+import { LocaleAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/localeAPI';
 import {
   loadTranslation,
   setTranslation,
-} from '@carbon/ibmdotcom-services-store/es/actions/translateAPI.js';
-import { TranslateAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/translateAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/translateAPI.js';
+import { TranslateAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/translateAPI';
 import {
   LocaleModalContainerState,
   LocaleModalContainerStateProps,

--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm-composite.ts
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm-composite.ts
@@ -16,7 +16,7 @@ import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings
 import {
   LeavingIBMLabels,
   Translation,
-} from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 import './leaving-ibm-modal';
 import './leaving-ibm-modal-body';
 import './leaving-ibm-modal-heading';

--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm-connect.ts
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm-connect.ts
@@ -8,15 +8,15 @@
  */
 
 import { ActionCreatorsMapObject, Dispatch, bindActionCreators } from 'redux';
-import { LocaleAPIState } from '@carbon/ibmdotcom-services-store/es/types/localeAPI';
+import { LocaleAPIState } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/localeAPI';
 import {
   LeavingIBMLabels,
   MiscLabels,
   TranslateAPIState,
-} from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
-import { loadTranslation } from '@carbon/ibmdotcom-services-store/es/actions/translateAPI.js';
-import { TranslateAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/translateAPI';
-import { setLanguage } from '@carbon/ibmdotcom-services-store/es/actions/localeAPI.js';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
+import { loadTranslation } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/translateAPI.js';
+import { TranslateAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/translateAPI';
+import { setLanguage } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/localeAPI.js';
 
 /**
  * The Redux state used for `<c4d-leaving-ibm-container>`.

--- a/packages/web-components/src/components/leaving-ibm/leaving-ibm-container.ts
+++ b/packages/web-components/src/components/leaving-ibm/leaving-ibm-container.ts
@@ -9,9 +9,9 @@
 
 import { ActionCreatorsMapObject, Store } from 'redux';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import store from '@carbon/ibmdotcom-services-store/es/store.js';
-import { LocaleAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/localeAPI';
-import { TranslateAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/translateAPI';
+import store from '../../internal/vendor/@carbon/ibmdotcom-services-store/store.js';
+import { LocaleAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/localeAPI';
+import { TranslateAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/translateAPI';
 import ConnectMixin from '../../globals/mixins/connect';
 import {
   mapStateToProps,

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
@@ -13,7 +13,7 @@ import on from '@carbon/web-components/es/globals/mixins/on.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import { MediaData } from '@carbon/ibmdotcom-services-store/es/types/kalturaPlayerAPI';
+import { MediaData } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/kalturaPlayerAPI';
 import ModalRenderMixin from '../../globals/mixins/modal-render';
 import Handle from '../../globals/internal/handle';
 import C4DVideoPlayerComposite from '../video-player/video-player-composite';

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-container.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-container.ts
@@ -9,8 +9,8 @@
 
 import { ActionCreatorsMapObject, Store } from 'redux';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import store from '@carbon/ibmdotcom-services-store/es/store.js';
-import { MediaPlayerAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/kalturaPlayerAPI';
+import store from '../../internal/vendor/@carbon/ibmdotcom-services-store/store.js';
+import { MediaPlayerAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/kalturaPlayerAPI';
 import ConnectMixin from '../../globals/mixins/connect';
 import {
   VideoPlayerContainerState,

--- a/packages/web-components/src/components/locale-modal/__tests__/locale-modal-composite.test.ts
+++ b/packages/web-components/src/components/locale-modal/__tests__/locale-modal-composite.test.ts
@@ -9,7 +9,7 @@
 
 import { html, render } from 'lit/html.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { LocaleList } from '@carbon/ibmdotcom-services-store/es/types/localeAPI';
+import { LocaleList } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/localeAPI';
 // Above import is interface-only ref and thus code won't be brought into the build
 import '../locale-modal-container';
 import localeData from '../__stories__/locale-data.json';

--- a/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
@@ -21,7 +21,7 @@ import HybridRenderMixin from '../../globals/mixins/hybrid-render';
 import {
   Country,
   LocaleList,
-} from '@carbon/ibmdotcom-services-store/es/types/localeAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/localeAPI';
 import './locale-modal';
 import C4DLocaleModal from './locale-modal';
 import './regions';

--- a/packages/web-components/src/components/locale-modal/locale-modal-container.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal-container.ts
@@ -16,17 +16,17 @@ import {
 } from 'redux';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import ConnectMixin from '../../globals/mixins/connect';
-import store from '@carbon/ibmdotcom-services-store/es/store.js';
+import store from '../../internal/vendor/@carbon/ibmdotcom-services-store/store.js';
 import {
   LocaleList,
   LocaleAPIState,
-} from '@carbon/ibmdotcom-services-store/es/types/localeAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/localeAPI';
 import {
   loadLanguage,
   setLanguage,
   loadLocaleList,
-} from '@carbon/ibmdotcom-services-store/es/actions/localeAPI.js';
-import { LocaleAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/localeAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/localeAPI.js';
+import { LocaleAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/localeAPI';
 import C4DLocaleModalComposite from './locale-modal-composite';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
 

--- a/packages/web-components/src/components/masthead/__stories__/links.ts
+++ b/packages/web-components/src/components/masthead/__stories__/links.ts
@@ -11,7 +11,7 @@ import {
   MastheadL1,
   MastheadLogoData,
   L0MenuItem,
-} from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+} from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 
 /* eslint-disable max-len */
 

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -26,7 +26,7 @@ import {
 import {
   UNAUTHENTICATED_STATUS,
   MASTHEAD_AUTH_METHOD,
-} from '@carbon/ibmdotcom-services-store/es/types/profileAPI.js';
+} from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI.js';
 import {
   authenticatedProfileItems,
   unauthenticatedProfileItems,

--- a/packages/web-components/src/components/masthead/__stories__/profile-items.ts
+++ b/packages/web-components/src/components/masthead/__stories__/profile-items.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { MastheadProfileItem } from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+import { MastheadProfileItem } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 
 const searchParams = new URLSearchParams();
 searchParams.append('response_type', 'token');

--- a/packages/web-components/src/components/masthead/__stories__/scoped-search-masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/scoped-search-masthead.stories.ts
@@ -17,7 +17,7 @@ import c4dLeftNav from '../left-nav';
 import '../masthead-container';
 import styles from './masthead.stories.scss';
 import { mastheadL0Data } from './links';
-import { UNAUTHENTICATED_STATUS } from '@carbon/ibmdotcom-services-store/es/types/profileAPI.js';
+import { UNAUTHENTICATED_STATUS } from '../../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI.js';
 import {
   authenticatedProfileItems,
   unauthenticatedProfileItems,

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -30,12 +30,12 @@ import {
   L0Megamenu,
   Megapanel,
   MegapanelLinkGroup,
-} from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 import {
   UNAUTHENTICATED_STATUS,
   CLOUD_UNAUTHENTICATED_STATUS,
   MASTHEAD_AUTH_METHOD,
-} from '@carbon/ibmdotcom-services-store/es/types/profileAPI.js';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI.js';
 import { MEGAMENU_RIGHT_NAVIGATION_STYLE_SCHEME } from './megamenu-right-navigation';
 import { C4D_CUSTOM_PROFILE_LOGIN } from '../../globals/internal/feature-flags';
 import C4DMastheadLogo from './masthead-logo';

--- a/packages/web-components/src/components/masthead/masthead-container.ts
+++ b/packages/web-components/src/components/masthead/masthead-container.ts
@@ -15,22 +15,22 @@ import {
   bindActionCreators,
 } from 'redux';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import { LocaleAPIState } from '@carbon/ibmdotcom-services-store/es/types/localeAPI';
+import { LocaleAPIState } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/localeAPI';
 import {
   L0MenuItem,
   TranslateAPIState,
-} from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
-import { ProfileAPIState } from '@carbon/ibmdotcom-services-store/es/types/profileAPI';
-import store from '@carbon/ibmdotcom-services-store/es/store.js';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
+import { ProfileAPIState } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/profileAPI';
+import store from '../../internal/vendor/@carbon/ibmdotcom-services-store/store.js';
 import {
   loadLanguage,
   setLanguage,
-} from '@carbon/ibmdotcom-services-store/es/actions/localeAPI.js';
-import { LocaleAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/localeAPI';
-import { loadTranslation } from '@carbon/ibmdotcom-services-store/es/actions/translateAPI.js';
-import { TranslateAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/translateAPI';
-import { loadUserStatus } from '@carbon/ibmdotcom-services-store/es/actions/profileAPI.js';
-import { ProfileAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/profileAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/localeAPI.js';
+import { LocaleAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/localeAPI';
+import { loadTranslation } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/translateAPI.js';
+import { TranslateAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/translateAPI';
+import { loadUserStatus } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/profileAPI.js';
+import { ProfileAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/profileAPI';
 import ConnectMixin from '../../globals/mixins/connect';
 
 import C4DMastheadComposite from './masthead-composite';

--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -19,7 +19,7 @@ import {
   L1CtaLink,
   L1SubmenuSectionHeading,
   MastheadL1,
-} from '@carbon/ibmdotcom-services-store/es/types/translateAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/translateAPI';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import ChevronDown16 from '@carbon/web-components/es/icons/chevron--down/16.js';

--- a/packages/web-components/src/components/video-player/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player/video-player-composite.ts
@@ -15,7 +15,7 @@ import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-lis
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import KalturaPlayerAPI from '@carbon/ibmdotcom-services/es/services/KalturaPlayer/KalturaPlayer.js';
 import HybridRenderMixin from '../../globals/mixins/hybrid-render';
-import { MediaData } from '@carbon/ibmdotcom-services-store/es/types/kalturaPlayerAPI';
+import { MediaData } from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/kalturaPlayerAPI';
 import {
   VIDEO_PLAYER_CONTENT_STATE,
   VIDEO_PLAYER_PLAYING_MODE,

--- a/packages/web-components/src/components/video-player/video-player-container.ts
+++ b/packages/web-components/src/components/video-player/video-player-container.ts
@@ -16,13 +16,13 @@ import {
 import {} from 'lit';
 import KalturaPlayerAPI from '@carbon/ibmdotcom-services/es/services/KalturaPlayer/KalturaPlayer.js';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
-import store from '@carbon/ibmdotcom-services-store/es/store.js';
+import store from '../../internal/vendor/@carbon/ibmdotcom-services-store/store.js';
 import {
   MediaData,
   MediaPlayerAPIState,
-} from '@carbon/ibmdotcom-services-store/es/types/kalturaPlayerAPI';
-import { loadMediaData } from '@carbon/ibmdotcom-services-store/es/actions/kalturaPlayerAPI.js';
-import { MediaPlayerAPIActions } from '@carbon/ibmdotcom-services-store/es/actions/kalturaPlayerAPI';
+} from '../../internal/vendor/@carbon/ibmdotcom-services-store/types/kalturaPlayerAPI';
+import { loadMediaData } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/kalturaPlayerAPI.js';
+import { MediaPlayerAPIActions } from '../../internal/vendor/@carbon/ibmdotcom-services-store/actions/kalturaPlayerAPI';
 import { Constructor } from '../../globals/defs';
 import ConnectMixin from '../../globals/mixins/connect';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';


### PR DESCRIPTION
### Related Ticket(s)

Closes #12078 

### Description

Turns out we were overzealous in https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/12010 by removing internal references to `@carbon/ibmdotcom-services-store`. This package has to work this way b/c its not published to npm.

### Testing instructions

The best, most representative way I've found to test this is to build the project, then use `npm pack` to get a tarball, then install the tarball in a target application that bundles one or more modules in the `web-components/es/` folder, which itself uses modules from `@carbon/ibmdotcom-services-store`.

1. Checkout this branch locally, and run `yarn build`
2. Run `npm pack`
```
$ cd packages/web-components
$ npm pack --pack-destination=/Users/m4olivei/Desktop
```
3. Clone this test appilcation, or any other app that uses `@carbon/ibmdotcom-web-components` v2.14.0-rc.0. For example https://github.com/m4olivei/carbon-webpack-play/tree/services-store
4. Run the following in the application
```
$ cd carbon-webpack-play
$ npm install ~/Desktop/carbon-ibmdotcom-web-components-2.14.0-rc.0.tgz
$ npm run build
```
5. Should build clean

### Changelog

**New**

- Re-introduces copying compiled modules from `@carbon/ibmdotcom-services-store` to `web-components/src/internal` directory.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
