### PR TITLE
fix(video-player): rtl caption wrong inline size

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2025
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -158,6 +158,7 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
   // Ensuring caption is correctly displayed when it has RTL mixed with LTR copy
   .#{$c4d-prefix}--video-player__video-caption[dir='rtl'] {
     direction: rtl;
+    max-inline-size: none;
     text-align: end;
     unicode-bidi: plaintext;
   }


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-11741

### Description

Fixing RTL caption display:

Before:
<img width="1348" height="209" alt="image" src="https://github.com/user-attachments/assets/95b1e98d-c69b-4b74-be43-2bbccb4a0b65" />

After:
<img width="1340" height="219" alt="image" src="https://github.com/user-attachments/assets/915aab91-e1e8-4c97-b037-01152c817729" />



<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
