### PR TITLE
fix(button-group): remove element selector restrictions

### DIFF
--- a/packages/web-components/src/components/button-group/button-group.ts
+++ b/packages/web-components/src/components/button-group/button-group.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,19 +31,7 @@ class C4DButtonGroup extends StableSelectorMixin(LitElement) {
   private _handleSlotChange(event: Event) {
     const childItems = (event.target as HTMLSlotElement)
       .assignedNodes()
-      .filter((elem) =>
-        (elem as HTMLElement).matches !== undefined
-          ? (elem as HTMLElement).matches(
-              (this.constructor as typeof C4DButtonGroup).selectorItem
-            ) ||
-            (elem as HTMLElement).matches(
-              (this.constructor as typeof C4DButtonGroup).selectorItemCTA
-            ) ||
-            (elem as HTMLElement).matches(
-              (this.constructor as typeof C4DButtonGroup).selectorItemDefaultCTA
-            )
-          : false
-      );
+      .filter((elem) => (elem as HTMLElement).matches !== undefined);
 
     childItems.forEach((elem, index) => {
       (elem as HTMLElement).setAttribute(


### PR DESCRIPTION
### Related Ticket(s)

[jira](https://jsw.ibm.com/browse/ADCMS-7379)

### Description

{{Add a human-readable description / detail summary of what the PR is changing and any details around how and why}}

{{If applicable, include a screenshot indicating an example or examples of what the PR is changing in the application}}

### Changelog

PR to remove the restrictions on the method that defines the child count on `button-group` 
The restrictions were filtering out valid components and causing the button group to misbehave.   

Before: 
<img width="965" height="589" alt="image" src="https://github.com/user-attachments/assets/a3a88f79-caec-4dc2-be93-6238e9d6ea40" />
(buttons on top of each other)

After:
<img width="952" height="632" alt="image" src="https://github.com/user-attachments/assets/0259bc73-5456-45ca-80b5-e96f2d849886" />
(Buttons side by side)