### PR TITLE
feat(card-group-item): render override to add a new div with part after

### DIFF
--- a/packages/web-components/src/components/card-group/card-group-item.ts
+++ b/packages/web-components/src/components/card-group/card-group-item.ts
@@ -1,12 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+import { TemplateResult, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import settings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
@@ -55,6 +56,22 @@ class C4DCardGroupItem extends C4DCard {
    */
   static get selectorFooter() {
     return `${c4dPrefix}-card-footer`;
+  }
+
+  render(): TemplateResult<1> {
+    return this._hasPictogram
+      ? html`
+          <div part="container">
+            ${this._renderInner()} ${this._renderArrow()}
+            <div part="after"></div>
+          </div>
+        `
+      : html`
+          <div part="container">
+            ${this._renderInner()}
+            <div part="after"></div>
+          </div>
+        `;
   }
 
   static styles = styles;


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-11324

### Description

This PR introduces a new override method for `render()`

in that method we're adding a new `<div part="after">` element for the AEM team/Jeremy Frank to interact and make the new features in the card group component. 

`<c4d-card-group>`
`  <c4d-card-group-item>`
`    <div part="container"> <!-- Existing container part -->`
`      <!-- Existing parts first (image-wrapper, wrapper, link) -->`
`      <div part="after"></div> <!-- NEW empty part last -->`
`    </div>`
`  <c4d-card-group-item>`
`<c4d-card-group>`

### Changelog

- packages/web-components/src/components/card-group/card-group-item.ts

- Creating a new encapsulated `render()` method so that `card-group-items` renders that new div inside of `div part=container`
