### PR TITLE
promo-banner/c4d-button-cta fix left space

### DIFF
--- a/packages/web-components/src/components/promo-banner/promo-banner.scss
+++ b/packages/web-components/src/components/promo-banner/promo-banner.scss
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -158,6 +158,7 @@ $xlg-12-column-upper-bound: ($max-breakpoint-width - 0.02) * (12 / 16);
   }
 
   ::slotted([slot='cta']) {
+    padding-inline-start: 2rem;
     inline-size: 100%;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-7530](https://jsw.ibm.com/browse/ADCMS-7530)

### Description
Adding 2 rem padding space for the promo-banner button to align on 4 column to the grid.
<img width="1602" height="152" alt="image" src="https://github.com/user-attachments/assets/f217ff91-7458-46a1-b3a0-656a3c941bc0" />
