### PR TITLE
fix(background-media): gradient rtl display issue

### DIFF
--- a/packages/styles/scss/components/background-media/_background-media.scss
+++ b/packages/styles/scss/components/background-media/_background-media.scss
@@ -69,6 +69,16 @@
     }
   }
 
+  .#{$prefix}--background-media--gradient--right-to-left {
+    @include breakpoint(lg) {
+      background-image: linear-gradient(
+        to left,
+        $background 25%,
+        rgba(255, 255, 255, 0) 75%
+      );
+    }
+  }
+
   .#{$prefix}--background-media--gradient--top-to-bottom {
     @include breakpoint(lg) {
       background-image: linear-gradient(

--- a/packages/styles/scss/components/card-section-offset/_card-section-offset.scss
+++ b/packages/styles/scss/components/card-section-offset/_card-section-offset.scss
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -103,6 +103,19 @@
       @include breakpoint(lg) {
         padding-block-start: $spacing-07;
       }
+    }
+  }
+
+  :host(:dir(rtl)) {
+    ::slotted([slot='heading']) {
+      margin-right: 1rem;
+    }
+
+    ::slotted([slot='action']) {
+      //important needed because <a slot="action" style="display: contents;"> in AEM has an inline style
+      /* stylelint-disable declaration-no-important */
+      display: block !important;
+      margin-right: 1rem !important;
     }
   }
 

--- a/packages/web-components/src/components/background-media/background-media.ts
+++ b/packages/web-components/src/components/background-media/background-media.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021, 2024
+ * Copyright IBM Corp. 2021, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -85,6 +85,12 @@ class C4DBackgroundMedia extends C4DImage {
   gradientHidden = false;
 
   /**
+   *  Determines if the direction is right-to-left
+   */
+  @property({ type: Boolean })
+  isRTL = false;
+
+  /**
    * @deprecated
    *
    * Mobile Position (bottom (default) | top)
@@ -162,6 +168,17 @@ class C4DBackgroundMedia extends C4DImage {
     return '';
   }
 
+  _handleIsRTL() {
+    this.isRTL =
+      this.dir === 'rtl' || getComputedStyle(this).direction === 'rtl';
+
+    if (this.isRTL) {
+      this.gradientDirection = GRADIENT_DIRECTION.RIGHT_TO_LEFT;
+    }
+
+    console.log(this.isRTL);
+  }
+
   /**
    * Append the c4d-background-media to the parent element where this component is being used.
    */
@@ -178,6 +195,10 @@ class C4DBackgroundMedia extends C4DImage {
     if (this.hasAttribute('default-src') && !this.videoPlayerContainer) {
       this.containsOnlyImages = true;
     }
+  }
+
+  firstUpdated(): void {
+    this._handleIsRTL();
   }
 
   render() {

--- a/packages/web-components/src/components/background-media/defs.ts
+++ b/packages/web-components/src/components/background-media/defs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2021
+ * Copyright IBM Corp. 2021, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,11 @@ export enum GRADIENT_DIRECTION {
    * Left to right
    */
   LEFT_TO_RIGHT = 'left-to-right',
+
+  /**
+   * Right to left
+   */
+  RIGHT_TO_LEFT = 'right-to-left',
 
   /**
    * Top to Bottom


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-7759

### Description

The background media component was not flipping the gradient to be from the right to the left when in RTL mode.
I've added the RTL logic to make it work in RTL as well:

old:
![image](https://github.com/user-attachments/assets/b54dfed0-b836-470c-a336-ccacc5ef7865)


new:
![image](https://github.com/user-attachments/assets/5638af2a-25b3-42bb-a612-d9ea868d0545)



