### PR TITLE
feat(callout-quote): new appearances enabled card and bubble

### DIFF
--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -191,55 +191,71 @@
     display: inline-block;
   }
 
+  //Hiding bubble-pointer as bubble-quote is mobible only
   .#{$prefix}-bubble-quote {
-    position: relative;
-    padding: 2.5rem;
-    border: 1px solid #8d8d8d;
-    border-radius: 0.25rem;
-    background: #f4f4f4;
-    margin-block-end: 3.81rem; /* match svg pointer height */
-    margin-inline: 0;
-
-    @include breakpoint-down(md) {
-      /* mobile inline gutters for the bubble quote */
-      margin-inline: 16px;
-      max-inline-size: calc(100% - 32px);
-    }
-
     .bubble-pointer {
-      --fill: #f4f4f4;
-      --stroke: #8d8d8d;
-
-      position: absolute;
-      inset-block-start: 100%;
-      inset-inline-start: 2rem;
-
-      @include breakpoint-down(md) {
-        /* adjusting the pointer top position a bit since the max-inline-size calc changes in mobile. */
-        inset-block-start: calc(100% - 1px);
-      }
-    }
-
-    .bubble-pointer-fill {
-      fill: var(--fill);
-    }
-
-    .bubble-pointer-stroke {
-      stroke: var(--stroke);
+      display: none;
     }
   }
 
