### PR TITLE
fix(callout-quote): enabling bubble quote variation

### DIFF
--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -189,5 +189,64 @@
     @extend .#{$c4d-prefix}--link-with-icon !optional;
 
     display: inline-block;
+  }
+
+  .#{$prefix}-bubble-quote {
+    position: relative;
+    padding: 2.5rem;
+    border: 1px solid #8d8d8d;
+    border-radius: 0.25rem;
+    background: #f4f4f4;
+    margin-block-end: 3.81rem; /* match svg pointer height */
+    margin-inline: 0;
+
+    @include breakpoint-down(md) {
+      /* mobile inline gutters for the bubble quote */
+      margin-inline: 16px;
+      max-inline-size: calc(100% - 32px);
+    }
+
+    .bubble-pointer {
+      --fill: #f4f4f4;
+      --stroke: #8d8d8d;
+
+      position: absolute;
+      inset-block-start: 100%;
+      inset-inline-start: 2rem;
+
+      @include breakpoint-down(md) {
+        /* adjusting the pointer top position a bit since the max-inline-size calc changes in mobile. */
+        inset-block-start: calc(100% - 1px);
+      }
+    }
+
+    .bubble-pointer-fill {
+      fill: var(--fill);
+    }
+
+    .bubble-pointer-stroke {
+      stroke: var(--stroke);
+    }
+  }
+
+  :host([mark-type='bubble-quote']) {
+    span.cds--quote__mark[part~='mark--opening'] {
+      z-index: 1;
+      inset-block-start: 2.5rem;
+      inset-inline-start: 0.875rem;
+
+      @include breakpoint-down(lg) {
+        inset-inline-start: 1.25rem;
+      }
+      @include breakpoint-down(md) {
+        inset-inline-start: 2.8rem;
+      }
+    }
+  }
+
+  /* Mirroing the bubble quote in RTL modes */
+  :host([lang='ar']) .#{$prefix}-bubble-quote .bubble-pointer {
+    inset-inline: auto 2rem;
+    transform: scaleX(-1);
   }
 }

--- a/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
+++ b/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,6 +24,7 @@ const quoteTypes = {
   [`${QUOTE_TYPES.LOW_HIGH_REVERSED_DOUBLE_CURVED}`]:
     QUOTE_TYPES.LOW_HIGH_REVERSED_DOUBLE_CURVED,
   [`${QUOTE_TYPES.CORNER_BRACKET}`]: QUOTE_TYPES.CORNER_BRACKET,
+  [`${QUOTE_TYPES.BUBBLE_QUOTE}`]: QUOTE_TYPES.BUBBLE_QUOTE,
 };
 
 const colorSchemeTypes = {

--- a/packages/web-components/src/components/quote/defs.ts
+++ b/packages/web-components/src/components/quote/defs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -37,4 +37,9 @@ export enum QUOTE_TYPES {
    * corner-bracket
    */
   CORNER_BRACKET = 'corner-bracket',
+
+  /**
+   * bubble-quote
+   */
+  BUBBLE_QUOTE = 'bubble-quote',
 }

--- a/packages/web-components/src/components/quote/quote.ts
+++ b/packages/web-components/src/components/quote/quote.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -45,6 +45,9 @@ const slotExistencePropertyNames = {
  * @csspart container - Quote container. Usage `c4d-quote::part(container)`
  * @csspart wrapper - Quote wrapper. Usage `c4d-quote::part(wrapper)`
  * @csspart hr - Horizontal rule. Usage `c4d-quote::part(wrapper)`
+ * @csspart bubble-pointer-svg - The bubble quote variation pointer. Usage `c4d-quote::part(bubble-pointer-svg)`
+ * @csspart bubble-pointer-fill-svg - The fill color of the pointer. Usage `c4d-quote::part(bubble-pointer-fill-svg)`
+ * @csspart bubble-pointer-stroke-svg - The stroke color of the pointer. Usage `c4d-quote::part(bubble-pointer-stroke-svg)`
  */
 @customElement(`${c4dPrefix}-quote`)
 class C4DQuote extends StableSelectorMixin(LitElement) {
@@ -177,6 +180,41 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
               class="${prefix}--quote__mark-closing"
               part="mark mark--closing"
               >」</span
+            >
+          </blockquote>
+        `;
+      case QUOTE_TYPES.BUBBLE_QUOTE:
+        return html`
+          <span class="${prefix}--quote__mark" part="mark mark--opening">
+            ${this.lc !== 'ar' ? '“' : '”'}
+          </span>
+          <blockquote
+            class="${prefix}--quote__copy ${prefix}-bubble-quote"
+            part="copy">
+            <slot></slot>
+            <svg
+              width="47"
+              height="37"
+              viewBox="0 0 47 37"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="bubble-pointer"
+              part="bubble-pointer-svg">
+              <path
+                d="M4 31.84V4.5C4 2.29086 2.20914 0.5 0 0.5V0H46.6569V0.5C45.596 0.5 44.5786 0.919855 43.8284 1.67L10.8284 34.67C8.30857 37.1899 4 35.4036 4 31.84Z"
+                fill="#F4F4F4"
+                class="bubble-pointer-fill"
+                part="bubble-pointer-fill-svg" />
+              <path
+                d="M0 0.5C2.20914 0.5 4 2.29086 4 4.5V31.84C4 35.4036 8.30857 37.1899 10.8284 34.67L43.8284 1.67C44.5786 0.919855 45.596 0.5 46.6569 0.5"
+                stroke="#8D8D8D"
+                class="bubble-pointer-stroke"
+                part="bubble-pointer-stroke-svg" />
+            </svg>
+            <span
+              class="${prefix}--quote__mark-closing"
+              part="mark mark--closing"
+              >${this.lc !== 'ar' ? '”' : '“'}</span
             >
           </blockquote>
         `;


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-7860

### Description

Enabling the bubble quote variation, other design changes as per 7860 must be addressed in AEM

![image](https://github.com/user-attachments/assets/78072848-b853-490b-9c44-78d4239ce596)

![image](https://github.com/user-attachments/assets/c06dfe86-ea2e-4da2-aa68-377f0a6a057c)


### Changelog

New design/styles added to enable the bubble quote variation
