### PR TITLE
feat(video-player): adding player icon shadow part

### DIFF
--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -44,6 +44,7 @@ const { stablePrefix: c4dPrefix } = settings;
  * @csspart video - The video. Usage `c4d-video-player::part(video)`
  * @csspart button - The play button. Usage `c4d-video-player::part(button)`
  * @csspart image - The thumbnail image. Usage `c4d-video-player::part(image)`
+ * @csspart play-video - The play video icon. Usage `c4d-video-player::part(play-video)`
  * @csspart video-container - The video container. Usage `c4d-video-player::part(video-container)`
  * @csspart caption - The caption. Usage `c4d-video-player::part(caption)`
  */
@@ -152,7 +153,7 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
                   default-src="${thumbnailUrl}"
                   alt="${ifNonEmpty(name)}"
                   part="image">
-                  ${PlayVideo({ slot: 'icon' })}
+                  ${PlayVideo({ slot: 'icon', part: 'play-video' })}
                 </c4d-image>
               </button>
             </div>


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-8313](https://jsw.ibm.com/browse/ADCMS-8313)

### Description

Adding a missing shadow-part for the video-player so the svg play icon can be styled from the AEM side.

### Changelog

**New**

Adding `part: 'play-video'` for the video-player component.