### PR TITLE
Fix/7579 toc scroll console error

### DIFF
--- a/packages/web-components/src/components/table-of-contents/table-of-contents.ts
+++ b/packages/web-components/src/components/table-of-contents/table-of-contents.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2025
+ * Copyright IBM Corp. 2020, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -309,11 +309,19 @@ class C4DTableOfContents extends MediaQueryMixin(
               : null,
             position: elem.getBoundingClientRect().y,
           }))
-          .filter((elem, index, arr) =>
-            elem.height === null
-              ? arr[index - 1].position < arr[index - 1].height!
-              : elem.position - 50 - this.stickyOffset > -elem.height
-          );
+          .filter((elem, index, arr) => {
+            if (elem.height === null) {
+              if (index <= 0) {
+                return false;
+              }
+              const prev = arr[index - 1];
+              if (!prev) {
+                return false;
+              }
+              return prev.position < (prev.height ?? 0);
+            }
+            return elem.position - 50 - this.stickyOffset > -elem.height;
+          });
 
         // Sets last section as active at the end of page in case there is not enough height for it to dynamically activate
         const bottomReached =


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-8128

### Description

The calculation that the ToC component does to map all the sections of the page and link them to the ToC's buttons was also being called on pages without the ToC enabled. That was causing the property 'position' to be undefined due to ToC trying to compute multiple items but only finding one, resulting in multiple of these errors in the console:

<img width="528" height="64" alt="image" src="https://github.com/user-attachments/assets/82391ea4-ea2e-45e2-8f9a-e0cce3133217" />


### Changelog
- packages/web-components/src/components/table-of-contents/table-of-contents.ts

added some conditions to validate if there are enough elements to trigger the calculations.
