### PR TITLE
ADCMS-9692 Fix carousel text overlap

### DIFF
--- a/packages/styles/scss/components/carousel/_carousel.scss
+++ b/packages/styles/scss/components/carousel/_carousel.scss
@@ -85,9 +85,9 @@
       // Achieves `sameHeight` effect for card group.
       // The cards must have `height:auto`.
       align-items: stretch;
-      margin-inline-end: calc(
-        #{$spacing-05} + var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
-      );
+      // margin-inline-end: calc(
+      //   #{$spacing-05} + var(--#{$c4d-prefix}--carousel--overflow-hint-size, #{$spacing-05})
+      // );
     }
 
     .#{$prefix}--carousel__scroll-contents--scrolling {


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-9692](https://jsw.ibm.com/browse/ADCMS-9692)

### Description

The Carousel with Callout Quote component exhibits a text overlap issue on browser resize and device orientation change. The issue stems from the web component performing height calculations applied as inline styles.

First, open the test page in the browser, then open developer tools and toggle the device toolbar on.
https://author-p131558-e1281330.adobeaemcloud.com/content/adobe-cms/language-masters/en/testing/jf-sandbox/quote-carousel-test-fw.html?wcmmode=disabled

Test with orientation change:

1. In the device toolbar, set it to iPad Air
2. Change orientation to landscape, and reload the page
3. Rotate device orientation to portrait
4. Observe text overlap issue, height on <blockquote> element remains fixed at original height

<img width="843" height="895" alt="image" src="https://github.com/user-attachments/assets/91ef54bc-9777-4bce-b384-118f171263a7" />


**Removed**
I removed the `margin-inline-end` calculator which it seems that without it the carousel is working just fine.
After applying the above steps for testing it looks like:
<img width="837" height="904" alt="image" src="https://github.com/user-attachments/assets/0a345480-3bd3-45e9-9657-cb22a5cf5ec6" />

