### PR TITLE
fix(masthead-menu-button): tweak hide condition to fix button hiding …

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-menu-button.ts
+++ b/packages/web-components/src/components/masthead/masthead-menu-button.ts
@@ -125,7 +125,9 @@ class C4DMastheadMenuButton extends HostListenerMixin(CDSHeaderMenuButton) {
   hideButtonIfNoNavItemsFound() {
     const NavMenuItems = this.closest(
       `${c4dPrefix}-masthead-container`
-    )?.querySelectorAll(`${c4dPrefix}-left-nav-menu, ${c4dPrefix}-left-nav-menu-item`);
+    )?.querySelectorAll(
+      `${c4dPrefix}-left-nav-menu, ${c4dPrefix}-left-nav-menu-item`
+    );
     if (!NavMenuItems?.length) {
       this.hideMenuButton = true;
       this.style.display = 'none';


### PR DESCRIPTION
…when masthead is not empty

### JIRA:  https://jsw.ibm.com/browse/ADCMS-10256

### Description
PR to address the Hamburger icon not being visible on mobile and tablet viewports  if all navigation link variations are set to Links

### Changelog


**Changed**

- changed the selectotr of the hideButtonIfNoNavItemsFound function.
