### PR TITLE
fix: double highlight issue

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -877,6 +877,9 @@ class C4DMastheadComposite extends HostListenerMixin(LitElement) {
     } else if (submenu instanceof Array) {
       matchFound = Boolean(
         (submenu as BasicLink[]).find((link) => {
+          if (link.url == '') {
+            return false;
+          }
           const normalizedLinkUrl = this._normalizeUrl(link.url);
           // Only match if link URL exists and equals current URL
           return (


### PR DESCRIPTION
### Related Ticket(s)

[JIRA]()

### Description
Adds Stop condition to handle empty strings on mastheads links 