### PR TITLE
fix(Videoplayer): Fix container div to fit its parent height

### DIFF
--- a/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
+++ b/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
@@ -126,7 +126,12 @@ let _embedQueue = Promise.resolve();
  * @param {number} attempt Per-call retry count
  * @private
  */
-function _scriptReady(resolve, reject, environment = _ibmEnvironment, attempt = 0) {
+function _scriptReady(
+  resolve,
+  reject,
+  environment = _ibmEnvironment,
+  attempt = 0
+) {
   /**
    * @param {object} root?.IBM.Mediacenter.player if exists then resolve
    */

--- a/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
+++ b/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
@@ -100,14 +100,6 @@ function _loadScript(environment = _ibmEnvironment) {
 const _timeoutRetries = 50;
 
 /**
- * Tracks the number of attempts for the script ready loop
- *
- * @type {number}
- * @private
- */
-let _attempt = 0;
-
-/**
  * Tracks the script status
  *
  * @type {boolean} _scriptLoading to track the script loading or not
@@ -116,13 +108,25 @@ let _attempt = 0;
 let _scriptLoading = false;
 
 /**
+ * Serializes concurrent embed calls. The IBM Mediacenter player.embed() does
+ * not reliably support simultaneous calls for the same entryId, so we chain
+ * each call onto the previous one to ensure they run sequentially.
+ *
+ * @type {Promise<any>}
+ * @private
+ */
+let _embedQueue = Promise.resolve();
+
+/**
  * Timeout loop to check script state is the _scriptLoaded state or _scriptLoading state
  *
  * @param {Function} resolve Resolve function
  * @param {Function} reject Reject function
+ * @param {string} environment The player environment
+ * @param {number} attempt Per-call retry count
  * @private
  */
-function _scriptReady(resolve, reject, environment = _ibmEnvironment) {
+function _scriptReady(resolve, reject, environment = _ibmEnvironment, attempt = 0) {
   /**
    * @param {object} root?.IBM.Mediacenter.player if exists then resolve
    */
@@ -130,18 +134,16 @@ function _scriptReady(resolve, reject, environment = _ibmEnvironment) {
     _scriptLoading = false;
     resolve();
   } else if (_scriptLoading) {
-    _attempt++;
-
-    if (_attempt < _timeoutRetries) {
+    if (attempt < _timeoutRetries) {
       setTimeout(() => {
-        _scriptReady(resolve, reject, environment);
+        _scriptReady(resolve, reject, environment, attempt + 1);
       }, 100);
     } else {
       reject();
     }
   } else {
     _loadScript(environment);
-    _scriptReady(resolve, reject, environment);
+    _scriptReady(resolve, reject, environment, attempt);
   }
 }
 
@@ -324,7 +326,8 @@ class KalturaPlayerAPIV7 {
         return kalturaPlayer;
       };
 
-      return legacyPromiseKWidget();
+      _embedQueue = _embedQueue.then(() => legacyPromiseKWidget());
+      return _embedQueue;
     });
   }
 }

--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -55,6 +55,7 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
     ::slotted(.#{$c4d-prefix}--video-player__video),
     .#{$c4d-prefix}--video-player__video {
       aspect-ratio: var(--native-file-aspect-ratio, 16 / 9);
+      block-size: 100%;
       inset: 50% 0 0 50%;
       min-block-size: 100%;
       min-inline-size: 100%;

--- a/packages/web-components/src/components/video-player-v7/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-composite.ts
@@ -438,8 +438,10 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
 
   renderLightDOM() {
     // setting the direction mode of the video player.
-    this.querySelector('.c4d--video-player__video')
-      ?.setAttribute('dir-mode', `${this.isRTL ? 'rtl' : 'ltr'}`);
+    this.querySelector('.c4d--video-player__video')?.setAttribute(
+      'dir-mode',
+      `${this.isRTL ? 'rtl' : 'ltr'}`
+    );
 
     const {
       aspectRatio,

--- a/packages/web-components/src/components/video-player-v7/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-composite.ts
@@ -438,8 +438,7 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
 
   renderLightDOM() {
     // setting the direction mode of the video player.
-    document
-      .querySelector('.c4d--video-player__video')
+    this.querySelector('.c4d--video-player__video')
       ?.setAttribute('dir-mode', `${this.isRTL ? 'rtl' : 'ltr'}`);
 
     const {


### PR DESCRIPTION
## Problem

When using `c4d-background-media` with a `c4d-video-player-container-v7` in `background-mode`, or placing two or more video player containers on the same page, only the first video would load. The remaining containers appeared but were never populated by the Kaltura player.

## Root causes & fixes

### 1. Concurrent `embed()` calls (`KalturaPlayer.js`)
Both containers called `IBM.Mediacenter.player.embed()` simultaneously with the same `entryId`. The IBM Mediacenter library does not reliably handle concurrent embed requests for the same video entry — the second call returns `null`, leaving its container with no player instance.

**Fix:** introduced a module-level `_embedQueue` that chains each `embed()` call onto the previous one, ensuring they run sequentially.

### 2. Shared retry counter (`KalturaPlayer.js`)
The `_attempt` counter used by `_scriptReady()` to wait for the IBM script to load was a shared module-level variable. Two concurrent callers each incremented it on every tick, effectively halving the 5s timeout to ~2.5s and causing one container to give up prematurely on a cold first load.

**Fix:** made `attempt` a per-call parameter passed through recursion instead of a shared module-level variable.

### 3. Wrong `querySelector` scope (`video-player-composite.ts`)
`renderLightDOM()` used `document.querySelector('.c4d--video-player__video')` to set the RTL `dir-mode` attribute, which always targeted the **first** video div in the entire document regardless of which container instance triggered the render.

**Fix:** scoped to `this.querySelector(...)` so each instance only targets its own video div.

### 4. Container div height (`_video-player.scss`)
The inner video container div was not inheriting its parent's height in `background-mode`, causing the video to be invisible even when successfully embedded.

**Fix:** added `block-size: 100%` to the container div.