### PR TITLE
fix(toc): centering clicked tabs in mobile

### DIFF
--- a/packages/web-components/src/components/table-of-contents/table-of-contents.ts
+++ b/packages/web-components/src/components/table-of-contents/table-of-contents.ts
@@ -200,6 +200,15 @@ class C4DTableOfContents extends MediaQueryMixin(
     const target = event.target as HTMLAnchorElement;
     if (target.matches?.(selectorItem)) {
       this._handleUserInitiatedJump(target.dataset.target!);
+
+      // This will make sure the clicked tab scrolls into view and is centered being completely visible in mobile res.
+      if (this._isMobile) {
+        target.scrollIntoView({
+          block: 'nearest',
+          inline: 'center',
+          behavior: 'smooth',
+        });
+      }
       event.preventDefault();
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

Closes [#6635](https://jsw.ibm.com/browse/ADCMS-6635)

### Description

The table of contents changes its navigation to a horizontal scrollable tabs section in mobile. When clicking through the tabs, there are tabs that can partially exist off the visible area. When they're clicked, the page scrolls to the desired content but the tab will remain there it is, sometimes being partially off the screen.

### Changelog

I added a `scrollIntoView()` that will make each clicked tab to scroll to the center of the visible area, ensuring its copy is fully visible


### Testing Instructions:

1. In the storybook, go to the `Table of Contents > Default` component and enter mobile view.
2. Click the tabs and they need to scroll to the center of the visible area instead of not moving



https://github.com/user-attachments/assets/e6cd7cc3-3089-4d6f-a9cc-a21513fbcfc3


