### PR TITLE
feat(promo-banner): add components

### DIFF
--- a/packages/web-components/src/components/promo-banner/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/promo-banner/__stories__/README.stories.mdx
@@ -1,0 +1,22 @@
+import {
+  Meta,
+  Props,
+  Story,
+  Canvas,
+  Description,
+} from "@storybook/addon-docs";
+import { cdnJs } from "../../../globals/internal/storybook-cdn";
+import "../index.ts";
+
+<Meta title="Promo Banner" />
+
+# Promo Banner
+
+<Canvas withToolbar>
+  <Story id="components-promo-banner--default" height="100px" />
+</Canvas>
+
+<Description markdown={`${cdnJs({ components: ["promo-banner"] })}`} />
+
+### `<caem-promo-banner>` attributes, properties, and events
+<Props of="caem-promo-banner" />

--- a/packages/web-components/src/components/promo-banner/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/promo-banner/__stories__/README.stories.mdx
@@ -1,12 +1,6 @@
-import {
-  Meta,
-  Props,
-  Story,
-  Canvas,
-  Description,
-} from "@storybook/addon-docs";
-import { cdnJs } from "../../../globals/internal/storybook-cdn";
-import "../index.ts";
+import { Meta, Props, Story, Canvas, Description } from '@storybook/addon-docs';
+import { cdnJs } from '../../../globals/internal/storybook-cdn';
+import '../index.ts';
 
 <Meta title="Promo Banner" />
 
@@ -16,7 +10,8 @@ import "../index.ts";
   <Story id="components-promo-banner--default" height="100px" />
 </Canvas>
 
-<Description markdown={`${cdnJs({ components: ["promo-banner"] })}`} />
+<Description markdown={`${cdnJs({ components: ['promo-banner'] })}`} />
 
-### `<caem-promo-banner>` attributes, properties, and events
-<Props of="caem-promo-banner" />
+### `<c4d-promo-banner>` attributes, properties, and events
+
+<Props of="c4d-promo-banner" />

