### PR TITLE
[feature] Add cart icon to Masthead for SAP Commerce integration

### DIFF
--- a/packages/services/src/services/SAPCommerce/SAPCommerce.js
+++ b/packages/services/src/services/SAPCommerce/SAPCommerce.js
@@ -1,0 +1,40 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Cookies from 'js-cookie';
+
+const _cookieName = 'activeCartId';
+
+class SAPCommerceAPI {
+  /**
+   * Check if the user has an active cart by looking for the non-empty cookie.
+   *
+   * @returns {boolean}
+   */
+  static hasActiveCart() {
+    const activeCartId = SAPCommerceAPI.getActiveCartId();
+    // Return true if the activeCartId cookie is non-empty.
+    return activeCartId !== '';
+  }
+
+  /**
+   * Returns the active cart id.
+   *
+   * @returns {string}
+   *   The active cart id if there is one, otherwise empty string.
+   */
+  static getActiveCartId() {
+    const activeCartId = Cookies.get(_cookieName);
+    return activeCartId && typeof activeCartId === 'string'
+      ? activeCartId.trim()
+      : '';
+  }
+}
+
+export default SAPCommerceAPI;

--- a/packages/services/src/services/SAPCommerce/SAPCommerce.js
+++ b/packages/services/src/services/SAPCommerce/SAPCommerce.js
@@ -35,6 +35,23 @@ class SAPCommerceAPI {
       ? activeCartId.trim()
       : '';
   }
+
+  /**
+   * Set the active cart id.
+   *
+   * @param {string} activeCartId
+   *   The active cart id.
+   */
+  static setActiveCartId(activeCartId) {
+    Cookies.set(_cookieName, activeCartId.trim());
+  }
+
+  /**
+   * Remove the active cart id.
+   */
+  static removeActiveCartId() {
+    Cookies.remove(_cookieName);
+  }
 }
 
 export default SAPCommerceAPI;

--- a/packages/services/src/services/SAPCommerce/index.js
+++ b/packages/services/src/services/SAPCommerce/index.js
@@ -1,0 +1,9 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+export { default as SAPCommerceAPI } from './SAPCommerce.js';

--- a/packages/services/src/services/index.js
+++ b/packages/services/src/services/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2021
+ * Copyright IBM Corp. 2016, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,6 +13,7 @@ export * from './Locale';
 export * from './MarketingSearch';
 export * from './MastheadLogo';
 export * from './Profile';
+export * from './SAPCommerce';
 export * from './SearchTypeahead';
 export * from './Translation';
 export * from './KalturaPlayer';

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -122,6 +122,7 @@ export const Default = (args) => {
     hasProfile,
     hasCart,
     mockActiveCartId,
+    cartLabel,
     hasSearch,
     hasContact,
     initialSearchTerm,
@@ -153,7 +154,8 @@ export const Default = (args) => {
               unauthenticatedProfileItems
             )}"
             custom-profile-login="${customProfileLogin}"
-            auth-method="${MASTHEAD_AUTH_METHOD.DEFAULT}"></c4d-masthead-container>
+            auth-method="${MASTHEAD_AUTH_METHOD.DEFAULT}"
+            cart-label="${ifNonEmpty(cartLabel)}"></c4d-masthead-container>
         `
       : html`
           <c4d-masthead-container
@@ -167,7 +169,8 @@ export const Default = (args) => {
             has-search="${hasSearch}"
             has-contact="${hasContact}"
             custom-profile-login="${customProfileLogin}"
-            auth-method="${authMethod}"></c4d-masthead-container>
+            auth-method="${authMethod}"
+            cart-label="${ifNonEmpty(cartLabel)}"></c4d-masthead-container>
         `}
   `;
 };
