### PR TITLE
fix(video): remove @state declaration for function _embedMedia

### DIFF
--- a/packages/web-components/src/components/cta/video-cta-composite.ts
+++ b/packages/web-components/src/components/cta/video-cta-composite.ts
@@ -41,7 +41,6 @@ class C4DVideoCTAComposite extends ModalRenderMixin(
    *
    * @internal
    */
-  @state()
   _embedMedia?: (videoId: string) => Promise<any>;
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6749](https://jsw.ibm.com/browse/ADCMS-6749)

### Description

Tangentially related to [ADCMS-6749](https://jsw.ibm.com/browse/ADCMS-6749). This fix addresses the following error when bundling the video-cta-container component in some environments:

```
Uncaught (in promise) Error: The following properties on element c4d-video-cta-container will not trigger updates as expected because they are set using class fields: _embedMedia. Native class fields and some compiled output will overwrite accessors used for detecting changes. See https://lit.dev/msg/class-field-shadowing for more information.
    at C4DVideoCTAContainer2.performUpdate (chunk-4KQNGL43.js?v=fb1a7d37:1973:17)
    at C4DVideoCTAContainer2.scheduleUpdate (chunk-4KQNGL43.js?v=fb1a7d37:1938:17)
    at C4DVideoCTAContainer2.__enqueueUpdate (chunk-4KQNGL43.js?v=fb1a7d37:1914:25)
```

### Changelog

**Changed**

- Removes `@state` decorator from `_embedMedia` method.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
