### PR TITLE
fix(card): push the footer to the bottom of the card consistently

### DIFF
--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -117,11 +117,16 @@
       }
     }
 
+    .#{$prefix}--card {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
+
     .#{$prefix}--card__wrapper {
       display: flex;
       flex: 1;
       justify-content: space-between;
-      block-size: 100%;
       min-block-size: $spacing-13;
       transition: $duration-moderate-01 motion(standard, productive);
 

--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -121,6 +121,7 @@
       display: flex;
       flex: 1;
       justify-content: space-between;
+      block-size: 100%;
       min-block-size: $spacing-13;
       transition: $duration-moderate-01 motion(standard, productive);
 


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-7121](https://jsw.ibm.com/browse/ADCMS-7121)
[ADCMS-7158](https://jsw.ibm.com/browse/ADCMS-7158)

### Description

Under certain conditions, the footer of a card, especially within a group, might not stick to the end of the card as intended. This fixes it so that the card footer is always at the end of the card.

### Changelog

**Changed**

- Force the footer of cards to be at the end, corrects an issue with Content Group Cards

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
