### PR TITLE
feat(video-player): Add image zoom on hover functionality

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -40,6 +40,16 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
     }
   }
 
+  :host(#{$c4d-prefix}-video-player-v7) #{$c4d-prefix}-image::part(image),
+  .#{$c4d-prefix}--video-player #{$c4d-prefix}-image::part(image) {
+    transition: scale $duration-slow-01 motion(standard, productive);
+    will-change: scale;
+
+    @media screen and (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+  }
+
   :host(#{$c4d-prefix}-video-player-v7[background-mode]),
   .#{$c4d-prefix}--video-player[background-mode] {
     .#{$c4d-prefix}--video-player__video-container {
@@ -220,6 +230,15 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
         opacity: 0.12;
       }
     }
+  }
+
+  :host(#{$c4d-prefix}-video-player-v7:not([intersection-mode]):not([auto-play]):not([background-mode]):not([disable-image-zoom]))
+    .#{$c4d-prefix}--video-player__image-overlay:hover
+    #{$c4d-prefix}-image::part(image),
+  .#{$c4d-prefix}--video-player:not([intersection-mode]):not([auto-play]):not([background-mode]):not([disable-image-zoom])
+    .#{$c4d-prefix}--video-player__image-overlay:hover
+    #{$c4d-prefix}-image::part(image) {
+    scale: 1.05;
   }
 
   .#{$c4d-prefix}--video-player__toggle-playback {

