### PR TITLE
fix(pricing-table): change token value for header cell bot spacing

### DIFF
--- a/packages/styles/scss/components/pricing-table/_pricing-table.scss
+++ b/packages/styles/scss/components/pricing-table/_pricing-table.scss
@@ -207,7 +207,7 @@
 
   .#{$prefix}--pricing-table-header-cell:not([scope='row']),
   :host(#{$c4d-prefix}-pricing-table-header-cell:not([scope='row'])) {
-    padding-block-end: $spacing-08;
+    padding-block-end: $spacing-07;
     transition: padding-block-end $duration-slow-01 motion(standard, productive);
 
     &.#{$prefix}--pricing-table-header-cell--sticky {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-11875

### Description

Pricing table header cell bottom spacing token change

<img width="1379" height="418" alt="image" src="https://github.com/user-attachments/assets/07d5e2d1-066b-44dc-b6fa-46d2a3f3f1ff" />

