### PR TITLE
fix(carousel): Fix gap calculation

### DIFF
--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -564,19 +564,17 @@ class C4DCarousel extends HostListenerMixin(StableSelectorMixin(LitElement)) {
    * Calculates the width between cards.
    */
   private _updateGap() {
-    const { _contentsNode: contentsNode, _slotNode: slotNode } = this;
+    const { _slotNode: slotNode } = this;
     const elems = slotNode!
       .assignedNodes()
       .filter((node) => node.nodeType === Node.ELEMENT_NODE);
+    const firstElementComputedStyle = getComputedStyle(elems[0] as HTMLElement);
+
     this._gap =
       elems.length <= 1
         ? 0
-        : (contentsNode!.scrollWidth -
-            elems.reduce(
-              (acc, elem) => acc + ((elem as HTMLElement).offsetWidth ?? 0),
-              0
-            )) /
-          (elems.length - 1);
+        : parseFloat(firstElementComputedStyle.marginLeft) +
+            parseFloat(firstElementComputedStyle.marginRight) ?? 0;
   }
 
   private _updateContentsPosition(changedProperties) {


### PR DESCRIPTION
### Related Ticket(s)

[JIRA](https://jsw.ibm.com/browse/ADCMS-7404)
### Description

PR To address the carousel component gap distance not being calculated properly. causing the slotted components to scroll too much and appear cropped.

### Changelog

**Changed**

changed the `_updateGap` function to calculate the gap value based on the margin of the fist element. 

### Testing instructions 
Open the carousel components on storybook and see that it scrolls properly and there are no regressions. 
