### PR TITLE
fix(masthead): globe icon logic fixed to display

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -12,7 +12,7 @@ import { state, property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import ArrowRight16 from '@carbon/web-components/es/icons/arrow--right/16.js';
 import ArrowLeft16 from '@carbon/web-components/es/icons/arrow--left/16.js';
-import EarthFilled from '@carbon/web-components/es/icons/earth--filled/20.js';
+import Wikis from '@carbon/web-components/es/icons/wikis/20.js';
 import ifNonEmpty from '@carbon/web-components/es/globals/directives/if-non-empty.js';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import root from 'window-or-global';
@@ -1185,11 +1185,12 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
 
   protected _renderLanguageSelector() {
     const { hasLanguageSelector } = this;
+
     return hasLanguageSelector === 'false'
       ? undefined
       : html`
           <div class="earth-language-icon" part="earth-l0-icon">
-            ${EarthFilled({ part: 'earth-l0-svg' })}
+            ${Wikis({ part: 'earth-l0-svg' })}
           </div>
         `;
   }
@@ -1631,6 +1632,13 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
 
     // Keep render root's height in sync with c4d-masthead.
     this._heightResizeObserver.observe(this.mastheadRef);
+
+    const mastheadHasLanguageSelector = this.querySelector('c4d-masthead[has-language-selector]');
+    if (mastheadHasLanguageSelector) {
+      this.hasLanguageSelector = 'true';
+    } else {
+      this.hasLanguageSelector = 'false';
+    }
   }
 
   updated(changedProperties) {

--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -1633,7 +1633,9 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
     // Keep render root's height in sync with c4d-masthead.
     this._heightResizeObserver.observe(this.mastheadRef);
 
-    const mastheadHasLanguageSelector = this.querySelector('c4d-masthead[has-language-selector]');
+    const mastheadHasLanguageSelector = this.querySelector(
+      'c4d-masthead[has-language-selector]'
+    );
     if (mastheadHasLanguageSelector) {
       this.hasLanguageSelector = 'true';
     } else {


### PR DESCRIPTION
### Related Ticket(s)

None - this is a work requested for the L0 work by Nishant and Neha



### Description

Adding a condition through an attribute to render the globe icon for the lang selector. 

By adding `has-language-selector` attribute to `c4d-masthead`, it'll display the globe icon:
![image](https://github.com/user-attachments/assets/7f1aa17a-1214-439a-a03e-e97573c8e911)

