### PR TITLE
fix(card-in-card): video to better fill parent container

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -115,7 +115,7 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
 
   .#{$c4d-prefix}--video-player__video-container {
     position: relative;
-    display: inline-block;
+    display: block;
     inline-size: 100%;
 
     &:focus {


### PR DESCRIPTION
### Related Ticket(s)

Closes https://jsw.ibm.com/browse/ADCMS-7507

### Description

changing the display property in the Card in Card's parent container so that the video fills it in properly.

Before:
![image](https://github.com/user-attachments/assets/8333b5b6-46db-44e5-bd7f-716aab145480)

After:
![image](https://github.com/user-attachments/assets/c3f46fd8-0d47-46aa-bc71-ebc5ce28e467)