--- a/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
+++ b/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
@@ -1,3 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { html } from 'lit-element';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import '../index';
@@ -55,7 +64,7 @@ export default {
   },
   decorators: [
     (story, { args: { tocLayout } }) => html`
-      <div class="caem-story-padding">
+      <div class="c4d-story-padding">
         ${tocLayout
           ? html`
               <c4d-table-of-contents class="cds--grid">
@@ -84,7 +93,7 @@ const Template = (args) => {
   const { heading, body, hasImage, cta, ctaType } = args;
 
   return html`
-    <caem-promo-banner>
+    <c4d-promo-banner>
       ${hasImage !== false // Need explicit check to test image container queries.
         ? html`
             <c4d-image
@@ -114,7 +123,7 @@ const Template = (args) => {
             >
           `
         : ''}
-    </caem-promo-banner>
+    </c4d-promo-banner>
   `;
 };
 

--- a/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
+++ b/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
@@ -16,6 +16,7 @@ import '@carbon/ibmdotcom-web-components/es/components/table-of-contents/index';
 import { types } from '@carbon/ibmdotcom-web-components/es/component-mixins/cta/cta';
 
 import readme from './README.stories.mdx';
+import { boolean, select, text } from '@storybook/addon-knobs';
 
 const incompatibleTypes = ['video', 'email', 'schedule', 'chat', 'call'];
 const ctaTypes = Object.values(types).filter(
@@ -26,6 +27,30 @@ export default {
   title: 'Components/Promo Banner',
   parameters: {
     ...readme.parameters,
+    knobs: {
+      PromoBanner: () => {
+        const heading = text(
+          'Heading (HTML Enabled)',
+          '<h5>Try a demo of Watson<span style="color:#0f62fe;">X</span></h5>'
+        );
+        const body = text(
+          'Body Text (HTML Enabled)',
+          '<p>Easily deploy and embed AI across your business.</p>'
+        );
+        const cta = text('CTA Label', 'Try Today');
+        const ctaType = select('CTA Type', ctaTypes, ctaTypes[0]);
+        const tocLayout = boolean('Render in TOC', false);
+        const hasImage = boolean('Has Image', true);
+        return {
+          heading,
+          body,
+          cta,
+          ctaType,
+          tocLayout,
+          hasImage,
+        };
+      },
+    },
   },
   argTypes: {
     heading: {
@@ -89,8 +114,8 @@ export default {
   ],
 };
 
-const Template = (args) => {
-  const { heading, body, hasImage, cta, ctaType } = args;
+const Template = (PromoBanner) => {
+  const { heading, body, hasImage, cta, ctaType } = PromoBanner;
 
   return html`
     <c4d-promo-banner>
@@ -127,4 +152,4 @@ const Template = (args) => {
   `;
 };
 
-export const Default = (_args) => Template(_args);
+export const Default = (PromoBanner) => Template(PromoBanner);

--- a/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
+++ b/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html } from 'lit-element';
+import { html } from 'lit';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import '../index';
 import '@carbon/ibmdotcom-web-components/es/components/cta/index';

--- a/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
+++ b/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
@@ -1,0 +1,121 @@
+import { html } from 'lit-element';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import '../index';
+import '@carbon/ibmdotcom-web-components/es/components/cta/index';
+import '@carbon/ibmdotcom-web-components/es/components/image/index';
+import '@carbon/ibmdotcom-web-components/es/components/table-of-contents/index';
+import { types } from '@carbon/ibmdotcom-web-components/es/component-mixins/cta/cta';
+
+import readme from './README.stories.mdx';
+
+const incompatibleTypes = ['video', 'email', 'schedule', 'chat', 'call'];
+const ctaTypes = Object.values(types).filter(
+  (val) => !!val && !incompatibleTypes.includes(val)
+);
+
+export default {
+  title: 'Components/Promo Banner',
+  parameters: {
+    ...readme.parameters,
+  },
+  argTypes: {
+    heading: {
+      control: { type: 'text' },
+      name: 'Heading (HTML Enabled)',
+      defaultValue:
+        '<h5>Try a demo of Watson<span style="color:#0f62fe;">X</span></h5>',
+    },
+    body: {
+      control: { type: 'text' },
+      name: 'Body Text (HTML Enabled)',
+      defaultValue: '<p>Easily deploy and embed AI across your business.</p>',
+    },
+    cta: {
+      control: { type: 'text' },
+      name: 'CTA Label',
+      defaultValue: 'Try Today',
+    },
+    ctaType: {
+      control: { type: 'select' },
+      options: ctaTypes,
+      name: 'CTA Type',
+      defaultValue: 'local',
+    },
+    tocLayout: {
+      control: { type: 'boolean' },
+      name: 'Render in TOC',
+      defaultValue: false,
+    },
+    hasImage: {
+      control: { type: 'boolean' },
+      name: 'Has Image',
+      defaultValue: true,
+      if: { arg: 'tocLayout', truthy: false },
+    },
+  },
+  decorators: [
+    (story, { args: { tocLayout } }) => html`
+      <div class="caem-story-padding">
+        ${tocLayout
+          ? html`
+              <c4d-table-of-contents class="cds--grid">
+                <div class="cds--row">
+                  <div class="cds--col cds--no-gutter">
+                    <div name="TOC Label" data-title="Promotional Banner">
+                      ${story()}
+                    </div>
+                  </div>
+                </div>
+              </c4d-table-of-contents>
+            `
+          : html`
+              <div class="cds--grid">
+                <div class="cds--row">
+                  <div class="cds--col cds--no-gutter">${story()}</div>
+                </div>
+              </div>
+            `}
+      </div>
+    `,
+  ],
+};
+
+const Template = (args) => {
+  const { heading, body, hasImage, cta, ctaType } = args;
+
+  return html`
+    <caem-promo-banner>
+      ${hasImage !== false // Need explicit check to test image container queries.
+        ? html`
+            <c4d-image
+              alt="Image alt text"
+              slot="image"
+              width="300"
+              height="300"
+              default-src="https://fpoimg.com/300x300?&bg_color=5396ee&text_color=161616">
+              <c4d-image-item
+                media="(min-width:1584px)"
+                srcset="https://fpoimg.com/600x600?&bg_color=ee5396&text_color=161616"></c4d-image-item>
+              <c4d-image-item
+                media="(min-width:1312px)"
+                srcset="https://fpoimg.com/400x400?&bg_color=53ee96&text_color=161616"></c4d-image-item>
+            </c4d-image>
+          `
+        : ''}
+      ${unsafeHTML(heading)} ${unsafeHTML(body)}
+      ${cta
+        ? html`
+            <c4d-button-cta
+              cta-type="${ctaType}"
+              kind="tertiary"
+              slot="cta"
+              href="https://example.com"
+              >${cta}</c4d-button-cta
+            >
+          `
+        : ''}
+    </caem-promo-banner>
+  `;
+};
+
+export const Default = (_args) => Template(_args);

--- a/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
+++ b/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
@@ -8,7 +8,7 @@
  */
 
 import { html } from 'lit';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html';
 import '../index';
 import '@carbon/ibmdotcom-web-components/es/components/cta/index';
 import '@carbon/ibmdotcom-web-components/es/components/image/index';

--- a/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
+++ b/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
@@ -52,41 +52,7 @@ export default {
       },
     },
   },
-  argTypes: {
-    heading: {
-      control: { type: 'text' },
-      name: 'Heading (HTML Enabled)',
-      defaultValue:
-        '<h5>Try a demo of Watson<span style="color:#0f62fe;">X</span></h5>',
-    },
-    body: {
-      control: { type: 'text' },
-      name: 'Body Text (HTML Enabled)',
-      defaultValue: '<p>Easily deploy and embed AI across your business.</p>',
-    },
-    cta: {
-      control: { type: 'text' },
-      name: 'CTA Label',
-      defaultValue: 'Try Today',
-    },
-    ctaType: {
-      control: { type: 'select' },
-      options: ctaTypes,
-      name: 'CTA Type',
-      defaultValue: 'local',
-    },
-    tocLayout: {
-      control: { type: 'boolean' },
-      name: 'Render in TOC',
-      defaultValue: false,
-    },
-    hasImage: {
-      control: { type: 'boolean' },
-      name: 'Has Image',
-      defaultValue: true,
-      if: { arg: 'tocLayout', truthy: true },
-    },
-  },
+
   decorators: [
     (story, { args: { tocLayout } }) => html`
       <div class="c4d-story-padding">
@@ -114,7 +80,8 @@ export default {
   ],
 };
 
-export const Default = ({ heading, body, hasImage, cta, ctaType }) => {
+export const Default = (args) => {
+  const { heading, body, hasImage, cta, ctaType } = args?.PromoBanner ?? {};
   return html`
     <c4d-promo-banner>
       ${hasImage !== false // Need explicit check to test image container queries.

--- a/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
+++ b/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
@@ -84,7 +84,7 @@ export default {
       control: { type: 'boolean' },
       name: 'Has Image',
       defaultValue: true,
-      if: { arg: 'tocLayout', truthy: false },
+      if: { arg: 'tocLayout', truthy: true },
     },
   },
   decorators: [
@@ -114,9 +114,7 @@ export default {
   ],
 };
 
-const Template = (PromoBanner) => {
-  const { heading, body, hasImage, cta, ctaType } = PromoBanner;
-
+export const Default = ({ heading, body, hasImage, cta, ctaType }) => {
   return html`
     <c4d-promo-banner>
       ${hasImage !== false // Need explicit check to test image container queries.
@@ -151,5 +149,3 @@ const Template = (PromoBanner) => {
     </c4d-promo-banner>
   `;
 };
-
-export const Default = (PromoBanner) => Template(PromoBanner);

--- a/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
+++ b/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
@@ -55,29 +55,31 @@ export default {
   },
 
   decorators: [
-    (story, { args: { tocLayout } }) => html`
-      <div class="c4d-story-padding">
-        ${tocLayout
-          ? html`
-              <c4d-table-of-contents class="cds--grid">
-                <div class="cds--row">
-                  <div class="cds--col cds--no-gutter">
-                    <div name="TOC Label" data-title="Promotional Banner">
-                      ${story()}
+    (story, { args }) => {
+      return html`
+        <div class="c4d-story-padding">
+          ${args?.PromoBanner?.tocLayout
+            ? html`
+                <c4d-table-of-contents class="cds--grid">
+                  <div class="cds--row">
+                    <div class="cds--col cds--no-gutter">
+                      <div name="TOC Label" data-title="Promotional Banner">
+                        ${story()}
+                      </div>
                     </div>
                   </div>
+                </c4d-table-of-contents>
+              `
+            : html`
+                <div class="cds--grid">
+                  <div class="cds--row">
+                    <div class="cds--col cds--no-gutter">${story()}</div>
+                  </div>
                 </div>
-              </c4d-table-of-contents>
-            `
-          : html`
-              <div class="cds--grid">
-                <div class="cds--row">
-                  <div class="cds--col cds--no-gutter">${story()}</div>
-                </div>
-              </div>
-            `}
-      </div>
-    `,
+              `}
+        </div>
+      `;
+    },
   ],
 };
 

--- a/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
+++ b/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
@@ -7,16 +7,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html';
 import '../index';
-import '@carbon/ibmdotcom-web-components/es/components/cta/index';
-import '@carbon/ibmdotcom-web-components/es/components/image/index';
-import '@carbon/ibmdotcom-web-components/es/components/table-of-contents/index';
-import { types } from '@carbon/ibmdotcom-web-components/es/component-mixins/cta/cta';
+import '../../cta/index';
+import '../../image/index';
+import '../../table-of-contents/index';
+import { types } from '../../../component-mixins/cta/cta';
 
 import readme from './README.stories.mdx';
-import { boolean, select, text } from '@storybook/addon-knobs';
 
 const incompatibleTypes = ['video', 'email', 'schedule', 'chat', 'call'];
 const ctaTypes = Object.values(types).filter(

--- a/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
+++ b/packages/web-components/src/components/promo-banner/__stories__/promo-banner.stories.ts
@@ -9,7 +9,7 @@
 
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { html } from 'lit';
-import { unsafeHTML } from 'lit/directives/unsafe-html';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import '../index';
 import '../../cta/index';
 import '../../image/index';
@@ -28,6 +28,7 @@ export default {
   parameters: {
     ...readme.parameters,
     knobs: {
+      escapeHTML: false,
       PromoBanner: () => {
         const heading = text(
           'Heading (HTML Enabled)',

--- a/packages/web-components/src/components/promo-banner/index.ts
+++ b/packages/web-components/src/components/promo-banner/index.ts
@@ -1,1 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import './promo-banner';

--- a/packages/web-components/src/components/promo-banner/index.ts
+++ b/packages/web-components/src/components/promo-banner/index.ts
@@ -1,0 +1,1 @@
+import './promo-banner';

--- a/packages/web-components/src/components/promo-banner/promo-banner.scss
+++ b/packages/web-components/src/components/promo-banner/promo-banner.scss
@@ -1,7 +1,17 @@
-@use '../../globals/scss/vars' as *;
-@use '../../globals/scss/imports' as *;
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+ 
+@use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 @use '@carbon/styles/scss/utilities';
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/type' as *;
 @use '@carbon/grid' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/utils/flex-grid' as *;
 
@@ -29,7 +39,7 @@ $lg-12-column-upper-bound: ($xlg-breakpoint-width - 0.02) * (12 / 16);
 $xlg-12-column-lower-bound: $xlg-breakpoint-width * (12 / 16);
 $xlg-12-column-upper-bound: ($max-breakpoint-width - 0.02) * (12 / 16);
 
-:host(#{$caem-prefix}-promo-banner) {
+:host(#{$c4d-prefix}-promo-banner) {
   display: block;
   /* stylelint-disable-next-line property-no-unknown */
   container: promo-banner / inline-size;
@@ -49,7 +59,7 @@ $xlg-12-column-upper-bound: ($max-breakpoint-width - 0.02) * (12 / 16);
 
     @include breakpoint-down(lg) {
       &:not(.no-cta) {
-        /* stylelint-disable-next-line caem/require-color-with-bg */
+        /* stylelint-disable-next-line c4d/require-color-with-bg */
         &:hover {
           background-color: $layer-hover;
         }

--- a/packages/web-components/src/components/promo-banner/promo-banner.scss
+++ b/packages/web-components/src/components/promo-banner/promo-banner.scss
@@ -1,0 +1,153 @@
+@use '../../globals/scss/vars' as *;
+@use '../../globals/scss/imports' as *;
+@use '@carbon/styles/scss/utilities';
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/grid' as *;
+@use '@carbon/ibmdotcom-styles/scss/globals/utils/flex-grid' as *;
+
+$css--plex: true !default;
+$half-gutter: $grid-gutter / 2;
+
+$md-breakpoint-width: map-get(map-get($grid-breakpoints, md), width);
+$lg-breakpoint-width: map-get(map-get($grid-breakpoints, lg), width);
+$xlg-breakpoint-width: map-get(map-get($grid-breakpoints, xlg), width);
+$max-breakpoint-width: map-get(map-get($grid-breakpoints, max), width);
+
+// TODO: Move these calculations to a single importable file.
+//
+// We need lower and upper bounds for a container occupying 12 / 16 columns at
+// the lg and xlg breakpoints. For the lower bound we take the breakpoint
+// size, less the 2rem of outer padding, multiplied by 12 / 16, less 2rem of
+// column padding. For the upper bound we take the next breakpoint size and
+// do a similar calculation with a slight tweak of subtracting 0.02 from the
+// breakpoint size as a starting point, similar to how the
+// breakpoint-between mixin works. Note that this approach my not work
+// cleanly for the narrow or condensed grid due to the necessary assumptions
+// made for padding widths.
+$lg-12-column-lower-bound: ($lg-breakpoint-width * (12 / 16)) - 2rem;
+$lg-12-column-upper-bound: ($xlg-breakpoint-width - 0.02) * (12 / 16);
+$xlg-12-column-lower-bound: $xlg-breakpoint-width * (12 / 16);
+$xlg-12-column-upper-bound: ($max-breakpoint-width - 0.02) * (12 / 16);
+
+:host(#{$caem-prefix}-promo-banner) {
+  display: block;
+  /* stylelint-disable-next-line property-no-unknown */
+  container: promo-banner / inline-size;
+
+  [hidden] {
+    /* stylelint-disable-next-line declaration-no-important */
+    display: none !important;
+  }
+
+  .banner-wrapper {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: start;
+    color: $text-primary;
+    background-color: $layer;
+    position: relative;
+
+    @include breakpoint-down(lg) {
+      &:not(.no-cta) {
+        /* stylelint-disable-next-line caem/require-color-with-bg */
+        &:hover {
+          background-color: $layer-hover;
+        }
+
+        &:focus-within {
+          outline: $spacing-01 solid $focus;
+          outline-offset: calc(-1 * #{$spacing-01});
+        }
+      }
+    }
+  }
+
+  .banner-image {
+    align-self: stretch;
+    position: relative;
+
+    @include make-col(4, 16);
+    @include breakpoint(lg) {
+      /* stylelint-disable-next-line scss/at-rule-no-unknown */
+      @container promo-banner (inline-size <= #{$lg-12-column-upper-bound}) {
+        display: none;
+      }
+    }
+
+    @include breakpoint(xlg) {
+      /* stylelint-disable-next-line scss/at-rule-no-unknown */
+      @container promo-banner (inline-size <= #{$xlg-12-column-upper-bound}) {
+        display: none;
+      }
+    }
+  }
+
+  ::slotted([slot='image']) {
+    /* stylelint-disable-next-line property-no-unknown */
+    aspect-ratio: auto;
+    padding-block: 0;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+  }
+
+  .banner-content {
+    flex-grow: 1;
+    padding-block: $spacing-05;
+    padding-inline: $half-gutter;
+
+    @include breakpoint(md) {
+      padding-block: $spacing-07;
+    }
+  }
+
+  .banner-cta {
+    padding-block: $spacing-05;
+    padding-inline: $half-gutter;
+    text-align: end;
+
+    @include make-col(1, 4);
+
+    @include breakpoint-down(lg) {
+      &:focus {
+        outline: none;
+      }
+
+      &::after {
+        content: '';
+        position: absolute;
+        display: block;
+        inset: 0;
+      }
+    }
+
+    @include breakpoint(md) {
+      @include make-col(1, 8);
+
+      padding-block: $spacing-07;
+    }
+
+    @include breakpoint(lg) {
+      text-align: start;
+
+      @include make-col(4, 16);
+      @include make-col-offset(2, 16);
+
+      /* stylelint-disable-next-line scss/at-rule-no-unknown */
+      @container promo-banner (inline-size <= #{$lg-12-column-upper-bound}) {
+        @include make-col(4, 12);
+      }
+    }
+
+    @include breakpoint(xlg) {
+      /* stylelint-disable-next-line scss/at-rule-no-unknown */
+      @container promo-banner (inline-size <= #{$xlg-12-column-upper-bound}) {
+        @include make-col(4, 12);
+      }
+    }
+  }
+
+  ::slotted([slot='cta']) {
+    width: 100%;
+  }
+}

--- a/packages/web-components/src/components/promo-banner/promo-banner.scss
+++ b/packages/web-components/src/components/promo-banner/promo-banner.scss
@@ -50,12 +50,12 @@ $xlg-12-column-upper-bound: ($max-breakpoint-width - 0.02) * (12 / 16);
   }
 
   .banner-wrapper {
+    position: relative;
     display: flex;
     flex-wrap: nowrap;
     align-items: start;
-    color: $text-primary;
     background-color: $layer;
-    position: relative;
+    color: $text-primary;
 
     @include breakpoint-down(lg) {
       &:not(.no-cta) {
@@ -73,8 +73,8 @@ $xlg-12-column-upper-bound: ($max-breakpoint-width - 0.02) * (12 / 16);
   }
 
   .banner-image {
-    align-self: stretch;
     position: relative;
+    align-self: stretch;
 
     @include make-col(4, 16);
     @include breakpoint(lg) {
@@ -94,11 +94,11 @@ $xlg-12-column-upper-bound: ($max-breakpoint-width - 0.02) * (12 / 16);
 
   ::slotted([slot='image']) {
     /* stylelint-disable-next-line property-no-unknown */
-    aspect-ratio: auto;
-    padding-block: 0;
-    height: 100%;
-    width: 100%;
     position: absolute;
+    aspect-ratio: auto;
+    block-size: 100%;
+    inline-size: 100%;
+    padding-block: 0;
   }
 
   .banner-content {
@@ -124,9 +124,9 @@ $xlg-12-column-upper-bound: ($max-breakpoint-width - 0.02) * (12 / 16);
       }
 
       &::after {
-        content: '';
         position: absolute;
         display: block;
+        content: '';
         inset: 0;
       }
     }
@@ -158,6 +158,6 @@ $xlg-12-column-upper-bound: ($max-breakpoint-width - 0.02) * (12 / 16);
   }
 
   ::slotted([slot='cta']) {
-    width: 100%;
+    inline-size: 100%;
   }
 }

--- a/packages/web-components/src/components/promo-banner/promo-banner.scss
+++ b/packages/web-components/src/components/promo-banner/promo-banner.scss
@@ -6,7 +6,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
- 
+
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 @use '@carbon/styles/scss/utilities';
 @use '@carbon/styles/scss/spacing' as *;

--- a/packages/web-components/src/components/promo-banner/promo-banner.ts
+++ b/packages/web-components/src/components/promo-banner/promo-banner.ts
@@ -1,9 +1,18 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { html, state, LitElement, queryAssignedNodes } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element';
 import { baseFontSize, breakpoints } from '@carbon/layout';
 import styles from './promo-banner.scss';
-import settings from '../../globals/settings';
+import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import CTAMixin, {
   icons as ctaIcons,
 } from '@carbon/ibmdotcom-web-components/es/component-mixins/cta/cta';
@@ -11,17 +20,17 @@ import { CTAMixinImpl } from '@carbon/ibmdotcom-web-components/es/component-mixi
 import ifNonEmpty from '@carbon/web-components/es/globals/directives/if-non-empty';
 import { CTA_TYPE } from '@carbon/ibmdotcom-web-components/es/components/cta/defs';
 
-const { stablePrefix: caemPrefix, c4dPrefix, prefix } = settings;
+const { stablePrefix: c4dPrefix, prefix } = settings;
 
 const breakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
 const layoutBreakpoint = window.matchMedia(`(min-width: ${breakpoint}px)`);
 
 /**
  * The Promo Banner component.
- * @element caem-promo-banner
+ * @element c4d-promo-banner
  */
-@customElement(`${caemPrefix}-promo-banner`)
-class CAEMPromoBanner extends CTAMixin(LitElement) {
+@customElement(`${c4dPrefix}-promo-banner`)
+class C4DPromoBanner extends CTAMixin(LitElement) {
   @state()
   isDesktopVersion = layoutBreakpoint.matches;
 
@@ -154,4 +163,4 @@ class CAEMPromoBanner extends CTAMixin(LitElement) {
   }
 }
 
-export default CAEMPromoBanner;
+export default C4DPromoBanner;

--- a/packages/web-components/src/components/promo-banner/promo-banner.ts
+++ b/packages/web-components/src/components/promo-banner/promo-banner.ts
@@ -7,8 +7,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, state, LitElement, queryAssignedNodes } from 'lit-element';
-import { classMap } from 'lit-html/directives/class-map.js';
+import { LitElement, html } from 'lit';
+import { state, queryAssignedNodes } from 'lit/decorators';
+import { classMap } from 'lit/directives/class-map';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element';
 import { baseFontSize, breakpoints } from '@carbon/layout';
 import styles from './promo-banner.scss';

--- a/packages/web-components/src/components/promo-banner/promo-banner.ts
+++ b/packages/web-components/src/components/promo-banner/promo-banner.ts
@@ -1,0 +1,157 @@
+import { html, state, LitElement, queryAssignedNodes } from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map.js';
+import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element';
+import { baseFontSize, breakpoints } from '@carbon/layout';
+import styles from './promo-banner.scss';
+import settings from '../../globals/settings';
+import CTAMixin, {
+  icons as ctaIcons,
+} from '@carbon/ibmdotcom-web-components/es/component-mixins/cta/cta';
+import { CTAMixinImpl } from '@carbon/ibmdotcom-web-components/es/component-mixins/cta/cta';
+import ifNonEmpty from '@carbon/web-components/es/globals/directives/if-non-empty';
+import { CTA_TYPE } from '@carbon/ibmdotcom-web-components/es/components/cta/defs';
+
+const { stablePrefix: caemPrefix, c4dPrefix, prefix } = settings;
+
+const breakpoint = parseFloat(breakpoints.lg.width) * baseFontSize;
+const layoutBreakpoint = window.matchMedia(`(min-width: ${breakpoint}px)`);
+
+/**
+ * The Promo Banner component.
+ * @element caem-promo-banner
+ */
+@customElement(`${caemPrefix}-promo-banner`)
+class CAEMPromoBanner extends CTAMixin(LitElement) {
+  @state()
+  isDesktopVersion = layoutBreakpoint.matches;
+
+  @queryAssignedNodes('image', false)
+  slottedImage;
+
+  @queryAssignedNodes('cta', false)
+  slottedCta;
+
+  handleSlotChange(e) {
+    this.requestUpdate();
+
+    const slotname = e?.target?.name ?? '';
+
+    if (slotname === 'cta') {
+      this.harvestCtaProps();
+    }
+  }
+
+  firstUpdated() {
+    layoutBreakpoint.addEventListener('change', (e) => {
+      this.isDesktopVersion = e.matches;
+    });
+    this.harvestCtaProps();
+  }
+
+  harvestCtaProps() {
+    const slotted_cta = this.querySelector('[slot="cta"]');
+
+    if (slotted_cta) {
+      const { _linkNode, ctaType, disabled, download, href, target } =
+        slotted_cta as CTAMixinImpl;
+
+      this._linkNode = _linkNode;
+      this.ctaType = ctaType;
+      this.disabled = disabled;
+      this.download = download;
+      this.href = href;
+      this.target = target;
+      this.requestUpdate();
+      return;
+    }
+
+    this._linkNode = undefined;
+    this.ctaType = '' as CTA_TYPE;
+    this.disabled = false;
+    this.download = '';
+    this.href = '';
+    this.target = '';
+    this.requestUpdate();
+  }
+
+  /**
+   * @inheritdoc
+   */
+  _renderIcon() {
+    const { ctaType } = this;
+    return html`
+      <slot name="icon">
+        ${ctaIcons[ctaType]?.({
+          class: `${prefix}--card__cta ${c4dPrefix}-ce--cta__icon`,
+        })}
+      </slot>
+    `;
+  }
+
+  _renderMobileLayout() {
+    const { href, disabled, target, download, innerText } = this;
+
+    const classes = {
+      'banner-wrapper': true,
+      'no-cta': !href,
+    };
+
+    return html`
+      <div class="${classMap(classes)}" part="wrapper">
+        <div class="banner-content" aria-hidden=${true} part="content">
+          <slot></slot>
+        </div>
+        ${href
+          ? html`
+              <a
+                class="banner-cta"
+                href=${href}
+                ?disabled=${ifNonEmpty(disabled)}
+                target=${ifNonEmpty(target)}
+                download=${ifNonEmpty(download)}
+                aria-label=${innerText}
+                part="cta">
+                <span class="banner-cta-icon" part="icon">
+                  ${this._renderIcon()}
+                </span>
+              </a>
+            `
+          : ''}
+      </div>
+    `;
+  }
+
+  _renderDesktopLayout() {
+    const { slottedImage, slottedCta, handleSlotChange } = this;
+    return html`
+      <div
+        class="banner-wrapper"
+        @slotchange=${handleSlotChange}
+        part="wrapper">
+        <div class="banner-image" ?hidden=${!slottedImage?.length} part="image">
+          <slot name="image"></slot>
+        </div>
+        <div class="banner-content" part="content">
+          <slot></slot>
+        </div>
+        <div class="banner-cta" ?hidden=${!slottedCta?.length} part="cta">
+          <slot name="cta"></slot>
+        </div>
+      </div>
+    `;
+  }
+
+  render() {
+    const { isDesktopVersion } = this;
+
+    return isDesktopVersion
+      ? this._renderDesktopLayout()
+      : this._renderMobileLayout();
+  }
+
+  static get styles() {
+    return styles;
+  }
+}
+
+export default CAEMPromoBanner;

--- a/packages/web-components/src/components/promo-banner/promo-banner.ts
+++ b/packages/web-components/src/components/promo-banner/promo-banner.ts
@@ -8,18 +8,18 @@
  */
 
 import { LitElement, html } from 'lit';
-import { state, queryAssignedNodes } from 'lit/decorators';
-import { classMap } from 'lit/directives/class-map';
-import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element';
+import { state, queryAssignedNodes } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
 import { baseFontSize, breakpoints } from '@carbon/layout';
 import styles from './promo-banner.scss';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import CTAMixin, {
   icons as ctaIcons,
-} from '@carbon/ibmdotcom-web-components/es/component-mixins/cta/cta';
-import { CTAMixinImpl } from '@carbon/ibmdotcom-web-components/es/component-mixins/cta/cta';
+  CTAMixinImpl,
+} from '../../component-mixins/cta/cta';
 import ifNonEmpty from '@carbon/web-components/es/globals/directives/if-non-empty';
-import { CTA_TYPE } from '@carbon/ibmdotcom-web-components/es/components/cta/defs';
+import { CTA_TYPE } from '../cta/defs';
 
 const { stablePrefix: c4dPrefix, prefix } = settings;
 


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6656](https://jsw.ibm.com/browse/ADCMS-6656)

### Description

Migrates the `promo-banner` component from carbon-for-aem into carbon-for-ibmdotcom

### Changelog

**New**

- Added the `c4d-promo-banner` component.