### PR TITLE
ADCMS-8845 - simple-narrative card-link space

### DIFF
--- a/packages/web-components/src/components/content-block-simple/content-block-simple.scss
+++ b/packages/web-components/src/components/content-block-simple/content-block-simple.scss
@@ -43,8 +43,24 @@
 
   ::slotted(#{$c4d-prefix}-card) {
     @include breakpoint('md') {
-      // inline-size: calc((100% - 2 * #{$spacing-05}) * 0.9);
       margin-inline-start: -$spacing-05;
+    }
+  }
+
+  /* TOC template (anything that's not FW) */
+  &:not(.cds--content-block--full-width-template) {
+    ::slotted(#{$c4d-prefix}-card[slot='footer']) {
+      /* sm and down */
+      @include breakpoint-down(md) {
+        inline-size: 100%;
+        max-inline-size: 100%;
+      }
+
+      /* md and larger */
+      @include breakpoint('md') {
+        inline-size: calc(50% + 1rem);
+        max-inline-size: 100vw;
+      }
     }
   }
 }
@@ -52,10 +68,20 @@
 :host(
     #{$c4d-prefix}-content-block-simple.cds--content-block--full-width-template
   ) {
-  ::slotted(#{$c4d-prefix}-card) {
+  ::slotted(#{$c4d-prefix}-card[slot='footer']) {
+    /* default for lg, xlg, max */
     inline-size: 34%;
-    @include breakpoint-down('lg') {
+
+    /* sm and down */
+    @include breakpoint-down(md) {
       inline-size: 100%;
+      max-inline-size: 100%;
+    }
+
+    /* md only */
+    @media (width >= 672px) and (width <= 1055.98px) {
+      inline-size: calc(50% + 1rem);
+      max-inline-size: 100vw;
     }
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-8845](https://jsw.ibm.com/browse/ADCMS-8845)

### Description

In [ADCMS-7531](https://jsw.ibm.com/browse/ADCMS-7531), the card link option was addressed to rebalance the width to 4 columns. This has been validated in Stage to be working on all breakpoints except md.

Now the card link has the right balance on all resolutions for both FW and TOC template.
<img width="668" height="841" alt="image" src="https://github.com/user-attachments/assets/db84e444-e85e-4e9a-8b8a-dcc9d7da4356" />
