### PR TITLE
fix(card): remove onclick handler for pictogram

### DIFF
--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -401,7 +401,6 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
     }
 
     if (this._hasPictogram) {
-      this.onclick = () => window.open(this.href, '_self');
       this.setAttribute('pictogram', '');
     } else {
       this.removeAttribute('pictogram');


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6850](https://jsw.ibm.com/browse/ADCMS-6850)

### Description

Removes an `onclick` handler on cards which is redundant and hinders customization by adopters. The `onlick` handler here is already covered by the `<a>` that has an `::after` pseudo element covering the card and capturing the click event for sighted and non-sighted users.

The `onclick` handler was added back in https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/6642.

### Changelog

**Changed**

- Removed `onclick` handler from pictogram cards

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
