### PR TITLE
fix(structured-list, pricing-table): correct coloration, spacing & alignment

### DIFF
--- a/packages/styles/scss/components/pricing-table/_pricing-table.scss
+++ b/packages/styles/scss/components/pricing-table/_pricing-table.scss
@@ -259,8 +259,12 @@
   }
 
   :host(#{$c4d-prefix}-pricing-table-cell[icon]) {
-    &[icon='checkmark'] {
+    &[icon='checkmark'] svg {
       color: $support-success;
+    }
+
+    svg {
+      margin-inline-end: $spacing-03;
     }
   }
 

--- a/packages/styles/scss/components/pricing-table/_pricing-table.scss
+++ b/packages/styles/scss/components/pricing-table/_pricing-table.scss
@@ -264,8 +264,8 @@
     }
 
     svg {
-      margin-inline-end: $spacing-03;
       flex-shrink: 0;
+      margin-inline-end: $spacing-03;
     }
   }
 

--- a/packages/styles/scss/components/pricing-table/_pricing-table.scss
+++ b/packages/styles/scss/components/pricing-table/_pricing-table.scss
@@ -265,6 +265,7 @@
 
     svg {
       margin-inline-end: $spacing-03;
+      flex-shrink: 0;
     }
   }
 

--- a/packages/styles/scss/components/structured-list/_structured-list.scss
+++ b/packages/styles/scss/components/structured-list/_structured-list.scss
@@ -287,8 +287,8 @@
     vertical-align: sub;
 
     svg {
-      fill: $icon-secondary;
       flex-shrink: 0;
+      fill: $icon-secondary;
     }
   }
 

--- a/packages/styles/scss/components/structured-list/_structured-list.scss
+++ b/packages/styles/scss/components/structured-list/_structured-list.scss
@@ -293,8 +293,16 @@
 
   .#{$prefix}--structured-list-cell[icon],
   :host(#{$c4d-prefix}-structured-list-cell[icon]) {
-    &[icon='checkmark'] {
+    &[icon='checkmark'] svg {
       color: $support-success;
     }
+
+    svg {
+      margin-inline-end: $spacing-03;
+    }
+  }
+
+  .#{$prefix}--structured-list-cell-icon-text-container {
+    display: flex;
   }
 }

--- a/packages/styles/scss/components/structured-list/_structured-list.scss
+++ b/packages/styles/scss/components/structured-list/_structured-list.scss
@@ -288,6 +288,7 @@
 
     svg {
       fill: $icon-secondary;
+      flex-shrink: 0;
     }
   }
 

--- a/packages/web-components/src/components/structured-list/structured-list-cell.ts
+++ b/packages/web-components/src/components/structured-list/structured-list-cell.ts
@@ -10,6 +10,7 @@
 import CDSStructuredListCell from '@carbon/web-components/es/components/structured-list/structured-list-cell.js';
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined';
 import Info16 from '@carbon/web-components/es/icons/information/16.js';
 import Checkmark20 from '@carbon/web-components/es/icons/checkmark/20.js';
 import Error20 from '@carbon/web-components/es/icons/error/20.js';
@@ -24,9 +25,11 @@ const { prefix, stablePrefix: c4dPrefix } = settings;
  * StructuredListCell
  *
  * @element c4d-structured-list-cell
+ * @csspart icon-text-container - Text wrapping element. Usage `c4d-structured-list-cell::part(icon-text)`
  * @csspart icon-text - Descriptive text of the cell. Usage `c4d-structured-list-cell::part(icon-text)`
  * @csspart tag - Tags of the cell. Usage `c4d-structured-list-cell::part(tag)`
  * @csspart icon - An icon. Usage `c4d-structured-list-cell::part(icon)`
+ * @csspart tooltip - CDSTooltip. Usage `c4d-structured-list-cell::part(icon)`
  */
 @customElement(`${c4dPrefix}-structured-list-cell`)
 class C4DStructuredListCell extends CDSStructuredListCell {
@@ -59,10 +62,14 @@ class C4DStructuredListCell extends CDSStructuredListCell {
   private _renderIcon() {
     const { icon, _iconsAllowed: iconMap } = this;
 
-    return html`${iconMap[icon!.toLowerCase()].call()}
+    return html` <div
+      class="${prefix}--structured-list-cell-icon-text-container"
+      part="icon-text-container">
+      ${iconMap[icon!.toLowerCase()].call(null, { part: 'icon' })}
       <span class="${prefix}--structured-list-cell-icon-text" part="icon-text">
         <slot></slot>
-      </span>`;
+      </span>
+    </div>`;
   }
 
   private _renderTags() {
@@ -85,9 +92,9 @@ class C4DStructuredListCell extends CDSStructuredListCell {
 
     return html`
       <cds-tooltip-icon
-        part="icon"
+        part="tooltip"
         alignment="start"
-        body-text="${tooltip}"
+        body-text="${ifDefined(tooltip)}"
         direction="right">
         ${Info16()}
       </cds-tooltip-icon>


### PR DESCRIPTION
### Description

Corrects v1->v2 regressions in the structured-list and pricing-table components with cells containging icons.

Current:
<img width="400" alt="Screenshot 2024-11-11 at 9 31 41 AM" src="https://github.com/user-attachments/assets/912e8a93-310d-4061-aeb6-18d67714a7e0">

Expected:
<img width="402" alt="Screenshot 2024-11-11 at 9 31 12 AM" src="https://github.com/user-attachments/assets/9115158c-7a16-49db-bfec-77a845642f51">


### Changelog

**Changed**

- Fixed spacing and alignment bugs
- Slight reworking of the `part` attributes
