### PR TITLE
fix(cta-block): adjust cta-block-item-row inline margin

### DIFF
--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -86,6 +86,7 @@
     }
 
     ::slotted(#{$c4d-prefix}-content-group:not([slot])),
+    ::slotted(#{$c4d-prefix}-cta-block-item-row:not([slot])),
     ::slotted([data-autoid^='c4d--tabs-']:not([slot])),
     ::slotted([data-autoid^='c4d--card']:not([slot])) {
       margin-inline-start: 0;


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-7025](https://jsw.ibm.com/browse/ADCMS-7025)

### Description

Adjustment to inline-margin-start for `<c4d-cta-block-item-row>`

### Changelog

**Changed**

- Adjusted inline-margin-start for `<c4d-cta-block-item-row>` when slotted into content block

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
