### PR TITLE
fix(styles): restore use of globals/imports.scss

### DIFF
--- a/packages/styles/scss/components/audio-player/_audio-player.scss
+++ b/packages/styles/scss/components/audio-player/_audio-player.scss
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/ratio-base' as *;
 @use '@carbon/styles/scss/components/slider';
 

--- a/packages/styles/scss/components/back-to-top/_back-to-top.scss
+++ b/packages/styles/scss/components/back-to-top/_back-to-top.scss
@@ -10,6 +10,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '@carbon/styles/scss/components/button' as *;
 
 @mixin back-to-top {

--- a/packages/styles/scss/components/background-media/_background-media.scss
+++ b/packages/styles/scss/components/background-media/_background-media.scss
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/utilities' as *;
 @use '@carbon/web-components/scss/components/tooltip/tooltip' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../image';
 
 @mixin background-media {

--- a/packages/styles/scss/components/button-group/_button-group.scss
+++ b/packages/styles/scss/components/button-group/_button-group.scss
@@ -11,8 +11,8 @@
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
-
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../lightbox-media-viewer';
 @use '../button';
 

--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/layout' as *;
 @use '@carbon/styles/scss/components/button' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin button {
   :host(#{$c4d-prefix}-button) {

--- a/packages/styles/scss/components/callout-quote/_callout-quote.scss
+++ b/packages/styles/scss/components/callout-quote/_callout-quote.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/hang' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../internal/callout/callout' as *;

--- a/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
+++ b/packages/styles/scss/components/callout-with-media/_callout-with-media.scss
@@ -13,6 +13,7 @@
 @use '@carbon/styles/scss/utilities' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/callout/callout' as *;
 @use '../../internal/content-block';
 @use '../../internal/content-item/content-item';

--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -16,6 +16,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/ratio-base' as *;
 @use '../../internal/content-section';
 @use '../card';

--- a/packages/styles/scss/components/card-in-card/_card-in-card.scss
+++ b/packages/styles/scss/components/card-in-card/_card-in-card.scss
@@ -13,6 +13,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/aspect-ratio';
 @use '../../globals/utils/ratio-base' as *;
 @use '../image';

--- a/packages/styles/scss/components/card-link/_card-link.scss
+++ b/packages/styles/scss/components/card-link/_card-link.scss
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../card';
 
 @mixin card-link {

--- a/packages/styles/scss/components/card-section-images/_card-section-images.scss
+++ b/packages/styles/scss/components/card-section-images/_card-section-images.scss
@@ -6,5 +6,6 @@
  */
 
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-section/content-section';
 @use '../card-group/card-group';

--- a/packages/styles/scss/components/card-section-offset/_card-section-offset.scss
+++ b/packages/styles/scss/components/card-section-offset/_card-section-offset.scss
@@ -14,6 +14,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../card-group/card-group';
 
 @mixin card-section-offset {

--- a/packages/styles/scss/components/card-section-simple/_card-section-simple.scss
+++ b/packages/styles/scss/components/card-section-simple/_card-section-simple.scss
@@ -6,5 +6,6 @@
  */
 
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-section/content-section';
 @use '../card-group/card-group';

--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -16,6 +16,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/content-width' as *;
 @use '../../globals/utils/ratio-base' as *;
 @use '../lightbox-media-viewer/lightbox-media-viewer';

--- a/packages/styles/scss/components/carousel/_carousel.scss
+++ b/packages/styles/scss/components/carousel/_carousel.scss
@@ -14,6 +14,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/styles/scss/components/button' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin carousel {
   :host(#{$c4d-prefix}-carousel),

--- a/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
+++ b/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
@@ -10,6 +10,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-block';
 @use '../card-group/card-group';
 

--- a/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
+++ b/packages/styles/scss/components/content-block-headlines/_content-block-headlines.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/utils/hang' as *;
 @use '../../internal/content-block';

--- a/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
+++ b/packages/styles/scss/components/content-block-horizontal/_content-block-horizontal.scss
@@ -11,6 +11,7 @@
 @use '../../internal/content-block';
 @use '../content-item-row';
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin content-block-horizontal {
   :host(#{$c4d-prefix}-content-block-horizontal) {

--- a/packages/styles/scss/components/content-block-media/_content-block-media.scss
+++ b/packages/styles/scss/components/content-block-media/_content-block-media.scss
@@ -10,6 +10,7 @@
 @use '@carbon/styles/scss/themes' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-block';
 @use '../../internal/content-group';
 @use '../../internal/content-item/content-item';

--- a/packages/styles/scss/components/content-block-mixed/_content-block-mixed.scss
+++ b/packages/styles/scss/components/content-block-mixed/_content-block-mixed.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-block';
 @use '../../internal/content-group';
 @use '../content-group-cards';

--- a/packages/styles/scss/components/content-block-segmented/_content-block-segmented.scss
+++ b/packages/styles/scss/components/content-block-segmented/_content-block-segmented.scss
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-block';
 @use '../../internal/content-group';
 @use '../../internal/content-item/content-item';

--- a/packages/styles/scss/components/content-block-simple/_content-block-simple.scss
+++ b/packages/styles/scss/components/content-block-simple/_content-block-simple.scss
@@ -8,6 +8,7 @@
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-block';
 @use '../../internal/content-item/content-item';
 @use '../image';

--- a/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
+++ b/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-group';
 @use '../link-with-icon';
 @use '../card';

--- a/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
+++ b/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../pictogram-item';
 
 @mixin content-group-pictograms {

--- a/packages/styles/scss/components/content-group-simple/_content-group-simple.scss
+++ b/packages/styles/scss/components/content-group-simple/_content-group-simple.scss
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-group';
 
 @mixin content-group-simple {

--- a/packages/styles/scss/components/content-group/_content-group.scss
+++ b/packages/styles/scss/components/content-group/_content-group.scss
@@ -10,6 +10,7 @@
 @use '@carbon/ibmdotcom-styles/scss/internal/content-block';
 @use '@carbon/ibmdotcom-styles/scss/internal/content-group';
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin content-group {
   :host(#{$c4d-prefix}-content-group),

--- a/packages/styles/scss/components/content-item-row-media/_content-item-row-media.scss
+++ b/packages/styles/scss/components/content-item-row-media/_content-item-row-media.scss
@@ -13,6 +13,7 @@
 @use '@carbon/styles/scss/utilities' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../link-list';
 
 @mixin content-item-row-media {

--- a/packages/styles/scss/components/content-item-row/_content-item-row.scss
+++ b/packages/styles/scss/components/content-item-row/_content-item-row.scss
@@ -14,6 +14,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../link-list';
 
 @mixin content-item-row {

--- a/packages/styles/scss/components/cta-block/_cta-block.scss
+++ b/packages/styles/scss/components/cta-block/_cta-block.scss
@@ -14,6 +14,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-block';
 @use '../../internal/content-item/content-item';
 @use '../button-group';

--- a/packages/styles/scss/components/cta-section/_cta-section.scss
+++ b/packages/styles/scss/components/cta-section/_cta-section.scss
@@ -13,6 +13,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-block';
 @use '../../internal/content-item/content-item';
 @use '../button-group';

--- a/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
+++ b/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
@@ -8,6 +8,7 @@
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../footer';
 @use '../masthead';
 

--- a/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
+++ b/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
@@ -8,6 +8,7 @@
 @use 'sass:math';
 
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/motion' as *;

--- a/packages/styles/scss/components/feature-card/_feature-card.scss
+++ b/packages/styles/scss/components/feature-card/_feature-card.scss
@@ -17,6 +17,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../components/image';
 @use '../../components/card';
 @use '../../globals/utils/aspect-ratio' as *;

--- a/packages/styles/scss/components/feature-section/_feature-section.scss
+++ b/packages/styles/scss/components/feature-section/_feature-section.scss
@@ -10,6 +10,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/aspect-ratio';
 @use '../../globals/carbon-grid';
 @use '../../globals/utils/ratio-base' as *;

--- a/packages/styles/scss/components/filter-panel/_filter-panel.scss
+++ b/packages/styles/scss/components/filter-panel/_filter-panel.scss
@@ -18,6 +18,7 @@
 @use '@carbon/web-components/scss/components/accordion/accordion';
 @use '@carbon/web-components/scss/components/modal/modal';
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin filter-panel {
   .#{$prefix}--filter__heading {

--- a/packages/styles/scss/components/footer/_footer-logo.scss
+++ b/packages/styles/scss/components/footer/_footer-logo.scss
@@ -16,6 +16,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 /// Footer title styles
 /// @access private

--- a/packages/styles/scss/components/footer/_footer-nav-group.scss
+++ b/packages/styles/scss/components/footer/_footer-nav-group.scss
@@ -13,6 +13,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 /// Footer nav group styles
 /// @access private

--- a/packages/styles/scss/components/footer/_footer-nav.scss
+++ b/packages/styles/scss/components/footer/_footer-nav.scss
@@ -15,6 +15,7 @@
 @use '@carbon/styles/scss/themes' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 /// Footer nav styles
 /// @access private

--- a/packages/styles/scss/components/footer/_footer.scss
+++ b/packages/styles/scss/components/footer/_footer.scss
@@ -14,6 +14,7 @@
 @use '@carbon/styles/scss/layout' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @use '@carbon/styles/scss/components/accordion';
 @use '@carbon/styles/scss/components/combo-box';

--- a/packages/styles/scss/components/footer/_legal-nav.scss
+++ b/packages/styles/scss/components/footer/_legal-nav.scss
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/themes' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/flex-grid' as *;
 
 /// Legal nav styles

--- a/packages/styles/scss/components/footer/_locale-button.scss
+++ b/packages/styles/scss/components/footer/_locale-button.scss
@@ -15,6 +15,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 /// Footer locale button
 /// @access private

--- a/packages/styles/scss/components/global-banner/_global-banner.scss
+++ b/packages/styles/scss/components/global-banner/_global-banner.scss
@@ -14,6 +14,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../image/index';
 
 @mixin global-banner {

--- a/packages/styles/scss/components/horizontal-rule/_horizontal-rule.scss
+++ b/packages/styles/scss/components/horizontal-rule/_horizontal-rule.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin horizontal-rule {
   $subtle-contrast: $border-subtle-01;

--- a/packages/styles/scss/components/image/_image.scss
+++ b/packages/styles/scss/components/image/_image.scss
@@ -6,6 +6,7 @@
  */
 
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/ratio-base' as *;
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/spacing' as *;

--- a/packages/styles/scss/components/in-page-banner/_in-page-banner.scss
+++ b/packages/styles/scss/components/in-page-banner/_in-page-banner.scss
@@ -10,6 +10,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-group';
 @use '../../globals/tokens/color-tokens' as *;
 

--- a/packages/styles/scss/components/layout/_layout.scss
+++ b/packages/styles/scss/components/layout/_layout.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 // $carbon--layouts has been replaced by standard spacing tokens
 $layout-spacings: $spacing-05, $spacing-06, $spacing-07, $spacing-09,

--- a/packages/styles/scss/components/leadspace-block/_leadspace-block.scss
+++ b/packages/styles/scss/components/leadspace-block/_leadspace-block.scss
@@ -15,6 +15,7 @@
 @use '../../globals/utils/content-width' as *;
 @use '../../globals/utils/hang' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../link-list';
 @use '../image';
 @use '../../internal/content-block';

--- a/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
+++ b/packages/styles/scss/components/leadspace-with-search/_leadspace-with-search.scss
@@ -14,6 +14,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-block';
 @use '../leadspace-block';
 

--- a/packages/styles/scss/components/leadspace/_leadspace.scss
+++ b/packages/styles/scss/components/leadspace/_leadspace.scss
@@ -20,6 +20,7 @@
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/utils/ratio-base' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../button-group';
 @use '../image';
 

--- a/packages/styles/scss/components/leaving-ibm/_leaving-ibm.scss
+++ b/packages/styles/scss/components/leaving-ibm/_leaving-ibm.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/web-components/scss/components/modal/modal' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin leaving-ibm {
   :host(#{$c4d-prefix}-leaving-ibm-composite),

--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -14,6 +14,7 @@
 @use '../expressive-modal/expressive-modal';
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../expressive-modal' as *;
 @use '../video-player' as *;
 

--- a/packages/styles/scss/components/link-list-section/_link-list-section.scss
+++ b/packages/styles/scss/components/link-list-section/_link-list-section.scss
@@ -11,6 +11,7 @@
 @use '@carbon/ibmdotcom-styles/scss/internal/content-section';
 @use '@carbon/ibmdotcom-styles/scss/globals/utils/flex-grid' as *;
 @use '@carbon/ibmdotcom-styles/scss/globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin link-list-section {
   :host(#{$c4d-prefix}-link-list-section) {

--- a/packages/styles/scss/components/link-list/_link-list.scss
+++ b/packages/styles/scss/components/link-list/_link-list.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../card';
 @use '../link-with-icon';

--- a/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
+++ b/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/styles/scss/components/link';
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../lightbox-media-viewer/lightbox-media-viewer';
 
 @mixin link-with-icon {

--- a/packages/styles/scss/components/list/_list.scss
+++ b/packages/styles/scss/components/list/_list.scss
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '@carbon/styles/scss/components/list';
 
 @mixin list {

--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -15,6 +15,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/layout/scss/convert' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/flex-grid' as *;
 
 @use '../card' as *;

--- a/packages/styles/scss/components/logo-grid/_logo-grid.scss
+++ b/packages/styles/scss/components/logo-grid/_logo-grid.scss
@@ -14,6 +14,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/hang' as *;
 @use '../../globals/utils/aspect-ratio';
 @use '../image';

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -16,6 +16,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '@carbon/styles/scss/components/button/tokens' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use 'vars' as *;
 
 /// @access private

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -14,6 +14,7 @@
 @use '@carbon/styles/scss/themes' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 // Include left navigation component
 /// @access private

--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -15,6 +15,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin masthead-megamenu-limit-height {
   overflow: var(--#{$c4d-prefix}-masthead-overflow);

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use 'vars' as *;
 
 /// @access private

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -21,6 +21,7 @@
 @use '@carbon/styles/scss/utilities' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../link-with-icon';
 @use 'vars' as *;
 

--- a/packages/styles/scss/components/pictogram-item/_pictogram-item.scss
+++ b/packages/styles/scss/components/pictogram-item/_pictogram-item.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../internal/content-item/content-item';
 @use '../link-with-icon';
 

--- a/packages/styles/scss/components/pricing-table/_pricing-table.scss
+++ b/packages/styles/scss/components/pricing-table/_pricing-table.scss
@@ -13,6 +13,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../button-group' as *;
 @use '../structured-list' as *;
 

--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/hang' as *;
 @use '../../components/horizontal-rule';
 @use '../../components/link-with-icon' as *;

--- a/packages/styles/scss/components/scroll-into-view/_scroll-into-view.scss
+++ b/packages/styles/scss/components/scroll-into-view/_scroll-into-view.scss
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin scroll-into-view {
   :root {

--- a/packages/styles/scss/components/search-with-typeahead/_search-with-typeahead.scss
+++ b/packages/styles/scss/components/search-with-typeahead/_search-with-typeahead.scss
@@ -17,6 +17,7 @@
 @use '@carbon/styles/scss/components/dropdown';
 @use '@carbon/styles/scss/components/select';
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../masthead/vars' as *;
 
 @mixin react-autosuggest-suggestion {

--- a/packages/styles/scss/components/structured-list/_structured-list.scss
+++ b/packages/styles/scss/components/structured-list/_structured-list.scss
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 // Overridden column spanning
 @mixin structured-list-colspan($colNumber) {

--- a/packages/styles/scss/components/tableofcontents/_table-of-contents.scss
+++ b/packages/styles/scss/components/tableofcontents/_table-of-contents.scss
@@ -17,6 +17,7 @@
 @use '../../globals/utils/flex-grid' as *;
 @use '../../globals/carbon-grid' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/hang' as *;
 @use '../layout/layout';
 

--- a/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
+++ b/packages/styles/scss/components/tabs-extended-media/_tabs-extended-media.scss
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/components/tabs';
 @use '../link-list';
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin tabs-extended-media {
   :host(#{$c4d-prefix}-tabs-extended-media) {

--- a/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
+++ b/packages/styles/scss/components/tabs-extended/_tabs-extended.scss
@@ -16,6 +16,7 @@
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '@carbon/styles/scss/components/button' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '@carbon/styles/scss/components/tabs/vars' as *;
 @use '@carbon/web-components/scss/components/tabs/tabs';
 

--- a/packages/styles/scss/components/tag-group/_tag-group.scss
+++ b/packages/styles/scss/components/tag-group/_tag-group.scss
@@ -8,6 +8,7 @@
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin tag-group {
   :host(#{$c4d-prefix}-tag-group) {

--- a/packages/styles/scss/components/tag-link/_tag-link.scss
+++ b/packages/styles/scss/components/tag-link/_tag-link.scss
@@ -11,6 +11,7 @@
 @use '@carbon/styles/scss/utilities' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 
 @mixin tag-link {
   :host(#{$c4d-prefix}-tag-link) a {

--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -6,6 +6,7 @@
  */
 
 @use '../../globals/vars' as *;
+@use '../../globals/imports' as *;
 @use '../../globals/utils/ratio-base' as *;
 @use '@carbon/styles/scss/colors' as *;
 @use '@carbon/styles/scss/config' as *;

--- a/packages/styles/scss/globals/_imports.scss
+++ b/packages/styles/scss/globals/_imports.scss
@@ -24,9 +24,3 @@
 
 @forward './utils/content-width';
 @forward './utils/ratio-base';
-
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}

--- a/packages/styles/scss/globals/_imports.scss
+++ b/packages/styles/scss/globals/_imports.scss
@@ -24,3 +24,9 @@
 
 @forward './utils/content-width';
 @forward './utils/ratio-base';
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
### Description

the carbon reset has all items box-sizing set to inherit. this changes that to border box and is intended mainly to see what shifts in Percy
