### PR TITLE
Notice & Choice served annually once marketing permission is received

### DIFF
--- a/packages/web-components/src/components/notice-choice/__stories__/notice-choice.stories.ts
+++ b/packages/web-components/src/components/notice-choice/__stories__/notice-choice.stories.ts
@@ -133,7 +133,7 @@ export const Default = (args) => {
     ncTeleDetail,
     ncEmailDetail,
     environment,
-    email
+    email,
   } = args?.NoticeChoice ?? {};
   return html`
     <c4d-notice-choice

--- a/packages/web-components/src/components/notice-choice/__stories__/notice-choice.stories.ts
+++ b/packages/web-components/src/components/notice-choice/__stories__/notice-choice.stories.ts
@@ -114,7 +114,8 @@ const props = () => {
       hideErrorMessages,
       'false'
     ),
-    environment: select('Environment', environment, 'prod'),
+    environment: select('Environment', environment, 'stage'),
+    email: text('Email', ''),
   };
 };
 
@@ -132,11 +133,13 @@ export const Default = (args) => {
     ncTeleDetail,
     ncEmailDetail,
     environment,
+    email
   } = args?.NoticeChoice ?? {};
   return html`
     <c4d-notice-choice
       language="${language}"
       country="${country}"
+      email="${email || ''}"
       question-choices="${questionchoices}"
       state="${state}"
       terms-condition-link="${termsConditionLink || ''}"

--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -20,7 +20,7 @@ import StableSelectorMixin from '../../globals/mixins/stable-selector';
 import styles from './notice-choice.scss';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
-import { ConnectionSend } from '@carbon/icons-react';
+
 
 const { prefix, stablePrefix: c4dPrefix } = settings;
 

--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -21,7 +21,6 @@ import styles from './notice-choice.scss';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
 
