### PR TITLE
fix(footer): pass along the placeholder text to combo-box

### DIFF
--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -321,6 +321,7 @@ class C4DFooterComposite extends MediaQueryMixin(
             slot="${slot}"
             trigger-content="${languageSelectorLabel}"
             label-text="${languageSelectorLabel}"
+            label="${languageSelectorLabel}"
             value="${selectedLanguage}"
             clear-selection-label="${clearSelectionLabel}">
             ${langList?.map(


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-7082](https://jsw.ibm.com/browse/ADCMS-7082)

### Description

Fixes an issue where the `placeholder` text in the `<input>` within the `<c4d-language-selector-desktop>` component was not being correctly passed along from the `<c4d-footer-container>` attributes.

### Testing instructions

* Go to the Footer > Default language only story. We're focused here on the `<c4d-language-selector-desktop>` component:

![image](https://github.com/user-attachments/assets/a8cde6ea-b18f-4e4d-806b-d30a1d7f65ad)

* Click the "x" to clear the language selection

**Expected result**

You should see the placeholder text "Choose a language"

### Changelog

**Changed**

- `<c4d-language-selector-desktop>` component will show placeholder text for empty value


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
