### PR TITLE
ADCMS-9105 leadspace title/buttons adjustments

### DIFF
--- a/packages/web-components/src/components/leadspace/leadspace-heading.ts
+++ b/packages/web-components/src/components/leadspace/leadspace-heading.ts
@@ -80,7 +80,7 @@ class C4DLeadspaceHeading extends StableSelectorMixin(LitElement) {
   }
 
   render() {
-    return html` <slot><h1 part="heading"></h1></slot> `;
+    return html` <h1 part="heading"><slot></slot></h1> `;
   }
 
   static get stableSelector() {


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-9105](https://jsw.ibm.com/browse/ADCMS-9105)

### Description

Button group is missing a bottom padding and title should stay on 6 columns for the C4IBM storybook
<img width="1616" height="789" alt="image" src="https://github.com/user-attachments/assets/cbf88b41-40d2-4614-a506-9f28265ac355" />


**Changed**
And fixed looks like:
<img width="1583" height="717" alt="image" src="https://github.com/user-attachments/assets/8ee7b173-b6fd-484a-bc5e-b7276bf4498f" />
