### PR TITLE
fix(card-group): spacing issue with condensed mode

### DIFF
--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -152,7 +152,7 @@
 
     &[grid-mode='condensed'] {
       .#{$prefix}--card {
-        margin-block-end: $spacing-05;
+        margin-block-end: 0;
       }
     }
 


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-10845

### Description

career job cards component extra  spacing displaying  between the cards.

### Changelog

- `packages/styles/scss/components/card-group/_card-group.scss`
- Removed the extra margin that was causing "condensed" mode to have a spacing among lines of cards

**before:**
<img width="845" height="538" alt="image" src="https://github.com/user-attachments/assets/f2c94bd3-2141-4176-90f4-d11ea2733f42" />

**after:**
<img width="1189" height="766" alt="image" src="https://github.com/user-attachments/assets/08213adc-61fc-47d2-b7e7-f7fd22fccc87" />

