### PR TITLE
feat(card group): adding left and right gutters to the cards when in …

### DIFF
--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -42,11 +42,19 @@
         1fr
       );
     }
+
+    @include breakpoint(sm) {
+      padding-inline: 16px;
+    }
   }
 
   :host(#{$c4d-prefix}-card-group[with-card-in-card][grid-mode]) {
     padding-block-start: 0;
     padding-inline: 1px;
+
+    @include breakpoint-down(md) {
+      padding-inline: 16px;
+    }
   }
 
   :host(#{$c4d-prefix}-card-group[with-card-in-card][grid-mode='default']) {

--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -43,8 +43,8 @@
       );
     }
 
-    @include breakpoint(sm) {
-      padding-inline: 16px;
+    @include breakpoint-down(md) {
+      padding-inline: $spacing-05;
     }
   }
 
@@ -53,7 +53,7 @@
     padding-inline: 1px;
 
     @include breakpoint-down(md) {
-      padding-inline: 16px;
+      padding-inline: $spacing-05;
     }
   }
 


### PR DESCRIPTION
…mobile

### Related Ticket(s)

Closes [#ADCMS-6599](https://jsw.ibm.com/browse/ADCMS-6599)

### Description

Adding left and right gutters to the Block Card Container component, specifically, so we make sure it's clear that cards are tappable and that they are indeed cards rather than background containers. 
All card groups that are wrapped by `c4d-card-group` will also be benefited from this update.

### Changelog

`16px` inline margin added to the c4d-card-group element when in mobile.

