### PR TITLE
fix(content-block-paragraph): fixing the logic to hide the component …

### DIFF
--- a/packages/web-components/src/components/content-block/content-block-paragraph.ts
+++ b/packages/web-components/src/components/content-block/content-block-paragraph.ts
@@ -48,19 +48,20 @@ class C4DContentBlockParagraph extends StableSelectorMixin(LitElement) {
     }
 
     const assignedNodes = slot.assignedNodes({ flatten: true });
-
-    // Check if all assigned nodes are empty or whitespace
-    const isEmpty = assignedNodes.every((node) => {
-      // Ensure `textContent` is non-null and trim for whitespace check
-      return node.nodeType !== Node.TEXT_NODE || !node.textContent?.trim();
-    });
-
-    // Hide or show the element based on slot content
-    if (isEmpty) {
-      this.style.display = 'none';
-    } else {
-      this.style.display = 'block';
-    }
+  
+    const hasTextContent = (node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        return !!node.textContent?.trim();
+      }
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        return [...node.childNodes].some(hasTextContent);
+      }
+      return false;
+    };
+  
+    const isEmpty = !assignedNodes.some(hasTextContent);
+  
+    this.style.display = isEmpty ? 'none' : 'block';
   }
 
   render() {

--- a/packages/web-components/src/components/content-block/content-block-paragraph.ts
+++ b/packages/web-components/src/components/content-block/content-block-paragraph.ts
@@ -48,7 +48,7 @@ class C4DContentBlockParagraph extends StableSelectorMixin(LitElement) {
     }
 
     const assignedNodes = slot.assignedNodes({ flatten: true });
-  
+
     const hasTextContent = (node) => {
       if (node.nodeType === Node.TEXT_NODE) {
         return !!node.textContent?.trim();
@@ -58,9 +58,9 @@ class C4DContentBlockParagraph extends StableSelectorMixin(LitElement) {
       }
       return false;
     };
-  
+
     const isEmpty = !assignedNodes.some(hasTextContent);
-  
+
     this.style.display = isEmpty ? 'none' : 'block';
   }
 


### PR DESCRIPTION
…when no copy

### Description

In this PR https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/12198, we created a logic to hide the component if it has no copy, however, that logic that hides and displays, was only considering direct text nodes, but in AEM we have a div for the RTE and only then the text content. It was resulting in the component to hide even if there's copy 

### Changelog

Modified the logic for the method `toggleVisibility()` to also look for any text or element nodes, in case of element nodes, we'll check if they have text content.


