### PR TITLE
fix(card-group): subgrid fixes

### DIFF
--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -59,6 +59,10 @@
   :host(#{$c4d-prefix}-card-group-item) {
     display: contents;
 
+    * {
+      row-gap: 0;
+    }
+
     .#{$prefix}--card {
       display: grid;
       border: 0;
@@ -73,6 +77,7 @@
         display: grid;
         justify-content: revert;
         grid-row: span 10;
+        grid-template-columns: subgrid;
         grid-template-rows: subgrid;
 
         &::before,
@@ -91,15 +96,15 @@
       .#{$prefix}--card__content {
         display: grid;
         grid-area: 1 / 1 / -1 / -1;
+        grid-template-columns: subgrid;
         grid-template-rows: subgrid;
-        row-gap: 0;
       }
 
       .#{$prefix}--card__copy {
         display: grid;
         grid-row: span 2;
+        grid-template-columns: subgrid;
         grid-template-rows: subgrid;
-        row-gap: 0;
       }
     }
 

--- a/packages/web-components/src/components/cta-block/cta-block.scss
+++ b/packages/web-components/src/components/cta-block/cta-block.scss
@@ -169,8 +169,8 @@
   position: relative;
   display: grid;
   grid-row: auto / span 5;
-  grid-template-rows: subgrid;
   grid-template-columns: subgrid;
+  grid-template-rows: subgrid;
   inline-size: 100%;
   margin-block: 0;
   margin-block-end: 0;

--- a/packages/web-components/src/components/cta-block/cta-block.scss
+++ b/packages/web-components/src/components/cta-block/cta-block.scss
@@ -170,6 +170,7 @@
   display: grid;
   grid-row: auto / span 5;
   grid-template-rows: subgrid;
+  grid-template-columns: subgrid;
   inline-size: 100%;
   margin-block: 0;
   margin-block-end: 0;


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-7128

### Description

Explicitly forces card-group-item internals to use `grid-template-column: subgrid` to ensure a 1-column width throughout

### Changelog

**Changed**

- card-group-item internals rely on card-group grid-column
