### PR TITLE
feat(star-rating): new component

### DIFF
--- a/packages/web-components/examples/stackblitz/components/dotcom-shell/src/index.scss
+++ b/packages/web-components/examples/stackblitz/components/dotcom-shell/src/index.scss
@@ -16,9 +16,9 @@ $feature-flags: (
 @import 'carbon-components/scss/globals/grid/grid';
 @import 'carbon-components/scss/components/ui-shell/content';
 
-@media (min-width: 66rem) {
+@media (width >= 66rem) {
   .cds--offset-lg-3 {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 }
 
@@ -27,7 +27,7 @@ $feature-flags: (
     margin: 30px 0;
 
     &:first-of-type {
-      margin-top: 0;
+      margin-block-start: 0;
     }
   }
 }

--- a/packages/web-components/examples/stackblitz/components/masthead-l1/src/index.scss
+++ b/packages/web-components/examples/stackblitz/components/masthead-l1/src/index.scss
@@ -17,12 +17,13 @@ $feature-flags: (
 @import 'carbon-components/scss/components/ui-shell/content';
 
 body {
-  padding: calc(#{$spacing-09} + #{mini-units(6)} + 1px) $spacing-09 $spacing-09 $spacing-09;
+  padding: calc(#{$spacing-09} + #{mini-units(6)} + 1px) $spacing-09 $spacing-09
+    $spacing-09;
 }
 
-@media (min-width: 66rem) {
+@media (width >= 66rem) {
   .cds--offset-lg-3 {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 }
 
@@ -31,7 +32,7 @@ body {
     margin: 30px 0;
 
     &:first-of-type {
-      margin-top: 0;
+      margin-block-start: 0;
     }
   }
 }

--- a/packages/web-components/examples/stackblitz/components/masthead/src/index.scss
+++ b/packages/web-components/examples/stackblitz/components/masthead/src/index.scss
@@ -17,20 +17,22 @@ $feature-flags: (
 @import 'carbon-components/scss/components/ui-shell/content';
 
 body {
-  padding: calc(#{$spacing-09} + #{mini-units(6)} + 1px) $spacing-09 $spacing-09 $spacing-09;
+  padding: calc(#{$spacing-09} + #{mini-units(6)} + 1px) $spacing-09 $spacing-09
+    $spacing-09;
 }
 
 .cds--content.dds-ce-demo--ui-shell-content {
-  @media (min-width: 66rem) {
+  @media (width >= 66rem) {
     .cds--offset-lg-3 {
-      margin-left: 0;
+      margin-inline-start: 0;
     }
   }
+
   h2 {
     margin: 30px 0;
 
     &:first-of-type {
-      margin-top: 0;
+      margin-block-start: 0;
     }
   }
 }

--- a/packages/web-components/examples/stackblitz/components/table-of-contents/src/index.scss
+++ b/packages/web-components/examples/stackblitz/components/table-of-contents/src/index.scss
@@ -21,6 +21,5 @@ body {
 }
 
 h3 {
-  padding-top: $spacing-05;
-  padding-bottom: $spacing-07;
+  padding-block: $spacing-05 $spacing-07;
 }

--- a/packages/web-components/examples/stackblitz/components/tabs-extended/src/styles.scss
+++ b/packages/web-components/examples/stackblitz/components/tabs-extended/src/styles.scss
@@ -11,6 +11,7 @@
 
 :root {
   @include theme.theme(themes.$white);
+
   background-color: var(--cds-background);
   color: var(--cds-text-primary);
 }

--- a/packages/web-components/examples/stackblitz/usage/webpack-handlebars/src/index.scss
+++ b/packages/web-components/examples/stackblitz/usage/webpack-handlebars/src/index.scss
@@ -16,8 +16,8 @@
 @include carbon--font-face-sans();
 
 body {
-  visibility: inherit; // Initially hidden to avoid FOUC
   padding: calc(#{mini-units(6)} + 1px) 0 0 0;
+  visibility: inherit; // Initially hidden to avoid FOUC
 }
 
 .bx--content.cds-ce-demo--ui-shell-content {
@@ -25,7 +25,7 @@ body {
     margin: 30px 0;
 
     &:first-of-type {
-      margin-top: 0;
+      margin-block-start: 0;
     }
   }
 }

--- a/packages/web-components/examples/stackblitz/usage/webpack-sass/src/index.scss
+++ b/packages/web-components/examples/stackblitz/usage/webpack-sass/src/index.scss
@@ -30,12 +30,12 @@ h2 {
   margin: $spacing-07 0;
 
   &:first-of-type {
-    margin-top: 0;
+    margin-block-start: 0;
   }
 }
 
 main {
-  margin: calc(#{mini-units(6)} + 1px) auto 0 auto;
+  max-inline-size: 99rem;
   padding: $spacing-09;
-  max-width: 99rem;
+  margin: calc(#{mini-units(6)} + 1px) auto 0 auto;
 }

--- a/packages/web-components/src/components/star-rating/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/star-rating/__stories__/README.stories.mdx
@@ -1,12 +1,6 @@
-import {
-  Meta,
-  Props,
-  Story,
-  Canvas,
-  Description,
-} from "@storybook/addon-docs";
-import { cdnJs } from "../../../globals/internal/storybook-cdn";
-import "../index";
+import { Meta, Props, Story, Canvas, Description } from '@storybook/addon-docs';
+import { cdnJs } from '../../../globals/internal/storybook-cdn';
+import '../index';
 
 <Meta title="Star Rating" />
 
@@ -16,8 +10,8 @@ import "../index";
   <Story id="components-star-rating--default" height="100px" />
 </Canvas>
 
-<Description markdown={`${cdnJs({ components: ["star-rating"] })}`} />
+<Description markdown={`${cdnJs({ components: ['star-rating'] })}`} />
 
-## `<caem-star-rating>` attributes, properties, and events
+## `<c4d-star-rating>` attributes, properties, and events
 
-<Props of="caem-star-rating" />
+<Props of="c4d-star-rating" />

--- a/packages/web-components/src/components/star-rating/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/star-rating/__stories__/README.stories.mdx
@@ -1,0 +1,23 @@
+import {
+  Meta,
+  Props,
+  Story,
+  Canvas,
+  Description,
+} from "@storybook/addon-docs";
+import { cdnJs } from "../../../globals/internal/storybook-cdn";
+import "../index";
+
+<Meta title="Star Rating" />
+
+# Star Rating
+
+<Canvas withToolbar>
+  <Story id="components-star-rating--default" height="100px" />
+</Canvas>
+
+<Description markdown={`${cdnJs({ components: ["star-rating"] })}`} />
+
+## `<caem-star-rating>` attributes, properties, and events
+
+<Props of="caem-star-rating" />

--- a/packages/web-components/src/components/star-rating/__stories__/star-rating.stories.ts
+++ b/packages/web-components/src/components/star-rating/__stories__/star-rating.stories.ts
@@ -1,38 +1,45 @@
-import { html } from 'lit-element';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined';
 import '../index';
 import readme from './README.stories.mdx';
 import { bxGrid8ColCentered } from '../../../globals/internal/storybook-decorators';
+import { boolean, number, text } from '@storybook/addon-knobs';
 
-export const Default = ({
-  disableTooltip,
-  label,
-  labelHref,
-  rating,
-  starCount,
-  tooltipText,
-}) => html`
-  <c4d-star-rating
-    ?disableTooltip="${disableTooltip}"
-    label="${ifDefined(label || undefined)}"
-    label-href="${ifDefined(labelHref || undefined)}"
-    rating="${rating}"
-    star-count="${starCount}"
-    tooltip="${tooltipText}"></c4d-star-rating>
-`;
+export const Default = (args) => {
+  const { disableTooltip, label, labelHref, rating, starCount, tooltipText } =
+    args?.StarRating ?? {};
+  return html`
+    <c4d-star-rating
+      ?disableTooltip="${disableTooltip}"
+      label="${ifDefined(label || undefined)}"
+      label-href="${ifDefined(labelHref || undefined)}"
+      rating="${rating}"
+      star-count="${starCount}"
+      tooltip="${tooltipText}"></c4d-star-rating>
+  `;
+};
 
-export const NoLabel = ({
-  disableTooltip,
-  rating,
-  starCount,
-  tooltipText,
-}) => html`
-  <c4d-star-rating
-    ?disableTooltip="${disableTooltip}"
-    rating="${rating}"
-    star-count="${starCount}"
-    tooltip="${tooltipText}"></c4d-star-rating>
-`;
+export const NoLabel = (args) => {
+  const { disableTooltip, rating, starCount, tooltipText } = (args =
+    args?.StarRating ?? {});
+
+  return html`
+    <c4d-star-rating
+      ?disableTooltip="${disableTooltip}"
+      rating="${rating}"
+      star-count="${starCount}"
+      tooltip="${tooltipText}"></c4d-star-rating>
+  `;
+};
 
 NoLabel.argTypes = {
   label: {
@@ -45,40 +52,27 @@ NoLabel.argTypes = {
 
 export default {
   title: 'Components/Star Rating',
-  argTypes: {
-    rating: {
-      name: 'Star rating',
-      control: { type: 'number' },
-      defaultValue: 4.5,
-    },
-    label: {
-      name: 'Label (optional)',
-      control: { type: 'text' },
-      defaultValue: '42 G2 reviews',
-    },
-    labelHref: {
-      name: 'Label link (optional)',
-      control: { type: 'text' },
-      defaultValue: '',
-    },
-    starCount: {
-      name: 'Max number of stars (optional)',
-      control: { type: 'number' },
-      defaultValue: 5,
-    },
-    tooltipText: {
-      name: 'Tooltip text (optional)',
-      control: { type: 'text' },
-      defaultValue: '',
-    },
-    disableTooltip: {
-      name: 'Disable tooltip (optional)',
-      control: { type: 'boolean' },
-      defaultValue: false,
-    },
-  },
   parameters: {
     ...readme.parameters,
+    hasStoryPaddin: true,
+    knobs: {
+      StarRating: () => {
+        const rating = number('Star Rating', 4.5);
+        const label = text('Label text (optional)', '42 G2 reviews');
+        const labelHref = text('Label link (optional)', '');
+        const starCount = number('Max number of stars (optional)', 5);
+        const tooltipText = text('Tooltip text (optional)', '');
+        const disableTooltip = boolean('Disable tooltip (optional)', false);
+        return {
+          rating,
+          label,
+          labelHref,
+          starCount,
+          tooltipText,
+          disableTooltip,
+        };
+      },
+    },
   },
   decorators: [
     (story) => bxGrid8ColCentered(story),

--- a/packages/web-components/src/components/star-rating/__stories__/star-rating.stories.ts
+++ b/packages/web-components/src/components/star-rating/__stories__/star-rating.stories.ts
@@ -11,7 +11,7 @@ import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined';
 import '../index';
 import readme from './README.stories.mdx';
-import { bxGrid8ColCentered } from '../../../globals/internal/storybook-decorators';
+import { Grid8ColCentered } from '../../../globals/internal/storybook-decorators';
 import { boolean, number, text } from '@storybook/addon-knobs';
 
 export const Default = (args) => {
@@ -41,20 +41,11 @@ export const NoLabel = (args) => {
   `;
 };
 
-NoLabel.argTypes = {
-  label: {
-    table: { disable: true },
-  },
-  labelHref: {
-    table: { disable: true },
-  },
-};
-
 export default {
   title: 'Components/Star Rating',
   parameters: {
     ...readme.parameters,
-    hasStoryPaddin: true,
+    hasStoryPadding: true,
     knobs: {
       StarRating: () => {
         const rating = number('Star Rating', 4.5);
@@ -75,7 +66,7 @@ export default {
     },
   },
   decorators: [
-    (story) => bxGrid8ColCentered(story),
+    (story) => Grid8ColCentered(story),
     (story) => html` <div style="margin-block-start: 2rem;">${story()}</div> `,
   ],
 };

--- a/packages/web-components/src/components/star-rating/__stories__/star-rating.stories.ts
+++ b/packages/web-components/src/components/star-rating/__stories__/star-rating.stories.ts
@@ -1,0 +1,92 @@
+import { html } from 'lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
+import '../index';
+import readme from './README.stories.mdx';
+import { bxGrid8ColCentered } from '../../../globals/internal/storybook-decorators';
+
+export const Default = ({
+  disableTooltip,
+  label,
+  labelHref,
+  rating,
+  starCount,
+  tooltipText,
+}) => html`
+  <caem-star-rating
+    ?disableTooltip="${disableTooltip}"
+    label="${ifDefined(label || undefined)}"
+    label-href="${ifDefined(labelHref || undefined)}"
+    rating="${rating}"
+    star-count="${starCount}"
+    tooltip="${tooltipText}"
+  ></caem-star-rating>
+`;
+
+export const NoLabel = ({
+  disableTooltip,
+  rating,
+  starCount,
+  tooltipText,
+}) => html`
+  <caem-star-rating
+    ?disableTooltip="${disableTooltip}"
+    rating="${rating}"
+    star-count="${starCount}"
+    tooltip="${tooltipText}"
+  ></caem-star-rating>
+`;
+
+NoLabel.argTypes = {
+  label: {
+    table: { disable: true },
+  },
+  labelHref: {
+    table: { disable: true },
+  },
+};
+
+export default {
+  title: 'Components/Star Rating',
+  argTypes: {
+    rating: {
+      name: 'Star rating',
+      control: { type: 'number' },
+      defaultValue: 4.5,
+    },
+    label: {
+      name: 'Label (optional)',
+      control: { type: 'text' },
+      defaultValue: '42 G2 reviews',
+    },
+    labelHref: {
+      name: 'Label link (optional)',
+      control: { type: 'text' },
+      defaultValue: '',
+    },
+    starCount: {
+      name: 'Max number of stars (optional)',
+      control: { type: 'number' },
+      defaultValue: 5,
+    },
+    tooltipText: {
+      name: 'Tooltip text (optional)',
+      control: { type: 'text' },
+      defaultValue: '',
+    },
+    disableTooltip: {
+      name: 'Disable tooltip (optional)',
+      control: { type: 'boolean' },
+      defaultValue: false,
+    },
+  },
+  parameters: {
+    ...readme.parameters,
+  },
+  decorators: [
+    story => bxGrid8ColCentered(story),
+    story =>
+      html`
+        <div style="margin-block-start: 2rem;">${story()}</div>
+      `,
+  ],
+};

--- a/packages/web-components/src/components/star-rating/__stories__/star-rating.stories.ts
+++ b/packages/web-components/src/components/star-rating/__stories__/star-rating.stories.ts
@@ -12,14 +12,13 @@ export const Default = ({
   starCount,
   tooltipText,
 }) => html`
-  <caem-star-rating
+  <c4d-star-rating
     ?disableTooltip="${disableTooltip}"
     label="${ifDefined(label || undefined)}"
     label-href="${ifDefined(labelHref || undefined)}"
     rating="${rating}"
     star-count="${starCount}"
-    tooltip="${tooltipText}"
-  ></caem-star-rating>
+    tooltip="${tooltipText}"></c4d-star-rating>
 `;
 
 export const NoLabel = ({
@@ -28,12 +27,11 @@ export const NoLabel = ({
   starCount,
   tooltipText,
 }) => html`
-  <caem-star-rating
+  <c4d-star-rating
     ?disableTooltip="${disableTooltip}"
     rating="${rating}"
     star-count="${starCount}"
-    tooltip="${tooltipText}"
-  ></caem-star-rating>
+    tooltip="${tooltipText}"></c4d-star-rating>
 `;
 
 NoLabel.argTypes = {
@@ -83,10 +81,7 @@ export default {
     ...readme.parameters,
   },
   decorators: [
-    story => bxGrid8ColCentered(story),
-    story =>
-      html`
-        <div style="margin-block-start: 2rem;">${story()}</div>
-      `,
+    (story) => bxGrid8ColCentered(story),
+    (story) => html` <div style="margin-block-start: 2rem;">${story()}</div> `,
   ],
 };

--- a/packages/web-components/src/components/star-rating/index.ts
+++ b/packages/web-components/src/components/star-rating/index.ts
@@ -1,1 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import './star-rating';

--- a/packages/web-components/src/components/star-rating/index.ts
+++ b/packages/web-components/src/components/star-rating/index.ts
@@ -1,0 +1,1 @@
+import './star-rating';

--- a/packages/web-components/src/components/star-rating/star-rating.scss
+++ b/packages/web-components/src/components/star-rating/star-rating.scss
@@ -53,6 +53,10 @@
     svg:nth-of-type(1) {
       position: initial;
     }
+
+    svg:nth-of-type(2):dir(rtl) {
+      transform: scaleX(-1);
+    }
   }
 
   .#{$prefix}-star-rating__label,

--- a/packages/web-components/src/components/star-rating/star-rating.scss
+++ b/packages/web-components/src/components/star-rating/star-rating.scss
@@ -13,9 +13,9 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/utilities/tooltip' as *;
 @use '@carbon/styles/scss/components/button/tokens' as *;
-@use '../../globals/scss/vars' as *;
+@use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
 
-:host(#{$caem-prefix}-star-rating) {
+:host(#{$c4d-prefix}-star-rating) {
   display: inline-block;
 
   .#{$prefix}-star-rating {

--- a/packages/web-components/src/components/star-rating/star-rating.scss
+++ b/packages/web-components/src/components/star-rating/star-rating.scss
@@ -1,0 +1,73 @@
+//
+// Copyright IBM Corp. 2024
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// @import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/type';
+@use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/type' as *;
+@use '@carbon/styles/scss/themes' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/utilities/tooltip' as *;
+@use '@carbon/styles/scss/components/button/tokens' as *;
+@use '../../globals/scss/vars' as *;
+
+:host(#{$caem-prefix}-star-rating) {
+  display: inline-block;
+
+  .#{$prefix}-star-rating {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-03 $spacing-05;
+  }
+
+  .#{$prefix}-star-rating__stars {
+    display: inline-flex;
+    align-items: center;
+    margin: 0;
+
+    &:not([disableTooltip]) {
+      @include tooltip--trigger('definition', top);
+      @include tooltip--placement('definition', 'top', 'center');
+    }
+  }
+
+  .#{$prefix}-star-count__star {
+    svg {
+      display: block;
+      fill: $button-primary;
+    }
+  }
+
+  .#{$prefix}-star-count__star--half {
+    position: relative;
+
+    svg {
+      position: absolute;
+      inset: 0;
+    }
+
+    svg:nth-of-type(1) {
+      position: initial;
+    }
+  }
+
+  .#{$prefix}-star-rating__label,
+  .#{$prefix}-star-rating__label a {
+    @include type-style('body-compact-02');
+
+    color: $border-inverse;
+  }
+
+  .#{$prefix}-star-rating__label a {
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+}

--- a/packages/web-components/src/components/star-rating/star-rating.ts
+++ b/packages/web-components/src/components/star-rating/star-rating.ts
@@ -6,16 +6,16 @@ import StarHalf16 from '@carbon/web-components/es/icons/star--half/16';
 import StarFilled16 from '@carbon/web-components/es/icons/star--filled/16';
 import styles from './star-rating.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
-import settings from '../../globals/settings';
+import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 
-const { stablePrefix: caemPrefix, prefix } = settings;
+const { stablePrefix: c4dPrefix, prefix } = settings;
 
 /**
  * The Star Rating component.
- * @element caem-star-rating
+ * @element c4d-star-rating
  */
-@customElement(`${caemPrefix}-star-rating`)
-class CAEMStarRating extends StableSelectorMixin(LitElement) {
+@customElement(`${c4dPrefix}-star-rating`)
+class C4DStarRating extends StableSelectorMixin(LitElement) {
   /**
    * Maximum number of stars that may be in a rating.
    */
@@ -110,11 +110,7 @@ class CAEMStarRating extends StableSelectorMixin(LitElement) {
     }
     return html`
       <div class="${prefix}-star-rating__label" part="label">
-        ${labelHref
-          ? html`
-              <a href="${labelHref}">${label}</a>
-            `
-          : label}
+        ${labelHref ? html` <a href="${labelHref}">${label}</a> ` : label}
       </div>
     `;
   }
@@ -126,7 +122,7 @@ class CAEMStarRating extends StableSelectorMixin(LitElement) {
    */
   protected _renderStars() {
     const { disableTooltip, tooltip, rating, starCount } = this;
-    const { renderStar } = this.constructor as typeof CAEMStarRating;
+    const { renderStar } = this.constructor as typeof C4DStarRating;
     const integer = Math.floor(rating);
     const decimal = rating - integer;
 
@@ -143,9 +139,8 @@ class CAEMStarRating extends StableSelectorMixin(LitElement) {
         aria-label="${tooltip}"
         class="${prefix}-star-rating__stars"
         ?disableTooltip="${disableTooltip}"
-        part="stars"
-      >
-        ${fillValues.map(fillValue => renderStar(fillValue))}
+        part="stars">
+        ${fillValues.map((fillValue) => renderStar(fillValue))}
       </figure>
     `;
   }
@@ -177,9 +172,7 @@ class CAEMStarRating extends StableSelectorMixin(LitElement) {
       markup = StarFilled16();
       classModifier = 'filled';
     } else if (fill >= 0.25) {
-      markup = html`
-        ${Star16()}${StarHalf16()}
-      `;
+      markup = html` ${Star16()}${StarHalf16()} `;
       classModifier = 'half';
     } else {
       markup = Star16();
@@ -188,18 +181,17 @@ class CAEMStarRating extends StableSelectorMixin(LitElement) {
     return html`
       <div
         class="${prefix}-star-count__star ${prefix}-star-count__star--${classModifier}"
-        part="star"
-      >
+        part="star">
         ${markup}
       </div>
     `;
   }
 
   static get stableSelector() {
-    return `${caemPrefix}--star-rating`;
+    return `${c4dPrefix}--star-rating`;
   }
 
   static styles = styles;
 }
 
-export default CAEMStarRating;
+export default C4DStarRating;

--- a/packages/web-components/src/components/star-rating/star-rating.ts
+++ b/packages/web-components/src/components/star-rating/star-rating.ts
@@ -1,4 +1,14 @@
-import { html, LitElement, property } from 'lit-element';
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators';
 import '@carbon/web-components/es/components/tooltip';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element';
 import Star16 from '@carbon/web-components/es/icons/star/16';

--- a/packages/web-components/src/components/star-rating/star-rating.ts
+++ b/packages/web-components/src/components/star-rating/star-rating.ts
@@ -173,7 +173,7 @@ class C4DStarRating extends StableSelectorMixin(LitElement) {
   /**
    * Renders an individual star at a given fill value.
    *
-   * @param {Number} fill The star's fill value.
+   * @param {number} fill The star's fill value.
    * @returns {TemplateResult} A template fragment representing a single star.
    */
   static renderStar(fill) {

--- a/packages/web-components/src/components/star-rating/star-rating.ts
+++ b/packages/web-components/src/components/star-rating/star-rating.ts
@@ -9,7 +9,7 @@
 
 import { html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
-import '@carbon/web-components/es/components/tooltip.js';
+import '@carbon/web-components/es/components/tooltip/tooltip.js';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
 import Star16 from '@carbon/web-components/es/icons/star/16.js';
 import StarHalf16 from '@carbon/web-components/es/icons/star--half/16.js';

--- a/packages/web-components/src/components/star-rating/star-rating.ts
+++ b/packages/web-components/src/components/star-rating/star-rating.ts
@@ -1,0 +1,205 @@
+import { html, LitElement, property } from 'lit-element';
+import '@carbon/web-components/es/components/tooltip';
+import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element';
+import Star16 from '@carbon/web-components/es/icons/star/16';
+import StarHalf16 from '@carbon/web-components/es/icons/star--half/16';
+import StarFilled16 from '@carbon/web-components/es/icons/star--filled/16';
+import styles from './star-rating.scss';
+import StableSelectorMixin from '../../globals/mixins/stable-selector';
+import settings from '../../globals/settings';
+
+const { stablePrefix: caemPrefix, prefix } = settings;
+
+/**
+ * The Star Rating component.
+ * @element caem-star-rating
+ */
+@customElement(`${caemPrefix}-star-rating`)
+class CAEMStarRating extends StableSelectorMixin(LitElement) {
+  /**
+   * Maximum number of stars that may be in a rating.
+   */
+  protected maxStarCount = 10;
+
+  /**
+   * Internal store for rating value.
+   */
+  private _rating = 0;
+
+  /**
+   * Internal store for star count value.
+   */
+  private _starCount = 5;
+
+  /**
+   * Internal store for custom tooltip text.
+   */
+  private _tooltip: string | null = null;
+
+  /**
+   * The rating that will inform the number of stars to display.
+   */
+  @property({ attribute: 'rating', reflect: true, type: Number })
+  set rating(value: number) {
+    const oldValue = this._rating;
+    // Place boundaries to avoid out-of-memory issues.
+    this._rating = Math.min(Math.max(value, 0), this.starCount);
+    this.requestUpdate('rating', oldValue);
+  }
+  get rating() {
+    return this._rating;
+  }
+
+  /**
+   * The text to display beside the rating.
+   */
+  @property({ attribute: 'label', reflect: true })
+  label?: string;
+
+  /**
+   * An optional href for the label.
+   */
+  @property({ attribute: 'label-href', reflect: true })
+  labelHref?: string;
+
+  /**
+   * The number of stars to display.
+   */
+  @property({ attribute: 'star-count', reflect: true, type: Number })
+  set starCount(value: number) {
+    const oldValue = this._starCount;
+    // Place boundaries to avoid out-of-memory issues.
+    this._starCount = Math.min(Math.max(value, 0), this.maxStarCount);
+    this.requestUpdate('starCount', oldValue);
+  }
+  get starCount() {
+    return this._starCount;
+  }
+
+  /**
+   * The tooltip text that appears when hovering over the stars. Also used as an
+   * accessible label for the stars.
+   */
+  @property({ attribute: 'tooltip', reflect: true })
+  set tooltip(value: string | null) {
+    const oldValue = this._tooltip;
+    this._tooltip = value;
+    this.requestUpdate('tooltip', oldValue);
+  }
+  get tooltip() {
+    return !this._tooltip
+      ? `${this.rating} out of ${this.starCount} stars`
+      : this._tooltip;
+  }
+
+  /**
+   * Disables the visible tooltip without removing accessibility text.
+   */
+  @property({ reflect: true, type: Boolean })
+  disableTooltip = false;
+
+  /**
+   * Renders the label.
+   *
+   * @returns {TemplateResult} A template fragment representing the label.
+   */
+  protected _renderLabel() {
+    const { label, labelHref } = this;
+    if (!label) {
+      return '';
+    }
+    return html`
+      <div class="${prefix}-star-rating__label" part="label">
+        ${labelHref
+          ? html`
+              <a href="${labelHref}">${label}</a>
+            `
+          : label}
+      </div>
+    `;
+  }
+
+  /**
+   * Renders the rating as a series of stars.
+   *
+   * @returns {TemplateResult} A template fragment representing a series of stars.
+   */
+  protected _renderStars() {
+    const { disableTooltip, tooltip, rating, starCount } = this;
+    const { renderStar } = this.constructor as typeof CAEMStarRating;
+    const integer = Math.floor(rating);
+    const decimal = rating - integer;
+
+    const fillValues = Array(starCount)
+      .fill(1, 0, integer)
+      .fill(0, integer, starCount);
+
+    if (decimal) {
+      fillValues[integer] = decimal;
+    }
+
+    return html`
+      <figure
+        aria-label="${tooltip}"
+        class="${prefix}-star-rating__stars"
+        ?disableTooltip="${disableTooltip}"
+        part="stars"
+      >
+        ${fillValues.map(fillValue => renderStar(fillValue))}
+      </figure>
+    `;
+  }
+
+  shouldUpdate() {
+    if (isNaN(this.rating) || isNaN(this.starCount)) {
+      return false;
+    }
+    return true;
+  }
+
+  render() {
+    return html`
+      <div class="${prefix}-star-rating" part="wrapper">
+        ${this._renderStars()} ${this._renderLabel()}
+      </div>
+    `;
+  }
+
+  /**
+   * Renders an individual star at a given fill value.
+   *
+   * @param {Number} fill The star's fill value.
+   * @returns {TemplateResult} A template fragment representing a single star.
+   */
+  static renderStar(fill) {
+    let markup, classModifier;
+    if (fill >= 0.75) {
+      markup = StarFilled16();
+      classModifier = 'filled';
+    } else if (fill >= 0.25) {
+      markup = html`
+        ${Star16()}${StarHalf16()}
+      `;
+      classModifier = 'half';
+    } else {
+      markup = Star16();
+      classModifier = 'empty';
+    }
+    return html`
+      <div
+        class="${prefix}-star-count__star ${prefix}-star-count__star--${classModifier}"
+        part="star"
+      >
+        ${markup}
+      </div>
+    `;
+  }
+
+  static get stableSelector() {
+    return `${caemPrefix}--star-rating`;
+  }
+
+  static styles = styles;
+}
+
+export default CAEMStarRating;

--- a/packages/web-components/src/globals/internal/storybook-decorators.ts
+++ b/packages/web-components/src/globals/internal/storybook-decorators.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html } from 'lit-element';
+
+/**
+ * Wraps provided Storybook story in Carbon grid with no columns.
+ *
+ * @param story Storybook story
+ * @returns {TemplateResult}
+ */
+export const bxGridNoCol = (story) => html`
+  <div class="cds--grid c4d-story-padding">
+    <div class="cds--row">${story instanceof Function ? story() : story}</div>
+  </div>
+`;
+
+/**
+ * Wraps provided Storybook story in Carbon grid with a single full-width column.
+ *
+ * @param story Storybook story
+ * @returns {TemplateResult}
+ */
+export const bxGrid16Col = (story) =>
+  bxGridNoCol(html` <div class="cds--col-lg-16">${story()}</div> `);
+
+/**
+ * Wraps provided Storybook story in Carbon grid with a half-width, centered column.
+ *
+ * @param story Storybook story
+ * @returns {TemplateResult}
+ */
+export const bxGrid8ColCentered = (story) =>
+  bxGridNoCol(
+    html` <div class="cds--offset-lg-4 cds--col-lg-8">${story()}</div> `
+  );

--- a/packages/web-components/src/globals/internal/storybook-decorators.ts
+++ b/packages/web-components/src/globals/internal/storybook-decorators.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html } from 'lit-element';
+import { html } from 'lit';
 
 /**
  * Wraps provided Storybook story in Carbon grid with no columns.

--- a/packages/web-components/src/globals/internal/storybook-decorators.ts
+++ b/packages/web-components/src/globals/internal/storybook-decorators.ts
@@ -15,7 +15,7 @@ import { html } from 'lit';
  * @param story Storybook story
  * @returns {TemplateResult}
  */
-export const bxGridNoCol = (story) => html`
+export const GridNoCol = (story) => html`
   <div class="cds--grid c4d-story-padding">
     <div class="cds--row">${story instanceof Function ? story() : story}</div>
   </div>
@@ -27,8 +27,8 @@ export const bxGridNoCol = (story) => html`
  * @param story Storybook story
  * @returns {TemplateResult}
  */
-export const bxGrid16Col = (story) =>
-  bxGridNoCol(html` <div class="cds--col-lg-16">${story()}</div> `);
+export const Grid16Col = (story) =>
+  GridNoCol(html` <div class="cds--col-lg-16">${story()}</div> `);
 
 /**
  * Wraps provided Storybook story in Carbon grid with a half-width, centered column.
@@ -36,7 +36,7 @@ export const bxGrid16Col = (story) =>
  * @param story Storybook story
  * @returns {TemplateResult}
  */
-export const bxGrid8ColCentered = (story) =>
-  bxGridNoCol(
+export const Grid8ColCentered = (story) =>
+  GridNoCol(
     html` <div class="cds--offset-lg-4 cds--col-lg-8">${story()}</div> `
   );


### PR DESCRIPTION
### Related Ticket(s)

[JIRA](https://jsw.ibm.com/browse/ADCMS-6667)

### Description

Migrates the`star-rating` component from `carbon-for-aem` into `carbon-for-ibmdotcom`.

### Changelog

**New**

- adds new `c4d-star-rating` component


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
