### PR TITLE
fix(translation-api): add stop condition if url is malformed

### DIFF
--- a/packages/services/src/services/Translation/Translation.js
+++ b/packages/services/src/services/Translation/Translation.js
@@ -164,6 +164,11 @@ class TranslationAPI {
         const host = regex.test(endpoint) ? '' : _host;
         const url = `${host}${urlEndpoint}/${locationParam}.json`;
 
+        // Stops the method if the url is malformed
+        if (/.*1.www.s81c.com\/#.*/.test(url)) {
+          return null;
+        }
+
         _requestsTranslation[key] = axios
           .get(url, {
             headers: {


### PR DESCRIPTION
### Related Ticket(s)

[JIRA](https://jsw.ibm.com/browse/ADCMS-10362)

### Description

PR to handle a malformed url triggering CORS  a error when the translation api is called with the fallback URL

### Changelog

**Changed**
Added condition to return null when the function returns a problematic URL 
