### PR TITLE
fix(masthead-l1): mobile dropdown with 0 width on iOS devices

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -150,6 +150,8 @@ $search-transition-timing: 95ms;
 
       &.is-open {
         box-shadow: 0 2px 6px 0 $shadow;
+        /* stylelint-disable-next-line declaration-no-important */
+        inline-size: 100vw !important;
       }
 
       &:not(.is-open) {


### PR DESCRIPTION
### Description
PR to fix l1 dropdown not appearing on IOS devices 

### Changelog
The component is not appearing because it has 0 width on iOS devices.
This PR forces full width on that component.
