### PR TITLE
fix(content-block-simple): update footer spacing

### DIFF
--- a/packages/web-components/src/components/content-block-simple/content-block-simple.scss
+++ b/packages/web-components/src/components/content-block-simple/content-block-simple.scss
@@ -36,4 +36,8 @@
   ::slotted([slot='media']) {
     max-inline-size: to-rem(640px);
   }
+
+  .#{$c4d-prefix}--content-block-footer {
+    margin-block-start: $spacing-07;
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-6496

### Description

Adds `margin-block-start` to the footer wrapper in the content-block-simple element.

### Changelog

**Changed**

- fix content-block-simple spacing