### PR TITLE
fix(feature-section): stretch image if needed

### DIFF
--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -125,7 +125,7 @@ $feature-flags: (
     ::slotted([slot='image']),
     #{$c4d-prefix}-image {
       z-index: 0;
-      height: 100%;
+      block-size: 100%;
 
       // Opacity is adjusted on hover. See above.
       &::before {

--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -125,6 +125,7 @@ $feature-flags: (
     ::slotted([slot='image']),
     #{$c4d-prefix}-image {
       z-index: 0;
+      height: 100%;
 
       // Opacity is adjusted on hover. See above.
       &::before {

--- a/packages/styles/scss/components/feature-section/_feature-section.scss
+++ b/packages/styles/scss/components/feature-section/_feature-section.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -120,8 +120,8 @@
     padding-inline: 0;
 
     ::slotted(#{$c4d-prefix}-image) {
-      height: 100%;
       overflow: hidden;
+      block-size: 100%;
 
       @include breakpoint(sm) {
         block-size: aspect-ratio(1, 1);

--- a/packages/styles/scss/components/feature-section/_feature-section.scss
+++ b/packages/styles/scss/components/feature-section/_feature-section.scss
@@ -120,6 +120,7 @@
     padding-inline: 0;
 
     ::slotted(#{$c4d-prefix}-image) {
+      height: 100%;
       overflow: hidden;
 
       @include breakpoint(sm) {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-6914

### Description

Stretches images in feature-card and feature-section if content causes component to grow vertically.

### Changelog

**Changed**

- updates feature-card & feature-section styles to stretch image to fill if needed