### PR TITLE
Feat/9680 masthead custom logo

### DIFF
--- a/packages/web-components/src/components/footer/footer-logo.ts
+++ b/packages/web-components/src/components/footer/footer-logo.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -46,15 +46,74 @@ class C4DFooterLogo extends StableSelectorMixin(FocusMixin(LitElement)) {
   @property({ reflect: true })
   slot = 'brand';
 
+  /**
+   * The custom logo path, if it's enabled
+   */
+  @property({ type: String, attribute: false })
+  customLogoPath = '';
+
+  /**
+   * The custom logo alternative text, if it's enabled
+   */
+  @property({ type: String, attribute: false })
+  customLogoAlt = '';
+
+  /**
+   * The custom logo href, if it's enabled
+   */
+  @property({ type: String, attribute: false })
+  customLogoHref = '';
+
+  /**
+   * If c4d-footer-container has the attribute 'custom-logo-override', it enables the custom logo and all its custom info
+   */
+  private hasCustomLogo() {
+    const footerContainerWithCustomLogo = this.closest(
+      'c4d-footer-container[custom-logo-override]'
+    );
+
+    if (!footerContainerWithCustomLogo) {
+      return;
+    }
+
+    const path = footerContainerWithCustomLogo.getAttribute(
+      'custom-logo-override'
+    );
+    const alt = footerContainerWithCustomLogo.getAttribute('custom-logo-alt');
+    const href = footerContainerWithCustomLogo.getAttribute('custom-logo-href');
+
+    if (path) {
+      this.customLogoPath = path;
+    }
+    if (alt) {
+      this.customLogoAlt = alt;
+    }
+    if (href) {
+      this.href = href;
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.hasCustomLogo();
+  }
+
   render() {
-    const { href, size } = this;
+    const { href, size, customLogoPath, customLogoAlt } = this;
+
     return html`
       <a
         part="logo-link"
         class="${c4dPrefix}--footer-logo__link"
-        aria-label="IBM logo"
+        aria-label="${customLogoAlt || 'IBM logo'}"
         href="${ifDefined(href)}">
-        ${size !== FOOTER_SIZE.MICRO
+        ${customLogoPath
+          ? html`<img
+              class="custom-logo-override"
+              src="${customLogoPath}"
+              alt="${customLogoAlt || 'Logo'}"
+              part="custom-logo-footer" />`
+          : size !== FOOTER_SIZE.MICRO
           ? IBM8BarLogoH65White()
           : IBM8BarLogoH23White()}
         <slot></slot>

--- a/packages/web-components/src/components/masthead/masthead-logo.ts
+++ b/packages/web-components/src/components/masthead/masthead-logo.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -67,9 +67,72 @@ class C4DMastheadLogo extends FocusMixin(
   @property({ reflect: true })
   slot = 'brand';
 
+  /**
+   * The custom logo path, if it's enabled
+   */
+  @property({ type: String, attribute: false })
+  customLogoPath = '';
+
+  /**
+   * The custom logo alternative text, if it's enabled
+   */
+  @property({ type: String, attribute: false })
+  customLogoAlt = '';
+
+  /**
+   * The custom logo href, if it's enabled
+   */
+  @property({ type: String, attribute: false })
+  customLogoHref = '';
+
+  /**
+   * If c4d-masthead-container has the attribute 'custom-logo-override', it enables the custom logo and all its custom info
+   */
+  private hasCustomLogo() {
+    const mastheadContainerWithCustomLogo = this.closest(
+      'c4d-masthead-container[custom-logo-override]'
+    );
+
+    if (!mastheadContainerWithCustomLogo) {
+      return;
+    }
+
+    const path = mastheadContainerWithCustomLogo.getAttribute(
+      'custom-logo-override'
+    );
+    const alt = mastheadContainerWithCustomLogo.getAttribute('custom-logo-alt');
+    const href =
+      mastheadContainerWithCustomLogo.getAttribute('custom-logo-href');
+
+    if (path) {
+      this.customLogoPath = path;
+    }
+    if (alt) {
+      this.customLogoAlt = alt;
+    }
+    if (href) {
+      this.href = href;
+    }
+  }
+
   // eslint-disable-next-line class-methods-use-this
   protected _renderInner() {
-    return html` <slot>${IBM8BarLogoH23()}</slot> `;
+    return html`
+      <slot>
+        ${this.customLogoPath
+          ? html`<img
+              class="custom-logo-override"
+              src="${this.customLogoPath}"
+              alt="${this.customLogoAlt || 'Logo'}"
+              part="custom-logo-masthead" />`
+          : IBM8BarLogoH23()}
+      </slot>
+    `;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.hasCustomLogo();
   }
 
   updated(changedProperties) {
@@ -79,7 +142,12 @@ class C4DMastheadLogo extends FocusMixin(
       this._hasSearchActive = this.hideLogo;
     }
     if (linkNode) {
-      linkNode.setAttribute('aria-label', 'IBM logo');
+      if (this.customLogoAlt) {
+        linkNode.setAttribute('aria-label', `${this.customLogoAlt}`);
+      } else {
+        linkNode.setAttribute('aria-label', 'IBM logo');
+      }
+
       linkNode.classList.remove(`${prefix}--link`);
       linkNode.classList.toggle(
         `${c4dPrefix}-ce--header__logo--has-search-active`,

--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -79,6 +79,32 @@ $pos-btn-bottom: calc(
     inline-size: 58px;
   }
 
+  [part='link']:has(img.custom-logo-override) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 5px;
+    block-size: 48px;
+    inline-size: 142px;
+
+    @include breakpoint-between(lg, max) {
+      inline-size: 126px;
+    }
+
+    @include breakpoint-between(sm, lg) {
+      inline-size: 94px;
+    }
+  }
+
+  [part='link'] img.custom-logo-override {
+    display: block;
+    block-size: auto;
+    inline-size: auto;
+    max-block-size: 100%;
+    max-inline-size: 100%;
+    object-fit: contain;
+  }
+
   .#{$c4d-prefix}-ce--header__logo--has-search-active {
     @include breakpoint-down(md) {
       display: none;


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-9680
and
https://jsw.ibm.com/browse/ADCMS-9705

### Description

Adding the ability to use custom logos in our c4d-masthead and c4d-footer components

<img width="816" height="77" alt="image" src="https://github.com/user-attachments/assets/d458a5ba-18a8-409e-9795-25f5f1ed74d1" />

<img width="1519" height="357" alt="image" src="https://github.com/user-attachments/assets/226ee43f-b30d-4958-8ee7-2dd8ddac0c4d" />


### Changelog

Updated: 
- packages/web-components/src/components/footer/footer-logo.ts
- packages/web-components/src/components/masthead/masthead-logo.ts

`c4d-masthead-container` and `c4d-footer-container` will start accepting three attributes:

`custom-logo-override="{path of the custom logo}"`

`custom-logo-alt="{custom alternative text for logo}"`

`custom-logo-href="{custom path for the logo href}"`

<img width="613" height="70" alt="image" src="https://github.com/user-attachments/assets/6f31c05e-095e-49f6-8a0d-33459bc7f77e" />


