### PR TITLE
feat(cta-text): icon zoom on hover animation

### DIFF
--- a/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
+++ b/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2024
+ * Copyright IBM Corp. 2016, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,6 +14,7 @@
 @use '../../globals/vars' as *;
 @use '../../globals/imports' as *;
 @use '../lightbox-media-viewer/lightbox-media-viewer';
+@use '@carbon/styles/scss/motion' as *;
 
 @mixin link-with-icon {
   .#{$prefix}--link-with-icon,
@@ -26,6 +27,41 @@
       align-self: center;
       vertical-align: middle;
     }
+    /* stylelint-disable a11y/media-prefers-reduced-motion */
+
+    @media screen and (prefers-reduced-motion: reduce) {
+      svg,
+      ::slotted(svg[slot='icon']) {
+        display: inline;
+        align-self: middle;
+        fill: currentColor;
+        margin-inline-start: $spacing-03;
+        transform-origin: center;
+        transition: none;
+      }
+    }
+    @media screen and (prefers-reduced-motion: reduce) {
+      svg,
+      ::slotted(svg[slot='icon']) {
+        display: inline;
+        align-self: middle;
+        fill: currentColor;
+        margin-inline-start: $spacing-03;
+        transform-origin: center;
+        transition: none;
+      }
+    }
+    @media screen and (prefers-reduced-motion: reduce) {
+      svg,
+      ::slotted(svg[slot='icon']) {
+        display: inline;
+        align-self: middle;
+        fill: currentColor;
+        margin-inline-start: $spacing-03;
+        transform-origin: center;
+        transition: none;
+      }
+    }
 
     svg,
     ::slotted(svg[slot='icon']) {
@@ -33,6 +69,16 @@
       align-self: middle;
       fill: currentColor;
       margin-inline-start: $spacing-03;
+      transform-origin: center;
+      transition: transform $duration-moderate-01
+        motion('standard', 'productive');
+    }
+
+    &:hover {
+      svg[part='test'],
+      ::slotted(svg[slot='icon'][part='test']) {
+        transform: scale(1.1);
+      }
     }
 
     &.#{$prefix}--link--visited {
@@ -128,6 +174,18 @@
   :host(#{$c4d-prefix}-text-cta) {
     &:focus {
       outline: none;
+    }
+  }
+
+  @media screen and (prefers-reduced-motion: reduce) {
+    .#{$prefix}--link-with-icon,
+    :host(#{$c4d-prefix}-link-with-icon),
+    :host(#{$c4d-prefix}-text-cta) {
+      svg,
+      ::slotted(svg[slot='icon']) {
+        transform: none;
+        transition: none;
+      }
     }
   }
 

--- a/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
+++ b/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
@@ -40,28 +40,6 @@
         transition: none;
       }
     }
-    @media screen and (prefers-reduced-motion: reduce) {
-      svg,
-      ::slotted(svg[slot='icon']) {
-        display: inline;
-        align-self: middle;
-        fill: currentColor;
-        margin-inline-start: $spacing-03;
-        transform-origin: center;
-        transition: none;
-      }
-    }
-    @media screen and (prefers-reduced-motion: reduce) {
-      svg,
-      ::slotted(svg[slot='icon']) {
-        display: inline;
-        align-self: middle;
-        fill: currentColor;
-        margin-inline-start: $spacing-03;
-        transform-origin: center;
-        transition: none;
-      }
-    }
 
     svg,
     ::slotted(svg[slot='icon']) {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-11461

### Description

icon zoom on hover animation implemented for cta text links:

<img width="603" height="199" alt="image" src="https://github.com/user-attachments/assets/11c2b002-82e5-4974-97b9-864150eb3f38" />
