### PR TITLE
feat(content-block): switching margin with padding

### DIFF
--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -28,12 +28,12 @@
   :host(#{$c4d-prefix}-content-block-headlines),
   .#{$prefix}--content-block {
     display: block;
-    margin-block: $spacing-07;
-    margin-block-end: $spacing-12;
+    padding-block: $spacing-07;
+    padding-block-end: $spacing-12;
 
     @include breakpoint('lg') {
-      margin-block: $spacing-10;
-      margin-block-end: $spacing-13;
+      padding-block: $spacing-10;
+      padding-block-end: $spacing-13;
     }
 
     &[complementary-style-scheme='with-border'] {


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-7400](https://jsw.ibm.com/browse/ADCMS-7400)

### Description

A white space had appeared between 2 components after Carbon v2 release when using black color background.

### Changelog

**Changed**

Replaced `margin-block` with `padding-block` for the `content-block` component.