### PR TITLE
Kaltura player title overwrite

### DIFF
--- a/packages/services/src/services/KalturaPlayer/KalturaPlayer.js
+++ b/packages/services/src/services/KalturaPlayer/KalturaPlayer.js
@@ -208,6 +208,12 @@ class KalturaPlayerAPI {
           closedCaptions: {
             plugin: true,
           },
+          /**
+           * When altering this default prop,
+           * please also check the video-player-container
+           * _getPlayerOptions prop of same name - as it also
+           * replicates the value bellow except for text
+           */
           titleLabel: {
             plugin: true,
             align: 'left',

--- a/packages/web-components/src/components/video-player/video-player-container.ts
+++ b/packages/web-components/src/components/video-player/video-player-container.ts
@@ -179,6 +179,15 @@ export const C4DVideoPlayerContainerMixin = <
     _getPlayerOptions() {
       const { backgroundMode, intersectionMode, autoPlay, muted } =
         this as unknown as C4DVideoPlayerComposite;
+      /**
+       * The overwritten media title.
+       *
+       * Quick and dirty turn around as C4DVideoPlayerComposite uses caption
+       * and C4DLightboxVideoPlayer uses customVideoName and none are
+       * part of the same type
+       */
+      const mediaTitle = this?.['customVideoName'] || this?.['caption'];
+
       let playerOptions = {};
       const autoplayPreference = this._getAutoplayPreference();
 
@@ -216,6 +225,19 @@ export const C4DVideoPlayerContainerMixin = <
             autoMute: muted,
           };
           break;
+      }
+
+      if (mediaTitle) {
+        playerOptions = {
+          ...playerOptions,
+          ...{
+            titleLabel: {
+              plugin: true,
+              align: 'left',
+              text: mediaTitle,
+            },
+          },
+        };
       }
 
       return playerOptions;

--- a/packages/web-components/tests/snapshots/c4d-video-player.md
+++ b/packages/web-components/tests/snapshots/c4d-video-player.md
@@ -3,7 +3,10 @@
 #### `should render with minimum attributes`
 
 ```
-<div class="c4d--video-player__video-container">
+<div
+  class="c4d--video-player__video-container"
+  part="video-container"
+>
   <div
     class="c4d--video-player__video"
     part="video"
@@ -32,7 +35,10 @@
 #### `should render with various attributes`
 
 ```
-<div class="c4d--video-player__video-container">
+<div
+  class="c4d--video-player__video-container"
+  part="video-container"
+>
   <slot>
   </slot>
 </div>


### PR DESCRIPTION
### Related Ticket(s)

Closes Jira 7731

### Description

Now the "captions" property (what a horrible choice of property name), which was used to override the media title in the video components slots, now also override the kaltura player title.

![image](https://github.com/user-attachments/assets/6f3d22d6-eebe-4a94-a340-5f2642b7f817)

![image](https://github.com/user-attachments/assets/42f4e876-fd61-43a4-9bb6-327852041de2)

### Changelog

**Changed**

- Web-components / Video Player Container
  - Get Player Options - Detect and extend the overriding properties used in the player container and overlay with player container
- Services / Kaltura Player
  - Left a comment on a default property that IF change is planned, there should also be a lookout for the prop of same name in the above Get Player Options method


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
