### PR TITLE
fix(toc): alignment issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci-check": "npm run format:diff && yarn lint:license && yarn lint && yarn lint:styles",
     "clean": "lerna run clean && lerna clean --yes && rimraf node_modules",
     "doctoc": "doctoc --title '## Table of Contents' docs",
-    "format": "prettier --cache --write '**/*.{js,md,scss,ts}'",
+    "format": "prettier --cache --write '**/*.{js,md,scss,ts}' && stylelint '**/*.{css,scss}' --fix",
     "format:diff": "prettier --cache --list-different '**/*.{js,md,scss,ts}'",
     "lint": "eslint packages --ext .js,.ts",
     "lint:license": "gulp lint:license",

--- a/packages/styles/scss/components/tableofcontents/_table-of-contents.scss
+++ b/packages/styles/scss/components/tableofcontents/_table-of-contents.scss
@@ -102,14 +102,17 @@ $hover-transition-timing: 95ms;
 
     position: inherit;
     z-index: 10;
-    padding: 0;
+
+    box-sizing: border-box;
     inset-block-start: auto;
+    padding-inline-start: 0;
   }
 
   .#{$prefix}--tableofcontents__content {
     @extend .#{$prefix}--col-lg-12;
 
-    padding: $spacing-05 0 $spacing-09 0;
+    box-sizing: border-box;
+    padding-block: $spacing-05 $spacing-09;
   }
 
   .#{$prefix}--tableofcontents {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-6886

### Description

Fixes alignment changes between v1 & v2 as exhibited [here](https://toc-comparison--carbon-demos.netlify.app/)

<img width="1383" alt="Screenshot 2024-11-22 at 10 59 21 AM" src="https://github.com/user-attachments/assets/1d068690-e2c5-4388-bf6c-1c66da5ee6f4">
<img width="615" alt="Screenshot 2024-11-22 at 10 59 36 AM" src="https://github.com/user-attachments/assets/27025370-9e39-405f-b716-7045afc9a011">


### Changelog

**Changed**

- add `stylelint --fix` to `yarn format` command
- fixes alignment changes in table of contents