--- a/packages/web-components/src/components/video-player-v7/__stories__/video-player.stories.react.tsx
+++ b/packages/web-components/src/components/video-player-v7/__stories__/video-player.stories.react.tsx
@@ -13,12 +13,13 @@ import C4DVideoPlayerContainer from '@carbon/ibmdotcom-web-components/es/compone
 import readme from './README.stories.react.mdx';
 
 export const Default = (args) => {
-  const { aspectRatio, caption, hideCaption, videoId } =
+  const { aspectRatio, caption, disableImageZoom, hideCaption, videoId } =
     args?.VideoPlayerContainer ?? {};
   return (
     <C4DVideoPlayerContainer
       aspectRatio={aspectRatio}
       caption={caption}
+      disableImageZoom={disableImageZoom}
       hideCaption={hideCaption}
       videoId={videoId}
     />
@@ -26,12 +27,13 @@ export const Default = (args) => {
 };
 
 export const aspectRatio1x1 = (args) => {
-  const { aspectRatio, caption, hideCaption, videoId } =
+  const { aspectRatio, caption, disableImageZoom, hideCaption, videoId } =
     args?.VideoPlayerContainer ?? {};
   return (
     <C4DVideoPlayerContainer
       aspectRatio={aspectRatio}
       caption={caption}
+      disableImageZoom={disableImageZoom}
       hideCaption={hideCaption}
       videoId={videoId}
     />
@@ -46,6 +48,7 @@ aspectRatio1x1.story = {
         return {
           aspectRatio: '1x1',
           caption: text('Custom caption (caption):', ''),
+          disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
           hideCaption: boolean('Hide caption (hideCaption):', false),
           thumbnail: text('Custom thumbnail (thumbnail):', ''),
           videoId: '1_9h94wo6b',
@@ -56,12 +59,13 @@ aspectRatio1x1.story = {
 };
 
 export const aspectRatio4x3 = (args) => {
-  const { aspectRatio, caption, hideCaption, videoId } =
+  const { aspectRatio, caption, disableImageZoom, hideCaption, videoId } =
     args?.VideoPlayerContainer ?? {};
   return (
     <C4DVideoPlayerContainer
       aspectRatio={aspectRatio}
       caption={caption}
+      disableImageZoom={disableImageZoom}
       hideCaption={hideCaption}
       videoId={videoId}
     />
@@ -76,6 +80,7 @@ aspectRatio4x3.story = {
         return {
           aspectRatio: '4x3',
           caption: text('Custom caption (caption):', ''),
+          disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
           hideCaption: boolean('Hide caption (hideCaption):', false),
           thumbnail: text('Custom thumbnail (thumbnail):', ''),
           videoId: '1_p2osmd1z',
@@ -101,6 +106,7 @@ export default {
     knobs: {
       VideoPlayerContainer: () => ({
         caption: text('Custom caption (caption):', ''),
+        disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
         hideCaption: boolean('Hide caption (hideCaption):', false),
         thumbnailUrl: text('Custom thumbnail (thumbnail):', ''),
         videoId: '1_w19e0yid',

--- a/packages/web-components/src/components/video-player-v7/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player-v7/__stories__/video-player.stories.ts
@@ -17,19 +17,7 @@ import { enumValsToArray } from '../../../globals/internal/enum-helpers';
 import { BUTTON_POSITION } from '../defs';
 
 export const Default = (args) => {
-  const { caption, hideCaption, thumbnail, videoId } = args?.VideoPlayer ?? {};
-  return html`
-    <c4d-video-player-container-v7
-      playing-mode="inline"
-      video-id=${videoId}
-      caption=${caption}
-      ?hide-caption=${hideCaption}
-      thumbnail=${thumbnail}></c4d-video-player-container-v7>
-  `;
-};
-
-export const aspectRatio1x1 = (args) => {
-  const { aspectRatio, caption, hideCaption, thumbnail, videoId } =
+  const { caption, disableImageZoom, hideCaption, thumbnail, videoId } =
     args?.VideoPlayer ?? {};
   return html`
     <c4d-video-player-container-v7
@@ -37,13 +25,28 @@ export const aspectRatio1x1 = (args) => {
       video-id=${videoId}
       caption=${caption}
       ?hide-caption=${hideCaption}
+      ?disable-image-zoom=${disableImageZoom}
+      thumbnail=${thumbnail}></c4d-video-player-container-v7>
+  `;
+};
+
+export const aspectRatio1x1 = (args) => {
+  const { aspectRatio, caption, disableImageZoom, hideCaption, thumbnail, videoId } =
+    args?.VideoPlayer ?? {};
+  return html`
+    <c4d-video-player-container-v7
+      playing-mode="inline"
+      video-id=${videoId}
+      caption=${caption}
+      ?hide-caption=${hideCaption}
+      ?disable-image-zoom=${disableImageZoom}
       aspect-ratio=${aspectRatio}
       thumbnail=${thumbnail}></c4d-video-player-container-v7>
   `;
 };
 
 export const aspectRatio4x3 = (args) => {
-  const { aspectRatio, caption, hideCaption, thumbnail, videoId } =
+  const { aspectRatio, caption, disableImageZoom, hideCaption, thumbnail, videoId } =
     args?.VideoPlayer ?? {};
   return html`
     <c4d-video-player-container-v7
@@ -52,6 +55,7 @@ export const aspectRatio4x3 = (args) => {
       aspect-ratio=${aspectRatio}
       caption=${caption}
       ?hide-caption=${hideCaption}
+      ?disable-image-zoom=${disableImageZoom}
       thumbnail=${thumbnail}></c4d-video-player-container-v7>
   `;
 };
@@ -60,6 +64,7 @@ export const withLightboxMediaViewer = (args) => {
   const {
     aspectRatio,
     caption,
+    disableImageZoom,
     hideCaption,
     thumbnail,
     videoId,
@@ -72,6 +77,7 @@ export const withLightboxMediaViewer = (args) => {
       caption=${caption}
       video-description="${ifDefined(customVideoDescription)}"
       ?hide-caption=${hideCaption}
+      ?disable-image-zoom=${disableImageZoom}
       thumbnail=${thumbnail}
       playing-mode="lightbox">
     </c4d-video-player-container-v7>
@@ -83,6 +89,7 @@ export const withLightboxAndCTA = (args) => {
   const {
     aspectRatio,
     caption,
+    disableImageZoom,
     hideCaption,
     thumbnail,
     videoId,
@@ -95,6 +102,7 @@ export const withLightboxAndCTA = (args) => {
       caption=${caption}
       video-description="${ifDefined(customVideoDescription)}"
       ?hide-caption=${hideCaption}
+      ?disable-image-zoom=${disableImageZoom}
       thumbnail=${thumbnail}
       playing-mode="lightbox">
       <div slot="cta" style="display: flex; gap: 1rem; margin-top: 1rem;">
@@ -125,7 +133,8 @@ export const autoplay = (args) => {
 };
 
 export const autoplayMuted = (args) => {
-  const { caption, hideCaption, thumbnail, videoId } = args?.VideoPlayer ?? {};
+  const { caption, hideCaption, thumbnail, videoId } =
+    args?.VideoPlayer ?? {};
   return html`
     <style>
       c4d-video-player-container-v7[background-mode] {
@@ -146,7 +155,8 @@ export const autoplayMuted = (args) => {
 };
 
 export const transparentBackground = (args) => {
-  const { caption, hideCaption, thumbnail, videoId } = args?.VideoPlayer ?? {};
+  const { caption, hideCaption, thumbnail, videoId } =
+    args?.VideoPlayer ?? {};
   return html`
     <style>
       c4d-video-player-container-v7[background-mode] {
@@ -165,7 +175,8 @@ export const transparentBackground = (args) => {
 };
 
 export const ambient = (args) => {
-  const { caption, hideCaption, thumbnail, videoId } = args?.VideoPlayer ?? {};
+  const { caption, hideCaption, thumbnail, videoId } =
+    args?.VideoPlayer ?? {};
   return html`
     <style>
       c4d-video-player-container-v7[background-mode] {
@@ -211,6 +222,7 @@ aspectRatio4x3.story = {
         return {
           aspectRatio: '4x3',
           caption: text('Custom caption (caption):', ''),
+          disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
           hideCaption: boolean('Hide caption (hideCaption):', false),
           thumbnail: text('Custom thumbnail (thumbnail):', ''),
           videoId: '1_p2osmd1z',
@@ -222,6 +234,7 @@ aspectRatio4x3.story = {
         VideoPlayer: {
           aspectRatio: '4x3',
           caption: '',
+          disableImageZoom: false,
           hideCaption: false,
           thumbnail: '',
           videoId: '1_p2osmd1z',
@@ -239,6 +252,7 @@ aspectRatio1x1.story = {
         return {
           aspectRatio: '1x1',
           caption: text('Custom caption (caption):', ''),
+          disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
           hideCaption: boolean('Hide caption (hideCaption):', false),
           thumbnail: text('Custom thumbnail (thumbnail):', ''),
           videoId: '1_9h94wo6b',
@@ -250,6 +264,7 @@ aspectRatio1x1.story = {
         VideoPlayer: {
           aspectRatio: '1x1',
           caption: '',
+          disableImageZoom: false,
           hideCaption: false,
           thumbnail: '',
           videoId: '1_9h94wo6b',
@@ -271,6 +286,7 @@ withLightboxMediaViewer.story = {
             'This is a custom video description.'
           ),
           caption: text('Custom caption (caption):', ''),
+          disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
           hideCaption: boolean('Hide caption (hideCaption):', false),
           thumbnail: text('Custom thumbnail (thumbnail):', ''),
           videoId: '0_ibuqxqbe',
@@ -283,6 +299,7 @@ withLightboxMediaViewer.story = {
           aspectRatio: '16x9',
           customVideoDescription: 'This is a custom video description',
           caption: '',
+          disableImageZoom: false,
           hideCaption: false,
           thumbnail: '',
           videoId: '0_ibuqxqbe',
@@ -304,6 +321,7 @@ withLightboxAndCTA.story = {
             'This is a custom video description with CTA buttons that will be forwarded to the lightbox.'
           ),
           caption: text('Custom caption (caption):', ''),
+          disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
           hideCaption: boolean('Hide caption (hideCaption):', false),
           thumbnail: text('Custom thumbnail (thumbnail):', ''),
           videoId: '0_ibuqxqbe',
@@ -317,6 +335,7 @@ withLightboxAndCTA.story = {
           customVideoDescription:
             'This is a custom video description with CTA buttons that will be forwarded to the lightbox.',
           caption: '',
+          disableImageZoom: false,
           hideCaption: false,
           thumbnail: '',
           videoId: '0_ibuqxqbe',
@@ -498,6 +517,7 @@ export default {
     knobs: {
       VideoPlayer: () => ({
         caption: text('Custom caption (caption):', ''),
+        disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
         hideCaption: boolean('Hide caption (hideCaption):', false),
         thumbnail: text('Custom thumbnail (thumbnail):', ''),
         videoId: '1_mq9h9c34',
@@ -507,6 +527,7 @@ export default {
       default: {
         VideoPlayer: {
           caption: '',
+          disableImageZoom: false,
           hideCaption: false,
           thumbnail: '',
           videoId: '1_mq9h9c34',

--- a/packages/web-components/src/components/video-player-v7/__tests__/video-player.test.ts
+++ b/packages/web-components/src/components/video-player-v7/__tests__/video-player.test.ts
@@ -23,6 +23,7 @@ const template = (props?) => {
     formatCaption,
     formatDuration,
     hideCaption,
+    disableImageZoom,
     name,
     thumbnailUrl,
     videoId,
@@ -33,6 +34,7 @@ const template = (props?) => {
       content-state="${ifDefined(contentState)}"
       duration="${ifDefined(duration)}"
       ?hide-caption="${hideCaption}"
+      ?disable-image-zoom="${disableImageZoom}"
       name="${ifDefined(name)}"
       thumbnail-url="${ifDefined(thumbnailUrl)}"
       video-id="${ifDefined(videoId)}"
@@ -72,6 +74,37 @@ describe('c4d-video-player-v7', function () {
     expect(document.querySelector('c4d-video-player-v7')).toMatchSnapshot({
       mode: 'shadow',
     });
+  });
+
+  it('should not have disable-image-zoom attribute by default', async function () {
+    render(
+      template({
+        thumbnailUrl: 'about:blank',
+      }),
+      document.body
+    );
+    await Promise.resolve();
+    expect(
+      document
+        .querySelector('c4d-video-player-v7')!
+        .hasAttribute('disable-image-zoom')
+    ).toBe(false);
+  });
+
+  it('should reflect disable-image-zoom attribute when disableImageZoom is true', async function () {
+    render(
+      template({
+        thumbnailUrl: 'about:blank',
+        disableImageZoom: true,
+      }),
+      document.body
+    );
+    await Promise.resolve();
+    expect(
+      document
+        .querySelector('c4d-video-player-v7')!
+        .hasAttribute('disable-image-zoom')
+    ).toBe(true);
   });
 
   it('should support hiding the caption (media title)', async function () {

--- a/packages/web-components/src/components/video-player-v7/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player-composite.ts
@@ -346,6 +346,12 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
   hideCaption = false;
 
   /**
+   * `true` to disable the image zoom on hover effect.
+   */
+  @property({ type: Boolean, attribute: 'disable-image-zoom' })
+  disableImageZoom = false;
+
+  /**
    * `true` to autoplay, mute, and hide player UI.
    */
   @property({ type: Boolean, attribute: 'background-mode', reflect: true })
@@ -609,6 +615,7 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
       formatCaption,
       formatDuration,
       hideCaption,
+      disableImageZoom,
       caption,
       customVideoDescription,
       mediaData = {},
@@ -632,6 +639,7 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
         part="video-player"
         duration="${ifNonEmpty(duration)}"
         ?hide-caption=${hideCaption}
+        ?disable-image-zoom=${disableImageZoom}
         name="${ifNonEmpty(caption || name)}"
         video-description="${ifNonEmpty(customVideoDescription)}"
         thumbnail-url="${ifNonEmpty(thumbnailUrl)}"

--- a/packages/web-components/src/components/video-player-v7/video-player.ts
+++ b/packages/web-components/src/components/video-player-v7/video-player.ts
@@ -277,6 +277,12 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
   autoplay = false;
 
   /**
+   * `true` to disable the image zoom on hover effect.
+   */
+  @property({ type: Boolean, attribute: 'disable-image-zoom', reflect: true })
+  disableImageZoom = false;
+
+  /**
    * Custom video description. This property should only be set when using `playing-mode="lightbox"`
    */
   @property({ attribute: 'video-description' })

--- a/packages/web-components/src/components/video-player/__stories__/video-player.stories.react.tsx
+++ b/packages/web-components/src/components/video-player/__stories__/video-player.stories.react.tsx
@@ -13,12 +13,13 @@ import C4DVideoPlayerContainer from '@carbon/ibmdotcom-web-components/es/compone
 import readme from './README.stories.react.mdx';
 
 export const Default = (args) => {
-  const { aspectRatio, caption, hideCaption, videoId } =
+  const { aspectRatio, caption, disableImageZoom, hideCaption, videoId } =
     args?.VideoPlayerContainer ?? {};
   return (
     <C4DVideoPlayerContainer
       aspectRatio={aspectRatio}
       caption={caption}
+      disableImageZoom={disableImageZoom}
       hideCaption={hideCaption}
       videoId={videoId}
     />
@@ -26,12 +27,13 @@ export const Default = (args) => {
 };
 
 export const aspectRatio1x1 = (args) => {
-  const { aspectRatio, caption, hideCaption, videoId } =
+  const { aspectRatio, caption, disableImageZoom, hideCaption, videoId } =
     args?.VideoPlayerContainer ?? {};
   return (
     <C4DVideoPlayerContainer
       aspectRatio={aspectRatio}
       caption={caption}
+      disableImageZoom={disableImageZoom}
       hideCaption={hideCaption}
       videoId={videoId}
     />
@@ -46,6 +48,7 @@ aspectRatio1x1.story = {
         return {
           aspectRatio: '1x1',
           caption: text('Custom caption (caption):', ''),
+          disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
           hideCaption: boolean('Hide caption (hideCaption):', false),
           thumbnail: text('Custom thumbnail (thumbnail):', ''),
           videoId: '0_ibuqxqbe',
@@ -56,12 +59,13 @@ aspectRatio1x1.story = {
 };
 
 export const aspectRatio4x3 = (args) => {
-  const { aspectRatio, caption, hideCaption, videoId } =
+  const { aspectRatio, caption, disableImageZoom, hideCaption, videoId } =
     args?.VideoPlayerContainer ?? {};
   return (
     <C4DVideoPlayerContainer
       aspectRatio={aspectRatio}
       caption={caption}
+      disableImageZoom={disableImageZoom}
       hideCaption={hideCaption}
       videoId={videoId}
     />
@@ -76,6 +80,7 @@ aspectRatio4x3.story = {
         return {
           aspectRatio: '4x3',
           caption: text('Custom caption (caption):', ''),
+          disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
           hideCaption: boolean('Hide caption (hideCaption):', false),
           thumbnail: text('Custom thumbnail (thumbnail):', ''),
           videoId: '0_ibuqxqbe',
@@ -101,6 +106,7 @@ export default {
     knobs: {
       VideoPlayerContainer: () => ({
         caption: text('Custom caption (caption):', ''),
+        disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
         hideCaption: boolean('Hide caption (hideCaption):', false),
         thumbnailUrl: text('Custom thumbnail (thumbnail):', ''),
         videoId: '0_ibuqxqbe',

--- a/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
+++ b/packages/web-components/src/components/video-player/__stories__/video-player.stories.ts
@@ -15,13 +15,15 @@ import { enumValsToArray } from '../../../globals/internal/enum-helpers';
 import { BUTTON_POSITION } from '../defs';
 
 export const Default = (args) => {
-  const { caption, hideCaption, thumbnail, videoId } = args?.VideoPlayer ?? {};
+  const { caption, disableImageZoom, hideCaption, thumbnail, videoId } =
+    args?.VideoPlayer ?? {};
   return html`
     <c4d-video-player-container
       playing-mode="inline"
       video-id=${videoId}
       caption=${caption}
       ?hide-caption=${hideCaption}
+      ?disable-image-zoom=${disableImageZoom}
       thumbnail=${thumbnail}
       background-mode></c4d-video-player-container>
 
@@ -32,7 +34,7 @@ export const Default = (args) => {
 };
 
 export const aspectRatio1x1 = (args) => {
-  const { aspectRatio, caption, hideCaption, thumbnail, videoId } =
+  const { aspectRatio, caption, disableImageZoom, hideCaption, thumbnail, videoId } =
     args?.VideoPlayer ?? {};
   return html`
     <c4d-video-player-container
@@ -41,12 +43,13 @@ export const aspectRatio1x1 = (args) => {
       aspect-ratio=${aspectRatio}
       caption=${caption}
       ?hide-caption=${hideCaption}
+      ?disable-image-zoom=${disableImageZoom}
       thumbnail=${thumbnail}></c4d-video-player-container>
   `;
 };
 
 export const aspectRatio4x3 = (args) => {
-  const { aspectRatio, caption, hideCaption, thumbnail, videoId } =
+  const { aspectRatio, caption, disableImageZoom, hideCaption, thumbnail, videoId } =
     args?.VideoPlayer ?? {};
   return html`
     <c4d-video-player-container
@@ -55,6 +58,7 @@ export const aspectRatio4x3 = (args) => {
       aspect-ratio=${aspectRatio}
       caption=${caption}
       ?hide-caption=${hideCaption}
+      ?disable-image-zoom=${disableImageZoom}
       thumbnail=${thumbnail}></c4d-video-player-container>
   `;
 };
@@ -75,7 +79,8 @@ export const autoplay = (args) => {
 };
 
 export const autoplayMuted = (args) => {
-  const { caption, hideCaption, thumbnail, videoId } = args?.VideoPlayer ?? {};
+  const { caption, hideCaption, thumbnail, videoId } =
+    args?.VideoPlayer ?? {};
   return html`
     <style>
       c4d-video-player-container[background-mode] {
@@ -123,6 +128,7 @@ aspectRatio4x3.story = {
         return {
           aspectRatio: '4x3',
           caption: text('Custom caption (caption):', ''),
+          disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
           hideCaption: boolean('Hide caption (hideCaption):', false),
           thumbnail: text('Custom thumbnail (thumbnail):', ''),
           videoId: '0_ibuqxqbe',
@@ -134,6 +140,7 @@ aspectRatio4x3.story = {
         VideoPlayer: {
           aspectRatio: '4x3',
           caption: '',
+          disableImageZoom: false,
           hideCaption: false,
           thumbnail: '',
           videoId: '0_ibuqxqbe',
@@ -151,6 +158,7 @@ aspectRatio1x1.story = {
         return {
           aspectRatio: '1x1',
           caption: text('Custom caption (caption):', ''),
+          disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
           hideCaption: boolean('Hide caption (hideCaption):', false),
           thumbnail: text('Custom thumbnail (thumbnail):', ''),
           videoId: '0_ibuqxqbe',
@@ -162,6 +170,7 @@ aspectRatio1x1.story = {
         VideoPlayer: {
           aspectRatio: '1x1',
           caption: '',
+          disableImageZoom: false,
           hideCaption: false,
           thumbnail: '',
           videoId: '0_ibuqxqbe',
@@ -287,6 +296,7 @@ export default {
     knobs: {
       VideoPlayer: () => ({
         caption: text('Custom caption (caption):', ''),
+        disableImageZoom: boolean('Disable image zoom (disableImageZoom):', false),
         hideCaption: boolean('Hide caption (hideCaption):', false),
         thumbnail: text('Custom thumbnail (thumbnail):', ''),
         videoId: '0_ibuqxqbe',
@@ -296,6 +306,7 @@ export default {
       default: {
         VideoPlayer: {
           caption: '',
+          disableImageZoom: false,
           hideCaption: false,
           thumbnail: '',
           videoId: '0_ibuqxqbe',

--- a/packages/web-components/src/components/video-player/__tests__/video-player.test.ts
+++ b/packages/web-components/src/components/video-player/__tests__/video-player.test.ts
@@ -23,6 +23,7 @@ const template = (props?) => {
     formatCaption,
     formatDuration,
     hideCaption,
+    disableImageZoom,
     name,
     thumbnailUrl,
     videoId,
@@ -33,6 +34,7 @@ const template = (props?) => {
       content-state="${ifDefined(contentState)}"
       duration="${ifDefined(duration)}"
       ?hide-caption="${hideCaption}"
+      ?disable-image-zoom="${disableImageZoom}"
       name="${ifDefined(name)}"
       thumbnail-url="${ifDefined(thumbnailUrl)}"
       video-id="${ifDefined(videoId)}"
@@ -72,6 +74,37 @@ describe('c4d-video-player', function () {
     expect(document.querySelector('c4d-video-player')).toMatchSnapshot({
       mode: 'shadow',
     });
+  });
+
+  it('should not have disable-image-zoom attribute by default', async function () {
+    render(
+      template({
+        thumbnailUrl: 'about:blank',
+      }),
+      document.body
+    );
+    await Promise.resolve();
+    expect(
+      document
+        .querySelector('c4d-video-player')!
+        .hasAttribute('disable-image-zoom')
+    ).toBe(false);
+  });
+
+  it('should reflect disable-image-zoom attribute when disableImageZoom is true', async function () {
+    render(
+      template({
+        thumbnailUrl: 'about:blank',
+        disableImageZoom: true,
+      }),
+      document.body
+    );
+    await Promise.resolve();
+    expect(
+      document
+        .querySelector('c4d-video-player')!
+        .hasAttribute('disable-image-zoom')
+    ).toBe(true);
   });
 
   it('should support hiding the caption', async function () {

--- a/packages/web-components/src/components/video-player/video-player-composite.ts
+++ b/packages/web-components/src/components/video-player/video-player-composite.ts
@@ -298,6 +298,12 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
   hideCaption = false;
 
   /**
+   * `true` to disable the image zoom on hover effect.
+   */
+  @property({ type: Boolean, attribute: 'disable-image-zoom' })
+  disableImageZoom = false;
+
+  /**
    * `true` to autoplay, mute, and hide player UI.
    */
   @property({ type: Boolean, attribute: 'background-mode', reflect: true })
@@ -448,6 +454,7 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
       formatCaption,
       formatDuration,
       hideCaption,
+      disableImageZoom,
       caption,
       customVideoDescription,
       mediaData = {},
@@ -470,6 +477,7 @@ class C4DVideoPlayerComposite extends HybridRenderMixin(
         part="video-player"
         duration="${ifNonEmpty(duration)}"
         ?hide-caption=${hideCaption}
+        ?disable-image-zoom=${disableImageZoom}
         name="${ifNonEmpty(caption || name)}"
         video-description="${ifNonEmpty(customVideoDescription)}"
         thumbnail-url="${ifNonEmpty(thumbnailUrl)}"

--- a/packages/web-components/src/components/video-player/video-player.ts
+++ b/packages/web-components/src/components/video-player/video-player.ts
@@ -257,6 +257,12 @@ class C4DVideoPlayer extends FocusMixin(StableSelectorMixin(LitElement)) {
   autoplay = false;
 
   /**
+   * `true` to disable the image zoom on hover effect.
+   */
+  @property({ type: Boolean, attribute: 'disable-image-zoom', reflect: true })
+  disableImageZoom = false;
+
+  /**
    * Custom video description. This property should only be set when using `playing-mode="lightbox"`
    */
   @property({ attribute: 'video-description' })


### PR DESCRIPTION
### Description

Adds an image zoom (scale) on hover to the video player placeholder image, with an option to disable via a new attribute.

### Changelog

**New**

- Video players now have an image zoom on hover effect and a `disable-image-zoom` attribute for disabling the effect