### PR TITLE
ADCMS-11741: fix/video-with-dm-rtl-caption

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -158,7 +158,7 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
   // Ensuring caption is correctly displayed when it has RTL mixed with LTR copy
   .#{$c4d-prefix}--video-player__video-caption[dir='rtl'] {
     direction: rtl;
-    max-inline-size: none;
+    max-inline-size: fit-content;
     text-align: end;
     unicode-bidi: plaintext;
   }


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-11741](https://jsw.ibm.com/browse/ADCMS-11741)

### Description

Fixing video caption misalignment in RTL.
<img width="1273" height="711" alt="image" src="https://github.com/user-attachments/assets/18b5a0e0-f4e1-4095-827b-ba7ea6cac886" />

