### PR TITLE
fix(content-item): fixing cta spacing in relation to the copy

### DIFF
--- a/packages/styles/scss/internal/content-item/_content-item.scss
+++ b/packages/styles/scss/internal/content-item/_content-item.scss
@@ -101,10 +101,6 @@
     margin-block-end: $spacing-05;
   }
 
-  ::slotted(#{$c4d-prefix}-link-with-icon) {
-    padding: $spacing-05 0 $spacing-07;
-  }
-
   :host(#{$c4d-prefix}-content-item-copy:not([has-cta])) {
     ::slotted(#{$c4d-prefix}-content-item-paragraph) {
       margin-block-end: 0;
@@ -121,5 +117,6 @@
 
   :host(#{$c4d-prefix}-content-item) ::slotted([slot='footer']) {
     margin-inline-start: 0;
+    padding-block: $spacing-05 $spacing-07;
   }
 }

--- a/packages/styles/scss/internal/content-item/_content-item.scss
+++ b/packages/styles/scss/internal/content-item/_content-item.scss
@@ -119,17 +119,7 @@
     margin-inline-start: 0;
   }
 
-  :host(#{$c4d-prefix}-content-item) ::slotted([slot='footer']:first-of-type) {
-    padding-top: $spacing-05;
-  }
-
-  :host(#{$c4d-prefix}-content-item) ::slotted([slot='footer']:last-of-type) {
-    padding-bottom: $spacing-07;
-  }
-
-  :host(#{$c4d-prefix}-content-item)
-    ::slotted([slot='footer']:not(:first-of-type):not(:last-of-type)) {
-    padding-top: 0;
-    padding-bottom: 0;
+  .#{$prefix}--content-item__cta {
+    padding-block: $spacing-05 $spacing-07;
   }
 }

--- a/packages/styles/scss/internal/content-item/_content-item.scss
+++ b/packages/styles/scss/internal/content-item/_content-item.scss
@@ -117,6 +117,19 @@
 
   :host(#{$c4d-prefix}-content-item) ::slotted([slot='footer']) {
     margin-inline-start: 0;
-    padding-block: $spacing-05 $spacing-07;
+  }
+
+  :host(#{$c4d-prefix}-content-item) ::slotted([slot='footer']:first-of-type) {
+    padding-top: $spacing-05;
+  }
+
+  :host(#{$c4d-prefix}-content-item) ::slotted([slot='footer']:last-of-type) {
+    padding-bottom: $spacing-07;
+  }
+
+  :host(#{$c4d-prefix}-content-item)
+    ::slotted([slot='footer']:not(:first-of-type):not(:last-of-type)) {
+    padding-top: 0;
+    padding-bottom: 0;
   }
 }

--- a/packages/styles/scss/internal/content-item/_content-item.scss
+++ b/packages/styles/scss/internal/content-item/_content-item.scss
@@ -101,6 +101,10 @@
     margin-block-end: $spacing-05;
   }
 
+  ::slotted(#{$c4d-prefix}-link-with-icon) {
+    padding: $spacing-05 0 $spacing-07;
+  }
+
   :host(#{$c4d-prefix}-content-item-copy:not([has-cta])) {
     ::slotted(#{$c4d-prefix}-content-item-paragraph) {
       margin-block-end: 0;


### PR DESCRIPTION
### Related Ticket(s)

Closes # [ADCMS-7259](https://jsw.ibm.com/browse/ADCMS-7259)

### Description

In the `c4d-content-item` component, the CTA should have 2rem of space between the paragraph and the CTA per [specs](https://www.figma.com/design/CVN80lAAGuolpeudRGS4BN/Content-section-v2?node-id=3-2648&t=Iw4WyJUr8nfD8sXD-1)

### Changelog

Adjusted padding for `c4d-link-with-icon` 
