### PR TITLE
ADCMS-11460: pricing-table-header-cell-cta SVG CSS removed

### DIFF
--- a/packages/styles/scss/components/pricing-table/_pricing-table.scss
+++ b/packages/styles/scss/components/pricing-table/_pricing-table.scss
@@ -349,13 +349,6 @@
 
     display: block;
     margin-block-start: $spacing-06;
-
-    .#{$prefix}--btn svg {
-      position: absolute;
-      inset-block-start: 50%;
-      inset-inline-end: $spacing-05;
-      transform: translateY(-50%);
-    }
   }
 
   .#{$prefix}--pricing-table-annotation-toggle,


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-11460](https://jsw.ibm.com/browse/ADCMS-11460)

### Description

Removing the CSS for the `:host(c4d-pricing-table-header-cell-cta) .cds--btn svg` to fix the zoom implementation done on the `c4d-button`