### PR TITLE
Fix/10209 unstable rtl video caption

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -154,6 +154,13 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
     );
   }
 
+  // Ensuring caption is correctly displayed when it has RTL mixed with LTR copy
+  .#{$c4d-prefix}--video-player__video-caption[dir='rtl'] {
+    direction: rtl;
+    text-align: end;
+    unicode-bidi: plaintext;
+  }
+
   .#{$c4d-prefix}--video-player__image-overlay {
     padding: 0;
     border: none;

--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -284,6 +284,9 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
   aspectRatio?: string;
 
   render() {
+    const isRTL =
+      this.dir === 'rtl' || getComputedStyle(this).direction === 'rtl';
+
     const {
       aspectRatio,
       duration,
@@ -329,7 +332,8 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
         : html`
             <div
               class="${c4dPrefix}--video-player__video-caption"
-              part="caption">
+              part="caption"
+              dir="${isRTL ? 'rtl' : 'ltr'}">
               ${formatCaption({
                 duration: formatDuration({
                   duration: !duration ? duration : duration * 1000,


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-10209

### Description

Video caption for `c4d-video-player` was not properly handling its copy when it has RTL writing mixed with LTR one.

As per Jira:

> Minutes are intertwine with the video caption.
In the RTL layout, the 'Watson' word is after the minutes, thus the phrase does not make sense. The minutes seems to be hand-coded into the page, not allowing the author to change the order of the words inside the phrase. Please correct it, making the minutes (1:35 min) appear last in the phrase, respecting the Right to left orientation layout.

<img width="645" height="92" alt="image" src="https://github.com/user-attachments/assets/33716c36-6435-440d-bce6-3331fd5ae9a9" />

Added some treatment in CSS to ensure the browser properly renders the video caption in that scenario:

<img width="496" height="71" alt="image" src="https://github.com/user-attachments/assets/c89fa41f-3b4d-41ec-8b44-e2631287c037" />


### Changelog

- packages/web-components/src/components/video-player/video-player.ts
Added some logic to tell if the `dir` of the caption is RTL or LTR

- packages/styles/scss/components/video-player/_video-player.scss
Added styles to ensure bidirecional copy is properly displayed on the different writing directions
