### PR TITLE
feat(card): space gutters for mobile

### DIFF
--- a/packages/styles/scss/components/card/_card.scss
+++ b/packages/styles/scss/components/card/_card.scss
@@ -34,6 +34,11 @@
   :host(#{$c4d-prefix}-content-group-cards-item) .#{$prefix}--card {
     @include tile($enable-experimental-tile-contrast: true);
 
+    @include breakpoint-down(md) {
+      inline-size: auto;
+      margin-inline: $spacing-05;
+    }
+
     position: relative;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6608](https://jsw.ibm.com/browse/ADCMS-6608)

### Description

It's difficult to see that cards are clickable rather than just having differently colored background when they display full-width. Add proper "gutter" space on the left and right sides of cards to suggest that they are clickable cards.

### Changelog

A `margin-inline: $spacing-05` was added for small screen to add left and right space on the card component.
