### PR TITLE
fix(masthead-menu-button): hide hamburger button when no nav menu items are present

### DIFF
--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -213,6 +213,60 @@ export const WithCustomTypeahead = (args) => {
             ?custom-typeahead-api=${true}></c4d-masthead-container>
         `}
   `;
+};
+
+export const WithNoNavData = (args) => {
+  const { grouped } = args?.MastheadComposite ?? {};
+
+  document.documentElement.addEventListener(
+    'c4d-search-with-typeahead-input',
+    async (e) => {
+      const results = await customTypeaheadApiFunction(
+        (e as CustomEvent).detail.value,
+        grouped
+      );
+      document.dispatchEvent(
+        new CustomEvent('c4d-custom-typeahead-api-results', { detail: results })
+      );
+    }
+  );
+
+  return html`
+    <style>
+      ${styles}
+    </style>
+    ${html`
+      <c4d-masthead-container
+        .l0Data="${[]}"
+        .authenticatedProfileItems="${ifNonEmpty(authenticatedProfileItems)}"
+        .unauthenticatedProfileItems="${ifNonEmpty(
+          unauthenticatedProfileItems
+        )}"
+        ?custom-typeahead-api=${true}></c4d-masthead-container>
+    `}
+  `;
+};
+
+WithNoNavData.story = {
+  name: 'With no nav data',
+  parameters: {
+    knobs: {},
+  },
+  propsSet: {
+    default: {
+      MastheadComposite: {
+        grouped: 'false',
+        hasProfile: 'true',
+        hasCart: false,
+        mockActiveCartId: '',
+        cartLabel: '',
+        hasSearch: 'true',
+        searchPlaceHolder: 'Search all of IBM',
+        selectedMenuItem: 'Services & Consulting',
+        userStatus: userStatuses.unauthenticated,
+      },
+    },
+  },
 };
 
 WithCustomTypeahead.story = {

--- a/packages/web-components/src/components/masthead/masthead-menu-button.ts
+++ b/packages/web-components/src/components/masthead/masthead-menu-button.ts
@@ -8,7 +8,7 @@
  */
 
 import { classMap } from 'lit/directives/class-map.js';
-import { html } from 'lit';
+import { html, PropertyValues } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
 import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';
@@ -93,7 +93,12 @@ class C4DMastheadMenuButton extends HostListenerMixin(CDSHeaderMenuButton) {
       buttonNode.focus();
     }
   }
-
+  firstUpdated() {
+    const boundHideButton = this.hideButtonIfNoNavItemsFound.bind(this);
+    window.addEventListener(`load`, () => {
+      boundHideButton();
+    });
+  }
   updated(changedProperties) {
     if (changedProperties.has('active')) {
       const {
@@ -124,6 +129,9 @@ class C4DMastheadMenuButton extends HostListenerMixin(CDSHeaderMenuButton) {
     if (!NavMenuItems?.length) {
       this.hideMenuButton = true;
       this.style.display = 'none';
+    } else if (this.style.display == 'none') {
+      this.hideMenuButton = false;
+      this.style.display = '';
     }
   }
 

--- a/packages/web-components/src/components/masthead/masthead-menu-button.ts
+++ b/packages/web-components/src/components/masthead/masthead-menu-button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -113,6 +113,17 @@ class C4DMastheadMenuButton extends HostListenerMixin(CDSHeaderMenuButton) {
 
     if (changedProperties.has('hideMenuButton')) {
       this._hasSearchActive = this.hideMenuButton;
+    }
+    this.hideButtonIfNoNavItemsFound();
+  }
+
+  hideButtonIfNoNavItemsFound() {
+    const NavMenuItems = this.closest(
+      `${c4dPrefix}-masthead-container`
+    )?.querySelectorAll(`${c4dPrefix}-left-nav-menu`);
+    if (!NavMenuItems?.length) {
+      this.hideMenuButton = true;
+      this.style.display = 'none';
     }
   }
 

--- a/packages/web-components/src/components/masthead/masthead-menu-button.ts
+++ b/packages/web-components/src/components/masthead/masthead-menu-button.ts
@@ -8,7 +8,7 @@
  */
 
 import { classMap } from 'lit/directives/class-map.js';
-import { html, PropertyValues } from 'lit';
+import { html } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import HostListener from '@carbon/web-components/es/globals/decorators/host-listener.js';
 import HostListenerMixin from '@carbon/web-components/es/globals/mixins/host-listener.js';


### PR DESCRIPTION
### Related Ticket(s)

[Jira](https://jsw.ibm.com/browse/ADCMS-4525)

### Description
This PR hides the hamburger menu button when no L0 nav items are present

### Changelog

**Changed*
- Set the `hideButton` variable to `true` and display to none on the `masthead-menu-button` component when no `left-nav-menu`  components are found under `masthead-container`
- Added new story to facilitate testing
