### PR TITLE
fix(callout-with-media): spacing adjustments

### DIFF
--- a/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
+++ b/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2016, 2023
+// Copyright IBM Corp. 2016, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -96,6 +96,8 @@
   :host(#{$c4d-prefix}-callout-with-media-video)
     ::slotted(#{$c4d-prefix}-video-player) {
     @extend :host(#{$c4d-prefix}-callout-caption);
+
+    margin-block-end: 0;
   }
 
   :host(#{$c4d-prefix}-callout-with-media-image[color-scheme='inverse'])
@@ -159,7 +161,7 @@
   .#{$prefix}--callout-with-media
     .#{$prefix}--callout__content
     .#{$prefix}--content-block {
-    padding-block-end: $spacing-10;
+    padding-block-end: $spacing-07;
   }
 
   :host(#{$c4d-prefix}-callout-with-media-image),


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6942](https://jsw.ibm.com/browse/ADCMS-6942)

### Description

Adjust spacing on the `<c4d-callout-with-media>` component per the [Figma specs](https://www.figma.com/design/ADYTE8HS12nn63RJLZOk87/Layout-component--callout-with-media--visual-specs--2.1?node-id=0-1&node-type=canvas&t=QNmoJfFTr6bA75Ak-0). Note that there are no v2 specs for this component.

### Changelog

**Changed**

- Adjust spacing for slotted elements to the `<c4d-callout-with-media>` component.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
