### PR TITLE
fix(video-player): remove padding zero causing issues

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -43,7 +43,6 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
   :host(#{$c4d-prefix}-video-player[background-mode]),
   .#{$c4d-prefix}--video-player[background-mode] {
     .#{$c4d-prefix}--video-player__video-container {
-      padding: 0;
       block-size: 100%;
     }
 


### PR DESCRIPTION
### Related Ticket(s)
[JIRA](https://jsw.ibm.com/browse/ADCMS-9617)

### Description

To fix AEM  issues when a card in card is within a caroussel

Before:
<img width="1228" height="779" alt="image" src="https://github.com/user-attachments/assets/22e9a778-c2a0-44ab-91f3-6d8067370750" />

After:
<img width="1228" height="779" alt="image" src="https://github.com/user-attachments/assets/8eb6c2b0-51e1-4491-a932-1c526e3ddc5b" />
