### PR TITLE
feat(masthead): adding shadow parts to svg arrow icons

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -227,7 +227,8 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
                   part="view-all view-all-left"
                   slot="view-all">
                   <span>${viewAll.title}</span>${this.ArrowIcon({
-                    slot: 'icon', part: 'l0-view-all-products-arrow'
+                    slot: 'icon',
+                    part: 'l0-view-all-products-arrow',
                   })}
                 </c4d-megamenu-link-with-icon>
               `

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -103,6 +103,7 @@ export interface CMApp {
  * @csspart view-all-left -  Targets the view all left. Usage: `c4d-masthead-composite::part(view-all-left)`
  * @csspart view-all-right -  Targets the view all right. Usage: `c4d-masthead-composite::part(view-all-right)`
  * @csspart view-all-bottom -  Targets the view all bottom. Usage: `c4d-masthead-composite::part(view-all-bottom)`
+ * @csspart l0-view-all-products-arrow -  Targets the view all products arrow icon. Usage: `c4d-masthead-composite::part(l0-view-all-products-arrow)`
  */
 @customElement(`${c4dPrefix}-masthead-composite`)
 class C4DMastheadComposite extends HostListenerMixin(LitElement) {
@@ -226,7 +227,7 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
                   part="view-all view-all-left"
                   slot="view-all">
                   <span>${viewAll.title}</span>${this.ArrowIcon({
-                    slot: 'icon',
+                    slot: 'icon', part: 'l0-view-all-products-arrow'
                   })}
                 </c4d-megamenu-link-with-icon>
               `

--- a/packages/web-components/src/components/masthead/megamenu-category-heading.ts
+++ b/packages/web-components/src/components/masthead/megamenu-category-heading.ts
@@ -27,7 +27,9 @@ const { stablePrefix: c4dPrefix } = settings;
 class C4DMegaMenuCategoryHeading extends C4DMegaMenuHeading {
   protected get _arrowIcon() {
     const isRTL = document.dir.toLowerCase() === 'rtl';
-    return isRTL ? ArrowLeft20({part: 'l0-arrow-cat-heading'}) : ArrowRight20({part: 'l0-arrow-cat-heading'});
+    return isRTL
+      ? ArrowLeft20({ part: 'l0-arrow-cat-heading' })
+      : ArrowRight20({ part: 'l0-arrow-cat-heading' });
   }
 
   @property({ reflect: true, type: Number, attribute: 'heading-level' })

--- a/packages/web-components/src/components/masthead/megamenu-category-heading.ts
+++ b/packages/web-components/src/components/masthead/megamenu-category-heading.ts
@@ -21,12 +21,13 @@ const { stablePrefix: c4dPrefix } = settings;
  * MegaMenu Category Heading.
  *
  * @element c4d-megamenu-category-heading
+ * @csspart l0-arrow-cat-heading -  Targets the heading category arrow icon. Usage: `c4d-megamenu-category-heading::part(l0-arrow-cat-heading)`
  */
 @customElement(`${c4dPrefix}-megamenu-category-heading`)
 class C4DMegaMenuCategoryHeading extends C4DMegaMenuHeading {
   protected get _arrowIcon() {
     const isRTL = document.dir.toLowerCase() === 'rtl';
-    return isRTL ? ArrowLeft20() : ArrowRight20();
+    return isRTL ? ArrowLeft20({part: 'l0-arrow-cat-heading'}) : ArrowRight20({part: 'l0-arrow-cat-heading'});
   }
 
   @property({ reflect: true, type: Number, attribute: 'heading-level' })

--- a/packages/web-components/src/components/masthead/megamenu-heading.ts
+++ b/packages/web-components/src/components/masthead/megamenu-heading.ts
@@ -29,6 +29,7 @@ const { stablePrefix: c4dPrefix } = settings;
  * @csspart heading-h5 - The h5 element of the megamenu heading. Usage: `c4d-megamenu-heading::part(heading-h5)`
  * @csspart heading-h6 - The h6 element of the megamenu heading. Usage: `c4d-megamenu-heading::part(heading-h6)`
  * @csspart heading-span - The span element containing slotted content. Usage: `c4d-megamenu-heading::part(heading-span)`
+ * @csspart l0-heading-arrow -  Targets the heading arrow icon. Usage: `c4d-megamenu-heading::part(l0-heading-arrow)`
  */
 @customElement(`${c4dPrefix}-megamenu-heading`)
 class C4DMegaMenuHeading extends HostListenerMixin(LitElement) {
@@ -52,7 +53,7 @@ class C4DMegaMenuHeading extends HostListenerMixin(LitElement) {
    */
   protected get _arrowIcon() {
     const isRTL = document.dir.toLowerCase() === 'rtl';
-    return isRTL ? ArrowLeft24() : ArrowRight24();
+    return isRTL ? ArrowLeft24({part:'l0-heading-arrow'}) : ArrowRight24({part:'l0-heading-arrow'});
   }
 
   /**

--- a/packages/web-components/src/components/masthead/megamenu-heading.ts
+++ b/packages/web-components/src/components/masthead/megamenu-heading.ts
@@ -53,7 +53,9 @@ class C4DMegaMenuHeading extends HostListenerMixin(LitElement) {
    */
   protected get _arrowIcon() {
     const isRTL = document.dir.toLowerCase() === 'rtl';
-    return isRTL ? ArrowLeft24({part:'l0-heading-arrow'}) : ArrowRight24({part:'l0-heading-arrow'});
+    return isRTL
+      ? ArrowLeft24({ part: 'l0-heading-arrow' })
+      : ArrowRight24({ part: 'l0-heading-arrow' });
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

none

### Description

In order to help the AEM team rebuild the masthead natively in AEM, I added shadow parts to the SVG icons so they can be targeted outside the shadow root and therefore styled accordingly.

### Changelog

New shadow parts added to the SVG icons

