### PR TITLE
Fix/10384 qa api pricing table mobile btns

### DIFF
--- a/packages/web-components/src/components/pricing-table/pricing-table.ts
+++ b/packages/web-components/src/components/pricing-table/pricing-table.ts
@@ -142,6 +142,16 @@ class C4DPricingTable extends HostListenerMixin(
     if (parentHasApiCall) {
       this.removeElementStyles(this);
     }
+
+    if (parentHasApiCall) {
+      const ctaBtns = document.querySelectorAll(
+        `${c4dPrefix}-pricing-table-header-cell-cta`
+      ) as NodeListOf<HTMLElement>;
+
+      ctaBtns.forEach((btn) => {
+        btn.style.maxWidth = '80%';
+      });
+    }
   }
 
   removeElementStyles(element) {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-10384

### Description

The pricing table CTAs were too lengthy in mobile. I added a script to make them have a max-width and do not span more than the screen width in mobile. 

Before:
<img width="402" height="425" alt="image" src="https://github.com/user-attachments/assets/52307e41-1bf2-4b1d-b195-6e3b0fee525a" />

After:
<img width="383" height="449" alt="image" src="https://github.com/user-attachments/assets/c138cf8b-ca51-4909-bc16-d9101b2fb765" />
 
