### PR TITLE
refactor(tile): use relative paths for imports in the same pkg

### DIFF
--- a/packages/web-components/src/components/tile/__stories__/tile-group.stories.ts
+++ b/packages/web-components/src/components/tile/__stories__/tile-group.stories.ts
@@ -10,7 +10,7 @@
 import { html } from 'lit';
 import '../index';
 import readme from './README--tile-group.stories.mdx';
-import '@carbon/ibmdotcom-web-components/es/components/image';
+import '../../image';
 import {
   Default as DefaultTile,
   WithImage as TileWithImage,

--- a/packages/web-components/src/components/tile/__stories__/tile.stories.ts
+++ b/packages/web-components/src/components/tile/__stories__/tile.stories.ts
@@ -11,8 +11,8 @@ import { html } from 'lit';
 import '@carbon/web-components/es/components/tag/tag';
 import '../index';
 import readme from './README--tile.stories.mdx';
-import '@carbon/ibmdotcom-web-components/es/components/cta/video-cta-container';
-import '@carbon/ibmdotcom-web-components/es/components/image';
+import '../../cta/video-cta-container';
+import '../../image';
 
 import { CTA_TYPE } from '@carbon/ibmdotcom-web-components/es/components/cta/defs';
 import { boolean, select, text } from '@storybook/addon-knobs';


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6691](https://jsw.ibm.com/browse/ADCMS-6691)
Follow up to https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/12091

### Description

Quick followup to https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/12091. Updates imports for the same package to be relative paths. Can avoid weird local development / bundling bugs and maintains consistency with the rest of the codebase.

### Changelog

**Changed**

- Adjusts `import '@carbon/ibmdotcom-web-components/es*';` imports to relative path imports.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
