### PR TITLE
fix(tile): add a knob to have deterministic random in label and headline

### DIFF
--- a/packages/web-components/src/components/tile/__stories__/tile-group.stories.ts
+++ b/packages/web-components/src/components/tile/__stories__/tile-group.stories.ts
@@ -16,7 +16,7 @@ import {
   WithImage as TileWithImage,
 } from './tile.stories';
 import { CTA_TYPE } from '../../cta/defs';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 
 const ctaTypeOptions = Object.values(CTA_TYPE).filter((value) => !!value);
 
@@ -46,6 +46,11 @@ export default {
           false
         );
 
+        const startSequenceNumber = number(
+          'Starting sequence number for random label and heading',
+          0
+        );
+
         const tocLayout = boolean('Use 3/4 layout', false);
 
         return {
@@ -55,6 +60,7 @@ export default {
           hasPictogram,
           alignWithContent,
           href,
+          startSequenceNumber,
           tocLayout,
         };
       },
@@ -94,6 +100,7 @@ export const Default = (args) => {
     hasPictogram,
     alignWithContent,
     href,
+    startSequenceNumber,
   } = args?.TileGroup ?? {};
   return html`
     <c4d-tile-group>
@@ -106,6 +113,7 @@ export const Default = (args) => {
             hasPictogram,
             alignWithContent,
             href,
+            startSequenceNumber,
           },
         })
       )}
@@ -121,6 +129,7 @@ export const WithImage = (args) => {
     hasPictogram,
     alignWithContent,
     href,
+    startSequenceNumber,
   } = args?.TileGroup ?? {};
   return html`
     <c4d-tile-group>
@@ -133,6 +142,7 @@ export const WithImage = (args) => {
             hasPictogram,
             alignWithContent,
             href,
+            startSequenceNumber,
           },
         })
       )}

--- a/packages/web-components/src/components/tile/__stories__/tile.stories.ts
+++ b/packages/web-components/src/components/tile/__stories__/tile.stories.ts
@@ -15,7 +15,7 @@ import '../../cta/video-cta-container';
 import '../../image';
 
 import { CTA_TYPE } from '../../cta/defs';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, select, text, number } from '@storybook/addon-knobs';
 
 const tagGroupContent = html`
   <c4d-tag-group>
@@ -48,7 +48,14 @@ const pictogramContent = html`
 
 const ctaTypeOptions = Object.values(CTA_TYPE).filter((value) => !!value);
 
