### PR TITLE
fix(content-block-segmented): spacing adjustments

### DIFF
--- a/packages/web-components/src/components/content-block-segmented/content-block-segmented.scss
+++ b/packages/web-components/src/components/content-block-segmented/content-block-segmented.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2023
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -32,20 +32,12 @@
   }
 }
 
-:host(#{$c4d-prefix}-content-block-segmented-item) ::slotted(*) {
-  margin-inline: $spacing-05;
-}
-
 // TODO: Consider applying this rule in general
 :host(#{$c4d-prefix}-content-block-segmented-item) {
   ::slotted(#{$c4d-prefix}-content-item-copy) {
     @include breakpoint(md) {
       inline-size: calc((100% - 2 * #{$spacing-05}) * 0.9);
     }
-  }
-
-  ::slotted([slot='footer']) {
-    margin-block-start: $spacing-07;
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6929](https://jsw.ibm.com/browse/ADCMS-6929)

### Description

Fixes spacing for the `<c4d-content-block-segmented-item>` component.

[Figma specs](https://www.figma.com/design/9mRDDnXj2FWnP1SBy88EYh/Content-block-v2?node-id=1-3099&node-type=canvas&t=jd4KO55hcGcO1hW9-0)

### Changelog

**Changed**

- Adjust spacing for slotted footer content to the `<c4d-content-block-segmented-item>` component

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
