### PR TITLE
fix(pricing-table): enabling overflow hints in mobile

### DIFF
--- a/packages/styles/scss/components/pricing-table/_pricing-table.scss
+++ b/packages/styles/scss/components/pricing-table/_pricing-table.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2022, 2024
+// Copyright IBM Corp. 2022, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -363,5 +363,10 @@
     opacity: 0;
     transform: translateY(-#{$spacing-05});
     transition: $duration-fast-02 motion(standard, productive);
+  }
+
+  :host(.overflowing-right) .overflow-indicator.right,
+  :host(.overflowing-left) .overflow-indicator.left {
+    opacity: 1;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-6628

### Description

The `Pricing Table` inherits its inner structure from the `Structured List component`. The latter has a built in logic to indicate mobile users that there's scrollable content to the right or to the left. 

This logic was not working due to some CSS constraints.

### Changelog

Added some new CSS rules to enable Overflow Hints as per Structured List component


https://github.com/user-attachments/assets/49e00d3c-0701-43d2-8d17-84adff8cd423


