### PR TITLE
feat(card): with pictograms hover behavior similar v1

### DIFF
--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -34,6 +34,11 @@
   :host(#{$c4d-prefix}-content-group-cards-item) .#{$prefix}--card {
     @include tile($enable-experimental-tile-contrast: true);
 
+    @include breakpoint-down(md) {
+      margin-inline: $spacing-05;
+      width: auto;
+    }
+
     position: relative;
     display: flex;
     flex-direction: column;

--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -212,10 +212,6 @@
         position: relative;
       }
 
-      .#{$prefix}--card__heading {
-        display: none;
-      }
-
       .#{$prefix}--card__copy {
         display: none;
         margin-block: $spacing-07 0;
@@ -229,8 +225,8 @@
       }
     }
 
-    /* Desktop Hover & Focus - Show Pictogram + Copy */
-    @media (hover: hover) {
+    /* Desktop Hover - Show Pictogram + Copy */
+    @include breakpoint-up(md) {
       .#{$prefix}--card:hover
         .#{$prefix}--card__motion
         ::slotted(#{$c4d-prefix}-card-heading) {
@@ -241,10 +237,31 @@
         .#{$prefix}--card__copy {
         display: block;
       }
+
+      &[pictogram] {
+        &[pictogram-placement='top'] .#{$prefix}--card {
+          ::slotted(#{$c4d-prefix}-card-heading) {
+            position: absolute;
+            inset-block-end: $spacing-05;
+            margin-block: auto 0;
+          }
+
+          .#{$prefix}--card__copy {
+            margin-block-start: $spacing-07;
+          }
+        }
+
+        &[pictogram-placement='bottom'] .#{$prefix}--card {
+          .#{$prefix}--card__copy {
+            position: relative;
+            inset-block-start: -$spacing-07;
+          }
+        }
+      }
     }
 
     /* Mobile - Always Show Everything */
-    @media (width <= 767px) {
+    @include breakpoint-down(md) {
       .#{$prefix}--card__heading,
       .#{$prefix}--card__copy {
         display: block !important;

--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -194,8 +194,8 @@
         padding-block-start: $spacing-07;
 
         @include breakpoint(md) {
-          display: flex;
-          flex: 1;
+          display: block;
+          // flex: 1;
           padding-inline-start: 0;
         }
       }
@@ -219,6 +219,7 @@
       }
 
       .#{$prefix}--card__copy {
+        display: none;
         margin-block: $spacing-07 0;
       }
 
@@ -227,6 +228,24 @@
         color: $link-primary;
         inset-block-end: $spacing-05;
         inset-inline-end: $spacing-05;
+      }
+    }
+
+    /* Desktop Hover & Focus - Show Pictogram + Copy */
+    @media (hover: hover) {
+      .#{$prefix}--card:hover .#{$prefix}--card__heading {
+        display: none;
+      }
+      .#{$prefix}--card:hover .#{$prefix}--card__copy {
+        display: block;
+      }
+    }
+
+    /* Mobile - Always Show Everything */
+    @media (width <= 767px) {
+      .#{$prefix}--card__heading,
+      .#{$prefix}--card__copy {
+        display: block;
       }
     }
 

--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -192,12 +192,6 @@
       ::slotted(#{$c4d-prefix}-card-heading) {
         margin-block-end: 0;
         padding-block-start: $spacing-07;
-
-        @include breakpoint(md) {
-          display: block;
-          // flex: 1;
-          padding-inline-start: 0;
-        }
       }
     }
 
@@ -218,6 +212,10 @@
         position: relative;
       }
 
+      .#{$prefix}--card__heading {
+        display: none;
+      }
+
       .#{$prefix}--card__copy {
         display: none;
         margin-block: $spacing-07 0;
@@ -233,10 +231,14 @@
 
     /* Desktop Hover & Focus - Show Pictogram + Copy */
     @media (hover: hover) {
-      .#{$prefix}--card:hover .#{$prefix}--card__heading {
+      .#{$prefix}--card:hover
+        .#{$prefix}--card__motion
+        ::slotted(#{$c4d-prefix}-card-heading) {
         display: none;
       }
-      .#{$prefix}--card:hover .#{$prefix}--card__copy {
+      .#{$prefix}--card:hover
+        .#{$prefix}--card__motion
+        .#{$prefix}--card__copy {
         display: block;
       }
     }
@@ -245,7 +247,7 @@
     @media (width <= 767px) {
       .#{$prefix}--card__heading,
       .#{$prefix}--card__copy {
-        display: block;
+        display: block !important;
       }
     }
 

--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -239,7 +239,8 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
       <div
         class="${prefix}--card__wrapper ${hasPictogram
           ? `${prefix}--card__pictogram`
-          : ''} ${prefix}--card__motion
+          : ''} ${hasPictogram && this._hasCopy
+          ? `${prefix}--card__motion`
           : ''}"
         part="wrapper">
         <div class="${prefix}--card__content" part="content">

--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -239,6 +239,7 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
       <div
         class="${prefix}--card__wrapper ${hasPictogram
           ? `${prefix}--card__pictogram`
+          : ''} ${prefix}--card__motion
           : ''}"
         part="wrapper">
         <div class="${prefix}--card__content" part="content">


### PR DESCRIPTION
[ADCMS-7539](https://jsw.ibm.com/browse/ADCMS-7539)

### Description

Card Group Pictogram uses the CIBM pictogram card, which was modified between v1 and v2 to remove the hover state. AEM specifically requested to maintain the v1 interaction.

**Issue**
At the sm breakpoint, the [v1 pattern](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card--pictogram) removes the hover and integrates all content into a single card display. This is not happening currently in AEM. Instead, the hover is being maintained across all breakpoints.

**Expected outcome**
Because we are maintaining the core v1 hover interaction at md-max, we also need to restore the original mobile state of the sm breakpoint card to condense all content into a non-hover view.