-const randomLabel = () => {
+const deterministicSequence = [
+  2, 5, 7, 4, 6, 0, 6, 4, 7, 4, 6, 6, 0, 4, 4, 3, 0, 0, 1, 6, 7, 7, 3, 0, 0, 0,
+  1, 7, 4, 5, 4, 6, 7, 4, 1, 4, 5, 0, 6, 7, 5, 3, 7, 0, 3, 3, 5, 2, 5, 3,
+];
+
+let steps = 0;
+
+const randomLabel = (startSequenceNumber) => {
   const labels = [
     'Est tempor per quam',
     'Velit vulputat lorem',
@@ -57,11 +64,19 @@ const randomLabel = () => {
     'Quisque non praesent',
     'Ornare turpis taciti in',
     'Ipsum egestas varius ut torquent',
+    'Natoque cras dictum nec sociosqu tempus phasellus',
   ];
-  return labels[Math.floor(Math.random() * labels.length)];
+  const label =
+    labels[
+      deterministicSequence[
+        (startSequenceNumber + steps) % deterministicSequence.length
+      ]
+    ];
+  steps++;
+  return label;
 };
 
-const randomHeadline = () => {
+const randomHeadline = (startSequenceNumber) => {
   const headlines = [
     'Est scelerisque habitant ac aptent ex suspendisse',
     'At quisque fringilla elementum adipiscing morbi',
@@ -72,7 +87,14 @@ const randomHeadline = () => {
     'Erat dictumst varius faucibus penatibus dignissim torquent',
     'Imperdiet commodo habitasse nisi eget mollis libero blandit tincidunt molestie',
   ];
-  return headlines[Math.floor(Math.random() * headlines.length)];
+  const headline =
+    headlines[
+      deterministicSequence[
+        (startSequenceNumber + steps) % deterministicSequence.length
+      ]
+    ];
+  steps++;
+  return headline;
 };
 
 export default {
@@ -100,6 +122,11 @@ export default {
           false
         );
 
+        const startSequenceNumber = number(
+          'Starting sequence number for random label and heading',
+          0
+        );
+
         return {
           hasPictogram,
           hasTagGroup,
@@ -107,6 +134,7 @@ export default {
           ctaCopy,
           alignWithContent,
           href,
+          startSequenceNumber,
         };
       },
     },
@@ -148,14 +176,16 @@ export const Default = (args) => {
     hasPictogram,
     alignWithContent,
     href,
+    startSequenceNumber,
   } = args?.Tile ?? {};
   return html`
     <c4d-tile
-      label="${randomLabel()}"
+      label="${randomLabel(startSequenceNumber)}"
       href="${href}"
       cta-type="${ctaType}"
       ?align-with-content="${alignWithContent}">
-      ${hasPictogram ? pictogramContent : undefined} ${randomHeadline()}
+      ${hasPictogram ? pictogramContent : undefined}
+      ${randomHeadline(startSequenceNumber)}
       ${hasTagGroup ? tagGroupContent : undefined}
 
       <p slot="cta">${ctaCopy}</p>
@@ -171,10 +201,11 @@ export const WithImage = (args) => {
     hasPictogram,
     alignWithContent,
     href,
+    startSequenceNumber,
   } = args?.Tile ?? {};
   return html`
     <c4d-tile
-      label="${randomLabel()}"
+      label="${randomLabel(startSequenceNumber)}"
       href="${href}"
       cta-type="${ctaType}"
       ?align-with-content="${alignWithContent}">
@@ -185,7 +216,8 @@ export const WithImage = (args) => {
         alt="Image Alt Text"
         default-src="https://fakeimg.pl/160x160/F7F3FF/6829C1/?retina=1&text=1:1&font=museo"></c4d-image>
 
-      ${randomHeadline()} ${hasTagGroup ? tagGroupContent : undefined}
+      ${randomHeadline(startSequenceNumber)}
+      ${hasTagGroup ? tagGroupContent : undefined}
 
       <p slot="cta">${ctaCopy}</p>
     </c4d-tile>
@@ -201,10 +233,11 @@ export const DoubleTile = (args) => {
     hasPictogram,
     alignWithContent,
     href,
+    startSequenceNumber,
   } = args?.Tile ?? {};
   return html`
     <c4d-tile
-      label="${randomLabel()}"
+      label="${randomLabel(startSequenceNumber)}"
       href="${href}"
       cta-type="${ctaType}"
       ?align-with-content="${alignWithContent}"
@@ -216,7 +249,8 @@ export const DoubleTile = (args) => {
         alt="Image Alt Text"
         default-src="https://fakeimg.pl/160x160/F7F3FF/6829C1/?retina=1&text=1:1&font=museo"
         class="c4d-tile__image-double"></c4d-image>
-      ${randomHeadline()} ${hasTagGroup ? tagGroupContent : undefined}
+      ${randomHeadline(startSequenceNumber)}
+      ${hasTagGroup ? tagGroupContent : undefined}
 
       <p slot="cta">${ctaCopy}</p>
     </c4d-tile>


### PR DESCRIPTION
### Related Ticket(s)

Follow up to https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/12091

### Description

Since merging https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/12091, we've been getting Percy complaining about differences in the tile stories. The reason is that those stories have a random selection of labels and headlines each time you visit the story anew.

This PR introduces a pre-generated sequence of index numbers for the list of labels and headlines, which you can "pre-seed" by chosing a starting sequence number. This ensures that given any stating sequence number the chosen labels and headlines will be the same always. That should allow us to run Percy consistently wthout having to approve changes on every commit.

Note: Percy will report the same annoying differences in the tile story on this PR too, but after its merged, should never bother us again over differences in the chosen labels and headlines.

### Changelog

**Changed**

- Updated tile stories with a parameter to facilitate consistent "random" choices in label and headline text

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
