### PR TITLE
fix(toc): tweak media query for sidebar at lg

### DIFF
--- a/packages/web-components/src/components/table-of-contents/table-of-contents.ts
+++ b/packages/web-components/src/components/table-of-contents/table-of-contents.ts
@@ -80,7 +80,7 @@ function findLastIndex<T>(
 @customElement(`${c4dPrefix}-table-of-contents`)
 class C4DTableOfContents extends MediaQueryMixin(
   HostListenerMixin(StableSelectorMixin(LitElement)),
-  { [MQBreakpoints.LG]: MQDirs.MAX }
+  { [MQBreakpoints.LG]: MQDirs.MIN }
 ) {
   /**
    * Defines TOC type, "" for default, `horizontal` for horizontal variant.
@@ -157,7 +157,7 @@ class C4DTableOfContents extends MediaQueryMixin(
    * Whether we're viewing smaller or larger window.
    */
   @state()
-  _isMobile = this.carbonBreakpoints.lg.matches;
+  _isMobile = !this.carbonBreakpoints.lg.matches;
 
   /**
    * The target elements matching `[name]` harvested from the document.
@@ -625,8 +625,8 @@ class C4DTableOfContents extends MediaQueryMixin(
     }
   }
 
-  mediaQueryCallbackMaxLG() {
-    this._isMobile = this.carbonBreakpoints.lg.matches;
+  mediaQueryCallbackLG() {
+    this._isMobile = !this.carbonBreakpoints.lg.matches;
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6990](https://jsw.ibm.com/browse/ADCMS-6990)

### Description

Adjusts the media query logic in the TOC component to line up with the Sass for the same. This fixes an issue where before, right on the lg breakpoint, the TOC was broken and stuck showing mostly mobile styles instead of desktop ones.

### Changelog

**Changed**

- TOC wlll now maintain the desktop layout for the lg breakpoint and above.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
