### PR TITLE
PrefType IBM then do not check IDM pref type

### DIFF
--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -750,7 +750,6 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
     let preText = '';
 
     // 1. Base text depending on email
-    console.log('emailValid', this.emailValid);
     if (!this.emailValid) {
       preText = content.annualDefaultText;
     } else {

--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -384,6 +384,17 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
   }
 
   onEmailChange() {
+    const isSupported = this.supportedBusinessPartners.some(
+      (partner) => partner.toLowerCase() === this.prefType.toLowerCase()
+    );
+
+    if (isSupported) {
+      this.isAnnualPeriodExpired = true;
+      this.emailValid = true;
+      this._handleEmailCheckFailure({ email: 'N', phone: 'N' }, true);
+      return;
+    }
+
     const email = this.email;
     const oneYearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
 
@@ -405,7 +416,6 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
 
         // If bad date, treat as expired
         if (!isValidDate) {
-          console.warn('Invalid annualPeriod:', lastUpdated);
           this.isAnnualPeriodExpired = true;
           this._handleEmailCheckFailure(data, true);
           return;
@@ -714,7 +724,8 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
       <span part="container">
         <div
           class="${prefix}--form-item cds--checkbox-wrapper"
-          part="checkbox-wrapper">
+          part="checkbox-wrapper"
+        >
           <input
             type="checkbox"
             class="${prefix}--checkbox"
@@ -722,15 +733,18 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
             id="${checkboxId}"
             name="${checkboxId}"
             ?checked="${checked}"
-            @change="${this.checkCombineEmailPhoneBoxChange}" />
+            @change="${this.checkCombineEmailPhoneBoxChange}"
+          />
           <label
             for="${checkboxId}"
             class="${prefix}--checkbox-label ${prefix}--nc__checkbox-${checkboxId}"
-            part="checkbox-label">
+            part="checkbox-label"
+          >
             <span
               class="${prefix}--checkbox-label-text"
               part="checkbox-label-text"
-              dir="auto">
+              dir="auto"
+            >
               ${unsafeHTML(preText)}
             </span>
           </label>
@@ -750,6 +764,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
     let preText = '';
 
     // 1. Base text depending on email
+    console.log('emailValid', this.emailValid);
     if (!this.emailValid) {
       preText = content.annualDefaultText;
     } else {
@@ -893,7 +908,8 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
           ? html`<span
               class="nc-error"
               part="error"
-              style="color:#da1e28;font-size:.75rem">
+              style="color:#da1e28;font-size:.75rem"
+            >
               ${checkbox.error}
             </span>`
           : null;
@@ -902,7 +918,8 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
         <span>
           <div
             class="${prefix}--form-item bx--checkbox-wrapper"
-            part="checkbox-wrapper checkbox-wrapper--mandatory">
+            part="checkbox-wrapper checkbox-wrapper--mandatory"
+          >
             <p part=${legalTextName} class=${legalTextName}>
               <input
                 type="checkbox"
@@ -910,15 +927,18 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
                 part="checkbox checkbox--mandatory"
                 id="${checkbox.mrs_field}"
                 name="${checkbox.mrs_field}"
-                @change="${this.checkBoxLegalChange}" />
+                @change="${this.checkBoxLegalChange}"
+              />
               <label
                 for="${checkbox.mrs_field}"
                 class="${prefix}--checkbox-label ${prefix}--nc__checkbox-${checkbox.mrs_field}"
-                part="checkbox-label checkbox-label--mandatory">
+                part="checkbox-label checkbox-label--mandatory"
+              >
                 <span
                   class="${prefix}--checkbox-label-text"
                   part="checkbox-label-text checkbox-label-text--mandatory"
-                  dir="auto">
+                  dir="auto"
+                >
                   ${checkbox.text}
                 </span>
               </label>
@@ -1094,7 +1114,8 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
         <cds-skeleton-text
           linecount="3"
           width="100%"
-          paragraph="true"></cds-skeleton-text>
+          paragraph="true"
+        ></cds-skeleton-text>
       </div>`;
     }
 

--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -384,17 +384,6 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
   }
 
   onEmailChange() {
-    const isSupported = this.supportedBusinessPartners.some(
-      (partner) => partner.toLowerCase() === this.prefType.toLowerCase()
-    );
-
-    if (isSupported) {
-      this.isAnnualPeriodExpired = true;
-      this.emailValid = true;
-      this._handleEmailCheckFailure({ email: 'N', phone: 'N' }, true);
-      return;
-    }
-
     const email = this.email;
     const oneYearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
 
@@ -404,6 +393,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
     checkEmailStatus(
       email,
       this.environment,
+      this.prefType,
       (data) => {
         this.isLoading = false;
         this.emailValid = true;

--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -724,8 +724,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
       <span part="container">
         <div
           class="${prefix}--form-item cds--checkbox-wrapper"
-          part="checkbox-wrapper"
-        >
+          part="checkbox-wrapper">
           <input
             type="checkbox"
             class="${prefix}--checkbox"
@@ -733,18 +732,15 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
             id="${checkboxId}"
             name="${checkboxId}"
             ?checked="${checked}"
-            @change="${this.checkCombineEmailPhoneBoxChange}"
-          />
+            @change="${this.checkCombineEmailPhoneBoxChange}" />
           <label
             for="${checkboxId}"
             class="${prefix}--checkbox-label ${prefix}--nc__checkbox-${checkboxId}"
-            part="checkbox-label"
-          >
+            part="checkbox-label">
             <span
               class="${prefix}--checkbox-label-text"
               part="checkbox-label-text"
-              dir="auto"
-            >
+              dir="auto">
               ${unsafeHTML(preText)}
             </span>
           </label>
@@ -908,8 +904,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
           ? html`<span
               class="nc-error"
               part="error"
-              style="color:#da1e28;font-size:.75rem"
-            >
+              style="color:#da1e28;font-size:.75rem">
               ${checkbox.error}
             </span>`
           : null;
@@ -918,8 +913,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
         <span>
           <div
             class="${prefix}--form-item bx--checkbox-wrapper"
-            part="checkbox-wrapper checkbox-wrapper--mandatory"
-          >
+            part="checkbox-wrapper checkbox-wrapper--mandatory">
             <p part=${legalTextName} class=${legalTextName}>
               <input
                 type="checkbox"
@@ -927,18 +921,15 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
                 part="checkbox checkbox--mandatory"
                 id="${checkbox.mrs_field}"
                 name="${checkbox.mrs_field}"
-                @change="${this.checkBoxLegalChange}"
-              />
+                @change="${this.checkBoxLegalChange}" />
               <label
                 for="${checkbox.mrs_field}"
                 class="${prefix}--checkbox-label ${prefix}--nc__checkbox-${checkbox.mrs_field}"
-                part="checkbox-label checkbox-label--mandatory"
-              >
+                part="checkbox-label checkbox-label--mandatory">
                 <span
                   class="${prefix}--checkbox-label-text"
                   part="checkbox-label-text checkbox-label-text--mandatory"
-                  dir="auto"
-                >
+                  dir="auto">
                   ${checkbox.text}
                 </span>
               </label>
@@ -1114,8 +1105,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
         <cds-skeleton-text
           linecount="3"
           width="100%"
-          paragraph="true"
-        ></cds-skeleton-text>
+          paragraph="true"></cds-skeleton-text>
       </div>`;
     }
 

--- a/packages/web-components/src/components/notice-choice/notice-choice.ts
+++ b/packages/web-components/src/components/notice-choice/notice-choice.ts
@@ -830,6 +830,7 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
   }
 
   checkBoxLegalChange(event: Event) {
+    event.preventDefault();
     const target = event.target as HTMLInputElement;
     if (!target) {
       return;
@@ -914,7 +915,9 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
               <label
                 for="${checkbox.mrs_field}"
                 class="${prefix}--checkbox-label ${prefix}--nc__checkbox-${checkbox.mrs_field}"
-                part="checkbox-label checkbox-label--mandatory">
+                part="checkbox-label checkbox-label--mandatory"
+                @click="${(e: Event) =>
+                  this.mandatoryCheckboxLabelClick(e, checkbox.mrs_field)}">
                 <span
                   class="${prefix}--checkbox-label-text"
                   part="checkbox-label-text checkbox-label-text--mandatory"
@@ -929,6 +932,16 @@ class NoticeChoice extends StableSelectorMixin(LitElement) {
       `;
     });
   }
+
+  mandatoryCheckboxLabelClick(event: Event, mrsField: string) {
+    event.preventDefault();
+    const input = this.shadowRoot?.getElementById(mrsField) as HTMLInputElement;
+    if (input) {
+      input.checked = !input.checked;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }
+
   postTextTemplate() {
     if (this.ncData) {
       const OtherPreferences = this.ncData.trialPrivacyText;

--- a/packages/web-components/src/components/notice-choice/services.ts
+++ b/packages/web-components/src/components/notice-choice/services.ts
@@ -68,6 +68,7 @@ export function loadSettings(env: string, onSuccess: any, onError: any) {
 export function checkEmailStatus(
   email: string,
   env: string,
+  prefType: string,
   onSuccess: (data: any) => void,
   onError: (err?: any) => void
 ) {
@@ -79,7 +80,7 @@ export function checkEmailStatus(
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ email }), // sending email in request body
+    body: JSON.stringify({ email, prefType }), // sending email in request body
   })
     .then((response) => {
       if (!response.ok) {


### PR DESCRIPTION
### Related Ticket(s)

[Noitce & Choice w3 Publisher](https://w3.ibm.com/w3publisher/urx/notice-and-choice-v23)

### Description

Notice & Choice is a legally required component to create a form where IBM collects its customer information.
This section shows the specific product's legal links, terms, and conditions. Along with this, it collects users' consent regarding communication preferences.

### Changelog

**New**
-  If IBM, do not check IDM preferences and simply return 'N' because Apptio or any other preference is not considered an IBM preference.

**Changed**


**Removed**

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->