### PR TITLE
fix(masthead-l1): fix unwanted item highlighting

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -937,7 +937,9 @@ class C4DMastheadL1 extends StableSelectorMixin(LitElement) {
         try {
           const elURL = new URL(el.href);
           const currURL = new URL(currentUrlPath || '');
-
+          if (/#/.test(el.href)) {
+            return false;
+          }
           // Compare url without query params.
           return (
             elURL.host === currURL.host && elURL.pathname === currURL.pathname

--- a/packages/web-components/src/components/masthead/masthead-l1.ts
+++ b/packages/web-components/src/components/masthead/masthead-l1.ts
@@ -937,7 +937,7 @@ class C4DMastheadL1 extends StableSelectorMixin(LitElement) {
         try {
           const elURL = new URL(el.href);
           const currURL = new URL(currentUrlPath || '');
-          if (/#/.test(el.href)) {
+          if (el.href.includes('#')) {
             return false;
           }
           // Compare url without query params.


### PR DESCRIPTION
### Related Ticket(s)
[JIRA](https://jsw.ibm.com/browse/ADCMS-7584)

### Description
This PR addresses multiple CTA highlighting in L1 components caused by anchor links pointing to sections within the page.

### Changelog


**Changed**

-  modifying the `_handleSelectedMenuItem`  function that sets the `active` attribute to stop propagating when the link `href` contains `#`

