### PR TITLE
Bugfix/kaltura lit render issue

### DIFF
--- a/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
+++ b/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
@@ -84,9 +84,19 @@ const _ibmScriptUrl = (environment = _ibmEnvironment) => {
  * @private
  */
 function _loadScript(environment = _ibmEnvironment) {
+  // loader.js uses top-level const/let declarations and cannot be safely re-injected
+  // into the same page — doing so throws "SyntaxError: Identifier already declared".
+  // If a script tag for this URL already exists in the DOM, skip injection and rely
+  // on the existing execution to eventually set IBM.Mediacenter.player. We still set
+  // the flag to true so _scriptReady stays in polling mode.
+  const loaderUrl = _ibmScriptUrl(environment);
+  if (document.querySelector(`script[src="${loaderUrl}"]`)) {
+    root._ibmKalturaScriptLoading = true;
+    return;
+  }
   root._ibmKalturaScriptLoading = true;
   const script = document.createElement('script');
-  script.src = _ibmScriptUrl(environment);
+  script.src = loaderUrl;
   script.async = true;
   document.body.appendChild(script);
 }
@@ -98,6 +108,18 @@ function _loadScript(environment = _ibmEnvironment) {
  * @private
  */
 const _timeoutRetries = 50;
+
+/**
+ * Milliseconds to wait for IBM.Mediacenter.player.embed() to resolve before
+ * treating it as a missed-event hang. On cached page loads, loader.js's
+ * player-plugin.js can fire its ready event before embed() registers its
+ * listener, leaving the returned Promise pending indefinitely. If that
+ * happens we reset the loader state and retry from scratch.
+ *
+ * @type {number}
+ * @private
+ */
+const _embedTimeoutMs = 8000;
 
 /**
  * Tracks the script loading status. Stored on `root` (window) so the value
@@ -119,10 +141,70 @@ if (root._ibmKalturaScriptLoading === undefined) {
  * not reliably support simultaneous calls for the same entryId, so we chain
  * each call onto the previous one to ensure they run sequentially.
  *
+ * Stored on `root` (window) so the value persists when this module is executed
+ * more than once in the same page (e.g. once as an async page script and again
+ * as a deferred Adobe Target Experience Fragment script). Without this, a second
+ * execution resets the queue to Promise.resolve(), breaking serialization and
+ * allowing simultaneous embed() calls that hang indefinitely.
+ *
  * @type {Promise<any>}
  * @private
  */
-let _embedQueue = Promise.resolve();
+if (root._ibmKalturaEmbedQueue === undefined) {
+  root._ibmKalturaEmbedQueue = Promise.resolve();
+}
+
+/**
+ * Installs a one-time Object.defineProperty setter on root.IBM.Mediacenter.player
+ * so that resolve() is called SYNCHRONOUSLY the instant loader.js assigns the
+ * player object — before player-plugin.js can fire its ready event. This closes
+ * the ~100 ms gap that the polling fallback leaves between the assignment and
+ * the first poll tick, which was causing embed() to miss the ready event (Bug 2).
+ *
+ * Falls back to the polling loop (_scriptReady) if defineProperty is not available
+ * or if IBM.Mediacenter has already been replaced after the trap was installed.
+ *
+ * @param {Function} resolve Resolve function
+ * @private
+ */
+function _trapPlayerReady(resolve) {
+  // If the player is already set, resolve immediately.
+  if (root?.IBM?.Mediacenter?.player) {
+    root._ibmKalturaScriptLoading = false;
+    resolve();
+    return;
+  }
+
+  // Ensure the IBM.Mediacenter path exists so we have an object to trap.
+  root.IBM ??= {};
+  root.IBM.Mediacenter ??= {};
+
+  const mc = root.IBM.Mediacenter;
+  let trapped = false;
+
+  try {
+    Object.defineProperty(mc, 'player', {
+      configurable: true,
+      enumerable: true,
+      set(value) {
+        // Restore as a plain writable property before anything else runs.
+        Object.defineProperty(mc, 'player', {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value,
+        });
+        if (!trapped) {
+          trapped = true;
+          root._ibmKalturaScriptLoading = false;
+          resolve();
+        }
+      },
+    });
+  } catch (_e) {
+    // defineProperty not supported in this environment — fall through to polling.
+  }
+}
 
 /**
  * Timeout loop to check script state is the _scriptLoaded state or _scriptLoading state
@@ -154,8 +236,10 @@ function _scriptReady(
       reject();
     }
   } else {
+    // Install the defineProperty trap BEFORE injecting loader.js so we catch
+    // the player assignment synchronously when loader.js sets IBM.Mediacenter.player.
+    _trapPlayerReady(resolve, reject);
     _loadScript(environment);
-    _scriptReady(resolve, reject, environment, attempt);
   }
 }
 
@@ -275,6 +359,7 @@ class KalturaPlayerAPIV7 {
     return await this.checkScript().then(() => {
       const legacyPromiseKWidget = async () => {
         const playerType = configuration?.playerType ?? 'VIDEO';
+        const envKey = configuration.playerEnvironment ?? _ibmEnvironment;
         const playerEnvironment =
           _ibmEnvironments[configuration.playerEnvironment] ??
           _ibmEnvironments[_ibmEnvironment];
@@ -317,11 +402,91 @@ class KalturaPlayerAPIV7 {
         }
 
         /**
-         * Embed the player and execute custom callback
+         * Embed the player and execute custom callback.
+         *
+         * Wraps embed() with a timeout guard: on cached page loads,
+         * loader.js's player-plugin.js may fire its ready event before
+         * embed() registers its listener, leaving the Promise pending
+         * indefinitely. If the timeout fires we reset the loader state so
+         * _scriptReady() re-injects loader.js, giving the plugin a fresh
+         * chance to fire its event after the listener is in place.
          */
-        const kalturaPlayer = await root?.IBM?.Mediacenter?.player?.embed(
-          playerConfiguration
-        );
+        // If the target element was removed from the DOM before we get here
+        // (e.g. Adobe Target replaced the mbox while embed() was queued),
+        // skip the embed entirely so we don't block _embedQueue indefinitely.
+        if (!document.getElementById(targetId)) {
+          return null;
+        }
+
+        let kalturaPlayer;
+        try {
+          kalturaPlayer = await Promise.race([
+            root.IBM.Mediacenter.player.embed(playerConfiguration),
+            new Promise((_, reject) =>
+              setTimeout(
+                () => reject(new Error('ibm_embed_timeout')),
+                _embedTimeoutMs
+              )
+            ),
+          ]);
+        } catch (embedErr) {
+          if (embedErr?.message !== 'ibm_embed_timeout') {
+            throw embedErr;
+          }
+
+          // Only perform a full reset (delete player, re-inject loader.js) when
+          // the loader has already finished (_ibmKalturaScriptLoading === false)
+          // AND loader.js is not yet in the DOM (so re-injection is safe).
+          // loader.js uses top-level const/let declarations and crashes with
+          // "SyntaxError: Identifier already declared" on a second injection, so
+          // we skip the delete+reinject path when it's already present and instead
+          // rely on polling to detect when IBM.Mediacenter.player becomes available.
+          const loaderUrl = _ibmScriptUrl(envKey);
+          const loaderAlreadyInjected = !!document.querySelector(
+            `script[src="${loaderUrl}"]`
+          );
+          if (root._ibmKalturaScriptLoading === false && !loaderAlreadyInjected) {
+            root._ibmKalturaScriptLoading = undefined;
+            if (root.IBM?.Mediacenter) {
+              delete root.IBM.Mediacenter;
+            }
+          }
+          await new Promise((res, rej) =>
+            _scriptReady(res, rej, envKey)
+          );
+
+          // Re-check after the async wait — the element may have been removed
+          // while _scriptReady was retrying (e.g. during a Target mbox swap).
+          if (!document.getElementById(targetId)) {
+            return null;
+          }
+
+          // Wrap the retry with the same timeout guard. If loader.js was already
+          // in the DOM (cannot be re-injected), IBM.Mediacenter.player.embed()
+          // may still hang because player-plugin.js's ready event already fired
+          // before this call was registered. In that case we return null so the
+          // queue unblocks rather than hanging the page permanently.
+          try {
+            kalturaPlayer = await Promise.race([
+              root.IBM.Mediacenter.player.embed(playerConfiguration),
+              new Promise((_, reject) =>
+                setTimeout(
+                  () => reject(new Error('ibm_embed_timeout_retry')),
+                  _embedTimeoutMs
+                )
+              ),
+            ]);
+          } catch (retryErr) {
+            if (retryErr?.message !== 'ibm_embed_timeout_retry') {
+              throw retryErr;
+            }
+            // Both the initial embed() and the retry timed out. The
+            // player-plugin.js ready event has been permanently missed on
+            // this page load. Return null to unblock _ibmKalturaEmbedQueue
+            // so subsequent embed calls can still proceed.
+            return null;
+          }
+        }
         customReadyCallback(kalturaPlayer);
 
         if (isCustomCreated) {
@@ -338,8 +503,10 @@ class KalturaPlayerAPIV7 {
         return kalturaPlayer;
       };
 
-      _embedQueue = _embedQueue.then(() => legacyPromiseKWidget());
-      return _embedQueue;
+      root._ibmKalturaEmbedQueue = root._ibmKalturaEmbedQueue
+        .catch(() => {})
+        .then(() => legacyPromiseKWidget());
+      return root._ibmKalturaEmbedQueue;
     });
   }
 }

