### PR TITLE
ADCMS-11460:button-icon hover zoom implementation

### DIFF
--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -18,14 +18,16 @@
   :host(#{$c4d-prefix}-button) {
     @include emit-layout-tokens();
 
-    display: inline-flex;@media screen and (prefers-reduced-motion: reduce) {
-svg {
-      @extend .#{$prefix}--btn__icon;
+    display: inline-flex;
 
-      transform-origin: center;
-      transition: none;
-}
-}
+    @media screen and (prefers-reduced-motion: reduce) {
+      svg {
+        @extend .#{$prefix}--btn__icon;
+
+        transform-origin: center;
+        transition: none;
+      }
+    }
 
     svg {
       @extend .#{$prefix}--btn__icon;

--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -1,5 +1,5 @@
 /**
-* Copyright IBM Corp. 2016, 2024
+* Copyright IBM Corp. 2016, 2026
 *
 * This source code is licensed under the Apache-2.0 license found in the
 * LICENSE file in the root directory of this source tree.
@@ -12,20 +12,40 @@
 @use '@carbon/styles/scss/components/button' as *;
 @use '../../globals/vars' as *;
 @use '../../globals/imports' as *;
+@use '@carbon/styles/scss/motion' as *;
 
 @mixin button {
   :host(#{$c4d-prefix}-button) {
     @include emit-layout-tokens();
 
-    display: inline-flex;
+    display: inline-flex;@media screen and (prefers-reduced-motion: reduce) {
+svg {
+      @extend .#{$prefix}--btn__icon;
+
+      transform-origin: center;
+      transition: none;
+}
+}
 
     svg {
       @extend .#{$prefix}--btn__icon;
+
+      transform-origin: center;
+      transition: transform $duration-moderate-01
+        motion('standard', 'productive');
     }
 
     .#{$prefix}--btn {
       flex-grow: 1;
       max-inline-size: 100%;
+
+      &:hover svg {
+        transform: scale(1.1);
+      }
+
+      &:focus-visible svg {
+        transform: scale(1.1);
+      }
     }
 
     .#{$prefix}--btn--hidden {

--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -18,16 +18,14 @@
   :host(#{$c4d-prefix}-button) {
     @include emit-layout-tokens();
 
-    display: inline-flex;
+    display: inline-flex;@media screen and (prefers-reduced-motion: reduce) {
+svg {
+      @extend .#{$prefix}--btn__icon;
 
-    @media screen and (prefers-reduced-motion: reduce) {
-      svg {
-        @extend .#{$prefix}--btn__icon;
-
-        transform-origin: center;
-        transition: none;
-      }
-    }
+      transform-origin: center;
+      transition: none;
+}
+}
 
     svg {
       @extend .#{$prefix}--btn__icon;

--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -18,18 +18,16 @@
   :host(#{$c4d-prefix}-button) {
     @include emit-layout-tokens();
 
-    display: inline-flex;@media screen and (prefers-reduced-motion: reduce) {
-svg {
-      @extend .#{$prefix}--btn__icon;
+    display: inline-flex;
 
-      transform-origin: center;
-      transition: none;
-}
-}
+    @media screen and (prefers-reduced-motion: reduce) {
+      svg {
+        transform-origin: center;
+        transition: none;
+      }
+    }
 
     svg {
-      @extend .#{$prefix}--btn__icon;
-
       transform-origin: center;
       transition: transform $duration-moderate-01
         motion('standard', 'productive');


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-11460](https://jsw.ibm.com/browse/ADCMS-11460)[ADCMS-11460](https://jsw.ibm.com/browse/ADCMS-11460)

### Description

The hover state for buttons should have a small zoom/scale effect on the icon.

-     Scale amount: 1.1 (20px to 22px)
-     Duration: $duration-moderate-01
-     Easing: motion('standard', 'productive')
