### PR TITLE
fix(background-media): missing overlay in mobile resolutions

### DIFF
--- a/packages/styles/scss/components/background-media/_background-media.scss
+++ b/packages/styles/scss/components/background-media/_background-media.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -39,16 +39,16 @@
     position: absolute;
     z-index: 1;
     display: block;
-    block-size: 100%;
-    inline-size: 100%;
-    inset-block-start: 0;
-    inset-inline-end: 0;
 
     background-image: linear-gradient(
       to bottom,
       $background 0%,
       rgba(255, 255, 255, 0) 100%
     );
+    block-size: 100%;
+    inline-size: 100%;
+    inset-block-start: 0;
+    inset-inline-end: 0;
   }
 
   .#{$prefix}--background-media--gradient--left-to-right {

--- a/packages/styles/scss/components/background-media/_background-media.scss
+++ b/packages/styles/scss/components/background-media/_background-media.scss
@@ -44,13 +44,11 @@
     inset-block-start: 0;
     inset-inline-end: 0;
 
-    @include breakpoint(md) {
-      background-image: linear-gradient(
-        to bottom,
-        $background 0%,
-        rgba(255, 255, 255, 0) 100%
-      );
-    }
+    background-image: linear-gradient(
+      to bottom,
+      $background 0%,
+      rgba(255, 255, 255, 0) 100%
+    );
   }
 
   .#{$prefix}--background-media--gradient--left-to-right {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-6638

### Description

On mobile, the gradient overlay doesn’t appear, which makes most text illegible due to the background image.

### Changelog

Removed a media query that was preventing the gradient to display on mobile as well

![image](https://github.com/user-attachments/assets/04cfead1-2e13-4065-9a3f-e5fd7173180e)

