### PR TITLE
fix innerText property

### DIFF
--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -792,16 +792,14 @@ class C4DCarousel extends HostListenerMixin(StableSelectorMixin(LitElement)) {
                   title="${prevButtonText || defaultPrevButtonText}">
                   ${CaretLeft20()}
                 </button>
+
                 <span
                   part="status"
                   class="${prefix}--carousel__navigation__status"
-                  aria-hidden="true"
-                  >${formatStatus(status)}</span
-                >
-                <span
-                  class="${prefix}--visually-hidden"
-                  aria-live="polite"
-                  part="visually-hidden"></span>
+                  aria-hidden="true">
+                  ${formatStatus(status)}
+                </span>
+
                 <button
                   part="next-button"
                   class="${prefix}--btn ${prefix}--btn--tertiary ${prefix}--btn--icon-only ${prefix}--carousel__navigation__btn"
@@ -813,20 +811,13 @@ class C4DCarousel extends HostListenerMixin(StableSelectorMixin(LitElement)) {
                 </button>
               </nav>
             `
-          : html`
-              <span
-                part="status"
-                class="${prefix}--carousel__navigation__status"
-                aria-hidden="true">
-                ${formatStatus(status)}
-              </span>
+          : null}
 
-              <span
-                class="${prefix}--visually-hidden"
-                aria-live="polite"
-                part="visually-hidden">
-              </span>
-            `}
+        <span
+          class="${prefix}--visually-hidden"
+          aria-live="polite"
+          part="visually-hidden">
+        </span>
       </div>
     `;
   }


### PR DESCRIPTION
### Related Ticket(s)
[ADCMS-10601](https://jsw.ibm.com/browse/ADCMS-10601)
Closes #12282 

### Description

When rendering a Carbon Carousel where all items fit within the visible area (i.e., no navigation controls are needed), the component should render cleanly without JavaScript errors.
A runtime error is thrown in the console: Uncaught TypeError: Cannot set properties of null (setting 'innerText')

### Changelog

**New**

${formatStatus(status)} syntax was missing in some places.
