### PR TITLE
ADCMS-12037: link-with-icon zoom-hover fix

### DIFF
--- a/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
+++ b/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
@@ -53,8 +53,8 @@
     }
 
     &:hover {
-      svg[part='test'],
-      ::slotted(svg[slot='icon'][part='test']) {
+      svg,
+      ::slotted(svg[slot='icon']) {
         transform: scale(1.1);
       }
     }


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-12037](https://jsw.ibm.com/browse/ADCMS-12037)
[ADCMS-11641](https://jsw.ibm.com/browse/ADCMS-11641)
[ADCMS-11640](https://jsw.ibm.com/browse/ADCMS-11640)
[ADCMS-11639](https://jsw.ibm.com/browse/ADCMS-11639)

### Description

The hover state for text links with icons should have a small zoom/scale effect on the icon.

    Scale amount: 1.1 (20px to 22px)
    Duration: $duration-moderate-01
    Easing: motion('standard', 'productive')
