### PR TITLE
feat(video-player): enable autoplay & load as muted

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -43,8 +43,8 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
     }
   }
 
-  :host(#{$c4d-prefix}-video-player[background-mode='true']),
-  .#{$c4d-prefix}--video-player[background-mode='true'] {
+  :host(#{$c4d-prefix}-video-player[background-mode]),
+  .#{$c4d-prefix}--video-player[background-mode] {
     .#{$c4d-prefix}--video-player__video-container {
       padding: 0;
       block-size: 100%;

--- a/packages/web-components/src/components/background-media/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/background-media/__stories__/README.stories.mdx
@@ -69,7 +69,7 @@ import '@carbon/ibmdotcom-web-components/es/components/background-media/index.js
   <c4d-video-player-container
     playing-mode="inline"
     video-id="0_ibuqxqbe"
-    background-mode="true">
+    background-mode>
   </c4d-video-player-container>
 </c4d-background-media>
 ```

--- a/packages/web-components/src/components/background-media/__stories__/background-media.stories.ts
+++ b/packages/web-components/src/components/background-media/__stories__/background-media.stories.ts
@@ -56,7 +56,7 @@ export const WithVideo = (args) => {
         opacity="${ifDefined(backgroundOpacity)}">
         <c4d-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></c4d-video-player-container>
+          background-mode></c4d-video-player-container>
       </c4d-background-media>
     </div>
   `;

--- a/packages/web-components/src/components/leadspace/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/leadspace/__stories__/README.stories.mdx
@@ -87,7 +87,7 @@ such:
   <c4d-background-media slot="image" opacity="100">
     <c4d-video-player-container
       video-id="1_9h94wo6b"
-      background-mode="true"></c4d-video-player-container>
+      background-mode></c4d-video-player-container>
   </c4d-background-media>
 </c4d-leadspace>
 ```

--- a/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
+++ b/packages/web-components/src/components/leadspace/__stories__/leadspace.stories.ts
@@ -190,7 +190,7 @@ export const SuperWithVideo = (args) => {
       <c4d-background-media slot="image" opacity="100">
         <c4d-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></c4d-video-player-container>
+          background-mode></c4d-video-player-container>
       </c4d-background-media>
     </c4d-leadspace>
   `;
@@ -335,7 +335,7 @@ export const TallWithVideo = (args) => {
       <c4d-background-media slot="image" opacity="100">
         <c4d-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></c4d-video-player-container>
+          background-mode></c4d-video-player-container>
       </c4d-background-media>
     </c4d-leadspace>
   `;
@@ -480,7 +480,7 @@ export const MediumWithVideo = (args) => {
       <c4d-background-media slot="image" opacity="100">
         <c4d-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></c4d-video-player-container>
+          background-mode></c4d-video-player-container>
       </c4d-background-media>
     </c4d-leadspace>
   `;
@@ -635,7 +635,7 @@ export const ShortWithVideo = (args) => {
       <c4d-background-media slot="image" opacity="100">
         <c4d-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></c4d-video-player-container>
+          background-mode></c4d-video-player-container>
       </c4d-background-media>
     </c4d-leadspace>
   `;
@@ -754,7 +754,7 @@ export const CenteredWithVideo = (args) => {
       <c4d-background-media slot="image" opacity="100">
         <c4d-video-player-container
           video-id="0_ibuqxqbe"
-          background-mode="true"></c4d-video-player-container>
+          background-mode></c4d-video-player-container>
       </c4d-background-media>
     </c4d-leadspace>
   `;

--- a/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -79,6 +79,42 @@ export const withLightboxMediaViewer = (args) => {
       playing-mode="lightbox">
     </c4d-video-player-container>
     <c4d-lightbox-video-player-container></c4d-lightbox-video-player-container>
+  `;
+};
+
+export const autoplay = (args) => {
+  const { aspectRatio, caption, hideCaption, thumbnail, videoId } =
+    args?.VideoPlayer ?? {};
+  return html`
+    <dds-video-player-container
+      auto-play
+      playing-mode="inline"
+      video-id=${videoId}
+      aspect-ratio=${aspectRatio}
+      caption=${caption}
+      ?hide-caption=${hideCaption}
+      thumbnail=${thumbnail}></dds-video-player-container>
+  `;
+};
+
+export const autoplayMuted = (args) => {
+  const { caption, hideCaption, thumbnail, videoId } = args?.VideoPlayer ?? {};
+  return html`
+    <style>
+      dds-video-player-container[background-mode] {
+        display: block;
+        aspect-ratio: 16/9;
+        outline: 2px solid red;
+      }
+    </style>
+    <dds-video-player-container
+      auto-play
+      muted
+      playing-mode="inline"
+      video-id=${videoId}
+      caption=${caption}
+      ?hide-caption=${hideCaption}
+      thumbnail=${thumbnail}></dds-video-player-container>
   `;
 };
 
@@ -161,6 +197,62 @@ withLightboxMediaViewer.story = {
         VideoPlayer: {
           aspectRatio: '16x9',
           customVideoDescription: 'This is a custom video description',
+          caption: '',
+          hideCaption: false,
+          thumbnail: '',
+          videoId: '0_ibuqxqbe',
+        },
+      },
+    },
+  },
+};
+
+autoplay.story = {
+  name: 'Autoplay',
+  parameters: {
+    knobs: {
+      VideoPlayer: () => {
+        return {
+          aspectRatio: '4x3',
+          caption: text('Custom caption (caption):', ''),
+          hideCaption: boolean('Hide caption (hideCaption):', false),
+          thumbnail: text('Custom thumbnail (thumbnail):', ''),
+          videoId: '0_ibuqxqbe',
+        };
+      },
+    },
+    propsSet: {
+      default: {
+        VideoPlayer: {
+          aspectRatio: '4x3',
+          caption: '',
+          hideCaption: false,
+          thumbnail: '',
+          videoId: '0_ibuqxqbe',
+        },
+      },
+    },
+  },
+};
+
+autoplayMuted.story = {
+  name: 'Autoplay muted',
+  parameters: {
+    knobs: {
+      VideoPlayer: () => {
+        return {
+          aspectRatio: '4x3',
+          caption: text('Custom caption (caption):', ''),
+          hideCaption: boolean('Hide caption (hideCaption):', false),
+          thumbnail: text('Custom thumbnail (thumbnail):', ''),
+          videoId: '0_ibuqxqbe',
+        };
+      },
+    },
+    propsSet: {
+      default: {
+        VideoPlayer: {
+          aspectRatio: '4x3',
           caption: '',
           hideCaption: false,
           thumbnail: '',

--- a/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
@@ -86,14 +86,14 @@ export const autoplay = (args) => {
   const { aspectRatio, caption, hideCaption, thumbnail, videoId } =
     args?.VideoPlayer ?? {};
   return html`
-    <dds-video-player-container
+    <c4d-video-player-container
       auto-play
       playing-mode="inline"
       video-id=${videoId}
       aspect-ratio=${aspectRatio}
       caption=${caption}
       ?hide-caption=${hideCaption}
-      thumbnail=${thumbnail}></dds-video-player-container>
+      thumbnail=${thumbnail}></c4d-video-player-container>
   `;
 };
 
@@ -101,20 +101,20 @@ export const autoplayMuted = (args) => {
   const { caption, hideCaption, thumbnail, videoId } = args?.VideoPlayer ?? {};
   return html`
     <style>
-      dds-video-player-container[background-mode] {
+      c4d-video-player-container[background-mode] {
         display: block;
         aspect-ratio: 16/9;
         outline: 2px solid red;
       }
     </style>
-    <dds-video-player-container
+    <c4d-video-player-container
       auto-play
       muted
       playing-mode="inline"
       video-id=${videoId}
       caption=${caption}
       ?hide-caption=${hideCaption}
-      thumbnail=${thumbnail}></dds-video-player-container>
+      thumbnail=${thumbnail}></c4d-video-player-container>
   `;
 };
 

--- a/packages/web-components/src/components/video-player/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player/video-player-composite.ts
@@ -196,7 +196,7 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
   /**
    * `true` to autoplay, mute, and hide player UI.
    */
-  @property({ type: Boolean, attribute: 'background-mode' })
+  @property({ type: Boolean, attribute: 'background-mode', reflect: true })
   backgroundMode = false;
 
   /**

--- a/packages/web-components/src/components/video-player/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player/video-player-composite.ts
@@ -144,6 +144,12 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
   autoPlay = false;
 
   /**
+   * `true` load videos with sound muted.
+   */
+  @property({ type: Boolean, attribute: 'muted' })
+  muted = false;
+
+  /**
    * The embedded Kaltura player element (that has `.sendNotification()`, etc. APIs), keyed by the video ID.
    */
   @property({ attribute: false })
@@ -214,7 +220,7 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
   /**
    * The current playback state
    */
-  @property()
+  @property({ type: Boolean })
   isPlaying = false;
 
   /**

--- a/packages/web-components/src/components/video-player/video-player-container.ts
+++ b/packages/web-components/src/components/video-player/video-player-container.ts
@@ -180,34 +180,42 @@ export const C4DVideoPlayerContainerMixin = <
       const { backgroundMode, autoPlay, muted } =
         this as unknown as C4DVideoPlayerComposite;
       let playerOptions = {};
-      const autoplayPreference = autoPlay
-        ? this._getAutoplayPreference()
-        : false;
+      const autoplayPreference = this._getAutoplayPreference();
 
-      if (backgroundMode) {
-        playerOptions = {
-          'topBarContainer.plugin': false,
-          'controlBarContainer.plugin': false,
-          'largePlayBtn.plugin': false,
-          'loadingSpinner.plugin': false,
-          'unMuteOverlayButton.plugin': false,
-          'EmbedPlayer.DisableVideoTagSupport': false,
-          loop: true,
-          autoMute: true,
-          autoPlay: autoplayPreference,
-          // Turn off CTA's including mid-roll card and end cards.
-          'ibm.callToActions': false,
-          // Turn off captions display, background/ambient videos have no
-          // audio.
-          closedCaptions: {
-            plugin: false,
-          },
-        };
-      } else {
-        playerOptions = {
-          autoMute: muted,
-          autoPlay: autoplayPreference,
-        };
+      switch (true) {
+        case autoPlay:
+          playerOptions = {
+            autoMute: muted,
+            autoPlay: autoplayPreference,
+          };
+          break;
+
+        case backgroundMode:
+          playerOptions = {
+            'topBarContainer.plugin': false,
+            'controlBarContainer.plugin': false,
+            'largePlayBtn.plugin': false,
+            'loadingSpinner.plugin': false,
+            'unMuteOverlayButton.plugin': false,
+            'EmbedPlayer.DisableVideoTagSupport': false,
+            loop: true,
+            autoMute: true,
+            autoPlay: autoplayPreference,
+            // Turn off CTA's including mid-roll card and end cards.
+            'ibm.callToActions': false,
+            // Turn off captions display, background/ambient videos have no
+            // audio.
+            closedCaptions: {
+              plugin: false,
+            },
+          };
+          break;
+
+        default:
+          playerOptions = {
+            autoMute: muted,
+          };
+          break;
       }
 
       return playerOptions;

--- a/packages/web-components/src/components/video-player/video-player-container.ts
+++ b/packages/web-components/src/components/video-player/video-player-container.ts
@@ -178,7 +178,7 @@ export const C4DVideoPlayerContainerMixin = <
 
     _getPlayerOptions() {
       const { backgroundMode, autoPlay, muted } =
-        this as unknown as DDSVideoPlayerComposite;
+        this as unknown as C4DVideoPlayerComposite;
       let playerOptions = {};
       const autoplayPreference = autoPlay
         ? this._getAutoplayPreference()

--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -293,7 +293,7 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
     );
 
     const parentIsAutoplay = Boolean(
-      (this.parentElement as DDSVideoPlayerContainer)?.autoPlay
+      (this.parentElement as C4DVideoPlayerContainer)?.autoPlay
     );
 
     this.backgroundMode = parentIsBackground;

--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -80,7 +80,8 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
   private _renderContent() {
     const { contentState, name, thumbnailUrl, backgroundMode } = this;
     return contentState === VIDEO_PLAYER_CONTENT_STATE.THUMBNAIL &&
-      !backgroundMode
+      !backgroundMode &&
+      !this.autoplay
       ? html`
           <div class="${c4dPrefix}--video-player__video" part="video">
             <button
@@ -184,8 +185,14 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
   /**
    * `true` to autoplay, mute video, and hide UI
    */
-  @property({ attribute: 'background-mode', reflect: true })
+  @property({ attribute: 'background-mode', reflect: true, type: Boolean })
   backgroundMode = false;
+
+  /**
+   * `true` to autoplay
+   */
+  @property({ attribute: 'auto-play', reflect: true, type: Boolean })
+  autoplay = false;
 
   /**
    * Custom video description. This property should only be set when using `playing-mode="lightbox"`
@@ -285,7 +292,12 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
       (this.parentElement as C4DVideoPlayerContainer)?.backgroundMode
     );
 
+    const parentIsAutoplay = Boolean(
+      (this.parentElement as DDSVideoPlayerContainer)?.autoPlay
+    );
+
     this.backgroundMode = parentIsBackground;
+    this.autoplay = parentIsAutoplay;
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-7129](https://jsw.ibm.com/browse/ADCMS-7129)

### Description

Ports a couple of v1 player fixes to v2 that got missed to fix auto-play while maintaining background-video mode:

Work that I've cherry-picked for this PR:
[ADCMS-6363](https://jsw.ibm.com/browse/ADCMS-6363)
https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/12070 (3d98787c5c7b6ec26d1a4a10762f212dc1d2b23e)
https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/12081 (863dfdc3690b98a44a1c862877bd1fa106cef12b)

### Changelog

**New**

- Adds `muted` attribute to `video-player-container`
- Adds storybook examples for `auto-play` and `muted` video player usage

**Changed**

- Fixes `auto-play` attribute on `video-player-container`
- Make `background-video` a reflected boolean attribute all the time.
- Fix a regression with auto-play video.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
