### PR TITLE
fix(button): fix disable state of the button

### DIFF
--- a/packages/web-components/src/components/button/button.ts
+++ b/packages/web-components/src/components/button/button.ts
@@ -141,18 +141,20 @@ class C4DButton extends CTAMixin(StableSelectorMixin(CDSButton)) {
       'tooltipText',
       'href',
     ];
+    const { iconSlot } = this;
 
     // Note that the parent may render a different <slot name="icon">
     // based on changes to either disabled, tooltipText, or href, so we make
     // sure to re-render the icon if any of those change, in addition to the
     // ctaType.
-    if (updateIconForProperties.some((prop) => changedProperties.has(prop))) {
-      const { iconSlot } = this;
-
+    if (
+      iconSlot &&
+      updateIconForProperties.some((prop) => changedProperties.has(prop))
+    ) {
       iconSlot.querySelector('svg')?.remove();
       iconSlot.innerHTML = this._renderButtonIcon();
       iconSlot
-        ?.querySelector('svg')
+        .querySelector('svg')
         ?.classList.add(`${prefix}--card__cta`, `${c4dPrefix}-ce--cta__icon`);
     }
   }

--- a/packages/web-components/src/components/button/button.ts
+++ b/packages/web-components/src/components/button/button.ts
@@ -34,8 +34,8 @@ class C4DButton extends CTAMixin(StableSelectorMixin(CDSButton)) {
   @query('a')
   _linkNode;
 
-  @property()
-  iconDiv;
+  @query(`slot[name='icon']`)
+  iconSlot?: HTMLElement;
 
   @property()
   span;
@@ -75,7 +75,7 @@ class C4DButton extends CTAMixin(StableSelectorMixin(CDSButton)) {
     const { ctaType } = this;
     const icon = icons[`${ctaType}-${document.dir}`] ?? icons[ctaType];
     return `
-        <span class="${prefix}--visually-hidden" part="visually-hidden-span">${
+        <span class="matt ${prefix}--visually-hidden" part="visually-hidden-span">${
       ariaLabels[ctaType]
     }</span>
         ${icon?.()?.strings?.join()}
@@ -135,17 +135,23 @@ class C4DButton extends CTAMixin(StableSelectorMixin(CDSButton)) {
 
   updated(changedProperties) {
     super.updated(changedProperties);
+    const updateIconForProperties = [
+      'ctaType',
+      'disabled',
+      'tooltipText',
+      'href',
+    ];
 
-    if (changedProperties.has('ctaType')) {
-      if (!this.iconDiv) {
-        this.iconDiv = this.shadowRoot?.querySelector("slot[name='icon']");
-      }
+    // Note that the parent may render a different <slot name="icon">
+    // based on changes to either disabled, tooltipText, or href, so we make
+    // sure to re-render the icon if any of those change, in addition to the
+    // ctaType.
+    if (updateIconForProperties.some((prop) => changedProperties.has(prop))) {
+      const { iconSlot } = this;
 
-      const { iconDiv } = this;
-
-      iconDiv.querySelector('svg')?.remove();
-      iconDiv.innerHTML = this._renderButtonIcon();
-      iconDiv
+      iconSlot.querySelector('svg')?.remove();
+      iconSlot.innerHTML = this._renderButtonIcon();
+      iconSlot
         ?.querySelector('svg')
         ?.classList.add(`${prefix}--card__cta`, `${c4dPrefix}-ce--cta__icon`);
     }

--- a/packages/web-components/src/components/button/button.ts
+++ b/packages/web-components/src/components/button/button.ts
@@ -75,7 +75,7 @@ class C4DButton extends CTAMixin(StableSelectorMixin(CDSButton)) {
     const { ctaType } = this;
     const icon = icons[`${ctaType}-${document.dir}`] ?? icons[ctaType];
     return `
-        <span class="matt ${prefix}--visually-hidden" part="visually-hidden-span">${
+        <span class="${prefix}--visually-hidden" part="visually-hidden-span">${
       ariaLabels[ctaType]
     }</span>
         ${icon?.()?.strings?.join()}


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6961](https://jsw.ibm.com/browse/ADCMS-6961)

### Description

Fixes some odd icon logic left in the button component. The fix allows us to consistently re-render the correct CTA type icon whenever a change in the parent component may mean a different `<slot name="icon">` element is rendered. This allows for consistency across disable/active states.

### Testing instructions

* Toggling disable knob and/or changing the `href` should maintain the expected icon and reflect the relevant state.
* Change CTA type knob state to make sure it reflects the right value

### Changelog

**Changed**

- Fixed icon issues in the button component for disable state

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
