### PR TITLE
fix(structured-list): adjust text cta css for slots

### DIFF
--- a/packages/styles/scss/components/structured-list/_structured-list.scss
+++ b/packages/styles/scss/components/structured-list/_structured-list.scss
@@ -317,7 +317,7 @@
   }
 
   :host(#{$c4d-prefix}-structured-list-cell) {
-    #{$c4d-prefix}-text-cta {
+    ::slotted(#{$c4d-prefix}-text-cta) {
       margin-inline-start: 0;
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

https://jsw.ibm.com/browse/ADCMS-11709

### Description

Adusting the css for slotted text ctas inside of c4d-structured-list-cell