-
 const { prefix, stablePrefix: c4dPrefix } = settings;
 
 /**
@@ -258,7 +257,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
       const mrsField = this.ncData?.mandatoryCheckbox[countyCode]
         .countryTransferText
         ? this.ncData?.mandatoryCheckbox[countyCode].countryTransferText
-          .mrs_field
+            .mrs_field
         : this.ncData?.mandatoryCheckbox[countyCode].chinaPIPLtext.mrs_field;
       this._onChange(mrsField, 'countyBasedCheckedNo');
 
@@ -371,9 +370,8 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
         break;
       }
       case 'email': {
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         if (hasValue && oldVal !== newVal && emailRegex.test(newVal)) {
-
           this.email = newVal;
           this.onEmailChange();
         }
@@ -409,14 +407,12 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
         const isExpired = emailStatus === 'P' && annualPeriodDate < oneYearAgo;
         this.isAnnualPeriodExpired = isExpired;
         this.showCheckBox = isExpired ? true : false;
-
       },
       (error) => {
         console.error('Error checking email status:', error);
       }
     );
   }
-
 
   static get stableSelector() {
     return `${c4dPrefix}--notice-choice`;
@@ -439,8 +435,8 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
     const mrsField = this.ncData?.mandatoryCheckbox[countyCode]
       .countryTransferText
       ? this.ncData?.mandatoryCheckbox[
-        this.isMandatoryCheckboxDisplayed.countryCode
-      ].countryTransferText.mrs_field
+          this.isMandatoryCheckboxDisplayed.countryCode
+        ].countryTransferText.mrs_field
       : this.ncData?.mandatoryCheckbox[countyCode].chinaPIPLtext.mrs_field;
     legalCheckbox.value = isChecked ? 1 : 0;
     this.preventFormSubmission = !isChecked;
@@ -491,13 +487,13 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
                   </span>
                 </label>
                 ${!this.hideErrorMessage && this.preventFormSubmission
-            ? html`<span
+                  ? html`<span
                       class="nc-error"
                       part="error"
                       style="color:#da1e28;font-size:.75rem"
                       >${mandatoryCheckbox.error}</span
                     >`
-            : ''}
+                  : ''}
               </p>
             </div>
           </span>
@@ -550,27 +546,38 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
       return html``;
     }
 
-
     const ecmTranslateContent = this.ncData;
     const country = this.country?.toLocaleLowerCase() || '';
     const state = this.state?.toLocaleLowerCase() || '';
 
-    let preText = "";
+    let preText = '';
 
     if (!this.email) {
       preText = ecmTranslateContent.annualDefaultText;
     } else {
-      preText = this.isAnnualPeriodExpired ? ecmTranslateContent.combinedConsent : ecmTranslateContent.annualText;
+      preText = this.isAnnualPeriodExpired
+        ? ecmTranslateContent.combinedConsent
+        : ecmTranslateContent.annualText;
     }
 
     if (ecmTranslateContent.state[country]) {
       if ((this.noticeOnly || []).includes(country)) {
-        preText = state === 'ca' || state === '' ? ecmTranslateContent.state[country]['ca'].noticeOnly : ecmTranslateContent.noticeOnly;
+        preText =
+          state === 'ca' || state === ''
+            ? ecmTranslateContent.state[country]['ca'].noticeOnly
+            : ecmTranslateContent.noticeOnly;
       } else {
-        preText = ecmTranslateContent.state[country][state]?.combinedConsent || ecmTranslateContent.combinedConsent;
+        preText =
+          ecmTranslateContent.state[country][state]?.combinedConsent ||
+          ecmTranslateContent.combinedConsent;
       }
     } else if ((this.noticeOnly || []).includes(country)) {
-      preText = state === 'ca' || state === '' || typeof state === 'undefined' ? ecmTranslateContent.state?.[country]?.['ca']?.noticeOnly ? ecmTranslateContent.state?.[country]?.['ca']?.noticeOnly : ecmTranslateContent.noticeOnly : ecmTranslateContent.noticeOnly;
+      preText =
+        state === 'ca' || state === '' || typeof state === 'undefined'
+          ? ecmTranslateContent.state?.[country]?.['ca']?.noticeOnly
+            ? ecmTranslateContent.state?.[country]?.['ca']?.noticeOnly
+            : ecmTranslateContent.noticeOnly
+          : ecmTranslateContent.noticeOnly;
     }
 
     const countryContent = ecmTranslateContent.country?.[country];
@@ -579,7 +586,9 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
       if (!this.email) {
         preText = ecmTranslateContent.annualDefaultText;
       } else {
-        preText = this.isAnnualPeriodExpired ? countryContent.combinedConsent : countryContent.annualText;
+        preText = this.isAnnualPeriodExpired
+          ? countryContent.combinedConsent
+          : countryContent.annualText;
       }
     }
 
@@ -589,10 +598,13 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
         const checkStatus: any = this.values.EMAIL;
         isPermissionOrSuppression = checkStatus.checkBoxStatus === 'PERMISSION';
       }
-      const checked = typeof this.values.EMAIL === 'object' ? isPermissionOrSuppression : this.values.EMAIL;
+      const checked =
+        typeof this.values.EMAIL === 'object'
+          ? isPermissionOrSuppression
+          : this.values.EMAIL;
 
       if (this.showCheckBox) {
-        return this.renderCheckbox(preText, checked)
+        return this.renderCheckbox(preText, checked);
       }
       return html`${unsafeHTML(preText)}`;
     }
@@ -623,10 +635,10 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
             this.combinedEmailPhonePrechecked && !checked
               ? 'CU'
               : !this.combinedEmailPhonePrechecked && checked
-                ? 'UC'
-                : this.combinedEmailPhonePrechecked && checked
-                  ? 'CC'
-                  : 'UU';
+              ? 'UC'
+              : this.combinedEmailPhonePrechecked && checked
+              ? 'CC'
+              : 'UU';
 
           break;
       }
@@ -672,7 +684,6 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
   }
 
   renderCombinedEmailPhoneSection() {
-
     const getPunsStatus = (key, checked) => {
       const countryLowerCase = this.country?.toLocaleLowerCase();
       const isNoticeOnly = (this.noticeOnly || []).includes(countryLowerCase);
@@ -709,54 +720,54 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
           ${this.countryBasedLegalNotice()} ${this.combinedPreTextTemplate()}
         </p>
         ${Object.keys(this.checkboxes).map((key) => {
-      const checked = this.values.EMAIL;
-      const punsStatus = getPunsStatus(key, checked);
-      const hiddenBox = {
-        id: `NC_HIDDEN_${key}`,
-        value: this.values[key]['checkBoxStatus']
-          ? this.values[key]['checkBoxStatus']
-          : this.values.EMAIL
-            ? 'PERMISSION'
-            : 'SUPPRESSION',
-      };
+          const checked = this.values.EMAIL;
+          const punsStatus = getPunsStatus(key, checked);
+          const hiddenBox = {
+            id: `NC_HIDDEN_${key}`,
+            value: this.values[key]['checkBoxStatus']
+              ? this.values[key]['checkBoxStatus']
+              : this.values.EMAIL
+              ? 'PERMISSION'
+              : 'SUPPRESSION',
+          };
 
-      if (typeof checked !== 'object') {
-        this.combinedEmailPhonePrechecked = checked ? true : false;
-      }
+          if (typeof checked !== 'object') {
+            this.combinedEmailPhonePrechecked = checked ? true : false;
+          }
 
-      if (
-        (this.noticeOnly || []).includes(this.country.toLocaleLowerCase())
-      ) {
-        const countryStatus = this.country
-          ? this.countrySettings[this.country.toLocaleLowerCase()]
-          : { email: 'opt-in', phone: 'opt-in' };
-        hiddenBox.value =
-          countryStatus.email === 'opt-out' ? 'PERMISSION' : 'SUPPRESSION';
-      }
+          if (
+            (this.noticeOnly || []).includes(this.country.toLocaleLowerCase())
+          ) {
+            const countryStatus = this.country
+              ? this.countrySettings[this.country.toLocaleLowerCase()]
+              : { email: 'opt-in', phone: 'opt-in' };
+            hiddenBox.value =
+              countryStatus.email === 'opt-out' ? 'PERMISSION' : 'SUPPRESSION';
+          }
 
-      this._onChange(
-        `NC_${key === 'PHONE' ? 'TELE' : key}_DETAIL`,
-        `${key}_${punsStatus}`
-      );
-      console.log(`${hiddenBox.id}_VALUE`, `NC_HIDDEN_${hiddenBox.value}`);
-      this._onChange(
-        `${hiddenBox.id}_VALUE`,
-        `NC_HIDDEN_${hiddenBox.value}`
-      );
+          this._onChange(
+            `NC_${key === 'PHONE' ? 'TELE' : key}_DETAIL`,
+            `${key}_${punsStatus}`
+          );
+          console.log(`${hiddenBox.id}_VALUE`, `NC_HIDDEN_${hiddenBox.value}`);
+          this._onChange(
+            `${hiddenBox.id}_VALUE`,
+            `NC_HIDDEN_${hiddenBox.value}`
+          );
 
-      if (Object.keys(this.checkboxes).length === 1) {
-        this._onChange(`NC_HIDDEN_PHONE_VALUE`, `NC_HIDDEN_PHONE_NONE`);
-      }
+          if (Object.keys(this.checkboxes).length === 1) {
+            this._onChange(`NC_HIDDEN_PHONE_VALUE`, `NC_HIDDEN_PHONE_NONE`);
+          }
 
-      return createHiddenInput(hiddenBox.id, hiddenBox.value);
-    })}
+          return createHiddenInput(hiddenBox.id, hiddenBox.value);
+        })}
         <div part="${prefix}--nc__post-text" class="${prefix}--nc__post-text">
           ${this.postTextTemplate()}
         </div>
         ${createHiddenInput(
-      'preventFormSubmission',
-      this.preventFormSubmission
-    )}
+          'preventFormSubmission',
+          this.preventFormSubmission
+        )}
         <input
           type="hidden"
           id="preventFormSubmission"
@@ -770,17 +781,17 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
     if (
       this.isMandatoryCheckboxDisplayed.isDisplayed &&
       this.country.toLocaleLowerCase() !==
-      this.isMandatoryCheckboxDisplayed.countryCode
+        this.isMandatoryCheckboxDisplayed.countryCode
     ) {
       const mrsField = this.ncData?.mandatoryCheckbox[
         this.isMandatoryCheckboxDisplayed.countryCode
       ].countryTransferText
         ? this.ncData?.mandatoryCheckbox[
-          this.isMandatoryCheckboxDisplayed.countryCode
-        ].countryTransferText.mrs_field
+            this.isMandatoryCheckboxDisplayed.countryCode
+          ].countryTransferText.mrs_field
         : this.ncData?.mandatoryCheckbox[
-          this.isMandatoryCheckboxDisplayed.countryCode
-        ].chinaPIPLtext.mrs_field;
+            this.isMandatoryCheckboxDisplayed.countryCode
+          ].chinaPIPLtext.mrs_field;
       this._onChange(mrsField, 'countyBasedCheckedNo');
     }
 

--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -408,7 +408,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
           this.renderCombinedEmailPhoneSection();
           return;
         }
-        
+
         const isExpired = emailStatus === 'P' && annualPeriodDate < oneYearAgo;
         this.isAnnualPeriodExpired = isExpired;
         this.showCheckBox = isExpired || emailStatus !== 'P';

--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -401,7 +401,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
 
         if (!isValidDate) {
           console.warn('Invalid annualPeriod:', annualPeriod);
-           this.showCheckBox = true;
+          this.showCheckBox = true;
           this.renderCombinedEmailPhoneSection();
           return;
         }
@@ -409,7 +409,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
         const isExpired = emailStatus === 'P' && annualPeriodDate < oneYearAgo;
         this.isAnnualPeriodExpired = isExpired;
         this.showCheckBox = isExpired ? true : false;
-        
+
       },
       (error) => {
         console.error('Error checking email status:', error);

--- a/packages/web-components/src/components/notice-choice/services.ts
+++ b/packages/web-components/src/components/notice-choice/services.ts
@@ -15,7 +15,8 @@ export function loadContent(
   const environment = env === 'prod' ? '1.www.s81c.com' : '1.wwwstage.s81c.com';
   script.async = false;
   script.charset = 'utf-8';
-  script.src = `https://${environment}/common/translations/notice/v23/${locale.toLocaleLowerCase()}/ncContent_v23.js`; // URL for the third-party library being loaded.
+  const timestamp = Date.now();
+  script.src = `https://${environment}/common/translations/notice/v23/${locale.toLocaleLowerCase()}/ncContent_v23.js?t=${timestamp}`;
   document.body.appendChild(script);
   script.onload = () => {
     try {
@@ -40,7 +41,7 @@ export function loadSettings(env: string, onSuccess: any, onError: any) {
   const environment = env === 'prod' ? '1.www.s81c.com' : '1.wwwstage.s81c.com';
   script.async = false;
   script.charset = 'utf-8';
-  script.src = `https://${environment}/common/noticechoice/settings.js`; // URL for the third-party library being loaded.
+  script.src = `https://${environment}/common/noticechoice/settings.js`;
   document.body.appendChild(script);
   script.onload = () => {
     try {
@@ -59,3 +60,29 @@ export function loadSettings(env: string, onSuccess: any, onError: any) {
     }
   };
 }
+export function checkEmailStatus(
+  email: string,
+  country: string,
+  env: string,
+  onSuccess: (data: any) => void,
+  onError: (err?: any) => void
+) {
+  const url = `https://pf-api-dummyemail.urx-perform.wdc.dev.cirrus.ibm.com/pf/api/v1/userEmail?email=${encodeURIComponent(email)}`;
+
+  fetch(url)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((data) => {
+      onSuccess(data);
+    })
+    .catch((err) => {
+      onError(err);
+    });
+
+}
+
+

--- a/packages/web-components/src/components/notice-choice/services.ts
+++ b/packages/web-components/src/components/notice-choice/services.ts
@@ -68,7 +68,7 @@ export function checkEmailStatus(
   onError: (err?: any) => void
 ) {
   const environment = env === 'prod' ? '1.www.s81c.com' : '1.wwwstage.s81c.com';
-  const url = `https://pf-api-dummyemail.urx-perform.wdc.dev.cirrus.ibm.com/pf/api/v1/userEmail?email=${encodeURIComponent(email)&&encodeURIComponent(country)}&env=${environment}`;
+  const url = `https://pf-api-dummyemail.urx-perform.wdc.dev.cirrus.ibm.com/pf/api/v1/userEmail?email=${encodeURIComponent(email) && encodeURIComponent(country)}&env=${environment}`;
 
   fetch(url)
     .then((response) => {

--- a/packages/web-components/src/components/notice-choice/services.ts
+++ b/packages/web-components/src/components/notice-choice/services.ts
@@ -67,7 +67,8 @@ export function checkEmailStatus(
   onSuccess: (data: any) => void,
   onError: (err?: any) => void
 ) {
-  const url = `https://pf-api-dummyemail.urx-perform.wdc.dev.cirrus.ibm.com/pf/api/v1/userEmail?email=${encodeURIComponent(email)}`;
+  const environment = env === 'prod' ? '1.www.s81c.com' : '1.wwwstage.s81c.com';
+  const url = `https://pf-api-dummyemail.urx-perform.wdc.dev.cirrus.ibm.com/pf/api/v1/userEmail?email=${encodeURIComponent(email)&&encodeURIComponent(country)}&env=${environment}`;
 
   fetch(url)
     .then((response) => {

--- a/packages/web-components/src/components/notice-choice/services.ts
+++ b/packages/web-components/src/components/notice-choice/services.ts
@@ -60,19 +60,23 @@ export function loadSettings(env: string, onSuccess: any, onError: any) {
     }
   };
 }
+
 export function checkEmailStatus(
   email: string,
-  country: string,
   env: string,
   onSuccess: (data: any) => void,
   onError: (err?: any) => void
 ) {
-  const environment = env === 'prod' ? '1.www.s81c.com' : '1.wwwstage.s81c.com';
-  const url = `https://pf-api-dummyemail.urx-perform.wdc.dev.cirrus.ibm.com/pf/api/v1/userEmail?email=${
-    encodeURIComponent(email) && encodeURIComponent(country)
-  }&env=${environment}`;
+  const environment = env === 'prod' ? 'www.ibm.com' : 'wwwstage.ibm.com';
+  const url = `https://${environment}/account/apis/v2.0/preference/get`;
 
-  fetch(url)
+  fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email }), // sending email in request body
+  })
     .then((response) => {
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -83,6 +87,8 @@ export function checkEmailStatus(
       onSuccess(data);
     })
     .catch((err) => {
+      console.error('Error checking email status:', err);
+
       onError(err);
     });
 }

--- a/packages/web-components/src/components/notice-choice/services.ts
+++ b/packages/web-components/src/components/notice-choice/services.ts
@@ -68,7 +68,9 @@ export function checkEmailStatus(
   onError: (err?: any) => void
 ) {
   const environment = env === 'prod' ? '1.www.s81c.com' : '1.wwwstage.s81c.com';
-  const url = `https://pf-api-dummyemail.urx-perform.wdc.dev.cirrus.ibm.com/pf/api/v1/userEmail?email=${encodeURIComponent(email) && encodeURIComponent(country)}&env=${environment}`;
+  const url = `https://pf-api-dummyemail.urx-perform.wdc.dev.cirrus.ibm.com/pf/api/v1/userEmail?email=${
+    encodeURIComponent(email) && encodeURIComponent(country)
+  }&env=${environment}`;
 
   fetch(url)
     .then((response) => {
@@ -83,7 +85,4 @@ export function checkEmailStatus(
     .catch((err) => {
       onError(err);
     });
-
 }
-
-

--- a/packages/web-components/tests/snapshots/c4d-masthead-composite.md
+++ b/packages/web-components/tests/snapshots/c4d-masthead-composite.md
@@ -11,6 +11,11 @@
     data-ibm-contact="contact-link"
   >
   </c4d-masthead-contact>
+  <div
+    class="earth-language-icon"
+    part="earth-l0-icon"
+  >
+  </div>
   <c4d-masthead-profile data-autoid="c4d--masthead-profile">
     <c4d-masthead-profile-item href="https://myibm.ibm.com/?lnk=mmi">
       My IBM
@@ -32,6 +37,11 @@
     data-ibm-contact="contact-link"
   >
   </c4d-masthead-contact>
+  <div
+    class="earth-language-icon"
+    part="earth-l0-icon"
+  >
+  </div>
   <c4d-masthead-profile
     authenticated=""
     data-autoid="c4d--masthead-profile"

--- a/packages/web-components/tests/snapshots/c4d-video-player.md
+++ b/packages/web-components/tests/snapshots/c4d-video-player.md
@@ -3,7 +3,10 @@
 #### `should render with minimum attributes`
 
 ```
-<div class="c4d--video-player__video-container">
+<div
+  class="c4d--video-player__video-container"
+  part="video-container"
+>
   <div
     class="c4d--video-player__video"
     part="video"
@@ -32,7 +35,10 @@
 #### `should render with various attributes`
 
 ```
-<div class="c4d--video-player__video-container">
+<div
+  class="c4d--video-player__video-container"
+  part="video-container"
+>
   <slot>
   </slot>
 </div>


### PR DESCRIPTION
### Related Ticket(s)

[Noitce & Choice w3 Publisher](https://w3.ibm.com/w3publisher/urx/notice-and-choice-v23)

### Description

Notice & Choice is a legally required component to create a form where IBM collects its customer information.
This section shows the specific product's legal links, terms, and conditions. Along with this, it collects users' consent regarding communication preferences.

### Changelog

**New**
- Notice & Choice is served annually once marketing permission is received 

**Changed**


**Removed**

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->