### PR TITLE
fix(carousel): gesture-duration-mobile

### DIFF
--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -24,8 +24,8 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 const { prefix, stablePrefix: c4dPrefix } = settings;
 
-const MAX_GESTURE_DURATION = 300; // max time allowed to do swipe
-const MIN_DISTANCE_TRAVELLED = 75; // min distance traveled to be considered swipe
+const MAX_GESTURE_DURATION = 600; // max time allowed to do swipe
+const MIN_DISTANCE_TRAVELLED = 25; // min distance traveled to be considered swipe
 const headingBottomMargin = 64; // tag constants used for same height calculations
 
 /**

--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -392,6 +392,7 @@ class C4DCarousel extends HostListenerMixin(StableSelectorMixin(LitElement)) {
       } else {
         this.start = Math.max(start - pageSize, 0);
       }
+      this._handleIsScrolling();
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-6609](https://jsw.ibm.com/browse/ADCMS-6609)

### Description

The current implementation of JavaScript based touch swiping does not work consistently for left/right swipe navigation.

### Changelog

Increased the gesture-duration and short the distance swipe and now animation behavior is increased and better.