### PR TITLE
ADCMS-12185: accessibility video-player aria-label fix

### DIFF
--- a/packages/web-components/src/components/video-player-v7/video-player.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player.ts
@@ -338,10 +338,9 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
                 class="${togglePlaybackClass}"
                 @click="${handleTogglePlayback}"
                 tabindex="0"
-                part="button">
-                ${this.isPlaying
-                  ? PauseOutline({ 'aria-label': 'Pause' })
-                  : PlayOutline({ 'aria-label': 'Play' })}
+                part="button"
+                aria-label="${this.isPlaying ? 'Pause' : 'Play'}">
+                ${this.isPlaying ? PauseOutline() : PlayOutline()}
               </button>
             `
           : null}

--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -318,10 +318,9 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
                 class="${togglePlaybackClass}"
                 @click="${handleTogglePlayback}"
                 tabindex="0"
-                part="button">
-                ${this.isPlaying
-                  ? PauseOutline({ 'aria-label': 'Pause' })
-                  : PlayOutline({ 'aria-label': 'Play' })}
+                part="button"
+                aria-label="${this.isPlaying ? 'Pause' : 'Play'}">
+                ${this.isPlaying ? PauseOutline() : PlayOutline()}
               </button>
             `
           : null}


### PR DESCRIPTION
### Related Ticket(s)

[ADCMS-12185](https://jsw.ibm.com/browse/ADCMS-12185)

### Description

Lighthouse reports multiple interactive elements without accessible names on the IBM Homepage.

The issue affects at least two Carbon components:

<strike>Masthead</strike>
c4d-video-player-container-v7

The audit highlights controls that are visually identifiable (language selector, media controls, etc.) but do not expose an accessible name to assistive technologies.

Examples observed include:

<del>Masthead language selector.</del>
Video player pause/play control.

The objective is to investigate why these controls are missing accessible names and implement the appropriate accessibility solution.

<img width="1609" height="740" alt="image" src="https://github.com/user-attachments/assets/313e5945-4e4e-4fe4-9139-c465c2887ffd" />