--- a/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
+++ b/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
@@ -240,6 +240,15 @@ function _scriptReady(
     // the player assignment synchronously when loader.js sets IBM.Mediacenter.player.
     _trapPlayerReady(resolve, reject);
     _loadScript(environment);
+    // Also poll as a backstop: if IBM.Mediacenter gets replaced wholesale instead
+    // of mutated in place, the trap above is orphaned and would never fire.
+    if (attempt < _timeoutRetries) {
+      setTimeout(() => {
+        _scriptReady(resolve, reject, environment, attempt + 1);
+      }, 100);
+    } else {
+      reject();
+    }
   }
 }
 

--- a/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
+++ b/packages/services/src/services/KalturaPlayerV7/KalturaPlayer.js
@@ -445,15 +445,16 @@ class KalturaPlayerAPIV7 {
           const loaderAlreadyInjected = !!document.querySelector(
             `script[src="${loaderUrl}"]`
           );
-          if (root._ibmKalturaScriptLoading === false && !loaderAlreadyInjected) {
+          if (
+            root._ibmKalturaScriptLoading === false &&
+            !loaderAlreadyInjected
+          ) {
             root._ibmKalturaScriptLoading = undefined;
             if (root.IBM?.Mediacenter) {
               delete root.IBM.Mediacenter;
             }
           }
-          await new Promise((res, rej) =>
-            _scriptReady(res, rej, envKey)
-          );
+          await new Promise((res, rej) => _scriptReady(res, rej, envKey));
 
           // Re-check after the async wait — the element may have been removed
           // while _scriptReady was retrying (e.g. during a Target mbox swap).

--- a/packages/services/src/services/KalturaPlayerV7/__tests__/KalturaPlayer.test.js
+++ b/packages/services/src/services/KalturaPlayerV7/__tests__/KalturaPlayer.test.js
@@ -204,6 +204,7 @@ describe('KalturaPlayerAPI', () => {
     const mediaId = 'test-media-id';
     _kalturaPlayerPluginMock();
     _mockKalturaPlayer();
+    document.body.innerHTML += '<div id="test-target-id"></div>';
 
     await KalturaPlayerAPI.embedMedia(
       mediaId,

--- a/packages/web-components/src/components/video-player-v7/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-composite.ts
@@ -52,6 +52,18 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
   _embedMedia?: (videoId: string) => Promise<any>;
 
   /**
+   * Listener registered on `at-content-rendering-succeeded/failed` while waiting
+   * for Adobe Target to settle before setting up the IntersectionObserver.
+   * Stored so it can be removed in `disconnectedCallback`.
+   */
+  private _atSettleHandler?: () => void;
+
+  /**
+   * Fallback timer ID used when Adobe Target never fires its settle events.
+   */
+  private _atFallback?: number;
+
+  /**
    * The placeholder for `_setAutoplayPreference()` Redux action that may be mixed in.
    */
   // @ts-ignore
@@ -135,10 +147,18 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
    */
   private _intersectionIntoViewHandler(entries: IntersectionObserverEntry[]) {
     const { videoId } = this;
-    entries.forEach((entry) => {
+    entries.forEach(async (entry) => {
       if (entry.isIntersecting && this._getAutoplayPreference() !== false) {
-        this._embedMedia?.(videoId);
-        this.playAllVideos();
+        await this.updateComplete;
+        this._embedMedia?.(videoId)?.then?.((player) => {
+          if (player) {
+            this.playAllVideos();
+          }
+        })?.catch?.((err) => {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn('[VP-DEBUG] embed failed in IO handler', err);
+          }
+        });
       }
     });
   }
@@ -410,7 +430,27 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
     }
 
     if (this.intersectionMode) {
-      this._cleanAndCreateObserverIntersection({ create: true });
+      const atJsActive = !!(window as any).adobe?.target;
+      if (atJsActive) {
+        const setupIO = () => this._cleanAndCreateObserverIntersection({ create: true });
+        const onATSettle = () => {
+          document.removeEventListener('at-content-rendering-succeeded', onATSettle);
+          document.removeEventListener('at-content-rendering-failed', onATSettle);
+          if (this._atFallback) {
+            clearTimeout(this._atFallback);
+            this._atFallback = undefined;
+          }
+          this._atSettleHandler = undefined;
+          setupIO();
+        };
+        this._atSettleHandler = onATSettle;
+        document.addEventListener('at-content-rendering-succeeded', onATSettle, { once: true });
+        document.addEventListener('at-content-rendering-failed', onATSettle, { once: true });
+        // Fallback: if AT events never fire, set up IO after 4s so video still works
+        this._atFallback = setTimeout(onATSettle, 4000) as unknown as number;
+      } else {
+        this._cleanAndCreateObserverIntersection({ create: true });
+      }
     }
 
     // initializing the MutationObserver to observe for changes in the direction mode
@@ -432,7 +472,24 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    if (this._atSettleHandler) {
+      document.removeEventListener('at-content-rendering-succeeded', this._atSettleHandler);
+      document.removeEventListener('at-content-rendering-failed', this._atSettleHandler);
+      this._atSettleHandler = undefined;
+    }
+    if (this._atFallback) {
+      clearTimeout(this._atFallback);
+      this._atFallback = undefined;
+    }
     this._cleanAndCreateObserverIntersection();
+    const { embeddedVideos = {} } = this;
+    Object.values(embeddedVideos).forEach((player: any) => {
+      try {
+        player?.destroy?.();
+      } catch (error) {
+        // Ignore errors from destroy.
+      }
+    });
   }
 
   updated(changedProperties) {

--- a/packages/web-components/src/components/video-player-v7/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-composite.ts
@@ -64,6 +64,27 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
   private _atFallback?: number;
 
   /**
+   * Observer watching for removal of the AEP Web SDK (alloy) prehiding style
+   * (`<style id="alloy-prehiding">`), which signals that personalization
+   * decisions have been rendered. Used instead of the at.js
+   * `at-content-rendering-*` events on pages running alloy, which never fires
+   * those events.
+   */
+  private _atPrehidingObserver?: MutationObserver;
+
+  /**
+   * Placeholder divs parked in `document.body` by `_embedVideoImpl` (mixed in
+   * by the container) while a Kaltura embed is queued or in flight. Tracked so
+   * `disconnectedCallback` can remove them: once removed, the
+   * `getElementById(targetId)` guard in `legacyPromiseKWidget` returns null
+   * and the dead embed drains from `_ibmKalturaEmbedQueue` immediately instead
+   * of fully embedding a hidden orphaned player.
+   *
+   * @internal
+   */
+  _ibmPendingEmbedDivs?: Set<HTMLElement>;
+
+  /**
    * The placeholder for `_setAutoplayPreference()` Redux action that may be mixed in.
    */
   // @ts-ignore
@@ -150,15 +171,17 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
     entries.forEach(async (entry) => {
       if (entry.isIntersecting && this._getAutoplayPreference() !== false) {
         await this.updateComplete;
-        this._embedMedia?.(videoId)?.then?.((player) => {
-          if (player) {
-            this.playAllVideos();
-          }
-        })?.catch?.((err) => {
-          if (process.env.NODE_ENV !== 'production') {
-            console.warn('[VP-DEBUG] embed failed in IO handler', err);
-          }
-        });
+        this._embedMedia?.(videoId)
+          ?.then?.((player) => {
+            if (player) {
+              this.playAllVideos();
+            }
+          })
+          ?.catch?.((err) => {
+            if (process.env.NODE_ENV !== 'production') {
+              console.warn('[VP-DEBUG] embed failed in IO handler', err);
+            }
+          });
       }
     });
   }
@@ -430,12 +453,40 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
     }
 
     if (this.intersectionMode) {
-      const atJsActive = !!(window as any).adobe?.target;
-      if (atJsActive) {
-        const setupIO = () => this._cleanAndCreateObserverIntersection({ create: true });
+      // alloy never fires at.js events, so we watch for #alloy-prehiding
+      // removal instead; classic at.js fires at-content-rendering-*. No
+      // signal pending means no personalization is coming, so skip the wait.
+      const prehidingEl = document.getElementById('alloy-prehiding');
+      const atObj = (window as any).adobe?.target;
+      const realAtJs =
+        !!atObj &&
+        (typeof atObj.getOffers === 'function' ||
+          typeof atObj.getOffer === 'function' ||
+          typeof atObj.applyOffers === 'function');
+      if (prehidingEl || realAtJs) {
+        // Warm the Kaltura SDK while we wait for AT to settle, so loader.js
+        // downloads in parallel with the AT defer instead of after it.
+        KalturaPlayerAPI.checkScript().catch(() => {});
+        let settled = false;
+        const setupIO = () =>
+          this._cleanAndCreateObserverIntersection({ create: true });
         const onATSettle = () => {
-          document.removeEventListener('at-content-rendering-succeeded', onATSettle);
-          document.removeEventListener('at-content-rendering-failed', onATSettle);
+          if (settled) {
+            return;
+          }
+          settled = true;
+          document.removeEventListener(
+            'at-content-rendering-succeeded',
+            onATSettle
+          );
+          document.removeEventListener(
+            'at-content-rendering-failed',
+            onATSettle
+          );
+          if (this._atPrehidingObserver) {
+            this._atPrehidingObserver.disconnect();
+            this._atPrehidingObserver = undefined;
+          }
           if (this._atFallback) {
             clearTimeout(this._atFallback);
             this._atFallback = undefined;
@@ -444,10 +495,34 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
           setupIO();
         };
         this._atSettleHandler = onATSettle;
-        document.addEventListener('at-content-rendering-succeeded', onATSettle, { once: true });
-        document.addEventListener('at-content-rendering-failed', onATSettle, { once: true });
-        // Fallback: if AT events never fire, set up IO after 4s so video still works
-        this._atFallback = setTimeout(onATSettle, 4000) as unknown as number;
+        document.addEventListener(
+          'at-content-rendering-succeeded',
+          onATSettle,
+          { once: true }
+        );
+        document.addEventListener('at-content-rendering-failed', onATSettle, {
+          once: true,
+        });
+        if (prehidingEl) {
+          // alloy: settle when the prehiding style is removed from the DOM.
+          this._atPrehidingObserver = new MutationObserver(() => {
+            if (!document.getElementById('alloy-prehiding')) {
+              onATSettle();
+            }
+          });
+          this._atPrehidingObserver.observe(
+            prehidingEl.parentNode || document.documentElement,
+            { childList: true }
+          );
+          // Guard against a race: removed between getElementById and observe().
+          if (!document.getElementById('alloy-prehiding')) {
+            onATSettle();
+          }
+        }
+        // Fallback: if no settle signal ever arrives, set up IO after 4s so video still works
+        if (!settled) {
+          this._atFallback = setTimeout(onATSettle, 4000) as unknown as number;
+        }
       } else {
         this._cleanAndCreateObserverIntersection({ create: true });
       }
@@ -473,13 +548,30 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
   disconnectedCallback() {
     super.disconnectedCallback();
     if (this._atSettleHandler) {
-      document.removeEventListener('at-content-rendering-succeeded', this._atSettleHandler);
-      document.removeEventListener('at-content-rendering-failed', this._atSettleHandler);
+      document.removeEventListener(
+        'at-content-rendering-succeeded',
+        this._atSettleHandler
+      );
+      document.removeEventListener(
+        'at-content-rendering-failed',
+        this._atSettleHandler
+      );
       this._atSettleHandler = undefined;
+    }
+    if (this._atPrehidingObserver) {
+      this._atPrehidingObserver.disconnect();
+      this._atPrehidingObserver = undefined;
     }
     if (this._atFallback) {
       clearTimeout(this._atFallback);
       this._atFallback = undefined;
+    }
+    // Removing these placeholders makes legacyPromiseKWidget's getElementById
+    // guard fail fast, draining dead embeds from the queue instead of
+    // blocking the next one behind a hidden orphaned player.
+    if (this._ibmPendingEmbedDivs) {
+      this._ibmPendingEmbedDivs.forEach((div) => div.remove());
+      this._ibmPendingEmbedDivs.clear();
     }
     this._cleanAndCreateObserverIntersection();
     const { embeddedVideos = {} } = this;

--- a/packages/web-components/src/components/video-player-v7/video-player-container.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-container.ts
@@ -117,6 +117,17 @@ export const C4DVideoPlayerContainerMixin = <
     _requestsEmbedVideo: { [videoId: string]: Promise<any> } = {};
 
     /**
+     * Placeholder divs parked in `document.body` by `_embedVideoImpl` while a
+     * Kaltura embed is queued or in flight. `disconnectedCallback` (in the
+     * composite) removes them so dead embeds drain from
+     * `_ibmKalturaEmbedQueue` immediately after this component is removed
+     * (e.g. when Adobe Target swaps DC for an XF).
+     *
+     * @internal
+     */
+    _ibmPendingEmbedDivs?: Set<HTMLElement>;
+
+    /**
      * Custom video name
      */
     @property({ type: String, attribute: 'customvideoname' })
@@ -311,25 +322,35 @@ export const C4DVideoPlayerContainerMixin = <
           'Cannot find the video player component to put the video content into.'
         );
       }
-      // Append the div to document.body (hidden off-screen) instead of videoPlayer.
-      // This prevents Lit's renderLightDOM() from detaching the div during the
-      // async _ibmKalturaEmbedQueue wait (which can be 6-20s). If the div is
-      // inside c4d-video-player-v7 when Lit re-renders after a Redux dispatch,
-      // the element is replaced and the div is detached — causing
-      // legacyPromiseKWidget's getElementById(playerId) to return null, so
-      // the embed returns null and the video stays on the thumbnail slot.
-      // By keeping the div in document.body, getElementById always finds it.
+      // Parked in document.body, not videoPlayer, so Lit's renderLightDOM()
+      // can't detach it mid-embed (the queue wait can run 6-20s) and orphan
+      // legacyPromiseKWidget's getElementById(playerId) lookup.
       div.style.cssText = 'position:fixed;left:-9999px;visibility:hidden';
       document.body.appendChild(div);
+      // Tracked so disconnectedCallback can remove it if this component is
+      // torn down mid-queue, freeing the embed instead of leaving it to
+      // finish as a hidden orphan.
+      (this._ibmPendingEmbedDivs ??= new Set()).add(div);
 
       let embedVideoHandle;
       try {
-        embedVideoHandle = await KalturaPlayerAPI.embedMedia(
-          videoId,
-          playerId,
-          this._getPlayerOptions()
-        );
-        const { width, height } = await KalturaPlayerAPI.api(videoId);
+        // Run the embed and the metadata fetch in parallel — saves a round-trip.
+        const [handle, { width, height }] = await Promise.all([
+          KalturaPlayerAPI.embedMedia(
+            videoId,
+            playerId,
+            this._getPlayerOptions()
+          ),
+          KalturaPlayerAPI.api(videoId),
+        ]);
+        embedVideoHandle = handle;
+
+        // If we were disconnected during the wait, discard the embed.
+        if (!this.isConnected) {
+          div.remove();
+          this._ibmPendingEmbedDivs?.delete(div);
+          return null;
+        }
 
         // Move the div (now containing Kaltura's iframe) into the video player.
         // Re-fetch _videoPlayer in case Lit re-rendered and replaced the element
@@ -337,9 +358,16 @@ export const C4DVideoPlayerContainerMixin = <
         const currentVideoPlayer = this._videoPlayer ?? videoPlayer;
         div.style.cssText = '';
         currentVideoPlayer.appendChild(div);
+        this._ibmPendingEmbedDivs?.delete(div);
 
-        currentVideoPlayer.style.setProperty('--native-file-width', `${width}px`);
-        currentVideoPlayer.style.setProperty('--native-file-height', `${height}px`);
+        currentVideoPlayer.style.setProperty(
+          '--native-file-width',
+          `${width}px`
+        );
+        currentVideoPlayer.style.setProperty(
+          '--native-file-height',
+          `${height}px`
+        );
         currentVideoPlayer.style.setProperty(
           '--native-file-aspect-ratio',
           `${width} / ${height}`
@@ -349,6 +377,7 @@ export const C4DVideoPlayerContainerMixin = <
         if (div.parentElement) {
           div.remove();
         }
+        this._ibmPendingEmbedDivs?.delete(div);
         throw error;
       }
 

--- a/packages/web-components/src/components/video-player-v7/video-player-container.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-container.ts
@@ -330,7 +330,10 @@ export const C4DVideoPlayerContainerMixin = <
       // Tracked so disconnectedCallback can remove it if this component is
       // torn down mid-queue, freeing the embed instead of leaving it to
       // finish as a hidden orphan.
-      (this._ibmPendingEmbedDivs ??= new Set()).add(div);
+      if (!this._ibmPendingEmbedDivs) {
+        this._ibmPendingEmbedDivs = new Set();
+      }
+      this._ibmPendingEmbedDivs.add(div);
 
       let embedVideoHandle;
       try {

--- a/packages/web-components/src/components/video-player-v7/video-player-container.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-container.ts
@@ -311,22 +311,51 @@ export const C4DVideoPlayerContainerMixin = <
           'Cannot find the video player component to put the video content into.'
         );
       }
-      videoPlayer.appendChild(div);
+      // Append the div to document.body (hidden off-screen) instead of videoPlayer.
+      // This prevents Lit's renderLightDOM() from detaching the div during the
+      // async _ibmKalturaEmbedQueue wait (which can be 6-20s). If the div is
+      // inside c4d-video-player-v7 when Lit re-renders after a Redux dispatch,
+      // the element is replaced and the div is detached — causing
+      // legacyPromiseKWidget's getElementById(playerId) to return null, so
+      // the embed returns null and the video stays on the thumbnail slot.
+      // By keeping the div in document.body, getElementById always finds it.
+      div.style.cssText = 'position:fixed;left:-9999px;visibility:hidden';
+      document.body.appendChild(div);
 
-      const embedVideoHandle = await KalturaPlayerAPI.embedMedia(
-        videoId,
-        playerId,
-        this._getPlayerOptions()
-      );
-      const { width, height } = await KalturaPlayerAPI.api(videoId);
-      videoPlayer.style.setProperty('--native-file-width', `${width}px`);
-      videoPlayer.style.setProperty('--native-file-height', `${height}px`);
-      videoPlayer.style.setProperty(
-        '--native-file-aspect-ratio',
-        `${width} / ${height}`
-      );
+      let embedVideoHandle;
+      try {
+        embedVideoHandle = await KalturaPlayerAPI.embedMedia(
+          videoId,
+          playerId,
+          this._getPlayerOptions()
+        );
+        const { width, height } = await KalturaPlayerAPI.api(videoId);
 
-      doc!.getElementById(playerId)!.dataset.videoId = videoId;
+        // Move the div (now containing Kaltura's iframe) into the video player.
+        // Re-fetch _videoPlayer in case Lit re-rendered and replaced the element
+        // while we were awaiting the embed queue.
+        const currentVideoPlayer = this._videoPlayer ?? videoPlayer;
+        div.style.cssText = '';
+        currentVideoPlayer.appendChild(div);
+
+        currentVideoPlayer.style.setProperty('--native-file-width', `${width}px`);
+        currentVideoPlayer.style.setProperty('--native-file-height', `${height}px`);
+        currentVideoPlayer.style.setProperty(
+          '--native-file-aspect-ratio',
+          `${width} / ${height}`
+        );
+      } catch (error) {
+        // Clean up hidden div if embed failed
+        if (div.parentElement) {
+          div.remove();
+        }
+        throw error;
+      }
+
+      const playerEl = doc!.getElementById(playerId);
+      if (playerEl) {
+        playerEl.dataset.videoId = videoId;
+      }
       const videoEmbed = doc!.getElementById(playerId)?.firstElementChild;
       if (videoEmbed) {
         (videoEmbed as HTMLElement).focus({ preventScroll: true });


### PR DESCRIPTION
## Fix: Video player autoplay with Adobe Target (`video-player-v7`)

### Problem

When Adobe Target replaced the Default Content with an Experience Fragment
containing a video player, the video would render the thumbnail but never
autoplay. The issue was intermittent.

**Root cause:** A race condition between Lit's render cycle and the Kaltura
embed queue. When Adobe Target injects the XF, it triggers a new Lit render
that can replace the `c4d-video-player-v7` element in the DOM — detaching the
Kaltura placeholder `div` that was already appended to it. By the time
Kaltura's serial queue got to the XF embed (up to 20s later),
`document.getElementById(placeholderId)` returned `null` and the embed
silently failed.

---

### Changes

**`video-player-composite.ts`**

- Added AT-defer logic in `connectedCallback`: when `adobe.target` is
  detected, the `IntersectionObserver` setup is deferred until
  `at-content-rendering-succeeded` or `at-content-rendering-failed` fires
  (4s fallback). This prevents the XF video from starting its embed flow
  before AT has finished injecting content.
- Added `await this.updateComplete` in `_intersectionIntoViewHandler` before
  calling `_embedMedia`, so Lit's first render has settled before the embed
  begins.
- Added `disconnectedCallback` cleanup for the AT event listeners and
  fallback timer.

**`video-player-container.ts`**

- In `_embedVideoImpl`, the Kaltura placeholder `div` is now appended to
  `document.body` (hidden off-screen) instead of directly into
  `c4d-video-player-v7`. This keeps it in the document regardless of any Lit
  re-renders during the async queue wait. After the embed resolves, the `div`
  (now containing the Kaltura iframe) is moved into the video player element.