### PR TITLE
fix(notice-choice): switch attribute to snake case

### DIFF
--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -56,7 +56,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
   @property({ type: String, attribute: 'language' })
   language = 'en';
 
-  @property({ type: String, attribute: 'currentLanguage' })
+  @property({ type: String, attribute: 'current-language' })
   currentLanguage = 'en';
 
   @property({ type: String, attribute: 'terms-condition-link' })


### PR DESCRIPTION
### Related Ticket(s)

Follow up to https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/12127

### Description

Following convention, switch `current-language` attribute to snake case.

### Changelog

**Changed**

- Changed `currentLanguage` attribute in `<c4d-notice-choice>` component to snake case

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
