### PR TITLE
fix(masthead-cart): new filter for id-id URL

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-cart.ts
+++ b/packages/web-components/src/components/masthead/masthead-cart.ts
@@ -85,8 +85,6 @@ class C4DMastheadCart extends StableSelectorMixin(LitElement) {
       href = `/store/${lc}/${cc}/checkout`;
     }
 
-    console.log(href);
-
     return html`
       <a
         part="cart-link"

--- a/packages/web-components/src/components/masthead/masthead-cart.ts
+++ b/packages/web-components/src/components/masthead/masthead-cart.ts
@@ -72,12 +72,15 @@ class C4DMastheadCart extends StableSelectorMixin(LitElement) {
 
     let href;
 
+    // To be investigated: Using Switch Case triggers a race condition for some reason.
     if (cc === 'uk') {
       href = '/store/en/gb/checkout';
     } else if (cc === 'ae') {
       href = '/store/en/ae/checkout';
     } else if (cc === 'sa') {
       href = '/store/en/sa/checkout';
+    } else if (cc === 'id') {
+      href = '/store/en/id/checkout';
     } else {
       href = `/store/${lc}/${cc}/checkout`;
     }


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-11522

### Description

New filter for the shopping cart URL:

when in ID-ID locale, the url should be: https://www.ibm.com/store/en/id/checkout

### Changelog

- packages/web-components/src/components/masthead/masthead-cart.ts

new 'ELIF' added to handle the proper id-id checkout URL