-  :host([mark-type='bubble-quote']) {
-    span.cds--quote__mark[part~='mark--opening'] {
-      z-index: 1;
-      inset-block-start: 2.5rem;
-      inset-inline-start: 0.875rem;
+  //Bubble-quote variation is mobile only
+  @include breakpoint-down(md) {
+    .#{$prefix}-bubble-quote {
+      position: relative;
+      padding: 2.5rem;
+      border: 1px solid #8d8d8d;
+      border-radius: 0.25rem;
+      background: #f4f4f4;
+      margin-block-end: 3.81rem; /* match svg pointer height */
+      margin-inline: 16px;
+      max-inline-size: calc(100% - 32px);
 
-      @include breakpoint-down(lg) {
-        inset-inline-start: 1.25rem;
+      .bubble-pointer {
+        --fill: #f4f4f4;
+        --stroke: #8d8d8d;
+
+        position: absolute;
+
+        display: block;
+        inset-block-start: 100%;
+        inset-inline-start: 2rem;
       }
-      @include breakpoint-down(md) {
+
+      .bubble-pointer-fill {
+        fill: var(--fill);
+      }
+
+      .bubble-pointer-stroke {
+        stroke: var(--stroke);
+      }
+    }
+  }
+
+  @include breakpoint-down(md) {
+    :host([appearance='bubble-quote']),
+    :host([appearance='card']) {
+      span.cds--quote__mark[part~='mark--opening'] {
+        z-index: 1;
+        inset-block-start: 2.5rem;
         inset-inline-start: 2.8rem;
+      }
+    }
+  }
+
+  @include breakpoint-down(md) {
+    :host([appearance='bubble-quote'])[mark-type='corner-bracket'],
+    :host([appearance='card'])[mark-type='corner-bracket'] {
+      span.cds--quote__mark[part~='mark--opening'] {
+        inset-inline-start: 2.2rem;
+      }
+    }
+  }
+
+  @include breakpoint-up(md) {
+    :host([appearance='bubble-quote'])[mark-type='corner-bracket'],
+    :host([appearance='card'])[mark-type='corner-bracket'] {
+      span.cds--quote__mark[part~='mark--opening'] {
+        inset-inline-start: -1.125rem;
       }
     }
   }

--- a/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
+++ b/packages/web-components/src/components/callout-quote/__stories__/callout-quote.stories.ts
@@ -15,6 +15,7 @@ import { QUOTE_TYPES } from '../../quote/quote';
 import { COLOR_SCHEME } from '../../../component-mixins/callout/defs';
 import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';
+import { APPEARANCE } from '../../quote/defs';
 
 const quoteTypes = {
   [`${QUOTE_TYPES.DEFAULT}`]: QUOTE_TYPES.DEFAULT,
@@ -24,7 +25,12 @@ const quoteTypes = {
   [`${QUOTE_TYPES.LOW_HIGH_REVERSED_DOUBLE_CURVED}`]:
     QUOTE_TYPES.LOW_HIGH_REVERSED_DOUBLE_CURVED,
   [`${QUOTE_TYPES.CORNER_BRACKET}`]: QUOTE_TYPES.CORNER_BRACKET,
-  [`${QUOTE_TYPES.BUBBLE_QUOTE}`]: QUOTE_TYPES.BUBBLE_QUOTE,
+};
+
+const appearance = {
+  [`${APPEARANCE.DEFAULT}`]: APPEARANCE.DEFAULT,
+  [`${APPEARANCE.CARD}`]: APPEARANCE.CARD,
+  [`${APPEARANCE.BUBBLE_QUOTE}`]: APPEARANCE.BUBBLE_QUOTE,
 };
 
 const colorSchemeTypes = {
@@ -39,13 +45,17 @@ export const Default = (args) => {
   const {
     copy,
     quoteMark,
+    appearance,
     sourceHeading,
     sourceCopy,
     sourceBottomCopy,
     colorScheme,
   } = args?.CalloutQuote ?? {};
   return html`
-    <c4d-callout-quote mark-type="${quoteMark}" color-scheme="${colorScheme}">
+    <c4d-callout-quote
+      mark-type="${quoteMark}"
+      appearance="${appearance}"
+      color-scheme="${colorScheme}">
       ${copy}
       <c4d-quote-source-heading> ${sourceHeading} </c4d-quote-source-heading>
       <c4d-quote-source-copy> ${sourceCopy} </c4d-quote-source-copy>
@@ -87,6 +97,11 @@ export default {
           'Quote Mark (markType):',
           quoteTypes,
           quoteTypes['double-curved']
+        ),
+        appearance: select(
+          'Appearance (Default - legacy | card and bubble-quote are mobile only):',
+          appearance,
+          appearance['legacy']
         ),
         sourceHeading: textNullable(
           'Source heading (source-heading slot)',

--- a/packages/web-components/src/components/quote/defs.ts
+++ b/packages/web-components/src/components/quote/defs.ts
@@ -37,6 +37,18 @@ export enum QUOTE_TYPES {
    * corner-bracket
    */
   CORNER_BRACKET = 'corner-bracket',
+}
+
+export enum APPEARANCE {
+  /**
+   * Default - legacy
+   */
+  DEFAULT = 'legacy',
+
+  /**
+   * card
+   */
+  CARD = 'card',
 
   /**
    * bubble-quote

--- a/packages/web-components/src/components/quote/quote.ts
+++ b/packages/web-components/src/components/quote/quote.ts
@@ -11,7 +11,7 @@ import { property } from 'lit/decorators.js';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import styles from './quote.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
-import { QUOTE_TYPES } from './defs';
+import { APPEARANCE, QUOTE_TYPES } from './defs';
 import '../horizontal-rule/horizontal-rule';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
 import LocaleAPI from '@carbon/ibmdotcom-services/es/services/Locale/Locale.js';
@@ -67,6 +67,10 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
   @property({ reflect: true, attribute: 'lang' })
   lc;
 
+  // Options: 'legacy' (default), 'card', 'bubble-quote' (last two are mobile only)
+  @property({ reflect: true, attribute: 'appearance' })
+  appearance = APPEARANCE.DEFAULT; // 'legacy' (default)
+
   /**
    * `true` if there is source heading.
    */
@@ -109,130 +113,166 @@ class C4DQuote extends StableSelectorMixin(LitElement) {
     this.requestUpdate();
   }
 
-  protected _renderQuote() {
+  protected _getQuoteMarks(): { open: string; close: string } {
     switch (this.markType) {
       case QUOTE_TYPES.SINGLE_CURVED:
-        return html`
-          <span class="${prefix}--quote__mark" part="mark mark--opening"
-            >‘</span
-          >
-          <blockquote class="${prefix}--quote__copy" part="copy">
-            <slot></slot
-            ><span
-              class="${prefix}--quote__mark-closing"
-              part="mark mark--closing"
-              >’</span
-            >
-          </blockquote>
-        `;
+        return { open: '‘', close: '’' };
       case QUOTE_TYPES.DOUBLE_ANGLE:
-        return html`
-          <span class="${prefix}--quote__mark" part="mark mark--opening"
-            >«</span
-          >
-          <blockquote class="${prefix}--quote__copy" part="copy">
-            <slot></slot
-            ><span
-              class="${prefix}--quote__mark-closing"
-              part="mark mark--closing"
-              >»</span
-            >
-          </blockquote>
-        `;
+        return { open: '«', close: '»' };
       case QUOTE_TYPES.SINGLE_ANGLE:
-        return html`
-          <span class="${prefix}--quote__mark" part="mark mark--opening"
-            >‹</span
-          >
-          <blockquote class="${prefix}--quote__copy" part="copy">
-            <slot></slot
-            ><span
-              class="${prefix}--quote__mark-closing"
-              part="mark mark--closing"
-              >›</span
-            >
-          </blockquote>
-        `;
+        return { open: '‹', close: '›' };
       case QUOTE_TYPES.LOW_HIGH_REVERSED_DOUBLE_CURVED:
-        return html`
-          <span class="${prefix}--quote__mark" part="mark mark--opening"
-            >„</span
-          >
-          <blockquote class="${prefix}--quote__copy" part="copy">
-            <slot></slot
-            ><span
-              class="${prefix}--quote__mark-closing"
-              part="mark mark--closing"
-              >“</span
-            >
-          </blockquote>
-        `;
+        return { open: '„', close: '“' };
       case QUOTE_TYPES.CORNER_BRACKET:
-        return html`
-          <span
-            class="${prefix}--quote__mark ${prefix}--quote__mark-corner-bracket"
-            part="mark mark--opening"
-            >「</span
-          >
-          <blockquote class="${prefix}--quote__copy" part="copy">
-            <slot></slot
-            ><span
-              class="${prefix}--quote__mark-closing"
-              part="mark mark--closing"
-              >」</span
-            >
-          </blockquote>
-        `;
-      case QUOTE_TYPES.BUBBLE_QUOTE:
-        return html`
-          <span class="${prefix}--quote__mark" part="mark mark--opening">
-            ${this.lc !== 'ar' ? '“' : '”'}
-          </span>
-          <blockquote
-            class="${prefix}--quote__copy ${prefix}-bubble-quote"
-            part="copy">
-            <slot></slot>
-            <svg
-              width="47"
-              height="37"
-              viewBox="0 0 47 37"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              class="bubble-pointer"
-              part="bubble-pointer-svg">
-              <path
-                d="M4 31.84V4.5C4 2.29086 2.20914 0.5 0 0.5V0H46.6569V0.5C45.596 0.5 44.5786 0.919855 43.8284 1.67L10.8284 34.67C8.30857 37.1899 4 35.4036 4 31.84Z"
-                fill="#F4F4F4"
-                class="bubble-pointer-fill"
-                part="bubble-pointer-fill-svg" />
-              <path
-                d="M0 0.5C2.20914 0.5 4 2.29086 4 4.5V31.84C4 35.4036 8.30857 37.1899 10.8284 34.67L43.8284 1.67C44.5786 0.919855 45.596 0.5 46.6569 0.5"
-                stroke="#8D8D8D"
-                class="bubble-pointer-stroke"
-                part="bubble-pointer-stroke-svg" />
-            </svg>
-            <span
-              class="${prefix}--quote__mark-closing"
-              part="mark mark--closing"
-              >${this.lc !== 'ar' ? '”' : '“'}</span
-            >
-          </blockquote>
-        `;
+        return { open: '「', close: '」' };
+      case QUOTE_TYPES.DEFAULT:
       default:
-        return html`
-          <span class="${prefix}--quote__mark" part="mark mark--opening"
-            >${this.lc !== 'ar' ? '“' : '”'}</span
-          >
-          <blockquote class="${prefix}--quote__copy" part="copy">
-            <slot></slot
-            ><span
-              class="${prefix}--quote__mark-closing"
-              part="mark mark--closing"
-              >${this.lc !== 'ar' ? '”' : '“'}</span
-            >
-          </blockquote>
-        `;
+        return {
+          open: this.lc !== 'ar' ? '“' : '”',
+          close: this.lc !== 'ar' ? '”' : '“',
+        };
     }
+  }
+
+  protected _renderQuote() {
+    // If the appearance is legacy (or not provided), use the original rendering logic
+    if (this.appearance === 'legacy') {
+      switch (this.markType) {
+        case QUOTE_TYPES.SINGLE_CURVED:
+          return html`
+            <span class="${prefix}--quote__mark" part="mark mark--opening"
+              >‘</span
+            >
+            <blockquote class="${prefix}--quote__copy" part="copy">
+              <slot></slot>
+              <span
+                class="${prefix}--quote__mark-closing"
+                part="mark mark--closing"
+                >’</span
+              >
+            </blockquote>
+          `;
+        case QUOTE_TYPES.DOUBLE_ANGLE:
+          return html`
+            <span class="${prefix}--quote__mark" part="mark mark--opening"
+              >«</span
+            >
+            <blockquote class="${prefix}--quote__copy" part="copy">
+              <slot></slot>
+              <span
+                class="${prefix}--quote__mark-closing"
+                part="mark mark--closing"
+                >»</span
+              >
+            </blockquote>
+          `;
+        case QUOTE_TYPES.SINGLE_ANGLE:
+          return html`
+            <span class="${prefix}--quote__mark" part="mark mark--opening"
+              >‹</span
+            >
+            <blockquote class="${prefix}--quote__copy" part="copy">
+              <slot></slot>
+              <span
+                class="${prefix}--quote__mark-closing"
+                part="mark mark--closing"
+                >›</span
+              >
+            </blockquote>
+          `;
+        case QUOTE_TYPES.LOW_HIGH_REVERSED_DOUBLE_CURVED:
+          return html`
+            <span class="${prefix}--quote__mark" part="mark mark--opening"
+              >„</span
+            >
+            <blockquote class="${prefix}--quote__copy" part="copy">
+              <slot></slot>
+              <span
+                class="${prefix}--quote__mark-closing"
+                part="mark mark--closing"
+                >“</span
+              >
+            </blockquote>
+          `;
+        case QUOTE_TYPES.CORNER_BRACKET:
+          return html`
+            <span
+              class="${prefix}--quote__mark ${prefix}--quote__mark-corner-bracket"
+              part="mark mark--opening">
+              「
+            </span>
+            <blockquote class="${prefix}--quote__copy" part="copy">
+              <slot></slot>
+              <span
+                class="${prefix}--quote__mark-closing"
+                part="mark mark--closing"
+                >」</span
+              >
+            </blockquote>
+          `;
+        default:
+          return html`
+            <span class="${prefix}--quote__mark" part="mark mark--opening">
+              ${this.lc !== 'ar' ? '“' : '”'}
+            </span>
+            <blockquote class="${prefix}--quote__copy" part="copy">
+              <slot></slot>
+              <span
+                class="${prefix}--quote__mark-closing"
+                part="mark mark--closing">
+                ${this.lc !== 'ar' ? '”' : '“'}
+              </span>
+            </blockquote>
+          `;
+      }
+    }
+    // For the appearances "card" and "bubble-quote"
+    else if (this.appearance === 'card' || this.appearance === 'bubble-quote') {
+      const marks = this._getQuoteMarks();
+      return html`
+        <span class="${prefix}--quote__mark" part="mark mark--opening">
+          ${marks.open}
+        </span>
+        <blockquote
+          class="${prefix}--quote__copy ${this.appearance === 'bubble-quote' ||
+          this.appearance === 'card'
+            ? `${prefix}-bubble-quote`
+            : ''}"
+          part="copy">
+          <slot></slot>
+          ${this.appearance === 'bubble-quote'
+            ? html`
+                <svg
+                  width="47"
+                  height="37"
+                  viewBox="0 0 47 37"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="bubble-pointer"
+                  part="bubble-pointer-svg">
+                  <path
+                    d="M4 31.84V4.5C4 2.29086 2.20914 0.5 0 0.5V0H46.6569V0.5C45.596 0.5 44.5786 0.919855 43.8284 1.67L10.8284 34.67C8.30857 37.1899 4 35.4036 4 31.84Z"
+                    fill="#F4F4F4"
+                    class="bubble-pointer-fill"
+                    part="bubble-pointer-fill-svg" />
+                  <path
+                    d="M0 0.5C2.20914 0.5 4 2.29086 4 4.5V31.84C4 35.4036 8.30857 37.1899 10.8284 34.67L43.8284 1.67C44.5786 0.919855 45.596 0.5 46.6569 0.5"
+                    stroke="#8D8D8D"
+                    class="bubble-pointer-stroke"
+                    part="bubble-pointer-stroke-svg" />
+                </svg>
+              `
+            : ''}
+          <span
+            class="${prefix}--quote__mark-closing"
+            part="mark mark--closing">
+            ${marks.close}
+          </span>
+        </blockquote>
+      `;
+    }
+    // Ensure all code paths return a value
+    return null;
   }
 
   protected _renderSource() {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-8432

### Description

Enabling new 'appearance' props to now be used along with 'Mark Types'.

![image](https://github.com/user-attachments/assets/3bc3a8e1-d02f-404f-b51a-f74ec5a6550f)


![image](https://github.com/user-attachments/assets/93d2a1bd-9af1-48b4-921c-4d74a488224f)

NOTE: the new appearances are mobile only. Default should display on all screens but "card" and "bubble-quote" are mobile only


### Changelog

**New**

- Callout quote component
New prop "appearance" added that enables two new styles: "card" quotes and "bubble" quotes

