### PR TITLE
feat(video-player): add cta handling to video-player lightbox mode

### DIFF
--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer.ts
@@ -148,7 +148,7 @@ class C4DLightboxMediaViewer extends C4DLightboxMediaViewerBody {
   connectedCallback() {
     super.connectedCallback();
 
-    this._ctaContents = this.querySelector('[slot="cta"]') || undefined;
+    this._ctaContents = this._ctaContents? this._ctaContents : this.querySelector('[slot="cta"]') || undefined;
     this._containingCarousel =
       (this.closest(`${c4dPrefix}-carousel`) as C4DCarousel) || undefined;
     this._containingModal =

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-media-viewer.ts
@@ -148,7 +148,9 @@ class C4DLightboxMediaViewer extends C4DLightboxMediaViewerBody {
   connectedCallback() {
     super.connectedCallback();
 
-    this._ctaContents = this._ctaContents? this._ctaContents : this.querySelector('[slot="cta"]') || undefined;
+    this._ctaContents = this._ctaContents
+      ? this._ctaContents
+      : this.querySelector('[slot="cta"]') || undefined;
     this._containingCarousel =
       (this.closest(`${c4dPrefix}-carousel`) as C4DCarousel) || undefined;
     this._containingModal =

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
@@ -91,7 +91,7 @@ class C4DLightboxVideoPlayerComposite extends ModalRenderMixin(
     if (currentEmbeddedVideo) {
       currentEmbeddedVideo.pause();
     }
-    
+
     // Return CTA element to original container
     if (this.ctaElement) {
       const container = document.querySelector(
@@ -102,7 +102,7 @@ class C4DLightboxVideoPlayerComposite extends ModalRenderMixin(
       }
       this.ctaElement = null;
     }
-    
+
     this.open = false;
     this._handleAriaAndHiddenState();
   };
@@ -205,11 +205,13 @@ class C4DLightboxVideoPlayerComposite extends ModalRenderMixin(
         if (open) {
           this._embedMedia?.(videoId);
           this._handleAriaAndHiddenState();
-          
+
           // Append CTA element to lightbox video player after modal renders
           if (this.ctaElement) {
             requestAnimationFrame(() => {
-              const lightboxPlayer = this.modalRenderRoot?.querySelector('c4d-lightbox-video-player');
+              const lightboxPlayer = this.modalRenderRoot?.querySelector(
+                'c4d-lightbox-video-player'
+              );
               if (lightboxPlayer && this.ctaElement) {
                 this.ctaElement.setAttribute('slot', 'cta');
                 lightboxPlayer.appendChild(this.ctaElement);

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player-composite.ts
@@ -91,6 +91,18 @@ class C4DLightboxVideoPlayerComposite extends ModalRenderMixin(
     if (currentEmbeddedVideo) {
       currentEmbeddedVideo.pause();
     }
+    
+    // Return CTA element to original container
+    if (this.ctaElement) {
+      const container = document.querySelector(
+        `c4d-video-player-container-v7[video-id="${videoId}"]`
+      ) as any;
+      if (container && typeof container._returnCTA === 'function') {
+        container._returnCTA();
+      }
+      this.ctaElement = null;
+    }
+    
     this.open = false;
     this._handleAriaAndHiddenState();
   };
@@ -106,6 +118,7 @@ class C4DLightboxVideoPlayerComposite extends ModalRenderMixin(
       videoId: requestedVideoId,
       name,
       customVideoDescription,
+      ctaElement,
     } = event.detail;
     if (this.videoCtaLightBox === false) {
       this.videoId = requestedVideoId;
@@ -116,8 +129,9 @@ class C4DLightboxVideoPlayerComposite extends ModalRenderMixin(
         playingMode === VIDEO_PLAYER_PLAYING_MODE.LIGHTBOX
       ) {
         this.customVideoName = name;
-        this.open = true;
         this.customVideoDescription = customVideoDescription;
+        this.ctaElement = ctaElement;
+        this.open = true;
       }
     }
   };
@@ -157,6 +171,12 @@ class C4DLightboxVideoPlayerComposite extends ModalRenderMixin(
   @property({ type: Boolean, attribute: 'video-cta-lightbox' })
   videoCtaLightBox = false;
 
+  /**
+   * Stored CTA element for forwarding from video player
+   */
+  @property({ attribute: false })
+  ctaElement?: HTMLElement | null;
+
   connectedCallback() {
     super.connectedCallback();
     this.modalRenderRoot = this.createModalRenderRoot(); // Creates modal render root up-front to hook the event listener
@@ -185,6 +205,17 @@ class C4DLightboxVideoPlayerComposite extends ModalRenderMixin(
         if (open) {
           this._embedMedia?.(videoId);
           this._handleAriaAndHiddenState();
+          
+          // Append CTA element to lightbox video player after modal renders
+          if (this.ctaElement) {
+            requestAnimationFrame(() => {
+              const lightboxPlayer = this.modalRenderRoot?.querySelector('c4d-lightbox-video-player');
+              if (lightboxPlayer && this.ctaElement) {
+                this.ctaElement.setAttribute('slot', 'cta');
+                lightboxPlayer.appendChild(this.ctaElement);
+              }
+            });
+          }
         }
       }
     }

--- a/packages/web-components/src/components/video-player-v7/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player-v7/__stories__/video-player.stories.ts
@@ -98,7 +98,7 @@ export const withLightboxAndCTA = (args) => {
       thumbnail=${thumbnail}
       playing-mode="lightbox">
       <div slot="cta" style="display: flex; gap: 1rem; margin-top: 1rem;">
-         <div slot="cta">
+        <div slot="cta">
           <c4d-button href="https://example.com" cta-type="local">
             Follow Link
           </c4d-button>
@@ -314,7 +314,8 @@ withLightboxAndCTA.story = {
       default: {
         VideoPlayer: {
           aspectRatio: '16x9',
-          customVideoDescription: 'This is a custom video description with CTA buttons that will be forwarded to the lightbox.',
+          customVideoDescription:
+            'This is a custom video description with CTA buttons that will be forwarded to the lightbox.',
           caption: '',
           hideCaption: false,
           thumbnail: '',

--- a/packages/web-components/src/components/video-player-v7/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player-v7/__stories__/video-player.stories.ts
@@ -79,6 +79,36 @@ export const withLightboxMediaViewer = (args) => {
   `;
 };
 
+export const withLightboxAndCTA = (args) => {
+  const {
+    aspectRatio,
+    caption,
+    hideCaption,
+    thumbnail,
+    videoId,
+    customVideoDescription,
+  } = args?.VideoPlayer ?? {};
+  return html`
+    <c4d-video-player-container-v7
+      video-id=${videoId}
+      aspect-ratio=${aspectRatio}
+      caption=${caption}
+      video-description="${ifDefined(customVideoDescription)}"
+      ?hide-caption=${hideCaption}
+      thumbnail=${thumbnail}
+      playing-mode="lightbox">
+      <div slot="cta" style="display: flex; gap: 1rem; margin-top: 1rem;">
+         <div slot="cta">
+          <c4d-button href="https://example.com" cta-type="local">
+            Follow Link
+          </c4d-button>
+        </div>
+      </div>
+    </c4d-video-player-container-v7>
+    <c4d-lightbox-video-player-container></c4d-lightbox-video-player-container>
+  `;
+};
+
 export const autoplay = (args) => {
   const { aspectRatio, caption, hideCaption, thumbnail, videoId } =
     args?.VideoPlayer ?? {};
@@ -252,6 +282,39 @@ withLightboxMediaViewer.story = {
         VideoPlayer: {
           aspectRatio: '16x9',
           customVideoDescription: 'This is a custom video description',
+          caption: '',
+          hideCaption: false,
+          thumbnail: '',
+          videoId: '0_ibuqxqbe',
+        },
+      },
+    },
+  },
+};
+
+withLightboxAndCTA.story = {
+  name: 'With lightbox and CTA',
+  parameters: {
+    knobs: {
+      VideoPlayer: () => {
+        return {
+          aspectRatio: '16x9',
+          customVideoDescription: text(
+            'Custom video description',
+            'This is a custom video description with CTA buttons that will be forwarded to the lightbox.'
+          ),
+          caption: text('Custom caption (caption):', ''),
+          hideCaption: boolean('Hide caption (hideCaption):', false),
+          thumbnail: text('Custom thumbnail (thumbnail):', ''),
+          videoId: '0_ibuqxqbe',
+        };
+      },
+    },
+    propsSet: {
+      default: {
+        VideoPlayer: {
+          aspectRatio: '16x9',
+          customVideoDescription: 'This is a custom video description with CTA buttons that will be forwarded to the lightbox.',
           caption: '',
           hideCaption: false,
           thumbnail: '',

--- a/packages/web-components/src/components/video-player-v7/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-composite.ts
@@ -167,12 +167,12 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
   @HostListener('eventContentStateChange')
   protected _handleContentStateChange(event: CustomEvent) {
     const { contentState, playingMode, videoId, ctaElement } = event.detail;
-    
+
     // Store CTA element for potential forwarding
     if (ctaElement) {
       this.ctaElement = ctaElement;
     }
-    
+
     if (
       contentState === VIDEO_PLAYER_CONTENT_STATE.VIDEO &&
       playingMode === VIDEO_PLAYER_PLAYING_MODE.INLINE &&

--- a/packages/web-components/src/components/video-player-v7/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-composite.ts
@@ -166,7 +166,13 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
    */
   @HostListener('eventContentStateChange')
   protected _handleContentStateChange(event: CustomEvent) {
-    const { contentState, playingMode, videoId } = event.detail;
+    const { contentState, playingMode, videoId, ctaElement } = event.detail;
+    
+    // Store CTA element for potential forwarding
+    if (ctaElement) {
+      this.ctaElement = ctaElement;
+    }
+    
     if (
       contentState === VIDEO_PLAYER_CONTENT_STATE.VIDEO &&
       playingMode === VIDEO_PLAYER_PLAYING_MODE.INLINE &&
@@ -367,6 +373,12 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
    */
   @property({ type: Boolean })
   isRTL = false;
+
+  /**
+   * Stored CTA element for forwarding to lightbox
+   */
+  @property({ attribute: false })
+  ctaElement?: HTMLElement | null;
 
   private observer!: MutationObserver;
 

--- a/packages/web-components/src/components/video-player-v7/video-player-container.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-container.ts
@@ -129,6 +129,34 @@ export const C4DVideoPlayerContainerMixin = <
     lc = '';
 
     /**
+     * Stored CTA element for forwarding to lightbox
+     */
+    @property({ attribute: false })
+    ctaElement?: HTMLElement | null;
+
+    /**
+     * Captures and removes the CTA element from light DOM
+     * @returns The captured CTA element or null
+     */
+    _captureCTA(): HTMLElement | null {
+      const ctaElement = this.querySelector('[slot="cta"]');
+      if (ctaElement && ctaElement.parentNode) {
+        this.ctaElement = ctaElement.parentNode.removeChild(ctaElement) as HTMLElement;
+        return this.ctaElement;
+      }
+      return null;
+    }
+
+    /**
+     * Returns the CTA element to the container
+     */
+    _returnCTA(): void {
+      if (this.ctaElement) {
+        this.appendChild(this.ctaElement);
+      }
+    }
+
+    /**
      * Sets the state that the API call for embedding the video for the given video ID is in progress.
      *
      * @param videoId The video ID.

--- a/packages/web-components/src/components/video-player-v7/video-player-container.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-container.ts
@@ -141,7 +141,9 @@ export const C4DVideoPlayerContainerMixin = <
     _captureCTA(): HTMLElement | null {
       const ctaElement = this.querySelector('[slot="cta"]');
       if (ctaElement && ctaElement.parentNode) {
-        this.ctaElement = ctaElement.parentNode.removeChild(ctaElement) as HTMLElement;
+        this.ctaElement = ctaElement.parentNode.removeChild(
+          ctaElement
+        ) as HTMLElement;
         return this.ctaElement;
       }
       return null;

--- a/packages/web-components/src/components/video-player-v7/video-player.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player.ts
@@ -82,6 +82,16 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
       this.contentState = VIDEO_PLAYER_CONTENT_STATE.VIDEO;
     }
     const { videoId, name, customVideoDescription } = this;
+    
+    // Capture CTA element from parent container if in lightbox mode
+    let ctaElement = null;
+    if (this.playingMode === VIDEO_PLAYER_PLAYING_MODE.LIGHTBOX) {
+      const container = this.closest('c4d-video-player-container-v7') as any;
+      if (container && typeof container._captureCTA === 'function') {
+        ctaElement = container._captureCTA();
+      }
+    }
+    
     const { eventContentStateChange } = this
       .constructor as typeof C4DVideoPlayer;
     this.dispatchEvent(
@@ -94,6 +104,7 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
           playingMode: this.playingMode,
           name,
           customVideoDescription,
+          ctaElement,
         },
       })
     );

--- a/packages/web-components/src/components/video-player-v7/video-player.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player.ts
@@ -82,7 +82,7 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
       this.contentState = VIDEO_PLAYER_CONTENT_STATE.VIDEO;
     }
     const { videoId, name, customVideoDescription } = this;
-    
+
     // Capture CTA element from parent container if in lightbox mode
     let ctaElement = null;
     if (this.playingMode === VIDEO_PLAYER_PLAYING_MODE.LIGHTBOX) {
@@ -91,7 +91,7 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
         ctaElement = container._captureCTA();
       }
     }
-    
+
     const { eventContentStateChange } = this
       .constructor as typeof C4DVideoPlayer;
     this.dispatchEvent(


### PR DESCRIPTION
### Related Ticket(s)

[JIRA](https://jsw.ibm.com/browse/ADCMS-11931)

### Description

This PR adds support for forwarding CTA elements from video player container to the lightbox media viewer when videos are played in lightbox mode

### Changelog

**New**

- Added a new Story under the Video-Player V7 to demonstrate implementation 
