### PR TITLE
feat(card-in-card): add gutter space on mobile

### DIFF
--- a/packages/styles/scss/components/card-in-card/_card-in-card.scss
+++ b/packages/styles/scss/components/card-in-card/_card-in-card.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,6 +24,11 @@
   :host(#{$c4d-prefix}-card-in-card) {
     block-size: auto;
 
+    @include breakpoint-down(md) {
+      background: none;
+      padding-inline: $spacing-05;
+    }
+
     .#{$prefix}--card:focus-within {
       border-color: $background;
       outline: none;
@@ -43,6 +48,10 @@
     &:hover {
       cursor: pointer;
 
+      @include breakpoint-down(md) {
+        cursor: auto;
+      }
+
       &::after {
         position: absolute;
         background: $card-background;
@@ -50,6 +59,10 @@
         content: '';
         inline-size: 100%;
         opacity: 0.08;
+
+        @include breakpoint-down(md) {
+          inline-size: auto;
+        }
       }
     }
 


### PR DESCRIPTION
### Related Ticket(s)

Closes # [ADCMS-6606](https://jsw.ibm.com/browse/ADCMS-6606)

### Description

It's difficult to see that cards are clickable rather than just having differently colored background when they display full-width in the TOC layout. Add proper "gutter" space on the left and right sides of cards to suggest that they are clickable cards.

### Changelog

**New**

Added left and right space using padding around the `card-in-card` component using the $spacing-05 token for mobile screen.
