### PR TITLE
(card): Remove class form footer to make component clickable

### DIFF
--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -464,6 +464,7 @@
     }
   }
 
+  .#{$prefix}--card .#{$prefix}--card__footer,
   :host(#{$c4d-prefix}-card-footer) a,
   :host(#{$c4d-prefix}-card-cta-footer) a,
   :host(#{$c4d-prefix}-card-in-card-footer) a,

--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -166,6 +166,10 @@
       content: '';
       inset: 0;
     }
+
+    .#{$prefix}--card__footer-wrapper {
+      margin-block-start: auto;
+    }
   }
 
   // Card with pictogram placement style
@@ -460,14 +464,11 @@
     }
   }
 
-  .#{$prefix}--card .#{$prefix}--card__footer,
   :host(#{$c4d-prefix}-card-footer) a,
   :host(#{$c4d-prefix}-card-cta-footer) a,
   :host(#{$c4d-prefix}-card-in-card-footer) a,
   :host(#{$c4d-prefix}-feature-card-footer) a,
   :host(#{$c4d-prefix}-feature-cta-footer) a {
-    /* Moves the footer down to the bottom in the card */
-    margin-block-start: auto;
     text-decoration: none;
 
     &:focus {

--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -258,7 +258,7 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
           ${hasPictogram && this.pictogramPlacement === PICTOGRAM_PLACEMENT.TOP
             ? this._renderCopy()
             : ''}
-          <div part="footer-wrapper">
+          <div part="footer-wrapper" class="${prefix}--card__footer-wrapper">
             <slot name="footer"></slot>
           </div>
         </div>

--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -258,7 +258,7 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
           ${hasPictogram && this.pictogramPlacement === PICTOGRAM_PLACEMENT.TOP
             ? this._renderCopy()
             : ''}
-          <div part="footer-wrapper" class="${prefix}--card__footer">
+          <div part="footer-wrapper">
             <slot name="footer"></slot>
           </div>
         </div>


### PR DESCRIPTION
### Related Ticket(s)
 
 [JIRA](https://jsw.ibm.com/browse/ADCMS-6596)
### Description

PR to solve 
> _Card's shadowroot element matching .cds--card__footer has a pseudo-element that blocks click access to the slotted link._


### Changelog
Removed class name from footer wrapper on the `card` component
