### PR TITLE
fix(carousel): rtl slides position miscalculation

### DIFF
--- a/packages/web-components/src/components/carousel/carousel.ts
+++ b/packages/web-components/src/components/carousel/carousel.ts
@@ -570,17 +570,21 @@ class C4DCarousel extends HostListenerMixin(StableSelectorMixin(LitElement)) {
    * Calculates the width between cards.
    */
   private _updateGap() {
-    if (this.dir === 'rtl') {
-      return;
-    }
     const { _slotNode: slotNode } = this;
     const elems = slotNode!.assignedElements();
 
+    if (elems.length < 2) {
+      this._gap = 0;
+      return;
+    }
+
+    const firstRect = elems[0].getBoundingClientRect();
+    const secondRect = elems[1].getBoundingClientRect();
+
     this._gap =
-      elems.length < 2
-        ? 0
-        : elems[1].getBoundingClientRect().left -
-          elems[0].getBoundingClientRect().right;
+      this.dir === 'rtl'
+        ? firstRect.left - secondRect.right
+        : secondRect.left - firstRect.right;
   }
 
   private _updateContentsPosition(changedProperties) {


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-11881

### Description

Carousel component was not correctly calculating the position of the slides in RTL mode.
I made a small change to the `_updateGap()` method to properly calculate them in RTL.

Before:
<img width="1259" height="738" alt="image" src="https://github.com/user-attachments/assets/ea0f4324-c411-48b2-9d91-e15f52b068ef" />

After:
<img width="1257" height="742" alt="image" src="https://github.com/user-attachments/assets/a051da0d-6bec-4559-910f-7e1c9b3bd667" />


### Changelog

- packages/web-components/src/components/carousel/carousel.ts
updates to the _updateGap() method
