### PR TITLE
fix(button): avoid taking any video name bubbled on the page

### DIFF
--- a/packages/web-components/src/components/button/button.ts
+++ b/packages/web-components/src/components/button/button.ts
@@ -7,16 +7,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { LitElement, html } from 'lit';
+import { html, LitElement } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import styles from './button.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
-import CTAMixin from '../../component-mixins/cta/cta';
+import CTAMixin, { ariaLabels, icons } from '../../component-mixins/cta/cta';
 import CDSButton from '@carbon/web-components/es/components/button/button.js';
+import { CTA_TYPE } from '../cta/defs';
 
-import { ariaLabels, icons } from '../../component-mixins/cta/cta';
 const { prefix, stablePrefix: c4dPrefix } = settings;
 
 /**
@@ -89,7 +89,11 @@ class C4DButton extends CTAMixin(StableSelectorMixin(CDSButton)) {
    */
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleVideoTitleUpdate = async (event) => {
-    if (event) {
+    if (
+      event &&
+      this.ctaType === CTA_TYPE.VIDEO &&
+      this.href === event.detail?.videoId
+    ) {
       const { videoDuration, videoName } = event.detail as any;
       const { formatVideoDuration, formatVideoCaption } = this;
       const formattedVideoDuration = formatVideoDuration({

--- a/packages/web-components/tests/e2e-storybook/cypress/integration/button-group/button-group.e2e.js
+++ b/packages/web-components/tests/e2e-storybook/cypress/integration/button-group/button-group.e2e.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright IBM Corp. 2021, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Sets the correct defaultPath for Button Group
+ *
+ * @type {string}
+ * @private
+ */
+const _defaultPath = '/iframe.html?id=components-button-group--default';
+
+/* eslint-disable cypress/no-unnecessary-waiting */
+describe('c4d-button-group | default', () => {
+  beforeEach(() => {
+    cy.visit(`/${_defaultPath}`);
+    cy.injectAxe();
+    cy.viewport(1280, 780);
+  });
+
+  it('should check a11y', () => {
+    cy.checkAxeA11y();
+  });
+
+  it('should use given labels', () => {
+    cy.visit(
+      `/${_defaultPath}&knob-Button%201=Test%20Me%20Once&knob-Button%202=Test%20Me%20Twice`
+    );
+    cy.get('c4d-button-group-item')
+      .first()
+      .should('have.text', 'Test Me Once')
+      .next()
+      .should('have.text', 'Test Me Twice');
+
+    cy.takeSnapshots();
+  });
+
+  it('should use given labels with video cta-type mixed in', () => {
+    cy.visit(
+      `/${_defaultPath}&knob-Button%201=Test%20Me%20Once&knob-Button%202=Test%20Me%20Twice&knob-CTA%20type%20(cta-type)%202=video`
+    );
+    cy.get('c4d-button-group-item')
+      .first()
+      .should('have.text', 'Test Me Once')
+      .next()
+      .should('have.text', 'Test Me Twice');
+
+    cy.takeSnapshots();
+  });
+
+  it('should use video name for a video cta-type that has no label', () => {
+    cy.visit(
+      `/${_defaultPath}&knob-Button%201=Test%20Me%20Once&knob-Button%202=%20&knob-CTA%20type%20(cta-type)%202=video`
+    );
+    cy.get('c4d-button-group-item')
+      .first()
+      .should('have.text', 'Test Me Once')
+      .next()
+      .should('not.be.empty');
+
+    cy.takeSnapshots();
+  });
+
+  it('should not use video name for buttons that are not cta-type video', () => {
+    cy.visit(
+      `/${_defaultPath}&knob-Button%201=%20&knob-Button%202=%20&knob-CTA%20type%20(cta-type)%202=video`
+    );
+    cy.get('c4d-button-group-item')
+      .first()
+      .should('contain.text', '')
+      .next()
+      .should('not.be.empty');
+
+    cy.takeSnapshots();
+  });
+});


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-7088](https://jsw.ibm.com/browse/ADCMS-7088)

### Description

As it was, button elements that had no label would adopt any video name fetched by the `<c4d-video-cta-container>` component, which may have been triggered by a completely unrelated CTA. This change now guards against that by ignoring events when the button is not a `cta-type="video"` or does not have the same video id as the fetched video.

### Changelog

**Changed**

- Fixes an issue with buttons not using a label placed on a page with other unrelated video CTAs

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
