### PR TITLE
Fix/8811 carousel spacing issues

### DIFF
--- a/packages/styles/scss/components/carousel/_carousel.scss
+++ b/packages/styles/scss/components/carousel/_carousel.scss
@@ -159,7 +159,7 @@
   }
 }
 
-:host(#{$c4d-prefix}-carousel[dir='rtl'].featured-carousel.slide-reverse) {
+:host([dir='rtl'].featured-carousel.slide-reverse) {
   nav.cds--carousel__navigation {
     //need to use 'right' to override the LTR property.
     /* stylelint-disable-next-line */
@@ -168,7 +168,7 @@
 }
 
 :host-context([dir='ltr']) {
-  :host(#{$c4d-prefix}-carousel.slide-reverse) {
+  :host(.slide-reverse) {
     nav.cds--carousel__navigation {
       //need to use 'left' to override the LTR property.
       /* stylelint-disable-next-line */


### PR DESCRIPTION
### Related Ticket(s)

Closes https://jsw.ibm.com/browse/ADCMS-8811

### Description

this fixes issues #9 and #3 from 8811

fixing the position of the carousel nav arrows when slide reverse is active:

<img width="1228" height="402" alt="image" src="https://github.com/user-attachments/assets/0ebffc89-1991-4cee-8fb6-ae538b9aa0fa" />


