### PR TITLE
Fix/10037 pricing table buttons squeezed

### DIFF
--- a/packages/web-components/src/components/pricing-table/pricing-table.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2022, 2024
+ * Copyright IBM Corp. 2022, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -133,6 +133,31 @@ class C4DPricingTable extends HostListenerMixin(
       });
   }
 
+  // Adjusting the col span of the pricing table that comes from the API call
+  setAPIPricingTableWidth() {
+    const parentHasApiCall = this.closest(
+      'div.tableProductPrice[isapicall="Api"]'
+    );
+
+    if (parentHasApiCall) {
+      this.replaceColSpanVars(this);
+    }
+  }
+
+  replaceColSpanVars(element) {
+    const styleAttr = element.getAttribute('style');
+    if (!styleAttr) {
+      return;
+    }
+
+    const newStyle = styleAttr.replace(
+      /--col-span-(\d+)\s*:/g,
+      '--col-span-lg-$1:'
+    );
+
+    element.setAttribute('style', newStyle);
+  }
+
   /**
    * Host listener for updating header element references when cells are
    * updated.
@@ -181,6 +206,8 @@ class C4DPricingTable extends HostListenerMixin(
 
   renderInner() {
     const { sentinelClass } = this.constructor as typeof C4DPricingTable;
+
+    this.setAPIPricingTableWidth();
 
     return html`
       <section

--- a/packages/web-components/src/components/pricing-table/utils.ts
+++ b/packages/web-components/src/components/pricing-table/utils.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,6 +9,24 @@
 
 import C4DPricingTableHeaderRow from './pricing-table-header-row';
 import C4DPricingTableRow from './pricing-table-row';
+import { breakpoints as BXBreakpoints } from '@carbon/layout';
+
+/**
+ * Converts REM to PX
+ * Ex: '2rem' will output '32'
+ */
+const remToPx = (rem) =>
+  rem.slice(0, -3) *
+  parseFloat(getComputedStyle(document.documentElement).fontSize);
+
+/**
+ * Checks if the screen resolution is Large or Greater
+ */
+function isLargeOrGreater() {
+  const windowWidth = window.innerWidth;
+
+  return windowWidth >= remToPx(BXBreakpoints.lg.width);
+}
 
 /**
  * Sets a CSS custom property on the given row that indicates the default
@@ -20,7 +38,9 @@ export const setColumnWidth = (
   const columnCount = row.children.length;
   let defaultColumnWidth: string;
   if (columnCount >= 6) {
-    defaultColumnWidth = '2';
+    //If we have more 5 columns, we set 4 as the default column width in Large and greater resolutions
+    // to enable scroll and avoid content being squished by narrow coluns
+    defaultColumnWidth = isLargeOrGreater() ? '4' : '2';
   } else if (columnCount >= 4) {
     defaultColumnWidth = '3';
   } else {
@@ -28,6 +48,18 @@ export const setColumnWidth = (
   }
   row.style.setProperty('--default-cols', defaultColumnWidth);
 };
+
+let resizeTimeout: number;
+window.addEventListener('resize', () => {
+  clearTimeout(resizeTimeout);
+  resizeTimeout = window.setTimeout(() => {
+    document
+      .querySelectorAll<C4DPricingTableHeaderRow | C4DPricingTableRow>(
+        'c4d-pricing-table-header-row, c4d-pricing-table-row'
+      )
+      .forEach((row) => setColumnWidth(row));
+  }, 150);
+});
 
 /**
  * Animates an element hidden.


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-10037

### Description


Buttons were too narrow when we had multiple columns to the pricing table due to column width not being properly set up

<img width="887" height="449" alt="image" src="https://github.com/user-attachments/assets/8667b90b-0c87-4d40-8b58-11ee5e30ae1d" />

