### PR TITLE
fix(card-group): incorrect mobile gutters for FW layout pages in AEM

### DIFF
--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -42,7 +42,9 @@
         1fr
       );
     }
+  }
 
+  :not(:host(#{$c4d-prefix}-card-group.is-full-width-template)) {
     @include breakpoint-down(md) {
       padding-inline: $spacing-05;
     }

--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -44,7 +44,7 @@
     }
   }
 
-  :not(:host(#{$c4d-prefix}-card-group.is-full-width-template)) {
+  :host(#{$c4d-prefix}-card-group):not(.is-full-width-template) {
     @include breakpoint-down(md) {
       padding-inline: $spacing-05;
     }

--- a/packages/web-components/src/components/card-group/card-group.ts
+++ b/packages/web-components/src/components/card-group/card-group.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -114,6 +114,12 @@ class C4DCardGroup extends StableSelectorMixin(LitElement) {
     ) {
       this.setAttribute('with-card-in-card', '');
     }
+
+    // Check if the component is living in a Full Width or Table of Contents template.
+    const isFullWidthTemplate =
+      document.body.getAttribute('data-fullwidthtemplate') === 'true';
+    //Adds a class if true, for better css treatment in mobile for FW pages.
+    this.classList.toggle('is-full-width-template', isFullWidthTemplate);
   }
 
   updated(changedProperties) {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-8167

### Description

[In this ticket](https://jsw.ibm.com/browse/ADCMS-6599) we added inline gutters for the card group in mobile.

But we found out that it would only work correctly in ToC pages, since FW ones already have that gutter in mobile resulting in an ever bigger gutter. 

### Changelog

I added a logic that will check if `body` has the attribute of `data-fullwidthtemplate="true"` - if we're in a FW template, the gutters will not be applied


`  :not(:host(#{$c4d-prefix}-card-group.is-full-width-template)) {`
    `@include breakpoint-down(md) {`
      `padding-inline: $spacing-05;`
   ` }`