@@ -227,6 +230,7 @@ WithCustomTypeahead.story = {
           hasProfile: 'true',
           hasCart: false,
           mockActiveCartId: '',
+          cartLabel: '',
           hasSearch: 'true',
           searchPlaceHolder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -335,6 +339,7 @@ withPlatform.story = {
           hasProfile: 'true',
           hasCart: false,
           mockActiveCartId: '',
+          cartLabel: '',
           hasSearch: 'true',
           searchPlaceHolder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -480,6 +485,7 @@ withAlternateLogoAndTooltip.story = {
           hasProfile: 'true',
           hasCart: false,
           mockActiveCartId: '',
+          cartLabel: '',
           hasSearch: 'true',
           searchPlaceholder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -528,6 +534,7 @@ WithScopedSearch.story = {
           hasProfile: 'true',
           hasCart: false,
           mockActiveCartId: '',
+          cartLabel: '',
           hasSearch: 'true',
           searchPlaceHolder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -584,6 +591,7 @@ export default {
         ),
         hasCart: boolean('show the cart functionality (has-cart)', false),
         mockActiveCartId: textNullable('mock active cart id', ''),
+        cartLabel: textNullable('cart label (cart-label)', ''),
         hasSearch: select(
           'show the search functionality (has-search)',
           ['true', 'false'],
@@ -627,6 +635,7 @@ export default {
           hasProfile: 'true',
           hasCart: false,
           mockActiveCartId: '',
+          cartLabel: '',
           hasSearch: 'true',
           initialSearchTerm: '',
           searchPlaceholder: 'Search all of IBM',

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -111,6 +111,7 @@ export const Default = (args) => {
   const {
     customProfileLogin,
     hasProfile,
+    hasCart,
     hasSearch,
     hasContact,
     initialSearchTerm,
@@ -132,6 +133,7 @@ export const Default = (args) => {
             initial-search-term="${ifDefined(initialSearchTerm)}"
             searchPlaceholder="${ifDefined(searchPlaceholder)}"
             has-profile="${hasProfile}"
+            ?has-cart="${hasCart}"
             has-search="${hasSearch}"
             has-contact="${hasContact}"
             .l0Data="${mastheadL0Data}"
@@ -150,6 +152,7 @@ export const Default = (args) => {
             initial-search-term="${ifDefined(initialSearchTerm)}"
             searchPlaceholder="${ifNonEmpty(searchPlaceholder)}"
             has-profile="${hasProfile}"
+            ?has-cart="${hasCart}"
             has-search="${hasSearch}"
             has-contact="${hasContact}"
             custom-profile-login="${customProfileLogin}"
@@ -211,6 +214,7 @@ WithCustomTypeahead.story = {
         MastheadComposite: {
           grouped: 'false',
           hasProfile: 'true',
+          hasCart: false,
           hasSearch: 'true',
           searchPlaceHolder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -317,6 +321,7 @@ withPlatform.story = {
         MastheadComposite: {
           platform: 'Platform',
           hasProfile: 'true',
+          hasCart: false,
           hasSearch: 'true',
           searchPlaceHolder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -460,6 +465,7 @@ withAlternateLogoAndTooltip.story = {
         MastheadComposite: {
           platform: null,
           hasProfile: 'true',
+          hasCart: false,
           hasSearch: 'true',
           searchPlaceholder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -506,6 +512,7 @@ WithScopedSearch.story = {
       default: {
         MastheadComposite: {
           hasProfile: 'true',
+          hasCard: false,
           hasSearch: 'true',
           searchPlaceHolder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -560,6 +567,7 @@ export default {
           ['true', 'false'],
           'true'
         ),
+        hasCart: boolean('show the cart functionality (has-cart)', false),
         hasSearch: select(
           'show the search functionality (has-search)',
           ['true', 'false'],
@@ -601,6 +609,7 @@ export default {
         MastheadComposite: {
           platform: null,
           hasProfile: 'true',
+          hasCart: false,
           hasSearch: 'true',
           initialSearchTerm: '',
           searchPlaceholder: 'Search all of IBM',

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -109,10 +109,10 @@ const enumToArray = (en) =>
     .map((key) => en[key]);
 
 const setActiveCartId = (activeCartId?: string) => {
-  if (typeof activeCartId !== 'string') {
-    SAPCommerceAPI.removeActiveCartId();
-  } else {
+  if (typeof activeCartId === 'string') {
     SAPCommerceAPI.setActiveCartId(activeCartId);
+  } else {
+    SAPCommerceAPI.removeActiveCartId();
   }
 };
 
@@ -526,7 +526,8 @@ WithScopedSearch.story = {
       default: {
         MastheadComposite: {
           hasProfile: 'true',
-          hasCard: false,
+          hasCart: false,
+          mockActiveCartId: '',
           hasSearch: 'true',
           searchPlaceHolder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -33,6 +33,7 @@ import {
 } from './profile-items';
 import { C4D_CUSTOM_PROFILE_LOGIN } from '../../../globals/internal/feature-flags';
 import readme from './README.stories.mdx';
+import SAPCommerceAPI from '@carbon/ibmdotcom-services/es/services/SAPCommerce/SAPCommerce.js';
 
 const userStatuses = {
   authenticated: 'test.user@ibm.com',
@@ -107,11 +108,20 @@ const enumToArray = (en) =>
     .filter((value) => typeof value === 'string')
     .map((key) => en[key]);
 
+const setActiveCartId = (activeCartId?: string) => {
+  if (typeof activeCartId !== 'string') {
+    SAPCommerceAPI.removeActiveCartId();
+  } else {
+    SAPCommerceAPI.setActiveCartId(activeCartId);
+  }
+};
+
 export const Default = (args) => {
   const {
     customProfileLogin,
     hasProfile,
     hasCart,
+    mockActiveCartId,
     hasSearch,
     hasContact,
     initialSearchTerm,
@@ -121,6 +131,7 @@ export const Default = (args) => {
     authMethod,
     useMock,
   } = args?.MastheadComposite ?? {};
+  setActiveCartId(mockActiveCartId);
   return html`
     <style>
       ${styles}
@@ -215,6 +226,7 @@ WithCustomTypeahead.story = {
           grouped: 'false',
           hasProfile: 'true',
           hasCart: false,
+          mockActiveCartId: '',
           hasSearch: 'true',
           searchPlaceHolder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -322,6 +334,7 @@ withPlatform.story = {
           platform: 'Platform',
           hasProfile: 'true',
           hasCart: false,
+          mockActiveCartId: '',
           hasSearch: 'true',
           searchPlaceHolder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -466,6 +479,7 @@ withAlternateLogoAndTooltip.story = {
           platform: null,
           hasProfile: 'true',
           hasCart: false,
+          mockActiveCartId: '',
           hasSearch: 'true',
           searchPlaceholder: 'Search all of IBM',
           selectedMenuItem: 'Services & Consulting',
@@ -568,6 +582,7 @@ export default {
           'true'
         ),
         hasCart: boolean('show the cart functionality (has-cart)', false),
+        mockActiveCartId: textNullable('mock active cart id', ''),
         hasSearch: select(
           'show the search functionality (has-search)',
           ['true', 'false'],
@@ -610,6 +625,7 @@ export default {
           platform: null,
           hasProfile: 'true',
           hasCart: false,
+          mockActiveCartId: '',
           hasSearch: 'true',
           initialSearchTerm: '',
           searchPlaceholder: 'Search all of IBM',

--- a/packages/web-components/src/components/masthead/masthead-cart.ts
+++ b/packages/web-components/src/components/masthead/masthead-cart.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import StableSelectorMixin from '../../globals/mixins/stable-selector';
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
+import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
+import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element';
+import ShoppingCart20 from '@carbon/web-components/es/icons/shopping--cart/20.js';
+import styles from './masthead.scss';
+
+const { prefix, stablePrefix: c4dPrefix } = settings;
+
+/**
+ * The Cart icon in the masthead.
+ *
+ * @element c4d-masthead-cart
+ * @csspart cart-link - The masthead cart link. Usage: `c4d-masthead-cart::part(cart-link)`
+ */
+@customElement(`${c4dPrefix}-masthead-cart`)
+class C4DMastheadCart extends StableSelectorMixin(LitElement) {
+  /**
+   * The `aria-label` attribute for the link.
+   */
+  @property({ attribute: 'link-label' })
+  linkLabel = 'Cart';
+
+  /**
+   * Tracks whether the user has an active cart to control the display.
+   * @todo flesh out the logic for reading the cookie
+   */
+  @property({ attribute: 'has-active-cart', reflect: true, type: Boolean })
+  hasActiveCart = true;
+
+  connectedCallback() {
+    super.connectedCallback();
+    // @todo flesh out the logic for reading the cookie
+  }
+
+  render() {
+    const { linkLabel, hasActiveCart } = this;
+
+    // @todo vary link by locale
+    return hasActiveCart
+      ? html`
+          <a
+            part="cart-link"
+            href="/store/en/US/checkout"
+            class="${prefix}--header__menu-item ${prefix}--header__menu-title"
+            aria-label="${linkLabel}"
+            >${ShoppingCart20()}</a
+          >
+        `
+      : undefined;
+  }
+
+  static get stableSelector() {
+    return `${c4dPrefix}--masthead-cart`;
+  }
+
+  static styles = styles;
+}

--- a/packages/web-components/src/components/masthead/masthead-cart.ts
+++ b/packages/web-components/src/components/masthead/masthead-cart.ts
@@ -36,7 +36,7 @@ class C4DMastheadCart extends StableSelectorMixin(LitElement) {
   /**
    * Tracks whether the user has an active cart to control the display.
    */
-  @property({ attribute: 'has-active-cart', reflect: true, type: Boolean })
+  @state()
   hasActiveCart = false;
 
   /**
@@ -55,24 +55,29 @@ class C4DMastheadCart extends StableSelectorMixin(LitElement) {
     });
   }
 
+  updated(changedProperties) {
+    super.updated(changedProperties);
+    const { hasActiveCart } = this;
+    if (changedProperties.has('hasActiveCart')) {
+      this.hidden = !hasActiveCart;
+    }
+  }
+
   render() {
     const {
       linkLabel,
-      hasActiveCart,
       locale: { cc, lc },
     } = this;
 
-    return hasActiveCart
-      ? html`
-          <a
-            part="cart-link"
-            href="/store/${lc}/${cc}/checkout"
-            class="${prefix}--header__menu-item ${prefix}--header__menu-title"
-            aria-label="${linkLabel}"
-            >${ShoppingCart20()}</a
-          >
-        `
-      : undefined;
+    return html`
+      <a
+        part="cart-link"
+        href="/store/${lc}/${cc}/checkout"
+        class="${prefix}--header__menu-item ${prefix}--header__menu-title"
+        aria-label="${linkLabel}"
+        >${ShoppingCart20()}</a
+      >
+    `;
   }
 
   static get stableSelector() {

--- a/packages/web-components/src/components/masthead/masthead-cart.ts
+++ b/packages/web-components/src/components/masthead/masthead-cart.ts
@@ -9,11 +9,12 @@
 
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import { html, LitElement } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element';
 import ShoppingCart20 from '@carbon/web-components/es/icons/shopping--cart/20.js';
 import styles from './masthead.scss';
+import LocaleAPI from '@carbon/ibmdotcom-services/es/services/Locale/Locale.js';
 
 const { prefix, stablePrefix: c4dPrefix } = settings;
 
@@ -38,20 +39,33 @@ class C4DMastheadCart extends StableSelectorMixin(LitElement) {
   @property({ attribute: 'has-active-cart', reflect: true, type: Boolean })
   hasActiveCart = true;
 
+  /**
+   * Store the locale. Defaults to en-us.
+   */
+  @state()
+  locale = { lc: 'en', cc: 'us' };
+
   connectedCallback() {
     super.connectedCallback();
     // @todo flesh out the logic for reading the cookie
+    // Fetch the locale for the page.
+    LocaleAPI.getLocale().then((locale) => {
+      this.locale = locale;
+    });
   }
 
   render() {
-    const { linkLabel, hasActiveCart } = this;
+    const {
+      linkLabel,
+      hasActiveCart,
+      locale: { cc, lc },
+    } = this;
 
-    // @todo vary link by locale
     return hasActiveCart
       ? html`
           <a
             part="cart-link"
-            href="/store/en/US/checkout"
+            href="/store/${lc}/${cc}/checkout"
             class="${prefix}--header__menu-item ${prefix}--header__menu-title"
             aria-label="${linkLabel}"
             >${ShoppingCart20()}</a

--- a/packages/web-components/src/components/masthead/masthead-cart.ts
+++ b/packages/web-components/src/components/masthead/masthead-cart.ts
@@ -15,6 +15,7 @@ import { carbonElement as customElement } from '@carbon/web-components/es/global
 import ShoppingCart20 from '@carbon/web-components/es/icons/shopping--cart/20.js';
 import styles from './masthead.scss';
 import LocaleAPI from '@carbon/ibmdotcom-services/es/services/Locale/Locale.js';
+import SAPCommerceAPI from '@carbon/ibmdotcom-services/es/services/SAPCommerce/SAPCommerce.js';
 
 const { prefix, stablePrefix: c4dPrefix } = settings;
 
@@ -34,10 +35,9 @@ class C4DMastheadCart extends StableSelectorMixin(LitElement) {
 
   /**
    * Tracks whether the user has an active cart to control the display.
-   * @todo flesh out the logic for reading the cookie
    */
   @property({ attribute: 'has-active-cart', reflect: true, type: Boolean })
-  hasActiveCart = true;
+  hasActiveCart = false;
 
   /**
    * Store the locale. Defaults to en-us.
@@ -47,7 +47,8 @@ class C4DMastheadCart extends StableSelectorMixin(LitElement) {
 
   connectedCallback() {
     super.connectedCallback();
-    // @todo flesh out the logic for reading the cookie
+    // Check the relevant cookie for whether the user has an active cart.
+    this.hasActiveCart = SAPCommerceAPI.hasActiveCart();
     // Fetch the locale for the page.
     LocaleAPI.getLocale().then((locale) => {
       this.locale = locale;
@@ -80,3 +81,5 @@ class C4DMastheadCart extends StableSelectorMixin(LitElement) {
 
   static styles = styles;
 }
+
+export default C4DMastheadCart;

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -51,6 +51,7 @@ import './masthead-contact';
 import './masthead-global-bar';
 import './masthead-profile';
 import './masthead-profile-item';
+import './masthead-cart';
 import './megamenu';
 import './megamenu-heading';
 import './megamenu-top-nav-menu';
@@ -1179,6 +1180,11 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
         `;
   }
 
+  protected _renderCart() {
+    const { hasCart } = this;
+    return hasCart ? html`<c4d-masthead-cart></c4d-masthead-cart>` : undefined;
+  }
+
   /**
    * Gets the appropriate profile items for the current masthead state.
    *
@@ -1504,6 +1510,12 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
   hasContact = 'true';
 
   /**
+   * `true` if Cart should be shown.
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'has-cart' })
+  hasCart = false;
+
+  /**
    * The selected authentication method, either `profile-api` (default), `cookie`, or `docs-api`.
    */
   @property({ attribute: 'auth-method' })
@@ -1632,7 +1644,8 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
         ${this._renderPlatformTitle()}
         ${!isMobileVersion ? this._renderTopNav() : ''} ${this._renderSearch()}
         <c4d-masthead-global-bar ?has-search-active=${activateSearch}>
-          ${this._renderContact()} ${this._renderProfileMenu()}
+          ${this._renderContact()} ${this._renderCart()}
+          ${this._renderProfileMenu()}
         </c4d-masthead-global-bar>
         ${this._renderL1()}
         <c4d-megamenu-overlay></c4d-megamenu-overlay>

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -1181,8 +1181,10 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
   }
 
   protected _renderCart() {
-    const { hasCart } = this;
-    return hasCart ? html`<c4d-masthead-cart></c4d-masthead-cart>` : undefined;
+    const { hasCart, cartLabel } = this;
+    return hasCart
+      ? html`<c4d-masthead-cart link-label="${cartLabel}"></c4d-masthead-cart>`
+      : undefined;
   }
 
   /**
@@ -1514,6 +1516,12 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
    */
   @property({ type: Boolean, reflect: true, attribute: 'has-cart' })
   hasCart = false;
+
+  /**
+   * Label for the cart icon.
+   */
+  @property({ type: String, reflect: true, attribute: 'cart-label' })
+  cartLabel = 'Cart';
 
   /**
    * The selected authentication method, either `profile-api` (default), `cookie`, or `docs-api`.

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -176,7 +176,7 @@ $pos-btn-bottom: calc(
 
 :host(#{$c4d-prefix}-masthead-profile),
 :host(#{$c4d-prefix}-masthead-contact),
-:host(#{$c4d-prefix}-masthead-cart[has-active-cart]) {
+:host(#{$c4d-prefix}-masthead-cart) {
   background-color: $background;
   inline-size: $spacing-09;
 
@@ -307,18 +307,18 @@ $pos-btn-bottom: calc(
 
 :host(#{$c4d-prefix}-masthead-cart) {
   position: relative;
-}
 
-:host(#{$c4d-prefix}-masthead-cart[has-active-cart])::after {
-  position: absolute;
-  display: block;
-  border-radius: 50%;
-  background-color: $button-primary-hover;
-  block-size: 10px;
-  content: '';
-  inline-size: 10px;
-  inset-block-start: 12px;
-  inset-inline-end: 10px;
+  &::after {
+    position: absolute;
+    display: block;
+    border-radius: 50%;
+    background-color: $button-primary-hover;
+    block-size: 10px;
+    content: '';
+    inline-size: 10px;
+    inset-block-start: 12px;
+    inset-inline-end: 10px;
+  }
 }
 
 :host(#{$c4d-prefix}-top-nav-item),

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -175,7 +175,8 @@ $pos-btn-bottom: calc(
 }
 
 :host(#{$c4d-prefix}-masthead-profile),
-:host(#{$c4d-prefix}-masthead-contact) {
+:host(#{$c4d-prefix}-masthead-contact),
+:host(#{$c4d-prefix}-masthead-cart[has-active-cart]) {
   background-color: $background;
   inline-size: $spacing-09;
 
@@ -302,6 +303,22 @@ $pos-btn-bottom: calc(
     background-color: transparent;
     block-size: 100%;
   }
+}
+
+:host(#{$c4d-prefix}-masthead-cart) {
+  position: relative;
+}
+
+:host(#{$c4d-prefix}-masthead-cart[has-active-cart])::after {
+  position: absolute;
+  display: block;
+  border-radius: 50%;
+  background-color: $button-primary-hover;
+  block-size: 10px;
+  content: '';
+  inline-size: 10px;
+  inset-block-start: 12px;
+  inset-inline-end: 10px;
 }
 
 :host(#{$c4d-prefix}-top-nav-item),


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6463](https://jsw.ibm.com/browse/ADCMS-6463)

### Description

Adds a new `<c4d-masthead-cart>` component to the Masthead. Needs to be opted in using `has-cart` attribute on the `<c4d-masthead-container>` component. When opted in, there is internal logic to read a cookie that will determine if the cart should be shown.

### Testing instructions

The cart icon functionality is controlled by two new knobs on the Masthead > Default story. The "show the cart functionality (has-cart)" checkbox toggles whether or not the cart renders at all. The "mock active cart id" will affect the cookie that the cart is looking for to show / hide. Anytime you change the "mock active cart id", you need to toggle the "show the cart functionality (has-cart)" so that the `<c4d-masthead-card>` component will re-render and check the cookie value. The cart icon should only appear when "show the cart functionality (has-cart)" is set **and** there is a non-empty value for "mock active cart id".

Check visuals against [Figma specs](https://www.figma.com/design/aQ0mMVEnxwDDoupkKeaNHc/Ecommerce-Mid-Fidelity-(delivery-file)?node-id=15928-64507&node-type=instance&t=bHBr0X1ykXryXSFP-0).

### Changelog

**New**

- `<c4d-masthead-cart>` component, automaticallly placed in `<c4d-masthead-global-bar>` when opted into via `has-cart` attribute on `<c4d-masthead-container>`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
