### PR TITLE
fix(masthead): enabling the icon and using the correct icon

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -1673,6 +1673,7 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
     return html`
       ${isMobileVersion ? this._renderLeftNav() : ''}
       <c4d-masthead
+        has-language-selector
         ?has-l1=${this.l1Data}
         aria-label="${ifNonEmpty(mastheadAssistiveText)}">
         <c4d-skip-to-content


### PR DESCRIPTION
### Related Ticket(s)

none - this is a work for the new L0 that will live inside of AEM

### Description

Enabling the world icon and using the correct one

![image](https://github.com/user-attachments/assets/5bf92b9d-3e3b-451c-891d-9332eefdc0c9)


