### PR TITLE
fix(leadspace): in storybook adding long copy to copy knob led to button being clipped away

### DIFF
--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -528,7 +528,7 @@ $btn-min-width: 26;
   :host(#{$c4d-prefix}-leadspace)[size='medium'] {
     @include breakpoint(lg) {
       .#{$c4d-prefix}--leadspace__overlay {
-        block-size: 30rem;
+        min-block-size: 30rem;
       }
     }
 

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -514,7 +514,7 @@ $btn-min-width: 26;
   :host(#{$c4d-prefix}-leadspace)[size='super'] {
     @include breakpoint(lg) {
       .#{$c4d-prefix}--leadspace__overlay {
-        block-size: 40rem;
+        min-block-size: 40rem;
       }
     }
 
@@ -548,7 +548,7 @@ $btn-min-width: 26;
   :host(#{$c4d-prefix}-leadspace)[size='short'] {
     @include breakpoint(lg) {
       .#{$c4d-prefix}--leadspace__overlay {
-        block-size: 20rem;
+        min-block-size: 20rem;
       }
     }
 
@@ -579,7 +579,7 @@ $btn-min-width: 26;
   :host(#{$c4d-prefix}-leadspace)[size='tall'] {
     @include breakpoint(lg) {
       .#{$c4d-prefix}--leadspace__overlay {
-        block-size: 35rem;
+        min-block-size: 35rem;
       }
     }
 

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -513,8 +513,8 @@ $btn-min-width: 26;
 
   :host(#{$c4d-prefix}-leadspace)[size='super'] {
     @include breakpoint(lg) {
-      .#{$c4d-prefix}--leadspace__overlay {
-        min-block-size: 40rem;
+      .#{$c4d-prefix}--leadspace--content__container {
+        min-block-size: 38rem;
       }
     }
 
@@ -527,8 +527,8 @@ $btn-min-width: 26;
 
   :host(#{$c4d-prefix}-leadspace)[size='medium'] {
     @include breakpoint(lg) {
-      .#{$c4d-prefix}--leadspace__overlay {
-        min-block-size: 30rem;
+      .#{$c4d-prefix}--leadspace--content__container {
+        min-block-size: 28rem;
       }
     }
 
@@ -578,8 +578,8 @@ $btn-min-width: 26;
 
   :host(#{$c4d-prefix}-leadspace)[size='tall'] {
     @include breakpoint(lg) {
-      .#{$c4d-prefix}--leadspace__overlay {
-        min-block-size: 35rem;
+      .#{$c4d-prefix}--leadspace--content__container {
+        min-block-size: 33rem;
       }
     }
 


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6827](https://jsw.ibm.com/browse/ADCMS-6827)

### Description

Adding **long** text to the leadspace copy knob leads to clipping the text & CTAs.

Issue:
![image](https://github.com/user-attachments/assets/7f51a789-33a8-463f-a408-b5d8628c7a93)


Fixed:
![image](https://github.com/user-attachments/assets/bcd9b23c-593c-480a-b145-9864408d2b99)


### NOTE
There's an apparent bug in all heading/title knobs in all components, when you try to modify it, we get the below error.
I've been trying to debug this error, but with @m4olivei 's help, we found out it's an issue that's been sitting there for a while now, so It would just be very time consuming for the tiny fix that was the original scope of this ticket
![example3](https://github.com/user-attachments/assets/6c613264-6bc8-4bcf-9bed-7c5a8350f236)

