### PR TITLE
fix(card-group): add keyframe animation and a new part

### DIFF
--- a/packages/web-components/src/components/card-group/card-group.scss
+++ b/packages/web-components/src/components/card-group/card-group.scss
@@ -1,10 +1,26 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 @use '@carbon/ibmdotcom-styles/scss/components/card-group' as *;
+
+@property --percentage {
+  inherits: false;
+  initial-value: 0%;
+  syntax: '<percentage>';
+}
+
+@keyframes wrap-border {
+  0% {
+    --percentage: 0%;
+  }
+
+  100% {
+    --percentage: 100%;
+  }
+}

--- a/packages/web-components/src/components/card/card.scss
+++ b/packages/web-components/src/components/card/card.scss
@@ -1,8 +1,24 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2020, 2026
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
 @use '@carbon/ibmdotcom-styles/scss/components/card';
+
+@property --percentage {
+  inherits: false;
+  initial-value: 0%;
+  syntax: '<percentage>';
+}
+
+@keyframes wrap-border {
+  0% {
+    --percentage: 0%;
+  }
+
+  100% {
+    --percentage: 100%;
+  }
+}

--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2025
+ * Copyright IBM Corp. 2019, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -484,9 +484,15 @@ class C4DCard extends CTAMixin(StableSelectorMixin(CDSLink)) {
       ? html`
           <div part="container">
             ${this._renderInner()} ${this._renderArrow()}
+            <div part="after"></div>
           </div>
         `
-      : html` <div part="container">${this._renderInner()}</div> `;
+      : html`
+          <div part="container">
+            ${this._renderInner()}
+            <div part="after"></div>
+          </div>
+        `;
   }
 
   static get stableSelector() {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-11643

### Description

Adding a new div with shadow part inside of c4d-card and adding keyframe tokens to `c4d-card` and `c4d-card-group-item`

### Changelog

- packages/web-components/src/components/card-group/card-group.scss
- packages/web-components/src/components/card/card.scss
-- Keyframes added for hover animation being worked by Jeremy


- packages/web-components/src/components/card/card.ts
-- New element with a shadow part inside of c4d-card to be targeted by Jeremy's work
