### PR TITLE
fix(video-player): play icon to be positioned at the lower right

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -191,8 +191,10 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
 
     svg {
       position: absolute;
-      inset-block-start: calc(50% - #{$spacing-07});
-      inset-inline-end: calc(50% - #{$spacing-07});
+      block-size: 2.5rem;
+      inline-size: 2.5rem;
+      inset-block-end: 1rem;
+      inset-inline-end: 1rem;
 
       circle,
       path {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-11455

### Description

Updating the position of the play/pause icon in the video players to be at the lower right corner.

<img width="967" height="770" alt="image" src="https://github.com/user-attachments/assets/b11d2fd3-4736-41c1-9543-01b2b5e0e86c" />



