### PR TITLE
Fix/content group cards medium and small res issue

### DIFF
--- a/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
+++ b/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
@@ -59,5 +59,13 @@
   :host(#{$c4d-prefix}-content-group-cards-item) {
     padding: list.slash($grid-gutter, 2);
     background: none;
+
+    @include breakpoint-down(lg) {
+      margin-inline-start: 0 !important;
+    }
+
+    @include breakpoint-down(md) {
+      padding-inline: $spacing-05;
+    }
   }
 }

--- a/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
+++ b/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
@@ -44,6 +44,10 @@
       grid-auto-rows: 1fr;
       grid-template-columns: 1fr 1fr;
     }
+
+    @include breakpoint-down(md) {
+      max-inline-size: 100%;
+    }
   }
 
   :host(#{$c4d-prefix}-content-group-cards-item),
@@ -59,13 +63,5 @@
   :host(#{$c4d-prefix}-content-group-cards-item) {
     padding: list.slash($grid-gutter, 2);
     background: none;
-
-    @include breakpoint-down(lg) {
-      margin-inline-start: 0 !important;
-    }
-
-    @include breakpoint-down(md) {
-      padding-inline: $spacing-05;
-    }
   }
 }

--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -92,6 +92,16 @@
       margin-inline-start: 0;
     }
 
+    ::slotted(#{$c4d-prefix}-content-group-cards-item:not([slot])) {
+      @include breakpoint('md') {
+        margin-inline-start: 0;
+      }
+
+      @include breakpoint('lg') {
+        margin-inline-start: $spacing-05;
+      }
+    }
+
     &__aside,
     ::slotted([slot='complementary']) {
       grid-area: complementary;


### PR DESCRIPTION
### Related Ticket(s)

Closes # [ADCMS-7030](https://jsw.ibm.com/browse/ADCMS-7030)

### Description

In medium and small resolutions, the cards are having an undesired horizontal overflow that was causing a scroll bar to appear.
I made a fix that will make them span full width, that's the behavior we have in the [v2 builds I found](https://ibmdotcom-webcomponents.s3.us-east.cloud-object-storage.appdomain.cloud/deploy-previews/11248/index.html?path=/story/overview-getting-started--page) for example, that came https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/11248



### Changelog

setting `margin-inline-start` to be 0 in resolutions lower than LG.

