### PR TITLE
fix(Kaltura): Adding global scope variable to control other Kaltura i…

### DIFF
--- a/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
+++ b/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
@@ -84,7 +84,7 @@ const _ibmScriptUrl = (environment = _ibmEnvironment) => {
  * @private
  */
 function _loadScript(environment = _ibmEnvironment) {
-  _scriptLoading = true;
+  root._ibmKalturaScriptLoading = true;
   const script = document.createElement('script');
   script.src = _ibmScriptUrl(environment);
   script.async = true;
@@ -100,12 +100,19 @@ function _loadScript(environment = _ibmEnvironment) {
 const _timeoutRetries = 50;
 
 /**
- * Tracks the script status
+ * Tracks the script loading status. Stored on `root` (window) so the value
+ * persists when this module is executed more than once in the same page
+ * (e.g. once as an async page script and again as a deferred Adobe Target
+ * Experience Fragment script). Without this, a second execution resets the
+ * flag to false and causes _loadScript() to inject loader.js a second time,
+ * creating a race condition that leaves embedMedia() pending indefinitely.
  *
- * @type {boolean} _scriptLoading to track the script loading or not
+ * @type {boolean}
  * @private
  */
-let _scriptLoading = false;
+if (root._ibmKalturaScriptLoading === undefined) {
+  root._ibmKalturaScriptLoading = false;
+}
 
 /**
  * Serializes concurrent embed calls. The IBM Mediacenter player.embed() does
@@ -136,9 +143,9 @@ function _scriptReady(
    * @param {object} root?.IBM.Mediacenter.player if exists then resolve
    */
   if (root?.IBM?.Mediacenter?.player) {
-    _scriptLoading = false;
+    root._ibmKalturaScriptLoading = false;
     resolve();
-  } else if (_scriptLoading) {
+  } else if (root._ibmKalturaScriptLoading) {
     if (attempt < _timeoutRetries) {
       setTimeout(() => {
         _scriptReady(resolve, reject, environment, attempt + 1);


### PR DESCRIPTION
 ### Description
Fixes a race condition in `KalturaPlayerV7/KalturaPlayer.js` where `embedMedia()` would get stuck in a perpetually pending Promise when the bundle was executed more than once on the same page.
 
**Root cause**
 
`_scriptLoading` was a module-level variable, meaning it reset to `false` every time the webpack bundle executed. In Adobe Target personalization scenarios, the bundle can load twice on the same page — once as an `async` script from the page-level leadspace, and again as a `defer` script injected by a Target Experience Fragment.
 
When the second execution ran while `loader.js` was still in flight:
1. `_scriptLoading` reset to `false`
2. `_scriptReady()` saw `_scriptLoading === false` and called `_loadScript()` again
3. A second `loader.js` was injected into the DOM
4. The race condition between the two `loader.js` instances left `embedMedia()` pending indefinitely — the video never rendered
The issue was only reproducible on page refresh (cached resources load fast, so Target fires before `loader.js` finishes). On a cold load, the cookie consent modal introduced enough delay that `loader.js` finished loading before the second bundle execution, so `_scriptReady()` resolved immediately and the race never occurred.
 
**Fix**
 
Moved `_scriptLoading` from module scope to `window` scope (`root._ibmKalturaScriptLoading`), initialized with an `=== undefined` guard so it is only set on the first execution. Subsequent executions inherit the existing state, preventing a second `_loadScript()` call.
 
```js
// Before — resets on every bundle execution
let _scriptLoading = false;
 
// After — persists across executions, only initialized once
if (root._ibmKalturaScriptLoading === undefined) {
  root._ibmKalturaScriptLoading = false;
}
```