### PR TITLE
fix(video-player): add preventScroll to focus call after Kaltura embed

### DIFF
--- a/packages/web-components/src/components/video-player-v7/video-player-container.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-container.ts
@@ -299,7 +299,7 @@ export const C4DVideoPlayerContainerMixin = <
       doc!.getElementById(playerId)!.dataset.videoId = videoId;
       const videoEmbed = doc!.getElementById(playerId)?.firstElementChild;
       if (videoEmbed) {
-        (videoEmbed as HTMLElement).focus();
+        (videoEmbed as HTMLElement).focus({ preventScroll: true });
       }
       return embedVideoHandle;
     }

--- a/packages/web-components/src/components/video-player/video-player-container.ts
+++ b/packages/web-components/src/components/video-player/video-player-container.ts
@@ -308,7 +308,7 @@ export const C4DVideoPlayerContainerMixin = <
       doc!.getElementById(playerId)!.dataset.videoId = videoId;
       const videoEmbed = doc!.getElementById(playerId)?.firstElementChild;
       if (videoEmbed) {
-        (videoEmbed as HTMLElement).focus();
+        (videoEmbed as HTMLElement).focus({ preventScroll: true });
       }
       return embedVideoHandle.kWidget();
     }


### PR DESCRIPTION
When _embedVideoImpl() embeds a Kaltura player, it calls .focus() on the embedded element to address an iOS issue (#8077) where focus must leave the web component shadow root before updates become interactive.

Without { preventScroll: true }, the browser scrolls the viewport to the focused element, overriding any hash-based navigation and causing pages with auto-embedded videos (leadspace, background-media) to jump unexpectedly on load.

Applies to both the legacy video-player and the v7 video-player-container.

Fixes scroll-to-top issue on pages with auto-play leadspace videos.