### PR TITLE
fix(left-nav): fix menu closing on iOS devices

### DIFF
--- a/packages/web-components/src/components/masthead/left-nav.ts
+++ b/packages/web-components/src/components/masthead/left-nav.ts
@@ -162,7 +162,6 @@ class C4DLeftNav extends StableSelectorMixin(CDSSideNav) {
   };
 
   private _handleClickOut(event: MouseEvent) {
-    debugger;
     const { selectorButtonToggle } = this.constructor as typeof C4DLeftNav;
     const toggleButton: HTMLElement | null = (
       this.getRootNode() as Document

--- a/packages/web-components/src/components/masthead/left-nav.ts
+++ b/packages/web-components/src/components/masthead/left-nav.ts
@@ -43,6 +43,7 @@ const FOLLOWING =
  * @csspart menu-sections - The element containing the menu sections slot. Usage: `c4d-left-nav::part(menu-sections)`
  */
 @customElement(`${c4dPrefix}-left-nav`)
+//@ts-ignore: Temporary override. shoud be removed when fixed upstream.
 class C4DLeftNav extends StableSelectorMixin(CDSSideNav) {
   /**
    * The handle for focus wrapping.

--- a/packages/web-components/src/components/masthead/left-nav.ts
+++ b/packages/web-components/src/components/masthead/left-nav.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -162,6 +162,7 @@ class C4DLeftNav extends StableSelectorMixin(CDSSideNav) {
   };
 
   private _handleClickOut(event: MouseEvent) {
+    debugger;
     const { selectorButtonToggle } = this.constructor as typeof C4DLeftNav;
     const toggleButton: HTMLElement | null = (
       this.getRootNode() as Document
@@ -232,6 +233,17 @@ class C4DLeftNav extends StableSelectorMixin(CDSSideNav) {
       }
     }
   };
+
+  //TODO: Remove this override when upstream bug is fixed.
+  //@ts-ignore: Overriding the Focus Out Function
+  private _handleFocusOut({ relatedTarget }: FocusEvent) {
+    const { collapseMode } = this;
+    if (collapseMode !== this.collapseMode) {
+      if (!this.contains(relatedTarget as Node)) {
+        this.expanded = false;
+      }
+    }
+  }
 
   /**
    * Usage mode of the side nav.


### PR DESCRIPTION
### Related Ticket(s)

[Jira](https://jsw.ibm.com/browse/ADCMS-7864) 

### Description

Paleative fix for L0 navigation closing when from an iPhone, and selecting a category from the Products menu.


**New**

- Addedd overrde for the `_handleFocusOut` method comming form upstream codebase. 
