### PR TITLE
feat(lightbox): take the theme from the slotted component

### DIFF
--- a/packages/web-components/src/components/cta/video-cta-composite.ts
+++ b/packages/web-components/src/components/cta/video-cta-composite.ts
@@ -126,8 +126,9 @@ class C4DVideoCTAComposite extends ModalRenderMixin(
   @HostListener('eventRunAction')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleRunAction(event: CustomEvent) {
-    const { ctaType, href, videoName, videoDescription, ctaContents, theme } =
+    const { ctaType, href, videoName, videoDescription, ctaContents } =
       event.detail;
+    let { theme } = event.detail;
     const { selectorVideoPlayer, selectorLightboxVideoPlayerComposite } = this
       .constructor as typeof C4DVideoCTAComposite;
     if (ctaType === CTA_TYPE.VIDEO) {
@@ -136,6 +137,9 @@ class C4DVideoCTAComposite extends ModalRenderMixin(
       this._videoDescription = videoDescription;
       this._ctaContents = ctaContents;
       if (ctaContents) {
+        if (!theme && ctaContents.hasAttribute('theme')) {
+          theme = ctaContents.getAttribute('theme');
+        }
         const videoPlayerComposite = (
           this.modalRenderRoot as Element
         ).querySelector(


### PR DESCRIPTION

### Description
This PR handles passing the theme from the slotted CTA component down to the lightbox when the event run action method is triggered. 

### Changelog

**New**
Theme prop propagation from slotted CTA to lightbox via the event run action method
