### PR TITLE
fix(content-block-segmented): remove content-layout class

### DIFF
--- a/packages/web-components/src/components/content-block-segmented/content-block-segmented.ts
+++ b/packages/web-components/src/components/content-block-segmented/content-block-segmented.ts
@@ -35,7 +35,6 @@ class C4DContentBlockSegmented extends C4DContentBlock {
       _hasMedia: hasMedia,
     } = this;
     return classMap({
-      [`${prefix}--content-layout`]: true,
       [`${prefix}--content-layout--with-complementary`]: hasComplementary,
       [`${c4dPrefix}-ce--content-layout--with-adjacent-heading-content`]:
         hasHeading && hasContent && !hasCopy && !hasMedia,


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ICIUC-544

### Description

Removes the `content-layout` class from the shadowroot of the content-block-segmented element. This class added extra margin to the component.

V1
<img width="785" alt="Screenshot 2024-11-05 at 10 19 46 AM" src="https://github.com/user-attachments/assets/edc0c188-dd48-4e0e-a8fc-6ec4573cf77f">

V2 _current_
<img width="793" alt="Screenshot 2024-11-05 at 10 20 23 AM" src="https://github.com/user-attachments/assets/a3849043-1bcd-4312-ba05-05b24103d74b">

V2 _with fix_
<img width="782" alt="Screenshot 2024-11-05 at 10 20 05 AM" src="https://github.com/user-attachments/assets/d93ce429-db0e-4aa0-a53d-5915c0a76524">


### Changelog

**Changed**

- Fixed alignment bug in content-block-segmented