### PR TITLE
Fix/9441 featured carousel rtl not working

### DIFF
--- a/packages/styles/scss/components/carousel/_carousel.scss
+++ b/packages/styles/scss/components/carousel/_carousel.scss
@@ -151,6 +151,14 @@
   }
 }
 
+:host(#{$c4d-prefix}-carousel[dir='rtl'].featured-carousel) {
+  nav.cds--carousel__navigation {
+    //need to use 'right' to override the LTR property.
+    /* stylelint-disable-next-line */
+    right: calc(50% + 32px);
+  }
+}
+
 @media print {
   :host(#{$c4d-prefix}-carousel),
   .#{$prefix}--carousel {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-9441

### Description

Featured Carousel in RTL mode was not properly positioning the controls, giving the impression that only 1 slide was available. 

Before:
<img width="1184" height="428" alt="image" src="https://github.com/user-attachments/assets/24aab199-681c-4cb8-9eb4-907a88a52d4f" />

After:
<img width="1188" height="611" alt="image" src="https://github.com/user-attachments/assets/606019f7-8381-42e1-aa57-52c4e6b88112" />


